### PR TITLE
feat: Muse Hub issues — create and list music project issues

### DIFF
--- a/alembic/versions/20260227_2034_ca7672bc4a13_add_musehub_issues_table.py
+++ b/alembic/versions/20260227_2034_ca7672bc4a13_add_musehub_issues_table.py
@@ -1,0 +1,49 @@
+"""Add musehub_issues table for issue tracking per repo.
+
+Revision ID: ca7672bc4a13
+Revises: 20260227_0001
+Create Date: 2026-02-27 20:34:25.445344+00:00
+
+Adds issue tracking to Muse Hub so musicians can open, list, and close
+production/creative issues against a repo (issue #42).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ca7672bc4a13"
+down_revision = "20260227_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "musehub_issues",
+        sa.Column("issue_id", sa.String(36), nullable=False),
+        sa.Column("repo_id", sa.String(36), nullable=False),
+        sa.Column("number", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(500), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False, server_default=""),
+        sa.Column("state", sa.String(20), nullable=False, server_default="open"),
+        sa.Column("labels", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["repo_id"], ["musehub_repos.repo_id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("issue_id"),
+    )
+    op.create_index("ix_musehub_issues_repo_id", "musehub_issues", ["repo_id"])
+    op.create_index("ix_musehub_issues_number", "musehub_issues", ["number"])
+    op.create_index("ix_musehub_issues_state", "musehub_issues", ["state"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_musehub_issues_state", table_name="musehub_issues")
+    op.drop_index("ix_musehub_issues_number", table_name="musehub_issues")
+    op.drop_index("ix_musehub_issues_repo_id", table_name="musehub_issues")
+    op.drop_table("musehub_issues")

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -990,3 +990,78 @@ List commits for a repo, newest first.
   "total": 1
 }
 ```
+
+---
+
+## Muse Hub Issues API
+
+Issue tracker for Muse Hub repos — lets musicians open, filter, and close production/creative issues (e.g. "hi-hat / synth pad clash in measure 8"). All endpoints are under `/api/v1/musehub/repos/{repo_id}/issues/` and require `Authorization: Bearer <token>`.
+
+Issue numbers (`number`) are sequential per repo, starting at 1. Labels are free-form strings; no validation at MVP.
+
+### POST /api/v1/musehub/repos/{repo_id}/issues
+
+Create a new issue in `open` state.
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `title` | string | yes | Issue title (1–500 chars) |
+| `body` | string | no | Markdown description (default `""`) |
+| `labels` | string[] | no | Free-form label strings (default `[]`) |
+
+**Response (201):**
+
+```json
+{
+  "issueId": "550e8400-e29b-41d4-a716-446655440000",
+  "number": 1,
+  "title": "Hi-hat / synth pad clash in measure 8",
+  "body": "Frequencies clash around 8 kHz.",
+  "state": "open",
+  "labels": ["bug", "musical"],
+  "createdAt": "2026-02-27T20:00:00Z"
+}
+```
+
+### GET /api/v1/musehub/repos/{repo_id}/issues
+
+List issues for a repo.
+
+**Query params:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `state` | `open` \| `closed` \| `all` | `open` | Filter by state |
+| `label` | string | — | Filter to issues containing this label |
+
+**Response (200):**
+
+```json
+{
+  "issues": [
+    {
+      "issueId": "550e8400-e29b-41d4-a716-446655440000",
+      "number": 1,
+      "title": "Hi-hat / synth pad clash in measure 8",
+      "body": "Frequencies clash around 8 kHz.",
+      "state": "open",
+      "labels": ["bug"],
+      "createdAt": "2026-02-27T20:00:00Z"
+    }
+  ]
+}
+```
+
+### GET /api/v1/musehub/repos/{repo_id}/issues/{issue_number}
+
+Get a single issue by its per-repo sequential number.
+
+**Response (200):** Full issue object (same shape as above). Returns **404** if the issue number does not exist.
+
+### POST /api/v1/musehub/repos/{repo_id}/issues/{issue_number}/close
+
+Close an issue (set `state` → `"closed"`).
+
+**Response (200):** Updated issue object with `"state": "closed"`. Returns **404** if the issue number does not exist.

--- a/maestro/api/routes/musehub/__init__.py
+++ b/maestro/api/routes/musehub/__init__.py
@@ -1,0 +1,19 @@
+"""Muse Hub route package.
+
+Composes sub-routers for repos/branches/commits and issue tracking under
+the shared ``/musehub`` prefix. Registered in ``maestro.main`` as:
+
+    app.include_router(musehub.router, prefix="/api/v1", tags=["musehub"])
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from maestro.api.routes.musehub import issues, repos
+
+router = APIRouter(prefix="/musehub", tags=["musehub"])
+
+router.include_router(repos.router)
+router.include_router(issues.router)
+
+__all__ = ["router"]

--- a/maestro/api/routes/musehub/issues.py
+++ b/maestro/api/routes/musehub/issues.py
@@ -1,0 +1,126 @@
+"""Muse Hub issue tracking route handlers.
+
+Endpoint summary:
+  POST /musehub/repos/{repo_id}/issues                   — create an issue
+  GET  /musehub/repos/{repo_id}/issues                   — list issues
+  GET  /musehub/repos/{repo_id}/issues/{issue_number}    — get a single issue
+  POST /musehub/repos/{repo_id}/issues/{issue_number}/close — close an issue
+
+All endpoints require a valid JWT Bearer token.
+No business logic lives here — all persistence is delegated to
+maestro.services.musehub_issues.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.auth.dependencies import TokenClaims, require_valid_token
+from maestro.db import get_db
+from maestro.models.musehub import IssueCreate, IssueListResponse, IssueResponse
+from maestro.services import musehub_issues
+from maestro.services import musehub_repository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.post(
+    "/repos/{repo_id}/issues",
+    response_model=IssueResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Open a new issue against a Muse Hub repo",
+)
+async def create_issue(
+    repo_id: str,
+    body: IssueCreate,
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> IssueResponse:
+    """Create a new issue in ``open`` state with an auto-incremented per-repo number."""
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    issue = await musehub_issues.create_issue(
+        db,
+        repo_id=repo_id,
+        title=body.title,
+        body=body.body,
+        labels=body.labels,
+    )
+    await db.commit()
+    return issue
+
+
+@router.get(
+    "/repos/{repo_id}/issues",
+    response_model=IssueListResponse,
+    summary="List issues for a Muse Hub repo",
+)
+async def list_issues(
+    repo_id: str,
+    state: str = Query("open", pattern="^(open|closed|all)$", description="Filter by state"),
+    label: str | None = Query(None, description="Filter by label string"),
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> IssueListResponse:
+    """Return issues for a repo. Defaults to open issues only.
+
+    Use ``?state=all`` to include closed issues, ``?state=closed`` for closed only.
+    Use ``?label=<string>`` to filter by a specific label.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    issues = await musehub_issues.list_issues(db, repo_id, state=state, label=label)
+    return IssueListResponse(issues=issues)
+
+
+@router.get(
+    "/repos/{repo_id}/issues/{issue_number}",
+    response_model=IssueResponse,
+    summary="Get a single issue by its per-repo number",
+)
+async def get_issue(
+    repo_id: str,
+    issue_number: int,
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> IssueResponse:
+    """Return a single issue. Returns 404 if the repo or issue number is not found."""
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    issue = await musehub_issues.get_issue(db, repo_id, issue_number)
+    if issue is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Issue not found")
+    return issue
+
+
+@router.post(
+    "/repos/{repo_id}/issues/{issue_number}/close",
+    response_model=IssueResponse,
+    summary="Close an issue",
+)
+async def close_issue(
+    repo_id: str,
+    issue_number: int,
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> IssueResponse:
+    """Set an issue's state to ``closed``. Returns 404 if not found."""
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    issue = await musehub_issues.close_issue(db, repo_id, issue_number)
+    if issue is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Issue not found")
+    await db.commit()
+    return issue

--- a/maestro/api/routes/musehub/repos.py
+++ b/maestro/api/routes/musehub/repos.py
@@ -1,4 +1,4 @@
-"""Muse Hub API routes — remote repo management for the Muse VCS.
+"""Muse Hub repo, branch, and commit route handlers.
 
 Endpoint summary:
   POST /musehub/repos                        — create a new remote repo
@@ -29,7 +29,7 @@ from maestro.services import musehub_repository
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/musehub", tags=["musehub"])
+router = APIRouter()
 
 
 @router.post(
@@ -83,7 +83,6 @@ async def list_branches(
     _: TokenClaims = Depends(require_valid_token),
 ) -> BranchListResponse:
     """Return all branch pointers for a repo, ordered by name."""
-    # Confirm repo exists before querying branches.
     repo = await musehub_repository.get_repo(db, repo_id)
     if repo is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -67,3 +67,32 @@ class CommitListResponse(CamelModel):
 
     commits: list[CommitResponse]
     total: int
+
+
+# ── Issue models ───────────────────────────────────────────────────────────────
+
+
+class IssueCreate(CamelModel):
+    """Body for POST /musehub/repos/{repo_id}/issues."""
+
+    title: str = Field(..., min_length=1, max_length=500, description="Issue title")
+    body: str = Field("", description="Issue description (Markdown)")
+    labels: list[str] = Field(default_factory=list, description="Free-form label strings")
+
+
+class IssueResponse(CamelModel):
+    """Wire representation of a Muse Hub issue."""
+
+    issue_id: str
+    number: int
+    title: str
+    body: str
+    state: str
+    labels: list[str]
+    created_at: datetime
+
+
+class IssueListResponse(CamelModel):
+    """List of issues for a repo."""
+
+    issues: list[IssueResponse]

--- a/maestro/services/musehub_issues.py
+++ b/maestro/services/musehub_issues.py
@@ -1,0 +1,133 @@
+"""Muse Hub issue persistence adapter — single point of DB access for issues.
+
+This module is the ONLY place that touches the ``musehub_issues`` table.
+Route handlers delegate here; no business logic lives in routes.
+
+Boundary rules:
+- Must NOT import state stores, SSE queues, or LLM clients.
+- Must NOT import maestro.core.* modules.
+- May import ORM models from maestro.db.musehub_models.
+- May import Pydantic response models from maestro.models.musehub.
+"""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db import musehub_models as db
+from maestro.models.musehub import IssueResponse
+
+logger = logging.getLogger(__name__)
+
+
+def _to_issue_response(row: db.MusehubIssue) -> IssueResponse:
+    return IssueResponse(
+        issue_id=row.issue_id,
+        number=row.number,
+        title=row.title,
+        body=row.body,
+        state=row.state,
+        labels=list(row.labels or []),
+        created_at=row.created_at,
+    )
+
+
+async def _next_issue_number(session: AsyncSession, repo_id: str) -> int:
+    """Return the next sequential issue number for the given repo (1-based)."""
+    stmt = select(func.max(db.MusehubIssue.number)).where(
+        db.MusehubIssue.repo_id == repo_id
+    )
+    current_max: int | None = (await session.execute(stmt)).scalar_one_or_none()
+    return (current_max or 0) + 1
+
+
+async def create_issue(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    title: str,
+    body: str,
+    labels: list[str],
+) -> IssueResponse:
+    """Persist a new issue in ``open`` state and return its wire representation."""
+    number = await _next_issue_number(session, repo_id)
+    issue = db.MusehubIssue(
+        repo_id=repo_id,
+        number=number,
+        title=title,
+        body=body,
+        state="open",
+        labels=labels,
+    )
+    session.add(issue)
+    await session.flush()
+    await session.refresh(issue)
+    logger.info("✅ Created issue #%d for repo %s: %s", number, repo_id, title)
+    return _to_issue_response(issue)
+
+
+async def list_issues(
+    session: AsyncSession,
+    repo_id: str,
+    *,
+    state: str = "open",
+    label: str | None = None,
+) -> list[IssueResponse]:
+    """Return issues for a repo, filtered by state and/or label.
+
+    ``state`` may be ``"open"``, ``"closed"``, or ``"all"``.
+    ``label`` filters to issues whose labels list contains the given string.
+    Results are ordered by issue number ascending.
+    """
+    stmt = select(db.MusehubIssue).where(db.MusehubIssue.repo_id == repo_id)
+
+    if state != "all":
+        stmt = stmt.where(db.MusehubIssue.state == state)
+
+    stmt = stmt.order_by(db.MusehubIssue.number)
+    rows = (await session.execute(stmt)).scalars().all()
+
+    results = [_to_issue_response(r) for r in rows]
+
+    if label is not None:
+        results = [r for r in results if label in r.labels]
+
+    return results
+
+
+async def get_issue(
+    session: AsyncSession,
+    repo_id: str,
+    issue_number: int,
+) -> IssueResponse | None:
+    """Return a single issue by its per-repo number, or None if not found."""
+    stmt = select(db.MusehubIssue).where(
+        db.MusehubIssue.repo_id == repo_id,
+        db.MusehubIssue.number == issue_number,
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return None
+    return _to_issue_response(row)
+
+
+async def close_issue(
+    session: AsyncSession,
+    repo_id: str,
+    issue_number: int,
+) -> IssueResponse | None:
+    """Set the issue state to ``closed``. Returns None if the issue does not exist."""
+    stmt = select(db.MusehubIssue).where(
+        db.MusehubIssue.repo_id == repo_id,
+        db.MusehubIssue.number == issue_number,
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return None
+    row.state = "closed"
+    await session.flush()
+    await session.refresh(row)
+    logger.info("✅ Closed issue #%d for repo %s", issue_number, repo_id)
+    return _to_issue_response(row)

--- a/tests/test_musehub_issues.py
+++ b/tests/test_musehub_issues.py
@@ -1,0 +1,359 @@
+"""Tests for Muse Hub issue tracking endpoints.
+
+Covers every acceptance criterion from issue #42:
+- POST /musehub/repos/{repo_id}/issues creates an issue in open state
+- Issue numbers are sequential per repo starting at 1
+- GET /musehub/repos/{repo_id}/issues returns open issues by default
+- GET .../issues?label=<label> filters by label
+- POST .../issues/{number}/close sets state to closed
+- GET .../issues/{number} returns 404 for unknown issue numbers
+- All endpoints require valid JWT
+
+All tests use the shared ``client``, ``auth_headers``, and ``db_session``
+fixtures from conftest.py.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.services import musehub_repository, musehub_issues
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _create_repo(client: AsyncClient, auth_headers: dict[str, str], name: str = "test-repo") -> str:
+    """Create a repo via the API and return its repo_id."""
+    response = await client.post(
+        "/api/v1/musehub/repos",
+        json={"name": name},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    return response.json()["repoId"]
+
+
+async def _create_issue(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    repo_id: str,
+    title: str = "Kick clashes with bass in measure 4",
+    body: str = "",
+    labels: list[str] | None = None,
+) -> dict[str, object]:
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/issues",
+        json={"title": title, "body": body, "labels": labels or []},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# POST /musehub/repos/{repo_id}/issues
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_create_issue_returns_open_state(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /issues creates an issue in 'open' state with all required fields."""
+    repo_id = await _create_repo(client, auth_headers, "open-state-repo")
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/issues",
+        json={"title": "Hi-hat / synth pad clash", "body": "Measure 8 has a frequency clash.", "labels": ["bug"]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["state"] == "open"
+    assert body["title"] == "Hi-hat / synth pad clash"
+    assert body["labels"] == ["bug"]
+    assert "issueId" in body
+    assert "number" in body
+    assert "createdAt" in body
+
+
+@pytest.mark.anyio
+async def test_issue_numbers_sequential(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Issue numbers within a repo are sequential starting at 1."""
+    repo_id = await _create_repo(client, auth_headers, "seq-repo")
+
+    first = await _create_issue(client, auth_headers, repo_id, title="First issue")
+    second = await _create_issue(client, auth_headers, repo_id, title="Second issue")
+    third = await _create_issue(client, auth_headers, repo_id, title="Third issue")
+
+    assert first["number"] == 1
+    assert second["number"] == 2
+    assert third["number"] == 3
+
+
+@pytest.mark.anyio
+async def test_issue_numbers_independent_per_repo(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Issue numbers restart at 1 for each repo independently."""
+    repo_a = await _create_repo(client, auth_headers, "repo-a")
+    repo_b = await _create_repo(client, auth_headers, "repo-b")
+
+    issue_a = await _create_issue(client, auth_headers, repo_a, title="Repo A issue")
+    issue_b = await _create_issue(client, auth_headers, repo_b, title="Repo B issue")
+
+    assert issue_a["number"] == 1
+    assert issue_b["number"] == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /musehub/repos/{repo_id}/issues
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_list_issues_default_open_only(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /issues with no params returns only open issues."""
+    repo_id = await _create_repo(client, auth_headers, "default-open-repo")
+    await _create_issue(client, auth_headers, repo_id, title="Open issue")
+
+    # Create a second issue and close it
+    issue = await _create_issue(client, auth_headers, repo_id, title="Closed issue")
+    await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/issues/{issue['number']}/close",
+        headers=auth_headers,
+    )
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/issues",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    issues = response.json()["issues"]
+    assert len(issues) == 1
+    assert issues[0]["state"] == "open"
+
+
+@pytest.mark.anyio
+async def test_list_issues_state_all_returns_all(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """?state=all returns both open and closed issues."""
+    repo_id = await _create_repo(client, auth_headers, "state-all-repo")
+    await _create_issue(client, auth_headers, repo_id, title="Open issue")
+    issue = await _create_issue(client, auth_headers, repo_id, title="To close")
+    await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/issues/{issue['number']}/close",
+        headers=auth_headers,
+    )
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/issues?state=all",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert len(response.json()["issues"]) == 2
+
+
+@pytest.mark.anyio
+async def test_list_issues_label_filter(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /issues?label=bug returns only issues that have the 'bug' label."""
+    repo_id = await _create_repo(client, auth_headers, "label-filter-repo")
+    await _create_issue(client, auth_headers, repo_id, title="Bug issue", labels=["bug"])
+    await _create_issue(client, auth_headers, repo_id, title="Feature issue", labels=["feature"])
+    await _create_issue(client, auth_headers, repo_id, title="Multi-label", labels=["bug", "musical"])
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/issues?label=bug",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    issues = response.json()["issues"]
+    assert len(issues) == 2
+    for issue in issues:
+        assert "bug" in issue["labels"]
+
+
+# ---------------------------------------------------------------------------
+# GET /musehub/repos/{repo_id}/issues/{issue_number}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_issue_not_found_returns_404(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /issues/{number} returns 404 for a number that doesn't exist."""
+    repo_id = await _create_repo(client, auth_headers, "not-found-repo")
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/issues/999",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_get_issue_returns_full_object(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /issues/{number} returns the full issue object."""
+    repo_id = await _create_repo(client, auth_headers, "get-issue-repo")
+    created = await _create_issue(
+        client, auth_headers, repo_id,
+        title="Delay tail bleeds into next section",
+        body="The reverb tail from the bridge extends 200ms into the verse.",
+        labels=["musical", "mix"],
+    )
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/issues/{created['number']}",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["issueId"] == created["issueId"]
+    assert body["title"] == "Delay tail bleeds into next section"
+    assert body["body"] == "The reverb tail from the bridge extends 200ms into the verse."
+    assert body["labels"] == ["musical", "mix"]
+
+
+# ---------------------------------------------------------------------------
+# POST /musehub/repos/{repo_id}/issues/{issue_number}/close
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_close_issue_changes_state(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /issues/{number}/close sets the issue state to 'closed'."""
+    repo_id = await _create_repo(client, auth_headers, "close-state-repo")
+    issue = await _create_issue(client, auth_headers, repo_id, title="Clipping at measure 12")
+    assert issue["state"] == "open"
+
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/issues/{issue['number']}/close",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["state"] == "closed"
+
+
+@pytest.mark.anyio
+async def test_close_nonexistent_issue_returns_404(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /issues/999/close returns 404 for an unknown issue number."""
+    repo_id = await _create_repo(client, auth_headers, "close-404-repo")
+
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/issues/999/close",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Auth guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_issues_require_auth(client: AsyncClient) -> None:
+    """All issue endpoints return 401 without a Bearer token."""
+    endpoints = [
+        ("POST", "/api/v1/musehub/repos/some-repo/issues"),
+        ("GET", "/api/v1/musehub/repos/some-repo/issues"),
+        ("GET", "/api/v1/musehub/repos/some-repo/issues/1"),
+        ("POST", "/api/v1/musehub/repos/some-repo/issues/1/close"),
+    ]
+    for method, url in endpoints:
+        if method == "POST":
+            response = await client.post(url, json={})
+        else:
+            response = await client.get(url)
+        assert response.status_code == 401, f"{method} {url} should require auth"
+
+
+# ---------------------------------------------------------------------------
+# Service layer — direct DB tests (no HTTP)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_create_issue_service_persists_to_db(db_session: AsyncSession) -> None:
+    """musehub_issues.create_issue() persists the row and returns correct fields."""
+    repo = await musehub_repository.create_repo(
+        db_session,
+        name="service-issue-repo",
+        visibility="private",
+        owner_user_id="user-abc",
+    )
+    await db_session.commit()
+
+    issue = await musehub_issues.create_issue(
+        db_session,
+        repo_id=repo.repo_id,
+        title="Bass note timing drift",
+        body="Measure 4, beat 3 — bass is 10ms late.",
+        labels=["timing", "bass"],
+    )
+    await db_session.commit()
+
+    fetched = await musehub_issues.get_issue(db_session, repo.repo_id, issue.number)
+    assert fetched is not None
+    assert fetched.title == "Bass note timing drift"
+    assert fetched.state == "open"
+    assert fetched.labels == ["timing", "bass"]
+    assert fetched.number == 1
+
+
+@pytest.mark.anyio
+async def test_list_issues_closed_state_filter(db_session: AsyncSession) -> None:
+    """list_issues() with state='closed' returns only closed issues."""
+    repo = await musehub_repository.create_repo(
+        db_session,
+        name="filter-state-repo",
+        visibility="private",
+        owner_user_id="user-xyz",
+    )
+    await db_session.commit()
+
+    open_issue = await musehub_issues.create_issue(
+        db_session, repo_id=repo.repo_id, title="Still open", body="", labels=[]
+    )
+    closed_issue = await musehub_issues.create_issue(
+        db_session, repo_id=repo.repo_id, title="Already closed", body="", labels=[]
+    )
+    await musehub_issues.close_issue(db_session, repo.repo_id, closed_issue.number)
+    await db_session.commit()
+
+    open_list = await musehub_issues.list_issues(db_session, repo.repo_id, state="open")
+    closed_list = await musehub_issues.list_issues(db_session, repo.repo_id, state="closed")
+    all_list = await musehub_issues.list_issues(db_session, repo.repo_id, state="all")
+
+    assert len(open_list) == 1
+    assert open_list[0].issue_id == open_issue.issue_id
+    assert len(closed_list) == 1
+    assert closed_list[0].issue_id == closed_issue.issue_id
+    assert len(all_list) == 2


### PR DESCRIPTION
## Summary
Implements Muse Hub issue tracking: create, list (with state/label filters), get, and close issues per repo.

## Issue
Closes #42

## Root Cause
Musicians had no way to track production/creative issues (e.g., "hi-hat/synth pad clash in measure 8") in the Muse Hub, forcing them to use out-of-band communication channels.

## Solution
- `maestro/api/routes/musehub/issues.py` — four endpoints: POST create, GET list, GET by number, POST close
- `maestro/api/routes/musehub/repos.py` — existing repo/branch/commit handlers extracted from flat `musehub.py` into package
- `maestro/services/musehub_issues.py` — service layer with `create_issue()`, `list_issues()`, `get_issue()`, `close_issue()`
- `maestro/models/musehub.py` — `IssueCreate`, `IssueResponse`, `IssueListResponse` Pydantic models
- `maestro/db/musehub_models.py` — `MusehubIssue` SQLAlchemy model
- Alembic migration for `musehub_issues` table
- Issue numbers are auto-incremented per repo; labels are free-form string arrays

## Layers Affected
- [x] Muse Hub routes (converted flat `musehub.py` → `musehub/` package)
- [x] Service layer
- [x] Database models + migration

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (no new errors)
- [x] `docker compose exec maestro pytest tests/test_musehub_issues.py -v` — 13/13 pass
- [x] `docker compose exec maestro pytest tests/test_musehub_repos.py -v` — 14/14 pass (no regressions)
- [x] Affected docs updated

## Tests Added (`tests/test_musehub_issues.py`)
- `test_create_issue_returns_open_state`
- `test_issue_numbers_sequential`
- `test_issue_numbers_independent_per_repo`
- `test_list_issues_default_open_only`
- `test_list_issues_state_all_returns_all`
- `test_list_issues_label_filter`
- `test_get_issue_not_found_returns_404`
- `test_get_issue_returns_full_object`
- `test_close_issue_changes_state`
- `test_close_nonexistent_issue_returns_404`
- `test_issues_require_auth`
- `test_create_issue_service_persists_to_db`
- `test_list_issues_closed_state_filter`

## Handoff
N/A — no SSE/MCP protocol change. New REST endpoints only. No Swift frontend changes required at MVP.