### PR TITLE
feat: muse log — commit history graph with parent chain and ASCII DAG

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -33,6 +33,7 @@ maestro/muse_cli/
     ├── init.py           — muse init  ✅ fully implemented
     ├── status.py         — muse status  ✅ branch + commit state display
     ├── commit.py         — muse commit  ✅ fully implemented (issue #32)
+    ├── log.py            — muse log    ✅ fully implemented (issue #33)
     ├── snapshot.py       — walk_workdir, hash_file, build_snapshot_manifest, compute IDs
     ├── models.py         — MuseCliCommit, MuseCliSnapshot, MuseCliObject (SQLAlchemy)
     ├── db.py             — open_session, upsert_object/snapshot/commit helpers
@@ -45,6 +46,45 @@ maestro/muse_cli/
 ```
 
 The CLI delegates to existing `maestro/services/muse_*.py` service modules. Stub subcommands print "not yet implemented" and exit 0.
+
+---
+
+## `muse log` Output Formats
+
+### Default (`git log` style)
+
+```
+commit a1b2c3d4e5f6...  (HEAD -> main)
+Parent: f9e8d7c6
+Date:   2026-02-27 17:30:00
+
+    boom bap demo take 1
+
+commit f9e8d7c6...
+Date:   2026-02-27 17:00:00
+
+    initial take
+```
+
+Commits are printed newest-first.  The first commit (root) has no `Parent:` line.
+
+### `--graph` mode
+
+Reuses `maestro.services.muse_log_render.render_ascii_graph` by adapting `MuseCliCommit` rows to the `MuseLogGraph`/`MuseLogNode` dataclasses the renderer expects.
+
+```
+* a1b2c3d4 boom bap demo take 1 (HEAD)
+* f9e8d7c6 initial take
+```
+
+Merge commits (two parents) require `muse merge` (issue #35) — `parent2_commit_id` is reserved for that iteration.
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--limit N` / `-n N` | 1000 | Cap the walk at N commits |
+| `--graph` | off | ASCII DAG mode |
 
 ---
 

--- a/maestro/muse_cli/commands/log.py
+++ b/maestro/muse_cli/commands/log.py
@@ -1,15 +1,204 @@
-"""muse log — display the variation history graph."""
+"""muse log — commit history display with parent chain and ASCII DAG.
+
+Walks the commit parent chain from the current branch HEAD and prints
+each commit newest-first.  Two output modes:
+
+Default (``git log`` style)::
+
+    commit a1b2c3d4  (HEAD -> main)
+    Parent: f9e8d7c6
+    Date:   2026-02-27 17:30:00
+
+        boom bap demo take 1
+
+Graph mode (``--graph``)::
+
+    * a1b2c3d4 boom bap demo take 1 (HEAD)
+    * f9e8d7c6 initial take
+
+``--graph`` reuses ``maestro.services.muse_log_render.render_ascii_graph``
+by adapting ``MuseCliCommit`` rows to the ``MuseLogGraph``/``MuseLogNode``
+dataclasses that the renderer expects.
+
+Merge commits (two parents) will be supported once ``muse merge`` lands
+in issue #35.  The current data model stores a single ``parent_commit_id``;
+``parent2_commit_id`` is reserved for that iteration.
+"""
 from __future__ import annotations
 
+import asyncio
+import json
+import logging
+import pathlib
+
 import typer
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer()
 
+_DEFAULT_LIMIT = 1000
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _load_commits(
+    session: AsyncSession,
+    head_commit_id: str,
+    limit: int,
+) -> list[MuseCliCommit]:
+    """Walk the parent chain from *head_commit_id*, returning newest-first.
+
+    Stops when the chain is exhausted or *limit* is reached.  Each commit
+    is fetched individually by primary key — O(N) round-trips — which is
+    acceptable for the typical log depth of a DAW session.
+    """
+    commits: list[MuseCliCommit] = []
+    current_id: str | None = head_commit_id
+    while current_id and len(commits) < limit:
+        commit = await session.get(MuseCliCommit, current_id)
+        if commit is None:
+            logger.warning("⚠️ Commit %s not found in DB — chain broken", current_id[:8])
+            break
+        commits.append(commit)
+        current_id = commit.parent_commit_id
+    return commits
+
+
+async def _log_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    limit: int,
+    graph: bool,
+) -> None:
+    """Core log logic — fully injectable for tests.
+
+    Reads repo state from ``.muse/``, loads commits from the DB session,
+    and writes formatted output via ``typer.echo``.
+    """
+    muse_dir = root / ".muse"
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]  # noqa: F841 — kept for future remote filtering
+
+    head_ref = (muse_dir / "HEAD").read_text().strip()   # "refs/heads/main"
+    branch = head_ref.rsplit("/", 1)[-1]                 # "main"
+    ref_path = muse_dir / pathlib.Path(head_ref)
+
+    head_commit_id = ""
+    if ref_path.exists():
+        head_commit_id = ref_path.read_text().strip()
+
+    if not head_commit_id:
+        typer.echo(f"No commits yet on branch {branch}")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    commits = await _load_commits(session, head_commit_id=head_commit_id, limit=limit)
+    if not commits:
+        typer.echo(f"No commits yet on branch {branch}")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    if graph:
+        _render_graph(commits, head_commit_id=head_commit_id)
+    else:
+        _render_log(commits, head_commit_id=head_commit_id, branch=branch)
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def _render_log(
+    commits: list[MuseCliCommit],
+    *,
+    head_commit_id: str,
+    branch: str,
+) -> None:
+    """Print commits in ``git log`` style, newest-first."""
+    for commit in commits:
+        head_marker = f"  (HEAD -> {branch})" if commit.commit_id == head_commit_id else ""
+        typer.echo(f"commit {commit.commit_id}{head_marker}")
+        if commit.parent_commit_id:
+            typer.echo(f"Parent: {commit.parent_commit_id[:8]}")
+        ts = commit.committed_at.strftime("%Y-%m-%d %H:%M:%S")
+        typer.echo(f"Date:   {ts}")
+        typer.echo("")
+        typer.echo(f"    {commit.message}")
+        typer.echo("")
+
+
+def _render_graph(commits: list[MuseCliCommit], *, head_commit_id: str) -> None:
+    """Render ASCII DAG via ``render_ascii_graph``.
+
+    Adapts ``MuseCliCommit`` rows to ``MuseLogGraph``/``MuseLogNode`` so
+    the existing renderer can be reused without modification.
+
+    Commits are passed in newest-first (as returned by ``_load_commits``);
+    the renderer expects oldest-first, so the list is reversed before
+    building the graph.
+    """
+    from maestro.services.muse_log_graph import MuseLogGraph, MuseLogNode
+    from maestro.services.muse_log_render import render_ascii_graph
+
+    nodes = tuple(
+        MuseLogNode(
+            variation_id=c.commit_id,
+            parent=c.parent_commit_id,
+            parent2=None,           # merge parent — added in issue #35
+            is_head=(c.commit_id == head_commit_id),
+            timestamp=c.committed_at.timestamp(),
+            intent=c.message,
+            affected_regions=(),
+        )
+        for c in reversed(commits)  # oldest → newest for the DAG walker
+    )
+    graph_obj = MuseLogGraph(project_id="muse-cli", head=head_commit_id, nodes=nodes)
+    typer.echo(render_ascii_graph(graph_obj))
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
 
 @app.callback(invoke_without_command=True)
-def log(ctx: typer.Context) -> None:
-    """Display the commit DAG for the current project."""
-    require_repo()
-    typer.echo("muse log: not yet implemented")
+def log(
+    ctx: typer.Context,
+    limit: int = typer.Option(
+        _DEFAULT_LIMIT,
+        "--limit",
+        "-n",
+        help="Maximum number of commits to show.",
+        min=1,
+    ),
+    graph: bool = typer.Option(
+        False,
+        "--graph",
+        help="Show ASCII DAG (git log --graph style).",
+    ),
+) -> None:
+    """Display the commit history for the current branch."""
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _log_async(root=root, session=session, limit=limit, graph=graph)
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse log failed: {exc}")
+        logger.error("❌ muse log error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/tests/muse_cli/test_cli_skeleton.py
+++ b/tests/muse_cli/test_cli_skeleton.py
@@ -29,8 +29,8 @@ ALL_SUBCOMMANDS = [
 # when invoked inside a repo with a bare .muse/ directory.
 # ``init``   is excluded: fully implemented (issue #31).
 # ``commit`` is excluded: fully implemented (issue #32).
+# ``log``    is excluded: fully implemented (issue #33).
 STUB_COMMANDS = [
-    "log",
     "checkout",
     "merge",
     "remote",
@@ -40,9 +40,9 @@ STUB_COMMANDS = [
 
 # Repo-dependent commands that exit 2 outside a .muse/ repo.
 # ``commit`` requires -m so its no-repo exit-2 test lives in test_commit.py.
+# ``log``    no-repo exit-2 test lives in test_log.py.
 REPO_DEPENDENT_COMMANDS = [
     "status",
-    "log",
     "checkout",
     "merge",
     "remote",

--- a/tests/muse_cli/test_log.py
+++ b/tests/muse_cli/test_log.py
@@ -1,0 +1,316 @@
+"""Tests for ``muse log``.
+
+All async tests call ``_log_async`` directly with an in-memory SQLite
+session and a ``tmp_path`` repo root — no real Postgres or running process
+required.  Commits are seeded via ``_commit_async`` so the two commands
+are tested as an integrated pair.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.commands.log import _log_async
+from maestro.muse_cli.errors import ExitCode
+
+
+# ---------------------------------------------------------------------------
+# Helpers (shared with test_commit.py pattern)
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _write_workdir(root: pathlib.Path, files: dict[str, bytes]) -> None:
+    workdir = root / "muse-work"
+    workdir.mkdir(exist_ok=True)
+    for name, content in files.items():
+        (workdir / name).write_bytes(content)
+
+
+async def _make_commits(
+    root: pathlib.Path,
+    session: AsyncSession,
+    messages: list[str],
+    file_seed: int = 0,
+) -> list[str]:
+    """Create N commits on the repo, each with unique file content."""
+    commit_ids: list[str] = []
+    for i, msg in enumerate(messages):
+        _write_workdir(root, {f"track_{file_seed + i}.mid": f"MIDI-{file_seed + i}".encode()})
+        cid = await _commit_async(message=msg, root=root, session=session)
+        commit_ids.append(cid)
+    return commit_ids
+
+
+# ---------------------------------------------------------------------------
+# test_log_shows_commits_newest_first
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_log_shows_commits_newest_first(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Three sequential commits appear in the log newest-first."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["take 1", "take 2", "take 3"])
+
+    capsys.readouterr()  # discard ✅ output from _commit_async calls
+    await _log_async(
+        root=tmp_path, session=muse_cli_db_session, limit=1000, graph=False
+    )
+    out = capsys.readouterr().out
+
+    # All three commit IDs should appear
+    for cid in cids:
+        assert cid in out
+
+    # Newest (take 3) should appear before oldest (take 1)
+    assert out.index(cids[2]) < out.index(cids[0])
+    # take 3 message first, take 1 last
+    assert out.index("take 3") < out.index("take 1")
+
+
+# ---------------------------------------------------------------------------
+# test_log_shows_correct_parent_chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_log_shows_correct_parent_chain(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Each commit's ``Parent:`` line shows the short ID of its predecessor."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["first", "second", "third"])
+
+    await _log_async(
+        root=tmp_path, session=muse_cli_db_session, limit=1000, graph=False
+    )
+    out = capsys.readouterr().out
+
+    # "third" commit (cids[2]) should show cids[1][:8] as its parent
+    assert f"Parent: {cids[1][:8]}" in out
+    # "second" commit shows cids[0][:8] as parent
+    assert f"Parent: {cids[0][:8]}" in out
+    # "first" commit has no parent — no Parent line for it
+    lines = out.splitlines()
+    # Find the block for the first commit (last in output = oldest)
+    first_commit_idx = out.index(cids[0])
+    first_commit_block = out[first_commit_idx:]
+    # The first block should not have a Parent: line before the next "commit " line
+    next_commit = first_commit_block.find("commit ", 8)  # skip the "commit <id>" itself
+    if next_commit == -1:
+        block = first_commit_block
+    else:
+        block = first_commit_block[:next_commit]
+    assert "Parent:" not in block
+
+
+# ---------------------------------------------------------------------------
+# test_log_limit_restricts_output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_log_limit_restricts_output(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--limit 2 shows exactly the two most recent commits."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(
+        tmp_path, muse_cli_db_session, ["take 1", "take 2", "take 3"]
+    )
+
+    await _log_async(
+        root=tmp_path, session=muse_cli_db_session, limit=2, graph=False
+    )
+    out = capsys.readouterr().out
+
+    assert out.count("commit ") == 2
+    # Most recent two appear
+    assert cids[2] in out  # take 3
+    assert cids[1] in out  # take 2
+    # Oldest excluded
+    assert cids[0] not in out
+
+
+# ---------------------------------------------------------------------------
+# test_log_shows_single_parent_line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_log_shows_single_parent_line(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A commit with one parent shows exactly one ``Parent:`` line.
+
+    Note: merge commits with two parents (``parent2_commit_id``) are
+    deferred to issue #35 (``muse merge``).  This test documents the
+    current single-parent behavior.
+    """
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["v1", "v2"])
+
+    await _log_async(
+        root=tmp_path, session=muse_cli_db_session, limit=1000, graph=False
+    )
+    out = capsys.readouterr().out
+
+    # Only one Parent: line in the entire output (the second commit references the first)
+    assert out.count("Parent:") == 1
+    assert f"Parent: {cids[0][:8]}" in out
+
+
+# ---------------------------------------------------------------------------
+# test_log_no_commits_exits_zero
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_log_no_commits_exits_zero(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``muse log`` on a repo with no commits exits 0 with a friendly message."""
+    import typer
+
+    _init_muse_repo(tmp_path)
+    # Deliberately do NOT commit anything
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _log_async(
+            root=tmp_path, session=muse_cli_db_session, limit=1000, graph=False
+        )
+
+    assert exc_info.value.exit_code == ExitCode.SUCCESS
+    out = capsys.readouterr().out
+    assert "No commits yet" in out
+    assert "main" in out
+
+
+# ---------------------------------------------------------------------------
+# test_log_outside_repo_exits_2
+# ---------------------------------------------------------------------------
+
+
+def test_log_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse log`` outside a .muse/ directory exits with code 2."""
+    import os
+    from typer.testing import CliRunner
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["log"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# test_log_graph_produces_ascii_output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_log_graph_produces_ascii_output(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--graph`` output contains ASCII graph characters (* and |)."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(tmp_path, muse_cli_db_session, ["beat 1", "beat 2", "beat 3"])
+
+    await _log_async(
+        root=tmp_path, session=muse_cli_db_session, limit=1000, graph=True
+    )
+    out = capsys.readouterr().out
+
+    assert "*" in out
+    # Each commit message should appear in the graph output
+    assert "beat 1" in out
+    assert "beat 2" in out
+    assert "beat 3" in out
+
+
+# ---------------------------------------------------------------------------
+# test_log_head_marker_on_newest_commit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_log_head_marker_on_newest_commit(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The most recent commit is labelled ``(HEAD -> main)``."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["first", "second"])
+
+    await _log_async(
+        root=tmp_path, session=muse_cli_db_session, limit=1000, graph=False
+    )
+    out = capsys.readouterr().out
+
+    # Only the newest commit (cids[1]) carries the HEAD marker
+    assert f"{cids[1]}  (HEAD -> main)" in out
+    # Older commit does NOT carry it
+    assert f"{cids[0]}  (HEAD -> main)" not in out
+
+
+# ---------------------------------------------------------------------------
+# test_log_limit_one_shows_only_head
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_log_limit_one_shows_only_head(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--limit 1`` shows only the HEAD commit, regardless of chain length."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["a", "b", "c"])
+
+    await _log_async(
+        root=tmp_path, session=muse_cli_db_session, limit=1, graph=False
+    )
+    out = capsys.readouterr().out
+
+    assert out.count("commit ") == 1
+    assert cids[2] in out
+    assert cids[1] not in out
+    assert cids[0] not in out


### PR DESCRIPTION
## Summary

Implements \`muse log\` end-to-end (issue #33).

Closes #33.

## Root Cause

\`muse log\` was a stub that printed "not yet implemented". Producers had no way to inspect their commit history or understand which versions they'd created.

## Solution

- \`_load_commits()\` walks the \`parent_commit_id\` chain from HEAD, returning commits newest-first
- Default mode renders \`git log\`-style output (full commit ID, Parent short ID, Date, indented message)
- \`--graph\` mode reuses \`render_ascii_graph()\` from \`maestro.services.muse_log_render\` by adapting \`MuseCliCommit\` rows to \`MuseLogGraph\`/\`MuseLogNode\` — zero renderer duplication
- \`--limit N\` / \`-n N\` caps the walk (default 1000)
- Exits 0 with "No commits yet on branch main" on empty repo
- Exits 2 outside a \`.muse/\` directory

## Layers Affected

- [x] Muse VCS (muse_cli commands)

## ID Derivation / Graph Note

Merge commits (two parents) require \`muse merge\` (issue #35). The renderer already supports \`parent2\` — \`_render_graph()\` passes \`parent2=None\` for now, which will be wired up in #35 without changing the renderer.

## Verification

- [x] \`docker compose exec maestro mypy maestro/ tests/\` — clean (410 files)
- [x] \`docker compose exec maestro pytest tests/muse_cli/ -q\` — 79 passed
- [x] Docs updated: \`docs/architecture/muse_vcs.md\`

## Tests Added

| Test | What it checks |
|------|----------------|
| \`test_log_shows_commits_newest_first\` | 3 commits → newest printed first |
| \`test_log_shows_correct_parent_chain\` | Parent: short ID correct per commit |
| \`test_log_limit_restricts_output\` | \`--limit 2\` shows only 2 commits |
| \`test_log_shows_single_parent_line\` | One parent → one Parent: line (documents merge deferral to #35) |
| \`test_log_no_commits_exits_zero\` | Empty repo → exit 0 + friendly message |
| \`test_log_outside_repo_exits_2\` | No .muse/ → exit 2 |
| \`test_log_graph_produces_ascii_output\` | \`--graph\` output contains \`*\` and commit messages |
| \`test_log_head_marker_on_newest_commit\` | Only HEAD commit carries \`(HEAD -> main)\` |
| \`test_log_limit_one_shows_only_head\` | \`-n 1\` returns exactly the HEAD commit |

## Handoff

N/A — no SSE/MCP/protocol change.