### PR TITLE
feat: repo-root detection utility — public repo.py, MuseNotARepoError, standard error message

### DIFF
--- a/maestro/muse_cli/_repo.py
+++ b/maestro/muse_cli/_repo.py
@@ -43,6 +43,12 @@ def find_repo_root(start: pathlib.Path | None = None) -> pathlib.Path | None:
         current = parent
 
 
+_NOT_A_REPO_MSG = (
+    'fatal: not a muse repository (or any parent up to mount point /)\n'
+    'Run "muse init" to initialize a new repository.'
+)
+
+
 def require_repo(start: pathlib.Path | None = None) -> pathlib.Path:
     """Return the repo root or exit 2 with a clear error message.
 
@@ -53,6 +59,10 @@ def require_repo(start: pathlib.Path | None = None) -> pathlib.Path:
     """
     root = find_repo_root(start)
     if root is None:
-        typer.echo("Not a Muse repository. Run `muse init`.")
+        typer.echo(_NOT_A_REPO_MSG)
         raise typer.Exit(code=ExitCode.REPO_NOT_FOUND)
     return root
+
+
+#: Public alias matching the function name specified in issue #46.
+require_repo_root = require_repo

--- a/maestro/muse_cli/errors.py
+++ b/maestro/muse_cli/errors.py
@@ -32,3 +32,7 @@ class RepoNotFoundError(MuseCLIError):
 
     def __init__(self, message: str = "Not a Muse repository. Run `muse init`.") -> None:
         super().__init__(message, exit_code=ExitCode.REPO_NOT_FOUND)
+
+
+#: Canonical public alias matching the name specified in issue #46.
+MuseNotARepoError = RepoNotFoundError

--- a/maestro/muse_cli/repo.py
+++ b/maestro/muse_cli/repo.py
@@ -1,0 +1,23 @@
+"""Public API for Muse CLI repository detection.
+
+This module is the stable, importable surface for ``find_repo_root()`` and
+``require_repo_root()``.  All internal commands continue to import from
+``_repo`` (the original private module); this public re-export exists so
+external tooling and new commands can depend on a name that is not
+prefixed with an underscore.
+
+Issue #46 specifies ``maestro.muse_cli.repo`` as the canonical location.
+"""
+from __future__ import annotations
+
+from maestro.muse_cli._repo import (
+    find_repo_root,
+    require_repo,
+    require_repo_root,
+)
+
+__all__ = [
+    "find_repo_root",
+    "require_repo",
+    "require_repo_root",
+]


### PR DESCRIPTION
## Summary
Closes #46. Finalises the repo-root detection utility by surfacing a stable public API, adding the `MuseNotARepoError` alias, updating the standardised error message, and expanding test coverage to 14 tests.

## Issue
Closes #46

## Root Cause
The core implementation already existed in `maestro/muse_cli/_repo.py` and was used by all 9 commands, but the public contract specified in issue #46 was not yet formalised: no `repo.py` public module, no `require_repo_root` alias, no `MuseNotARepoError` in `errors.py`, and the error message was informal rather than git-style.

## Solution
- Created `maestro/muse_cli/repo.py` as the canonical public import surface (re-exports `find_repo_root`, `require_repo`, `require_repo_root`). All existing internal commands continue to import from `_repo.py` — no callers were changed.
- Added `require_repo_root = require_repo` alias in `_repo.py`.
- Added `MuseNotARepoError = RepoNotFoundError` alias in `errors.py`.
- Updated the "not a repo" error message to the git-style format specified in the issue.
- Expanded `tests/muse_cli/test_repo.py` from 10 to 14 tests.
- Updated `docs/architecture/muse_vcs.md` with public API signature, detection rules, `MUSE_REPO_ROOT` semantics, and the standard error message.

## Layers Affected
- [ ] Intent Engine
- [ ] Pipeline
- [ ] Maestro Handlers
- [ ] Agent Teams
- [ ] Storpheus Client
- [x] Muse VCS
- [ ] MCP
- [ ] DAW Adapter
- [ ] Auth / Budget
- [ ] RAG
- [ ] Variation
- [ ] SSE Protocol (handoff required — see below)

## Verification
- [x] `docker compose -f docker-compose.yml run --rm -v <worktree>/maestro:/app/maestro -v <worktree>/tests:/app/tests --no-deps maestro mypy ...` — clean (4 files, no issues)
- [x] `docker compose -f docker-compose.yml run --rm ... pytest tests/muse_cli/test_repo.py -v` — 14 passed
- [x] Affected docs updated (`docs/architecture/muse_vcs.md`)

## Tests Added
- `test_require_repo_error_message_matches_standard` — regression for git-style error message format
- `test_require_repo_root_alias_is_identical` — alias identity check
- `test_muse_not_a_repo_error_alias` — `MuseNotARepoError is RepoNotFoundError`
- `test_public_repo_module_exports_find_repo_root` — public module exports `find_repo_root`
- `test_public_repo_module_exports_require_repo_root` — public module exports `require_repo_root`

## Handoff (if SSE/MCP protocol changed)
N/A — no protocol change. Muse CLI internal change only.