### PR TITLE
feat: muse status — working tree diff, staged files, and in-progress merge display

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -34,13 +34,14 @@ maestro/muse_cli/
 └── commands/
     ├── __init__.py
     ├── init.py           — muse init  ✅ fully implemented
-    ├── status.py         — muse status  ✅ branch + commit state display
+    ├── status.py         — muse status  ✅ fully implemented (issue #44)
     ├── commit.py         — muse commit  ✅ fully implemented (issue #32)
     ├── log.py            — muse log    ✅ fully implemented (issue #33)
-    ├── snapshot.py       — walk_workdir, hash_file, build_snapshot_manifest, compute IDs
+    ├── snapshot.py       — walk_workdir, hash_file, build_snapshot_manifest, compute IDs,
+    │                        diff_workdir_vs_snapshot (added/modified/deleted/untracked sets)
     ├── models.py         — MuseCliCommit, MuseCliSnapshot, MuseCliObject (SQLAlchemy)
-    ├── db.py             — open_session, upsert_object/snapshot/commit helpers
-    ├── log.py            — muse log     (stub — issue #33)
+    ├── db.py             — open_session, upsert/get helpers, get_head_snapshot_manifest
+    ├── merge_engine.py   — read_merge_state(), MergeState dataclass (MERGE_STATE.json reader)
     ├── checkout.py       — muse checkout (stub — issue #34)
     ├── merge.py          — muse merge   (stub — issue #35)
     ├── remote.py         — muse remote  (stub — issue #38)
@@ -49,6 +50,84 @@ maestro/muse_cli/
 ```
 
 The CLI delegates to existing `maestro/services/muse_*.py` service modules. Stub subcommands print "not yet implemented" and exit 0.
+
+---
+
+## `muse status` Output Formats
+
+`muse status` operates in three modes depending on repository state.
+
+### Mode 1 — Clean working tree
+
+No changes since the last commit:
+
+```
+On branch main
+nothing to commit, working tree clean
+```
+
+### Mode 2 — Uncommitted changes
+
+Files have been modified, added, or deleted relative to the last snapshot:
+
+```
+On branch main
+
+Changes since last commit:
+  (use "muse commit -m <msg>" to record changes)
+
+        modified:   beat.mid
+        new file:   lead.mp3
+        deleted:    scratch.mid
+```
+
+- `modified:` — file exists in both the last snapshot and `muse-work/` but its sha256 hash differs.
+- `new file:` — file is present in `muse-work/` but absent from the last committed snapshot.
+- `deleted:` — file was in the last committed snapshot but is no longer present in `muse-work/`.
+
+### Mode 3 — In-progress merge
+
+When `.muse/MERGE_STATE.json` exists (written by `muse merge` when conflicts are detected):
+
+```
+On branch main
+
+You have unmerged paths.
+  (fix conflicts and run "muse commit")
+
+Unmerged paths:
+        both modified:   beat.mid
+        both modified:   lead.mp3
+```
+
+Resolve conflicts manually, then `muse commit` to record the merge.
+
+### No commits yet
+
+On a branch that has never been committed to:
+
+```
+On branch main, no commits yet
+
+Untracked files:
+  (use "muse commit -m <msg>" to record changes)
+
+        beat.mid
+```
+
+If `muse-work/` is empty or missing: `On branch main, no commits yet` (single line).
+
+### Implementation
+
+| Layer | File | Responsibility |
+|-------|------|----------------|
+| Command | `maestro/muse_cli/commands/status.py` | Typer callback + `_status_async` |
+| Diff engine | `maestro/muse_cli/snapshot.py` | `diff_workdir_vs_snapshot()` |
+| Merge reader | `maestro/muse_cli/merge_engine.py` | `read_merge_state()` / `MergeState` |
+| DB helper | `maestro/muse_cli/db.py` | `get_head_snapshot_manifest()` |
+
+`_status_async` is the injectable async core (tested directly without a running server).
+Exit codes: 0 success, 2 outside a Muse repo, 3 internal error.
 
 ---
 

--- a/maestro/muse_cli/commands/status.py
+++ b/maestro/muse_cli/commands/status.py
@@ -1,40 +1,181 @@
 """muse status — show working-tree state relative to HEAD.
 
-MVP implementation: reads ``.muse/HEAD`` to determine the current branch,
-then checks whether that branch has any commits.  Full working-tree diff
-(added / modified / deleted / untracked files) is tracked in issue #44.
+Output modes
+------------
+
+**Clean working tree** (no uncommitted changes)::
+
+    On branch main
+    nothing to commit, working tree clean
+
+**Uncommitted changes** (modified / added / deleted files)::
+
+    On branch main
+
+    Changes since last commit:
+      (use "muse commit -m <msg>" to record changes)
+
+            modified:   beat.mid
+            new file:   lead.mp3
+            deleted:    scratch.mid
+
+**In-progress merge** (``MERGE_STATE.json`` present)::
+
+    On branch main
+
+    You have unmerged paths.
+      (fix conflicts and run "muse commit")
+
+    Unmerged paths:
+            both modified:   beat.mid
+
+**No commits yet** (branch has never been committed to)::
+
+    On branch main, no commits yet
+
+    Untracked files:
+      (use "muse commit -m <msg>" to record changes)
+
+            beat.mid
 """
 from __future__ import annotations
 
+import asyncio
+import json
+import logging
 import pathlib
 
 import typer
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import get_head_snapshot_manifest, open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.merge_engine import read_merge_state
+from maestro.muse_cli.snapshot import diff_workdir_vs_snapshot, walk_workdir
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer()
 
 
-@app.callback(invoke_without_command=True)
-def status(ctx: typer.Context) -> None:
-    """Show the current branch and commit state."""
-    root = require_repo()
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _status_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+) -> None:
+    """Core status logic — fully injectable for tests.
+
+    Reads repo state from ``.muse/``, queries the DB session for the HEAD
+    snapshot manifest, diffs the working tree, and writes formatted output
+    via :func:`typer.echo`.
+
+    Args:
+        root:    Repository root (directory containing ``.muse/``).
+        session: An open async DB session used to load the HEAD snapshot.
+    """
     muse_dir = root / ".muse"
 
+    # -- Branch name --
     head_path = muse_dir / "HEAD"
-    if not head_path.exists():
-        # Bare .muse/ directory created outside of `muse init`; nothing to report.
-        typer.echo("muse status: not yet implemented")
-        return
-
-    head_ref = head_path.read_text().strip()  # e.g. "refs/heads/main"
+    head_ref = head_path.read_text().strip()          # "refs/heads/main"
     branch = head_ref.rsplit("/", 1)[-1] if "/" in head_ref else head_ref
 
-    ref_path = muse_dir / head_ref
-    if not ref_path.exists() or not ref_path.read_text().strip():
-        typer.echo(f"On branch {branch}, no commits yet")
+    # -- In-progress merge --
+    merge_state = read_merge_state(root)
+    if merge_state is not None and merge_state.conflicts:
+        typer.echo(f"On branch {branch}")
+        typer.echo("")
+        typer.echo("You have unmerged paths.")
+        typer.echo('  (fix conflicts and run "muse commit")')
+        typer.echo("")
+        typer.echo("Unmerged paths:")
+        for conflict_path in sorted(merge_state.conflicts):
+            typer.echo(f"\tboth modified:   {conflict_path}")
+        typer.echo("")
         return
 
-    # Branch has commits — full diff not yet implemented (issue #44).
+    # -- Check for any commits on this branch --
+    ref_path = muse_dir / pathlib.Path(head_ref)
+    head_commit_id = ""
+    if ref_path.exists():
+        head_commit_id = ref_path.read_text().strip()
+
+    if not head_commit_id:
+        # No commits yet -- show untracked working-tree files if any.
+        workdir = root / "muse-work"
+        untracked_files: list[str] = []
+        if workdir.exists():
+            manifest = walk_workdir(workdir)
+            untracked_files = sorted(manifest.keys())
+
+        if untracked_files:
+            typer.echo(f"On branch {branch}, no commits yet")
+            typer.echo("")
+            typer.echo("Untracked files:")
+            typer.echo('  (use "muse commit -m <msg>" to record changes)')
+            typer.echo("")
+            for path in untracked_files:
+                typer.echo(f"\t{path}")
+            typer.echo("")
+        else:
+            typer.echo(f"On branch {branch}, no commits yet")
+        return
+
+    # -- Load HEAD snapshot manifest from DB --
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]
+
+    last_manifest = await get_head_snapshot_manifest(session, repo_id, branch) or {}
+
+    # -- Diff workdir vs HEAD snapshot --
+    workdir = root / "muse-work"
+    added, modified, deleted, _ = diff_workdir_vs_snapshot(workdir, last_manifest)
+
+    if not added and not modified and not deleted:
+        typer.echo(f"On branch {branch}")
+        typer.echo("nothing to commit, working tree clean")
+        return
+
+    # -- Display changes --
     typer.echo(f"On branch {branch}")
-    typer.echo("muse status: full diff not yet implemented")
+    typer.echo("")
+    typer.echo("Changes since last commit:")
+    typer.echo('  (use "muse commit -m <msg>" to record changes)')
+    typer.echo("")
+    for path in sorted(modified):
+        typer.echo(f"\tmodified:   {path}")
+    for path in sorted(added):
+        typer.echo(f"\tnew file:   {path}")
+    for path in sorted(deleted):
+        typer.echo(f"\tdeleted:    {path}")
+    typer.echo("")
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def status(ctx: typer.Context) -> None:
+    """Show the current branch and working-tree state relative to HEAD."""
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _status_async(root=root, session=session)
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"muse status failed: {exc}")
+        logger.error("muse status error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/muse_cli/merge_engine.py
+++ b/maestro/muse_cli/merge_engine.py
@@ -1,0 +1,84 @@
+"""Muse VCS merge-state reader.
+
+Provides :func:`read_merge_state` — a pure filesystem read that detects an
+in-progress merge and returns conflict information.  The presence of
+``.muse/MERGE_STATE.json`` signals that a three-way merge was started but
+has unresolved conflicts that must be fixed before committing.
+
+``MERGE_STATE.json`` schema (all fields optional except ``conflicts``):
+
+.. code-block:: json
+
+    {
+        "conflicts":    ["path/to/file1.mid", "path/to/file2.mid"],
+        "other_branch": "feature/variation-b",
+        "merge_base":   "abc123def456..."
+    }
+"""
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+_MERGE_STATE_FILENAME = "MERGE_STATE.json"
+
+
+@dataclass(frozen=True)
+class MergeState:
+    """Describes an in-progress merge with unresolved conflicts.
+
+    Attributes:
+        conflicts:    Relative paths (POSIX) of files with merge conflicts.
+        other_branch: Name of the branch being merged in, if recorded.
+        merge_base:   Commit ID of the common ancestor, if recorded.
+    """
+
+    conflicts: list[str] = field(default_factory=list)
+    other_branch: str | None = None
+    merge_base: str | None = None
+
+
+def read_merge_state(root: pathlib.Path) -> MergeState | None:
+    """Return :class:`MergeState` if a merge is in progress, otherwise ``None``.
+
+    Reads ``.muse/MERGE_STATE.json`` from *root*.  Returns ``None`` when the
+    file does not exist (no in-progress merge) or when it cannot be parsed.
+
+    Args:
+        root: The repository root directory (the directory containing ``.muse/``).
+
+    Returns:
+        A :class:`MergeState` instance describing the in-progress merge, or
+        ``None`` if no merge is in progress.
+    """
+    merge_state_path = root / ".muse" / _MERGE_STATE_FILENAME
+    if not merge_state_path.exists():
+        return None
+
+    try:
+        data: dict[str, object] = json.loads(merge_state_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("⚠️ Failed to read %s: %s", _MERGE_STATE_FILENAME, exc)
+        return None
+
+    raw_conflicts = data.get("conflicts", [])
+    conflicts: list[str] = (
+        [str(c) for c in raw_conflicts] if isinstance(raw_conflicts, list) else []
+    )
+
+    other_branch: str | None = (
+        str(data["other_branch"]) if "other_branch" in data else None
+    )
+    merge_base: str | None = (
+        str(data["merge_base"]) if "merge_base" in data else None
+    )
+
+    return MergeState(
+        conflicts=conflicts,
+        other_branch=other_branch,
+        merge_base=merge_base,
+    )

--- a/tests/muse_cli/test_status.py
+++ b/tests/muse_cli/test_status.py
@@ -1,0 +1,263 @@
+"""Tests for ``muse status`` — working-tree diff and merge state display.
+
+All DB-dependent tests use ``_status_async`` directly with an in-memory
+SQLite session (via the ``muse_cli_db_session`` fixture in conftest.py)
+so no real Postgres instance is required.
+
+Async tests use ``@pytest.mark.anyio`` (configured for asyncio mode in
+pyproject.toml).
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.commands.status import _status_async
+from maestro.muse_cli.errors import ExitCode
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror commit test helpers to keep tests self-contained)
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    """Create a minimal .muse/ layout."""
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")  # no commits yet
+    return rid
+
+
+def _populate_workdir(root: pathlib.Path, files: dict[str, bytes] | None = None) -> None:
+    """Create muse-work/ with the given files."""
+    workdir = root / "muse-work"
+    workdir.mkdir(exist_ok=True)
+    if files is None:
+        files = {"beat.mid": b"MIDI-DATA"}
+    for name, content in files.items():
+        (workdir / name).write_bytes(content)
+
+
+# ---------------------------------------------------------------------------
+# Clean working tree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_status_clean_after_commit(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """After a commit with no subsequent changes, status reports a clean tree."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"MIDI"})
+
+    await _commit_async(
+        message="initial commit",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+    # Flush so the snapshot row is visible to _status_async in the same session.
+    await muse_cli_db_session.flush()
+
+    await _status_async(root=tmp_path, session=muse_cli_db_session)
+
+    captured = capsys.readouterr()
+    assert "nothing to commit, working tree clean" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Uncommitted changes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_status_shows_modified_file(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A file changed after the last commit appears as 'modified:'."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"VERSION1"})
+
+    await _commit_async(
+        message="initial",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+    await muse_cli_db_session.flush()
+
+    # Modify the file without committing.
+    (tmp_path / "muse-work" / "beat.mid").write_bytes(b"VERSION2")
+
+    await _status_async(root=tmp_path, session=muse_cli_db_session)
+
+    captured = capsys.readouterr()
+    assert "modified:" in captured.out
+    assert "beat.mid" in captured.out
+
+
+@pytest.mark.anyio
+async def test_status_shows_new_file(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A file added to muse-work/ after the last commit appears as 'new file:'."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"MIDI"})
+
+    await _commit_async(
+        message="initial",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+    await muse_cli_db_session.flush()
+
+    # Add a new file that was not in the committed snapshot.
+    (tmp_path / "muse-work" / "lead.mp3").write_bytes(b"MP3")
+
+    await _status_async(root=tmp_path, session=muse_cli_db_session)
+
+    captured = capsys.readouterr()
+    assert "new file:" in captured.out
+    assert "lead.mp3" in captured.out
+
+
+@pytest.mark.anyio
+async def test_status_shows_deleted_file(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A file removed from muse-work/ after the last commit appears as 'deleted:'."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"MIDI", "scratch.mid": b"TMP"})
+
+    await _commit_async(
+        message="initial",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+    await muse_cli_db_session.flush()
+
+    # Remove one file without committing.
+    (tmp_path / "muse-work" / "scratch.mid").unlink()
+
+    await _status_async(root=tmp_path, session=muse_cli_db_session)
+
+    captured = capsys.readouterr()
+    assert "deleted:" in captured.out
+    assert "scratch.mid" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Untracked files (no commits yet)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_status_shows_untracked(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Files in muse-work/ on a branch with no commits are listed as untracked."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"MIDI", "lead.mp3": b"MP3"})
+
+    # Do NOT commit — branch has no history.
+    await _status_async(root=tmp_path, session=muse_cli_db_session)
+
+    captured = capsys.readouterr()
+    assert "Untracked files" in captured.out
+    assert "beat.mid" in captured.out
+    assert "lead.mp3" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# In-progress merge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_status_during_merge_shows_conflicts(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When MERGE_STATE.json is present, conflict paths appear with 'both modified:'."""
+    _init_muse_repo(tmp_path)
+
+    merge_state = {
+        "conflicts": ["beat.mid", "lead.mp3"],
+        "other_branch": "feature/variation-b",
+    }
+    (tmp_path / ".muse" / "MERGE_STATE.json").write_text(json.dumps(merge_state))
+
+    await _status_async(root=tmp_path, session=muse_cli_db_session)
+
+    captured = capsys.readouterr()
+    assert "You have unmerged paths" in captured.out
+    assert "both modified:" in captured.out
+    assert "beat.mid" in captured.out
+    assert "lead.mp3" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# No commits yet (clean working tree)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_status_no_commits_yet(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A repo with no commits and no muse-work/ files shows 'no commits yet'."""
+    _init_muse_repo(tmp_path)
+    # No muse-work/ directory, no commits.
+
+    await _status_async(root=tmp_path, session=muse_cli_db_session)
+
+    captured = capsys.readouterr()
+    assert "no commits yet" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Outside a repo
+# ---------------------------------------------------------------------------
+
+
+def test_status_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse status`` exits 2 when there is no ``.muse/`` directory."""
+    from typer.testing import CliRunner
+
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["status"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == int(ExitCode.REPO_NOT_FOUND)
+    assert "not a muse repository" in result.output.lower()


### PR DESCRIPTION
## Summary
Implements `muse status` command showing working tree diff vs last commit, staged files, and in-progress merge state.

## Issue
Closes #44

## Root Cause
The `muse status` command was a stub that printed "muse status: full diff not yet implemented", leaving musicians with no visibility into working tree state before committing.

## Solution
- **`commands/status.py`**: replaces the stub with a full implementation. `_status_async` is the injectable async core tested without a live server.
- **`snapshot.py`**: adds `diff_workdir_vs_snapshot()` returning four disjoint path sets — `(added, modified, deleted, untracked)`.
- **`merge_engine.py`** (new): `read_merge_state()` reads `.muse/MERGE_STATE.json` and returns a `MergeState` dataclass. Returns `None` when no merge is in progress.
- **`db.py`**: adds `get_head_snapshot_manifest()` to load the HEAD snapshot manifest in a single async call.
- **`docs/architecture/muse_vcs.md`**: documents all three output modes with example output and an implementation layer table.

## Three Output Modes

**Clean tree:**
```
On branch main
nothing to commit, working tree clean
```

**Uncommitted changes:**
```
On branch main

Changes since last commit:
  (use "muse commit -m <msg>" to record changes)

        modified:   beat.mid
        new file:   lead.mp3
        deleted:    scratch.mid
```

**In-progress merge:**
```
On branch main

You have unmerged paths.
  (fix conflicts and run "muse commit")

Unmerged paths:
        both modified:   beat.mid
```

## Layers Affected
- [x] Muse VCS (muse_cli commands, snapshot, merge_engine, db)

## Verification
- [x] `docker compose exec maestro mypy maestro/muse_cli/ tests/muse_cli/` — clean (5 new/modified files)
- [x] `docker compose exec maestro pytest tests/muse_cli/test_status.py -v` — 8/8 passed
- [x] Affected docs updated

## Tests Added
- `test_status_clean_after_commit`
- `test_status_shows_modified_file`
- `test_status_shows_new_file`
- `test_status_shows_deleted_file`
- `test_status_shows_untracked`
- `test_status_during_merge_shows_conflicts`
- `test_status_no_commits_yet`
- `test_status_outside_repo_exits_2`

## Handoff
N/A — no protocol change; no SSE events or MCP tool schemas affected.