### PR TITLE
feat: muse merge — fast-forward and 3-way merge with path-level conflict detection

### DIFF
--- a/.agent-task
+++ b/.agent-task
@@ -1,0 +1,4 @@
+WORKFLOW=issue-to-pr
+ISSUE_NUMBER=35
+ISSUE_TITLE=feat: `muse merge` — fast-forward and 3-way merge with path-level conflict detection
+ISSUE_URL=https://github.com/cgcardona/maestro/issues/35

--- a/alembic/versions/0002_muse_cli_commits_parent2.py
+++ b/alembic/versions/0002_muse_cli_commits_parent2.py
@@ -1,0 +1,35 @@
+"""Add parent2_commit_id to muse_cli_commits for merge commits.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-02-27
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "muse_cli_commits",
+        sa.Column("parent2_commit_id", sa.String(64), nullable=True),
+    )
+    op.create_index(
+        "ix_muse_cli_commits_parent2_commit_id",
+        "muse_cli_commits",
+        ["parent2_commit_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_muse_cli_commits_parent2_commit_id",
+        table_name="muse_cli_commits",
+    )
+    op.drop_column("muse_cli_commits", "parent2_commit_id")

--- a/maestro/muse_cli/commands/commit.py
+++ b/maestro/muse_cli/commands/commit.py
@@ -36,6 +36,7 @@ from maestro.muse_cli.db import (
     upsert_snapshot,
 )
 from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.merge_engine import read_merge_state
 from maestro.muse_cli.models import MuseCliCommit
 from maestro.muse_cli.snapshot import (
     build_snapshot_manifest,
@@ -69,6 +70,17 @@ async def _commit_async(
     the Typer callback surfaces a clean message rather than a traceback.
     """
     muse_dir = root / ".muse"
+
+    # ── Guard: block commit while a conflicted merge is in progress ──────
+    merge_state = read_merge_state(root)
+    if merge_state is not None and merge_state.conflict_paths:
+        typer.echo(
+            "❌ You have unresolved merge conflicts.\n"
+            "   Fix conflicts in the listed files, then run 'muse commit'."
+        )
+        for path in sorted(merge_state.conflict_paths):
+            typer.echo(f"\tboth modified:   {path}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
 
     # ── Repo identity ────────────────────────────────────────────────────
     repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())

--- a/maestro/muse_cli/commands/merge.py
+++ b/maestro/muse_cli/commands/merge.py
@@ -89,7 +89,7 @@ async def _merge_async(
 
     # ── Repo identity ────────────────────────────────────────────────────
     repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
-    repo_id = repo_data["repo_id"]  # noqa: F841 — kept for future remote-scoped ops
+    repo_id = repo_data["repo_id"]
 
     # ── Current branch ───────────────────────────────────────────────────
     head_ref = (muse_dir / "HEAD").read_text().strip()   # "refs/heads/main"
@@ -192,7 +192,7 @@ async def _merge_async(
 
     merge_commit = MuseCliCommit(
         commit_id=merge_commit_id,
-        repo_id=repo_data["repo_id"],
+        repo_id=repo_id,
         branch=current_branch,
         parent_commit_id=ours_commit_id,
         parent2_commit_id=theirs_commit_id,

--- a/maestro/muse_cli/commands/merge.py
+++ b/maestro/muse_cli/commands/merge.py
@@ -1,15 +1,246 @@
-"""muse merge — three-way merge of two variation branches."""
+"""muse merge — fast-forward and 3-way merge with path-level conflict detection.
+
+Algorithm
+---------
+1. Block if ``.muse/MERGE_STATE.json`` already exists (merge in progress).
+2. Resolve ``ours_commit_id`` from ``.muse/refs/heads/<current_branch>``.
+3. Resolve ``theirs_commit_id`` from ``.muse/refs/heads/<target_branch>``.
+4. Find merge base: LCA of the two commits via BFS over the commit graph.
+5. **Fast-forward** — if ``base == ours``, target is strictly ahead: move the
+   current branch pointer to ``theirs`` (no new commit).
+6. **Already up-to-date** — if ``base == theirs``, current branch is already
+   ahead of target: exit 0.
+7. **3-way merge** — branches have diverged:
+   a. Compute ``diff(base → ours)`` and ``diff(base → theirs)``.
+   b. Detect conflicts (paths changed on both sides).
+   c. If conflicts exist: write ``.muse/MERGE_STATE.json`` and exit 1.
+   d. Otherwise: build merged manifest, persist snapshot, insert merge commit
+      with two parent IDs, advance branch pointer.
+"""
 from __future__ import annotations
 
+import asyncio
+import datetime
+import json
+import logging
+import pathlib
+
 import typer
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import (
+    get_commit_snapshot_manifest,
+    insert_commit,
+    open_session,
+    upsert_snapshot,
+)
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.merge_engine import (
+    apply_merge,
+    detect_conflicts,
+    diff_snapshots,
+    find_merge_base,
+    read_merge_state,
+    write_merge_state,
+)
+from maestro.muse_cli.models import MuseCliCommit
+from maestro.muse_cli.snapshot import compute_commit_id, compute_snapshot_id
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer()
 
 
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _merge_async(
+    *,
+    branch: str,
+    root: pathlib.Path,
+    session: AsyncSession,
+) -> None:
+    """Run the merge pipeline.
+
+    All filesystem and DB side-effects are isolated here so tests can inject
+    an in-memory SQLite session and a ``tmp_path`` root without touching a
+    real database.
+
+    Raises :class:`typer.Exit` with the appropriate exit code on every
+    terminal condition (success, conflict, or user error) so the Typer
+    callback surfaces a clean message.
+
+    Args:
+        branch:  Name of the branch to merge into the current branch.
+        root:    Repository root (directory containing ``.muse/``).
+        session: Open async DB session.
+    """
+    muse_dir = root / ".muse"
+
+    # ── Guard: merge already in progress ────────────────────────────────
+    if read_merge_state(root) is not None:
+        typer.echo(
+            'Merge in progress. Resolve conflicts and run "muse merge --continue".'
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # ── Repo identity ────────────────────────────────────────────────────
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]  # noqa: F841 — kept for future remote-scoped ops
+
+    # ── Current branch ───────────────────────────────────────────────────
+    head_ref = (muse_dir / "HEAD").read_text().strip()   # "refs/heads/main"
+    current_branch = head_ref.rsplit("/", 1)[-1]         # "main"
+    our_ref_path = muse_dir / pathlib.Path(head_ref)
+
+    ours_commit_id = our_ref_path.read_text().strip() if our_ref_path.exists() else ""
+    if not ours_commit_id:
+        typer.echo("❌ Current branch has no commits. Cannot merge.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # ── Target branch ────────────────────────────────────────────────────
+    their_ref_path = muse_dir / "refs" / "heads" / branch
+    theirs_commit_id = (
+        their_ref_path.read_text().strip() if their_ref_path.exists() else ""
+    )
+    if not theirs_commit_id:
+        typer.echo(f"❌ Branch '{branch}' has no commits or does not exist.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # ── Already up-to-date (same HEAD) ───────────────────────────────────
+    if ours_commit_id == theirs_commit_id:
+        typer.echo("Already up-to-date.")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    # ── Find merge base (LCA) ────────────────────────────────────────────
+    base_commit_id = await find_merge_base(session, ours_commit_id, theirs_commit_id)
+
+    # ── Fast-forward: ours IS the base → theirs is ahead ─────────────────
+    if base_commit_id == ours_commit_id:
+        our_ref_path.write_text(theirs_commit_id)
+        typer.echo(
+            f"✅ Fast-forward: {current_branch} → {theirs_commit_id[:8]}"
+        )
+        logger.info(
+            "✅ muse merge fast-forward %r to %s", current_branch, theirs_commit_id[:8]
+        )
+        return
+
+    # ── Already up-to-date: theirs IS the base → we are ahead ────────────
+    if base_commit_id == theirs_commit_id:
+        typer.echo("Already up-to-date.")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    # ── 3-way merge ──────────────────────────────────────────────────────
+    # Load snapshot manifests for base, ours, and theirs.
+    base_manifest: dict[str, str] = {}
+    if base_commit_id is not None:
+        loaded_base = await get_commit_snapshot_manifest(session, base_commit_id)
+        base_manifest = loaded_base or {}
+
+    ours_manifest = await get_commit_snapshot_manifest(session, ours_commit_id) or {}
+    theirs_manifest = (
+        await get_commit_snapshot_manifest(session, theirs_commit_id) or {}
+    )
+
+    ours_changed = diff_snapshots(base_manifest, ours_manifest)
+    theirs_changed = diff_snapshots(base_manifest, theirs_manifest)
+    conflict_paths = detect_conflicts(ours_changed, theirs_changed)
+
+    if conflict_paths:
+        write_merge_state(
+            root,
+            base_commit=base_commit_id or "",
+            ours_commit=ours_commit_id,
+            theirs_commit=theirs_commit_id,
+            conflict_paths=sorted(conflict_paths),
+            other_branch=branch,
+        )
+        typer.echo(f"❌ Merge conflict in {len(conflict_paths)} file(s):")
+        for path in sorted(conflict_paths):
+            typer.echo(f"\tboth modified:   {path}")
+        typer.echo('Fix conflicts and run "muse commit" to conclude the merge.')
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # ── Build merged snapshot ─────────────────────────────────────────────
+    merged_manifest = apply_merge(
+        base_manifest,
+        ours_manifest,
+        theirs_manifest,
+        ours_changed,
+        theirs_changed,
+        conflict_paths,
+    )
+
+    merged_snapshot_id = compute_snapshot_id(merged_manifest)
+    await upsert_snapshot(session, manifest=merged_manifest, snapshot_id=merged_snapshot_id)
+    await session.flush()
+
+    # ── Build merge commit ────────────────────────────────────────────────
+    committed_at = datetime.datetime.now(datetime.timezone.utc)
+    merge_message = f"Merge branch '{branch}' into {current_branch}"
+    parent_ids = sorted([ours_commit_id, theirs_commit_id])
+    merge_commit_id = compute_commit_id(
+        parent_ids=parent_ids,
+        snapshot_id=merged_snapshot_id,
+        message=merge_message,
+        committed_at_iso=committed_at.isoformat(),
+    )
+
+    merge_commit = MuseCliCommit(
+        commit_id=merge_commit_id,
+        repo_id=repo_data["repo_id"],
+        branch=current_branch,
+        parent_commit_id=ours_commit_id,
+        parent2_commit_id=theirs_commit_id,
+        snapshot_id=merged_snapshot_id,
+        message=merge_message,
+        author="",
+        committed_at=committed_at,
+    )
+    await insert_commit(session, merge_commit)
+
+    # ── Advance branch pointer ────────────────────────────────────────────
+    our_ref_path.write_text(merge_commit_id)
+
+    typer.echo(
+        f"✅ Merge commit [{current_branch} {merge_commit_id[:8]}] "
+        f"— merged '{branch}' into '{current_branch}'"
+    )
+    logger.info(
+        "✅ muse merge commit %s on %r (parents: %s, %s)",
+        merge_commit_id[:8],
+        current_branch,
+        ours_commit_id[:8],
+        theirs_commit_id[:8],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
 @app.callback(invoke_without_command=True)
-def merge(ctx: typer.Context) -> None:
-    """Three-way merge of two variation branches."""
-    require_repo()
-    typer.echo("muse merge: not yet implemented")
+def merge(
+    ctx: typer.Context,
+    branch: str = typer.Argument(..., help="Name of the branch to merge into HEAD."),
+) -> None:
+    """Merge a branch into the current branch (fast-forward or 3-way)."""
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _merge_async(branch=branch, root=root, session=session)
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse merge failed: {exc}")
+        logger.error("❌ muse merge error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/muse_cli/commands/status.py
+++ b/maestro/muse_cli/commands/status.py
@@ -88,14 +88,14 @@ async def _status_async(
 
     # -- In-progress merge --
     merge_state = read_merge_state(root)
-    if merge_state is not None and merge_state.conflicts:
+    if merge_state is not None and merge_state.conflict_paths:
         typer.echo(f"On branch {branch}")
         typer.echo("")
         typer.echo("You have unmerged paths.")
         typer.echo('  (fix conflicts and run "muse commit")')
         typer.echo("")
         typer.echo("Unmerged paths:")
-        for conflict_path in sorted(merge_state.conflicts):
+        for conflict_path in sorted(merge_state.conflict_paths):
             typer.echo(f"\tboth modified:   {conflict_path}")
         typer.echo("")
         return

--- a/maestro/muse_cli/merge_engine.py
+++ b/maestro/muse_cli/merge_engine.py
@@ -1,30 +1,57 @@
-"""Muse VCS merge-state reader.
+"""Muse VCS merge engine — fast-forward and 3-way path-level merge.
 
-Provides :func:`read_merge_state` — a pure filesystem read that detects an
-in-progress merge and returns conflict information.  The presence of
-``.muse/MERGE_STATE.json`` signals that a three-way merge was started but
-has unresolved conflicts that must be fixed before committing.
+Public API
+----------
+Pure functions (no I/O):
 
-``MERGE_STATE.json`` schema (all fields optional except ``conflicts``):
+- :func:`diff_snapshots` — paths that changed between two snapshot manifests.
+- :func:`detect_conflicts` — paths changed on *both* branches since the base.
+- :func:`apply_merge` — build merged manifest for a conflict-free 3-way merge.
+
+Async helpers (require a DB session):
+
+- :func:`find_merge_base` — lowest common ancestor (LCA) of two commits.
+
+Filesystem helpers:
+
+- :func:`read_merge_state` — detect and load an in-progress merge.
+- :func:`write_merge_state` — persist conflict state before exiting.
+
+``MERGE_STATE.json`` schema
+---------------------------
 
 .. code-block:: json
 
     {
-        "conflicts":    ["path/to/file1.mid", "path/to/file2.mid"],
-        "other_branch": "feature/variation-b",
-        "merge_base":   "abc123def456..."
+        "base_commit":    "abc123...",
+        "ours_commit":    "def456...",
+        "theirs_commit":  "789abc...",
+        "conflict_paths": ["beat.mid", "lead.mp3"],
+        "other_branch":   "feature/experiment"
     }
+
+``other_branch`` is optional; all other fields are required when conflicts exist.
 """
 from __future__ import annotations
 
 import json
 import logging
 import pathlib
+from collections import deque
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
 _MERGE_STATE_FILENAME = "MERGE_STATE.json"
+
+
+# ---------------------------------------------------------------------------
+# MergeState dataclass
+# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
@@ -32,14 +59,23 @@ class MergeState:
     """Describes an in-progress merge with unresolved conflicts.
 
     Attributes:
-        conflicts:    Relative paths (POSIX) of files with merge conflicts.
-        other_branch: Name of the branch being merged in, if recorded.
-        merge_base:   Commit ID of the common ancestor, if recorded.
+        conflict_paths: Relative paths (POSIX) of files with merge conflicts.
+        base_commit:    Commit ID of the common ancestor (merge base).
+        ours_commit:    Commit ID of HEAD when the merge was initiated.
+        theirs_commit:  Commit ID of the branch being merged in.
+        other_branch:   Name of the branch being merged in, if recorded.
     """
 
-    conflicts: list[str] = field(default_factory=list)
+    conflict_paths: list[str] = field(default_factory=list)
+    base_commit: str | None = None
+    ours_commit: str | None = None
+    theirs_commit: str | None = None
     other_branch: str | None = None
-    merge_base: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Filesystem helpers
+# ---------------------------------------------------------------------------
 
 
 def read_merge_state(root: pathlib.Path) -> MergeState | None:
@@ -65,20 +101,230 @@ def read_merge_state(root: pathlib.Path) -> MergeState | None:
         logger.warning("⚠️ Failed to read %s: %s", _MERGE_STATE_FILENAME, exc)
         return None
 
-    raw_conflicts = data.get("conflicts", [])
-    conflicts: list[str] = (
+    raw_conflicts = data.get("conflict_paths", [])
+    conflict_paths: list[str] = (
         [str(c) for c in raw_conflicts] if isinstance(raw_conflicts, list) else []
     )
 
-    other_branch: str | None = (
-        str(data["other_branch"]) if "other_branch" in data else None
-    )
-    merge_base: str | None = (
-        str(data["merge_base"]) if "merge_base" in data else None
-    )
+    def _str_or_none(key: str) -> str | None:
+        return str(data[key]) if key in data else None
 
     return MergeState(
-        conflicts=conflicts,
-        other_branch=other_branch,
-        merge_base=merge_base,
+        conflict_paths=conflict_paths,
+        base_commit=_str_or_none("base_commit"),
+        ours_commit=_str_or_none("ours_commit"),
+        theirs_commit=_str_or_none("theirs_commit"),
+        other_branch=_str_or_none("other_branch"),
     )
+
+
+def write_merge_state(
+    root: pathlib.Path,
+    *,
+    base_commit: str,
+    ours_commit: str,
+    theirs_commit: str,
+    conflict_paths: list[str],
+    other_branch: str | None = None,
+) -> None:
+    """Write ``.muse/MERGE_STATE.json`` to signal an in-progress conflicted merge.
+
+    Args:
+        root:           Repository root (directory containing ``.muse/``).
+        base_commit:    Commit ID of the merge base (LCA).
+        ours_commit:    Commit ID of HEAD at merge time.
+        theirs_commit:  Commit ID of the branch being merged in.
+        conflict_paths: List of POSIX paths with unresolved conflicts.
+        other_branch:   Human-readable name of the branch being merged in.
+    """
+    merge_state_path = root / ".muse" / _MERGE_STATE_FILENAME
+    data: dict[str, object] = {
+        "base_commit": base_commit,
+        "ours_commit": ours_commit,
+        "theirs_commit": theirs_commit,
+        "conflict_paths": sorted(conflict_paths),
+    }
+    if other_branch is not None:
+        data["other_branch"] = other_branch
+    merge_state_path.write_text(json.dumps(data, indent=2))
+    logger.info("✅ Wrote MERGE_STATE.json with %d conflict(s)", len(conflict_paths))
+
+
+def clear_merge_state(root: pathlib.Path) -> None:
+    """Remove ``.muse/MERGE_STATE.json`` after a successful merge or resolution."""
+    merge_state_path = root / ".muse" / _MERGE_STATE_FILENAME
+    if merge_state_path.exists():
+        merge_state_path.unlink()
+        logger.debug("✅ Cleared MERGE_STATE.json")
+
+
+# ---------------------------------------------------------------------------
+# Pure merge functions (no I/O, no DB)
+# ---------------------------------------------------------------------------
+
+
+def diff_snapshots(
+    base_manifest: dict[str, str],
+    other_manifest: dict[str, str],
+) -> set[str]:
+    """Return the set of paths that differ between *base_manifest* and *other_manifest*.
+
+    A path is included when it was:
+
+    - **added** — present in *other* but absent from *base*.
+    - **deleted** — present in *base* but absent from *other*.
+    - **modified** — present in both but with a different ``object_id``.
+
+    Args:
+        base_manifest:  ``{path: object_id}`` for the common ancestor snapshot.
+        other_manifest: ``{path: object_id}`` for the branch snapshot.
+
+    Returns:
+        Set of POSIX paths that changed.
+    """
+    base_paths = set(base_manifest.keys())
+    other_paths = set(other_manifest.keys())
+
+    added = other_paths - base_paths
+    deleted = base_paths - other_paths
+    common = base_paths & other_paths
+    modified = {p for p in common if base_manifest[p] != other_manifest[p]}
+
+    return added | deleted | modified
+
+
+def detect_conflicts(
+    ours_changed: set[str],
+    theirs_changed: set[str],
+) -> set[str]:
+    """Return paths changed on *both* branches since the merge base.
+
+    A conflict occurs when both ``ours`` and ``theirs`` modified the same path
+    independently.  The caller decides how to handle these (write
+    ``MERGE_STATE.json`` and exit, or apply one side's version).
+
+    Args:
+        ours_changed:   Paths changed on the current branch since the base.
+        theirs_changed: Paths changed on the target branch since the base.
+
+    Returns:
+        Set of conflicting POSIX paths.
+    """
+    return ours_changed & theirs_changed
+
+
+def apply_merge(
+    base_manifest: dict[str, str],
+    ours_manifest: dict[str, str],
+    theirs_manifest: dict[str, str],
+    ours_changed: set[str],
+    theirs_changed: set[str],
+    conflict_paths: set[str],
+) -> dict[str, str]:
+    """Build the merged snapshot manifest for a *conflict-free* 3-way merge.
+
+    Only non-conflicting changes are applied:
+
+    - Paths changed only on ours → take ours version (or deletion).
+    - Paths changed only on theirs → take theirs version (or deletion).
+    - Conflict paths → excluded (caller already wrote ``MERGE_STATE.json``).
+
+    Args:
+        base_manifest:  ``{path: object_id}`` for the common ancestor.
+        ours_manifest:  ``{path: object_id}`` for the current branch HEAD.
+        theirs_manifest: ``{path: object_id}`` for the target branch HEAD.
+        ours_changed:   Paths changed on the current branch since base.
+        theirs_changed: Paths changed on the target branch since base.
+        conflict_paths: Paths with conflicts (must be empty for a clean merge).
+
+    Returns:
+        Merged ``{path: object_id}`` manifest.
+    """
+    merged: dict[str, str] = dict(base_manifest)
+
+    # Apply non-conflicting ours changes.
+    for path in ours_changed - conflict_paths:
+        if path in ours_manifest:
+            merged[path] = ours_manifest[path]
+        else:
+            merged.pop(path, None)
+
+    # Apply non-conflicting theirs changes.
+    for path in theirs_changed - conflict_paths:
+        if path in theirs_manifest:
+            merged[path] = theirs_manifest[path]
+        else:
+            merged.pop(path, None)
+
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Async merge helpers (require a DB session)
+# ---------------------------------------------------------------------------
+
+
+async def find_merge_base(
+    session: AsyncSession,
+    commit_id_a: str,
+    commit_id_b: str,
+) -> str | None:
+    """Find the Lowest Common Ancestor (LCA) of two commits.
+
+    Uses BFS to collect all ancestors of *commit_id_a* (inclusive), then
+    walks *commit_id_b*'s ancestor graph (BFS) until the first node found
+    in *a*'s ancestor set is reached.
+
+    Supports merge commits with two parents (``parent_commit_id`` and
+    ``parent2_commit_id``).
+
+    Args:
+        session:      An open async DB session.
+        commit_id_a:  First commit ID (e.g., current branch HEAD).
+        commit_id_b:  Second commit ID (e.g., target branch HEAD).
+
+    Returns:
+        The LCA commit ID, or ``None`` if the commits share no common ancestor
+        (disjoint histories).
+    """
+    from maestro.muse_cli.models import MuseCliCommit
+
+    async def _all_ancestors(start: str) -> set[str]:
+        """BFS from *start*, returning all reachable commit IDs (inclusive)."""
+        visited: set[str] = set()
+        queue: deque[str] = deque([start])
+        while queue:
+            cid = queue.popleft()
+            if cid in visited:
+                continue
+            visited.add(cid)
+            commit: MuseCliCommit | None = await session.get(MuseCliCommit, cid)
+            if commit is None:
+                continue
+            if commit.parent_commit_id:
+                queue.append(commit.parent_commit_id)
+            if commit.parent2_commit_id:
+                queue.append(commit.parent2_commit_id)
+        return visited
+
+    a_ancestors = await _all_ancestors(commit_id_a)
+
+    # BFS from B — return the first node that is in A's ancestor set.
+    visited_b: set[str] = set()
+    queue_b: deque[str] = deque([commit_id_b])
+    while queue_b:
+        cid = queue_b.popleft()
+        if cid in visited_b:
+            continue
+        visited_b.add(cid)
+        if cid in a_ancestors:
+            return cid
+        commit = await session.get(MuseCliCommit, cid)
+        if commit is None:
+            continue
+        if commit.parent_commit_id:
+            queue_b.append(commit.parent_commit_id)
+        if commit.parent2_commit_id:
+            queue_b.append(commit.parent2_commit_id)
+
+    return None

--- a/maestro/muse_cli/models.py
+++ b/maestro/muse_cli/models.py
@@ -82,6 +82,9 @@ class MuseCliCommit(Base):
     parent_commit_id: Mapped[str | None] = mapped_column(
         String(64), nullable=True, index=True
     )
+    parent2_commit_id: Mapped[str | None] = mapped_column(
+        String(64), nullable=True, index=True
+    )
     snapshot_id: Mapped[str] = mapped_column(
         String(64),
         ForeignKey("muse_cli_snapshots.snapshot_id", ondelete="RESTRICT"),

--- a/tests/muse_cli/test_merge.py
+++ b/tests/muse_cli/test_merge.py
@@ -1,0 +1,406 @@
+"""Integration tests for ``muse merge``.
+
+Tests exercise ``_merge_async`` directly with an in-memory SQLite session and
+a ``tmp_path`` root so no real Postgres instance is required.
+
+All async tests use ``@pytest.mark.anyio``.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import pathlib
+import uuid
+
+import pytest
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.commands.merge import _merge_async
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.merge_engine import read_merge_state, write_merge_state
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+from maestro.muse_cli.snapshot import compute_snapshot_id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    """Create minimal ``.muse/`` layout for testing."""
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(json.dumps({"repo_id": rid, "schema_version": "1"}))
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _write_workdir(root: pathlib.Path, files: dict[str, bytes]) -> None:
+    """Overwrite muse-work/ with exactly the given files (cleans stale files)."""
+    import shutil
+
+    workdir = root / "muse-work"
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir()
+    for name, content in files.items():
+        (workdir / name).write_bytes(content)
+
+
+def _create_branch(root: pathlib.Path, branch: str, from_branch: str = "main") -> None:
+    """Create a new branch pointing at the same commit as from_branch."""
+    muse = root / ".muse"
+    src = muse / "refs" / "heads" / from_branch
+    dst = muse / "refs" / "heads" / branch
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(src.read_text() if src.exists() else "")
+
+
+def _switch_branch(root: pathlib.Path, branch: str) -> None:
+    """Update HEAD to point at branch."""
+    (root / ".muse" / "HEAD").write_text(f"refs/heads/{branch}")
+
+
+def _head_commit(root: pathlib.Path, branch: str | None = None) -> str:
+    """Return current HEAD commit_id for the branch (default: current branch)."""
+    muse = root / ".muse"
+    if branch is None:
+        head_ref = (muse / "HEAD").read_text().strip()
+        branch = head_ref.rsplit("/", 1)[-1]
+    ref_path = muse / "refs" / "heads" / branch
+    return ref_path.read_text().strip() if ref_path.exists() else ""
+
+
+async def _persist_empty_snapshot(session: AsyncSession) -> str:
+    """Upsert the canonical empty-manifest snapshot so FK constraints pass."""
+    sid = compute_snapshot_id({})
+    existing = await session.get(MuseCliSnapshot, sid)
+    if existing is None:
+        session.add(MuseCliSnapshot(snapshot_id=sid, manifest={}))
+        await session.flush()
+    return sid
+
+
+# ---------------------------------------------------------------------------
+# Fast-forward merge tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_merge_fast_forward_moves_pointer(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """FF merge: when target is ahead, HEAD advances without a new commit."""
+    rid = _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"V1"})
+    # First commit on main.
+    await _commit_async(message="initial", root=tmp_path, session=muse_cli_db_session)
+    initial_commit = _head_commit(tmp_path)
+
+    # Create experiment branch from main and advance it.
+    _create_branch(tmp_path, "experiment")
+    _switch_branch(tmp_path, "experiment")
+    _write_workdir(tmp_path, {"beat.mid": b"V2"})
+    await _commit_async(message="experiment step", root=tmp_path, session=muse_cli_db_session)
+    experiment_commit = _head_commit(tmp_path, "experiment")
+
+    # Switch back to main and merge experiment → should fast-forward.
+    _switch_branch(tmp_path, "main")
+    await _merge_async(branch="experiment", root=tmp_path, session=muse_cli_db_session)
+
+    # main HEAD should now point at experiment's commit.
+    assert _head_commit(tmp_path, "main") == experiment_commit
+    # No new merge commit created — DB still has exactly 2 commits.
+    result = await muse_cli_db_session.execute(select(MuseCliCommit))
+    commits = result.scalars().all()
+    assert len(commits) == 2  # initial + experiment (no merge commit added)
+
+
+@pytest.mark.anyio
+async def test_merge_already_up_to_date_exits_0(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Merging a branch that is behind current HEAD exits 0."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"a.mid": b"V1"})
+    await _commit_async(message="initial", root=tmp_path, session=muse_cli_db_session)
+
+    # Create stale branch pointing at same commit.
+    _create_branch(tmp_path, "stale")
+
+    # Advance main.
+    _write_workdir(tmp_path, {"a.mid": b"V2"})
+    await _commit_async(message="ahead", root=tmp_path, session=muse_cli_db_session)
+
+    # Merging stale into main → already up-to-date.
+    with pytest.raises(typer.Exit) as exc_info:
+        await _merge_async(branch="stale", root=tmp_path, session=muse_cli_db_session)
+
+    assert exc_info.value.exit_code == ExitCode.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# 3-way merge tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_merge_creates_merge_commit_two_parents(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """3-way merge creates a commit with exactly two parent IDs."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"base.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+    base_commit = _head_commit(tmp_path)
+
+    # Branch off: create 'feature' from main.
+    _create_branch(tmp_path, "feature")
+
+    # Advance main with a unique change.
+    _write_workdir(tmp_path, {"base.mid": b"BASE", "main_only.mid": b"MAIN"})
+    await _commit_async(message="main step", root=tmp_path, session=muse_cli_db_session)
+    ours_commit = _head_commit(tmp_path)
+
+    # Advance feature with a different unique change.
+    _switch_branch(tmp_path, "feature")
+    _write_workdir(tmp_path, {"base.mid": b"BASE", "feature_only.mid": b"FEAT"})
+    await _commit_async(
+        message="feature step", root=tmp_path, session=muse_cli_db_session
+    )
+    theirs_commit = _head_commit(tmp_path, "feature")
+
+    # Merge feature into main (both diverged from base).
+    _switch_branch(tmp_path, "main")
+    await _merge_async(branch="feature", root=tmp_path, session=muse_cli_db_session)
+
+    # A new merge commit must exist.
+    merge_commit_id = _head_commit(tmp_path, "main")
+    assert merge_commit_id != ours_commit
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == merge_commit_id)
+    )
+    merge_commit = result.scalar_one()
+    assert merge_commit.parent_commit_id == ours_commit
+    assert merge_commit.parent2_commit_id == theirs_commit
+
+
+@pytest.mark.anyio
+async def test_merge_auto_merges_non_conflicting(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Files changed on only one branch are taken without conflict."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"shared.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+
+    # Feature adds a new file.
+    _create_branch(tmp_path, "feature")
+    _switch_branch(tmp_path, "feature")
+    _write_workdir(tmp_path, {"shared.mid": b"BASE", "new.mid": b"NEW"})
+    await _commit_async(message="feature adds new.mid", root=tmp_path, session=muse_cli_db_session)
+    theirs_commit = _head_commit(tmp_path, "feature")
+
+    # Main modifies the shared file (different from feature).
+    _switch_branch(tmp_path, "main")
+    _write_workdir(tmp_path, {"shared.mid": b"MAIN_CHANGE"})
+    await _commit_async(message="main changes shared", root=tmp_path, session=muse_cli_db_session)
+
+    # Merge should succeed (no conflicts).
+    await _merge_async(branch="feature", root=tmp_path, session=muse_cli_db_session)
+
+    # No MERGE_STATE.json written.
+    assert read_merge_state(tmp_path) is None
+
+    # The merge commit's snapshot must contain both the main change and the new file.
+    merge_commit_id = _head_commit(tmp_path, "main")
+    from maestro.muse_cli.db import get_commit_snapshot_manifest
+    merged_manifest = await get_commit_snapshot_manifest(
+        muse_cli_db_session, merge_commit_id
+    )
+    assert merged_manifest is not None
+    assert "new.mid" in merged_manifest
+
+
+@pytest.mark.anyio
+async def test_merge_detects_conflict_same_path(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Both branches changed same file → MERGE_STATE.json written, exit 1."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+
+    _create_branch(tmp_path, "experiment")
+
+    # Main modifies beat.mid.
+    _write_workdir(tmp_path, {"beat.mid": b"MAIN_VERSION"})
+    await _commit_async(message="main changes beat", root=tmp_path, session=muse_cli_db_session)
+
+    # Experiment also modifies beat.mid.
+    _switch_branch(tmp_path, "experiment")
+    _write_workdir(tmp_path, {"beat.mid": b"EXPERIMENT_VERSION"})
+    await _commit_async(message="experiment changes beat", root=tmp_path, session=muse_cli_db_session)
+
+    # Try to merge back into main → conflict expected.
+    _switch_branch(tmp_path, "main")
+    with pytest.raises(typer.Exit) as exc_info:
+        await _merge_async(
+            branch="experiment", root=tmp_path, session=muse_cli_db_session
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_merge_state_json_structure(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """MERGE_STATE.json contains all required fields on conflict."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+
+    _create_branch(tmp_path, "experiment")
+
+    _write_workdir(tmp_path, {"beat.mid": b"MAIN_V"})
+    await _commit_async(message="main", root=tmp_path, session=muse_cli_db_session)
+    ours_commit = _head_commit(tmp_path, "main")
+
+    _switch_branch(tmp_path, "experiment")
+    _write_workdir(tmp_path, {"beat.mid": b"EXP_V"})
+    await _commit_async(message="exp", root=tmp_path, session=muse_cli_db_session)
+    theirs_commit = _head_commit(tmp_path, "experiment")
+
+    _switch_branch(tmp_path, "main")
+    with pytest.raises(typer.Exit):
+        await _merge_async(
+            branch="experiment", root=tmp_path, session=muse_cli_db_session
+        )
+
+    state = read_merge_state(tmp_path)
+    assert state is not None
+    assert state.ours_commit == ours_commit
+    assert state.theirs_commit == theirs_commit
+    assert state.base_commit is not None
+    assert "beat.mid" in state.conflict_paths
+
+    # Validate the raw JSON has all required keys.
+    raw = json.loads((tmp_path / ".muse" / "MERGE_STATE.json").read_text())
+    for key in ("base_commit", "ours_commit", "theirs_commit", "conflict_paths"):
+        assert key in raw, f"Missing key: {key}"
+
+
+@pytest.mark.anyio
+async def test_merge_conflict_blocks_further_commit(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """``muse commit`` while in conflicted state exits 1."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+
+    # Write a MERGE_STATE.json with conflicts.
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit="ours111",
+        theirs_commit="their222",
+        conflict_paths=["beat.mid"],
+    )
+
+    # Attempt to commit while conflicts exist.
+    with pytest.raises(typer.Exit) as exc_info:
+        await _commit_async(
+            message="should fail", root=tmp_path, session=muse_cli_db_session
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_merge_in_progress_blocks_second_merge(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Second ``muse merge`` during a conflict exits 1 with clear message."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"a.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+
+    # Simulate a merge already in progress.
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit="ours111",
+        theirs_commit="their222",
+        conflict_paths=["a.mid"],
+        other_branch="feature",
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _merge_async(
+            branch="feature", root=tmp_path, session=muse_cli_db_session
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Error / edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_merge_outside_repo_exits_2(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Invoking the merge Typer command outside a repo exits 2."""
+    from typer.testing import CliRunner
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["merge", "feature"], catch_exceptions=False)
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_merge_target_branch_no_commits_exits_1(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Merging a branch that doesn't exist / has no commits exits 1."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"a.mid": b"V"})
+    await _commit_async(message="initial", root=tmp_path, session=muse_cli_db_session)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _merge_async(
+            branch="nonexistent", root=tmp_path, session=muse_cli_db_session
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_merge_same_branch_exits_0(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Merging a branch into itself (same HEAD) exits 0 — already up-to-date."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"a.mid": b"V"})
+    await _commit_async(message="initial", root=tmp_path, session=muse_cli_db_session)
+    # Create an alias branch pointing at the same commit.
+    _create_branch(tmp_path, "alias")
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _merge_async(
+            branch="alias", root=tmp_path, session=muse_cli_db_session
+        )
+
+    assert exc_info.value.exit_code == ExitCode.SUCCESS

--- a/tests/muse_cli/test_merge_engine.py
+++ b/tests/muse_cli/test_merge_engine.py
@@ -33,7 +33,6 @@ from maestro.muse_cli.snapshot import compute_snapshot_id
 
 
 def _make_commit(
-    session: AsyncSession,
     *,
     parent: str | None = None,
     parent2: str | None = None,

--- a/tests/muse_cli/test_merge_engine.py
+++ b/tests/muse_cli/test_merge_engine.py
@@ -1,0 +1,367 @@
+"""Unit tests for the Muse CLI merge engine (pure functions + find_merge_base).
+
+All async tests use ``@pytest.mark.anyio``.  Pure-function tests are
+synchronous and exercise the filesystem-free merge logic in isolation.
+``find_merge_base`` tests use the in-memory SQLite session from ``conftest.py``.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.merge_engine import (
+    MergeState,
+    apply_merge,
+    detect_conflicts,
+    diff_snapshots,
+    find_merge_base,
+    read_merge_state,
+    write_merge_state,
+)
+from maestro.muse_cli.models import MuseCliCommit
+from maestro.muse_cli.snapshot import compute_snapshot_id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_commit(
+    session: AsyncSession,
+    *,
+    parent: str | None = None,
+    parent2: str | None = None,
+    branch: str = "main",
+) -> MuseCliCommit:
+    """Build (but don't yet persist) a MuseCliCommit with a random commit_id."""
+    import datetime
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    manifest: dict[str, str] = {}
+    snapshot_id = compute_snapshot_id(manifest)
+    commit_id = str(uuid.uuid4()).replace("-", "")[:64].ljust(64, "0")
+    return MuseCliCommit(
+        commit_id=commit_id,
+        repo_id="test-repo",
+        branch=branch,
+        parent_commit_id=parent,
+        parent2_commit_id=parent2,
+        snapshot_id=snapshot_id,
+        message="test commit",
+        author="",
+        committed_at=now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# diff_snapshots — pure function tests
+# ---------------------------------------------------------------------------
+
+
+def test_diff_snapshots_empty_base_all_added() -> None:
+    """Every path in other is 'added' when base is empty."""
+    changed = diff_snapshots({}, {"a.mid": "aaa", "b.mid": "bbb"})
+    assert changed == {"a.mid", "b.mid"}
+
+
+def test_diff_snapshots_deleted_paths() -> None:
+    """Paths removed from other relative to base are detected."""
+    changed = diff_snapshots({"a.mid": "aaa", "b.mid": "bbb"}, {"a.mid": "aaa"})
+    assert changed == {"b.mid"}
+
+
+def test_diff_snapshots_modified_paths() -> None:
+    """Paths with different object_ids are detected as modified."""
+    changed = diff_snapshots({"a.mid": "old"}, {"a.mid": "new"})
+    assert changed == {"a.mid"}
+
+
+def test_diff_snapshots_unchanged_paths_excluded() -> None:
+    """Paths with identical object_ids are NOT included."""
+    changed = diff_snapshots({"a.mid": "same"}, {"a.mid": "same"})
+    assert changed == set()
+
+
+def test_diff_snapshots_mixed() -> None:
+    """Added, modified, deleted, and unchanged paths handled correctly."""
+    base = {"a.mid": "aaa", "b.mid": "bbb", "c.mid": "ccc"}
+    other = {"a.mid": "aaa", "b.mid": "BBB", "d.mid": "ddd"}
+    changed = diff_snapshots(base, other)
+    assert changed == {"b.mid", "c.mid", "d.mid"}
+
+
+# ---------------------------------------------------------------------------
+# detect_conflicts — pure function tests
+# ---------------------------------------------------------------------------
+
+
+def test_detect_conflicts_disjoint_no_conflicts() -> None:
+    """No conflict when each branch changes different paths."""
+    assert detect_conflicts({"a.mid"}, {"b.mid"}) == set()
+
+
+def test_detect_conflicts_same_path_is_conflict() -> None:
+    """Same path changed on both sides is a conflict."""
+    assert detect_conflicts({"beat.mid", "x.mid"}, {"beat.mid", "y.mid"}) == {"beat.mid"}
+
+
+def test_detect_conflicts_empty_inputs() -> None:
+    assert detect_conflicts(set(), set()) == set()
+
+
+# ---------------------------------------------------------------------------
+# apply_merge — pure function tests
+# ---------------------------------------------------------------------------
+
+
+def test_apply_merge_takes_ours_only_change() -> None:
+    """A path changed only on ours is taken from ours manifest."""
+    base = {"a.mid": "base"}
+    ours = {"a.mid": "ours"}
+    theirs = {"a.mid": "base"}
+    ours_changed = {"a.mid"}
+    theirs_changed: set[str] = set()
+    merged = apply_merge(base, ours, theirs, ours_changed, theirs_changed, set())
+    assert merged["a.mid"] == "ours"
+
+
+def test_apply_merge_takes_theirs_only_change() -> None:
+    """A path changed only on theirs is taken from theirs manifest."""
+    base = {"a.mid": "base"}
+    ours = {"a.mid": "base"}
+    theirs = {"a.mid": "theirs"}
+    merged = apply_merge(base, ours, theirs, set(), {"a.mid"}, set())
+    assert merged["a.mid"] == "theirs"
+
+
+def test_apply_merge_deleted_on_ours() -> None:
+    """A path deleted on ours (not in ours manifest) is removed from merged."""
+    base = {"a.mid": "base", "b.mid": "base"}
+    ours = {"b.mid": "base"}   # a.mid deleted on ours
+    theirs = {"a.mid": "base", "b.mid": "base"}
+    ours_changed = {"a.mid"}
+    merged = apply_merge(base, ours, theirs, ours_changed, set(), set())
+    assert "a.mid" not in merged
+
+
+def test_apply_merge_conflict_paths_not_applied() -> None:
+    """Conflict paths are excluded — base version is kept."""
+    base = {"x.mid": "base"}
+    ours = {"x.mid": "ours"}
+    theirs = {"x.mid": "theirs"}
+    ours_changed = {"x.mid"}
+    theirs_changed = {"x.mid"}
+    conflict_paths = {"x.mid"}
+    merged = apply_merge(base, ours, theirs, ours_changed, theirs_changed, conflict_paths)
+    # Conflict path keeps base version (neither side applied).
+    assert merged["x.mid"] == "base"
+
+
+def test_apply_merge_both_sides_add_different_files() -> None:
+    """Non-conflicting additions from both sides appear in merged manifest."""
+    base: dict[str, str] = {}
+    ours = {"a.mid": "aaa"}
+    theirs = {"b.mid": "bbb"}
+    merged = apply_merge(base, ours, theirs, {"a.mid"}, {"b.mid"}, set())
+    assert merged == {"a.mid": "aaa", "b.mid": "bbb"}
+
+
+# ---------------------------------------------------------------------------
+# read_merge_state / write_merge_state — filesystem tests
+# ---------------------------------------------------------------------------
+
+
+def test_read_merge_state_no_file_returns_none(tmp_path: pathlib.Path) -> None:
+    (tmp_path / ".muse").mkdir()
+    assert read_merge_state(tmp_path) is None
+
+
+def test_write_and_read_merge_state_roundtrip(tmp_path: pathlib.Path) -> None:
+    (tmp_path / ".muse").mkdir()
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit="ours111",
+        theirs_commit="theirs222",
+        conflict_paths=["beat.mid", "lead.mp3"],
+        other_branch="feature/x",
+    )
+    state = read_merge_state(tmp_path)
+    assert state is not None
+    assert state.base_commit == "base000"
+    assert state.ours_commit == "ours111"
+    assert state.theirs_commit == "theirs222"
+    assert sorted(state.conflict_paths) == ["beat.mid", "lead.mp3"]
+    assert state.other_branch == "feature/x"
+
+
+def test_read_merge_state_invalid_json_returns_none(tmp_path: pathlib.Path) -> None:
+    muse_dir = tmp_path / ".muse"
+    muse_dir.mkdir()
+    (muse_dir / "MERGE_STATE.json").write_text("not-valid-json{{")
+    assert read_merge_state(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# find_merge_base — async tests (require DB session)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_find_merge_base_lca(muse_cli_db_session: AsyncSession) -> None:
+    """LCA is correct for a simple fork-and-rejoin graph.
+
+    Graph:
+        base ← A ← ours
+             ↖
+              B ← theirs
+
+    Expected LCA = base.
+    """
+    import datetime
+
+    session = muse_cli_db_session
+    now = datetime.datetime.now(datetime.timezone.utc)
+    snapshot_id = compute_snapshot_id({})
+
+    def _commit(cid: str, parent: str | None = None, parent2: str | None = None) -> MuseCliCommit:
+        return MuseCliCommit(
+            commit_id=cid,
+            repo_id="test",
+            branch="main",
+            parent_commit_id=parent,
+            parent2_commit_id=parent2,
+            snapshot_id=snapshot_id,
+            message="msg",
+            author="",
+            committed_at=now,
+        )
+
+    # Persist an empty snapshot so FK constraints pass.
+    from maestro.muse_cli.models import MuseCliSnapshot
+    session.add(MuseCliSnapshot(snapshot_id=snapshot_id, manifest={}))
+    await session.flush()
+
+    base = _commit("base" + "0" * 60)
+    commit_a = _commit("aaaa" + "0" * 60, parent=base.commit_id)
+    commit_b = _commit("bbbb" + "0" * 60, parent=base.commit_id)
+    session.add_all([base, commit_a, commit_b])
+    await session.flush()
+
+    lca = await find_merge_base(session, commit_a.commit_id, commit_b.commit_id)
+    assert lca == base.commit_id
+
+
+@pytest.mark.anyio
+async def test_find_merge_base_same_commit(muse_cli_db_session: AsyncSession) -> None:
+    """LCA of a commit with itself is the commit itself."""
+    import datetime
+
+    session = muse_cli_db_session
+    snapshot_id = compute_snapshot_id({})
+    from maestro.muse_cli.models import MuseCliSnapshot
+    session.add(MuseCliSnapshot(snapshot_id=snapshot_id, manifest={}))
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    c = MuseCliCommit(
+        commit_id="cccc" + "0" * 60,
+        repo_id="test",
+        branch="main",
+        parent_commit_id=None,
+        parent2_commit_id=None,
+        snapshot_id=snapshot_id,
+        message="x",
+        author="",
+        committed_at=now,
+    )
+    session.add(c)
+    await session.flush()
+
+    lca = await find_merge_base(session, c.commit_id, c.commit_id)
+    assert lca == c.commit_id
+
+
+@pytest.mark.anyio
+async def test_find_merge_base_linear_returns_ancestor(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """For a linear history A ← B, LCA(A, B) = A."""
+    import datetime
+
+    session = muse_cli_db_session
+    snapshot_id = compute_snapshot_id({})
+    from maestro.muse_cli.models import MuseCliSnapshot
+    session.add(MuseCliSnapshot(snapshot_id=snapshot_id, manifest={}))
+    await session.flush()
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    commit_a = MuseCliCommit(
+        commit_id="aaaa" + "1" * 60,
+        repo_id="r",
+        branch="main",
+        parent_commit_id=None,
+        parent2_commit_id=None,
+        snapshot_id=snapshot_id,
+        message="a",
+        author="",
+        committed_at=now,
+    )
+    commit_b = MuseCliCommit(
+        commit_id="bbbb" + "1" * 60,
+        repo_id="r",
+        branch="main",
+        parent_commit_id=commit_a.commit_id,
+        parent2_commit_id=None,
+        snapshot_id=snapshot_id,
+        message="b",
+        author="",
+        committed_at=now,
+    )
+    session.add_all([commit_a, commit_b])
+    await session.flush()
+
+    lca = await find_merge_base(session, commit_a.commit_id, commit_b.commit_id)
+    assert lca == commit_a.commit_id
+
+
+@pytest.mark.anyio
+async def test_find_merge_base_disjoint_returns_none(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Disjoint histories (no shared ancestor) return None."""
+    import datetime
+
+    session = muse_cli_db_session
+    snapshot_id = compute_snapshot_id({})
+    from maestro.muse_cli.models import MuseCliSnapshot
+    session.add(MuseCliSnapshot(snapshot_id=snapshot_id, manifest={}))
+    await session.flush()
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    def _c(cid: str) -> MuseCliCommit:
+        return MuseCliCommit(
+            commit_id=cid,
+            repo_id="r",
+            branch="main",
+            parent_commit_id=None,
+            parent2_commit_id=None,
+            snapshot_id=snapshot_id,
+            message="x",
+            author="",
+            committed_at=now,
+        )
+
+    c1 = _c("1111" + "0" * 60)
+    c2 = _c("2222" + "0" * 60)
+    session.add_all([c1, c2])
+    await session.flush()
+
+    lca = await find_merge_base(session, c1.commit_id, c2.commit_id)
+    assert lca is None


### PR DESCRIPTION
## Summary

- Implements `muse merge <branch>` with fast-forward and 3-way merge strategies
- Conflict detection at file-path granularity writes `.muse/MERGE_STATE.json` and exits 1
- Merge commit has two parent IDs (`parent_commit_id` + `parent2_commit_id`)

## Issue

Closes #35

## Root Cause

N/A — new feature

## Solution

**Merge algorithm (path-level granularity):**
1. Guard: if `MERGE_STATE.json` exists, block with clear message
2. Resolve HEAD commits for both branches from `.muse/refs/heads/`
3. Find merge base (LCA) via BFS over commit graph (supports existing merge commits with two parents)
4. **Fast-forward**: if base == ours, advance branch pointer to theirs — no new commit
5. **Already up-to-date**: if base == theirs, exit 0
6. **3-way merge**: diff(base→ours) and diff(base→theirs) at path level; detect conflicts (intersection); if none → build merged manifest + merge commit; if conflicts → write `MERGE_STATE.json` and exit 1

**Files changed:**
- `maestro/muse_cli/merge_engine.py` — extended with `find_merge_base()`, `diff_snapshots()`, `detect_conflicts()`, `apply_merge()`, `write_merge_state()`; updated `MergeState` schema to `conflict_paths/base_commit/ours_commit/theirs_commit`
- `maestro/muse_cli/commands/merge.py` — full implementation of `_merge_async()` and Typer command
- `maestro/muse_cli/commands/commit.py` — blocks commit while `MERGE_STATE.json` has conflicts
- `maestro/muse_cli/commands/status.py` — updated to use `conflict_paths` field
- `maestro/muse_cli/db.py` — added `get_commit_snapshot_manifest()`
- `maestro/muse_cli/models.py` — `parent2_commit_id` column (already in branch)
- `alembic/versions/0002_muse_cli_commits_parent2.py` — migration for `parent2_commit_id`
- `docs/architecture/muse_vcs.md` — documented merge algorithm, `MERGE_STATE.json` schema, conflict resolution workflow

## Layers Affected

- [x] Muse VCS (merge_engine, commands/merge, commands/commit, commands/status, db)

## Verification

- [x] `docker compose exec maestro mypy maestro/muse_cli/ tests/muse_cli/` — clean
- [x] All 31 new tests pass

## Tests Added

**`tests/muse_cli/test_merge_engine.py`** (pure functions + DB):
- `test_diff_snapshots_*` (5 tests) — added/deleted/modified/unchanged/mixed
- `test_detect_conflicts_*` (3 tests) — disjoint/same-path/empty
- `test_apply_merge_*` (5 tests) — ours-only/theirs-only/deleted/conflict-excluded/both-add
- `test_read_merge_state_*` / `test_write_and_read_merge_state_roundtrip` (3 tests)
- `test_find_merge_base_lca` — LCA correct for simple fork-and-rejoin graph
- `test_find_merge_base_same_commit`, `_linear_returns_ancestor`, `_disjoint_returns_none`

**`tests/muse_cli/test_merge.py`** (integration):
- `test_merge_fast_forward_moves_pointer`
- `test_merge_already_up_to_date_exits_0`
- `test_merge_creates_merge_commit_two_parents`
- `test_merge_auto_merges_non_conflicting`
- `test_merge_detects_conflict_same_path`
- `test_merge_state_json_structure`
- `test_merge_conflict_blocks_further_commit`
- `test_merge_in_progress_blocks_second_merge`
- `test_merge_outside_repo_exits_2`
- `test_merge_target_branch_no_commits_exits_1`
- `test_merge_same_branch_exits_0`

## Handoff

N/A — no SSE protocol or API contract change. `muse merge` is a CLI-only command.