### PR TITLE
feat: muse grep <pattern> — search for a musical pattern across all commits

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -2061,6 +2061,25 @@ Swing comparison between HEAD and a reference commit.
 **Producer:** `_swing_compare_async()`
 **Consumer:** `_format_compare()`
 
+### `GrepMatch`
+
+**Module:** `maestro/muse_cli/commands/grep_cmd.py`
+
+A single commit that matched the `muse grep` search pattern.  Implemented as a
+plain `dataclass` (not `TypedDict`) so that `dataclasses.asdict()` can be used
+directly for JSON serialisation without any additional mapping step.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | Full 64-char commit SHA |
+| `branch` | `str` | Branch name at the time of the commit |
+| `message` | `str` | Full commit message |
+| `committed_at` | `str` | ISO-8601 UTC timestamp string |
+| `match_source` | `str` | Where the pattern was found: `"message"`, `"branch"`, or `"midi_content"` (future) |
+
+**Producer:** `_match_commit()`, `_grep_async()`
+**Consumer:** `_render_matches()`, callers using `--json` output
+
 ---
 
 ## `Any` Status

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -1,7 +1,7 @@
 """Muse CLI — Typer application root.
 
 Entry point for the ``muse`` console script. Registers all MVP
-subcommands (init, status, commit, log, checkout, merge, remote,
+subcommands (init, status, commit, grep, log, checkout, merge, remote,
 push, pull, open, play) as Typer sub-applications.
 """
 from __future__ import annotations
@@ -11,6 +11,7 @@ import typer
 from maestro.muse_cli.commands import (
     checkout,
     commit,
+    grep_cmd,
     init,
     log,
     merge,
@@ -31,6 +32,7 @@ cli = typer.Typer(
 cli.add_typer(init.app, name="init", help="Initialise a new Muse repository.")
 cli.add_typer(status.app, name="status", help="Show working-tree drift against HEAD.")
 cli.add_typer(commit.app, name="commit", help="Record a new variation in history.")
+cli.add_typer(grep_cmd.app, name="grep", help="Search for a musical pattern across all commits.")
 cli.add_typer(log.app, name="log", help="Display the variation history graph.")
 cli.add_typer(checkout.app, name="checkout", help="Checkout a historical variation.")
 cli.add_typer(merge.app, name="merge", help="Three-way merge two variation branches.")

--- a/maestro/muse_cli/commands/grep_cmd.py
+++ b/maestro/muse_cli/commands/grep_cmd.py
@@ -1,0 +1,317 @@
+"""muse grep — search for a musical pattern across all commits.
+
+This command searches Muse VCS commit history for a given pattern and returns
+all commits where the pattern is found.
+
+**Current implementation (stub):** The pattern is matched against commit
+*messages* and *branch names* using case-insensitive substring matching.
+Full MIDI content analysis — scanning note sequences, intervals, and chord
+shapes inside committed snapshots — is reserved for a future iteration.
+
+Pattern formats recognised (planned for MIDI content search, not yet analysed):
+
+- Note sequence:  ``"C4 E4 G4"``
+- Interval run:   ``"+4 +3"``
+- Chord symbol:   ``"Cm7"``
+
+Future work (MIDI analysis)
+---------------------------
+When MIDI content search is implemented each committed snapshot will be decoded
+from its object store, parsed into note events, and compared against the
+pattern using the flags below:
+
+- ``--transposition-invariant`` (default ``True``): match regardless of key.
+- ``--rhythm-invariant``: match regardless of rhythm/timing.
+- ``--track``: restrict search to a named track.
+- ``--section``: restrict search to a labelled section.
+
+Until then these flags are accepted to preserve the CLI contract but only
+``--commits`` and ``--json`` affect output; the four MIDI-analysis flags are
+recorded for future use and produce a warning when supplied.
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import logging
+import pathlib
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+_DEFAULT_LIMIT = 1000
+
+
+# ---------------------------------------------------------------------------
+# Domain model
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class GrepMatch:
+    """A single commit that matched the search pattern.
+
+    ``match_source`` records *where* the pattern was found:
+    - ``"message"`` — in the commit message (implemented)
+    - ``"branch"``  — in the branch name (implemented)
+    - ``"midi_content"`` — inside a committed MIDI snapshot (future work)
+    """
+
+    commit_id: str
+    branch: str
+    message: str
+    committed_at: str  # ISO-8601 string
+    match_source: str
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _load_all_commits(
+    session: AsyncSession,
+    head_commit_id: str,
+    limit: int,
+) -> list[MuseCliCommit]:
+    """Walk the parent chain from *head_commit_id*, returning newest-first.
+
+    Stops when the chain is exhausted or *limit* is reached.
+    """
+    commits: list[MuseCliCommit] = []
+    current_id: str | None = head_commit_id
+    while current_id and len(commits) < limit:
+        commit = await session.get(MuseCliCommit, current_id)
+        if commit is None:
+            logger.warning("⚠️ Commit %s not found in DB — chain broken", current_id[:8])
+            break
+        commits.append(commit)
+        current_id = commit.parent_commit_id
+    return commits
+
+
+def _match_commit(
+    commit: MuseCliCommit,
+    pattern: str,
+    *,
+    track: str | None,
+    section: str | None,
+    transposition_invariant: bool,
+    rhythm_invariant: bool,
+) -> GrepMatch | None:
+    """Return a :class:`GrepMatch` if the commit matches *pattern*, else ``None``.
+
+    Currently performs case-insensitive substring matching against commit
+    messages and branch names.  The ``track``, ``section``,
+    ``transposition_invariant``, and ``rhythm_invariant`` flags are accepted
+    for API stability but are no-ops until MIDI content search is implemented.
+    """
+    pat = pattern.lower()
+
+    if pat in commit.message.lower():
+        return GrepMatch(
+            commit_id=commit.commit_id,
+            branch=commit.branch,
+            message=commit.message,
+            committed_at=commit.committed_at.isoformat(),
+            match_source="message",
+        )
+
+    if pat in commit.branch.lower():
+        return GrepMatch(
+            commit_id=commit.commit_id,
+            branch=commit.branch,
+            message=commit.message,
+            committed_at=commit.committed_at.isoformat(),
+            match_source="branch",
+        )
+
+    # NOTE: MIDI content search (track / section / transposition / rhythm filters)
+    # is not yet implemented.  The flags above will be wired here in future.
+    return None
+
+
+async def _grep_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    pattern: str,
+    track: str | None,
+    section: str | None,
+    transposition_invariant: bool,
+    rhythm_invariant: bool,
+    show_commits: bool,
+    output_json: bool,
+) -> list[GrepMatch]:
+    """Core grep logic — fully injectable for tests.
+
+    Reads repo state from ``.muse/``, walks the commit chain, and returns
+    all :class:`GrepMatch` objects that satisfy *pattern*.
+    """
+    muse_dir = root / ".muse"
+    head_ref = (muse_dir / "HEAD").read_text().strip()  # "refs/heads/main"
+    branch = head_ref.rsplit("/", 1)[-1]  # "main"
+    ref_path = muse_dir / pathlib.Path(head_ref)
+
+    head_commit_id = ""
+    if ref_path.exists():
+        head_commit_id = ref_path.read_text().strip()
+
+    if not head_commit_id:
+        typer.echo(f"No commits yet on branch {branch} — nothing to search.")
+        return []
+
+    commits = await _load_all_commits(session, head_commit_id=head_commit_id, limit=_DEFAULT_LIMIT)
+
+    matches: list[GrepMatch] = []
+    for commit in commits:
+        m = _match_commit(
+            commit,
+            pattern,
+            track=track,
+            section=section,
+            transposition_invariant=transposition_invariant,
+            rhythm_invariant=rhythm_invariant,
+        )
+        if m is not None:
+            matches.append(m)
+
+    return matches
+
+
+def _render_matches(
+    matches: list[GrepMatch],
+    *,
+    pattern: str,
+    show_commits: bool,
+    output_json: bool,
+) -> None:
+    """Write grep results to stdout.
+
+    Three output modes:
+    - ``--json``:    machine-readable JSON array.
+    - ``--commits``: one ``commit_id`` per line (like ``git grep --name-only``).
+    - default:       human-readable summary with context.
+    """
+    if output_json:
+        typer.echo(
+            json.dumps(
+                [dataclasses.asdict(m) for m in matches],
+                indent=2,
+            )
+        )
+        return
+
+    if not matches:
+        typer.echo(f"No commits match pattern: {pattern!r}")
+        return
+
+    if show_commits:
+        for m in matches:
+            typer.echo(m.commit_id)
+        return
+
+    # Default human-readable output
+    typer.echo(f"Pattern: {pattern!r}  ({len(matches)} match(es))\n")
+    for m in matches:
+        typer.echo(f"commit {m.commit_id}")
+        typer.echo(f"Branch:  {m.branch}")
+        typer.echo(f"Date:    {m.committed_at}")
+        typer.echo(f"Match:   [{m.match_source}]")
+        typer.echo(f"Message: {m.message}")
+        typer.echo("")
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def grep(
+    ctx: typer.Context,
+    pattern: str = typer.Argument(..., help="Pattern to search for (note sequence, interval, chord, or text)."),
+    track: str | None = typer.Option(
+        None,
+        "--track",
+        help="[Future] Restrict search to a named track.",
+        show_default=False,
+    ),
+    section: str | None = typer.Option(
+        None,
+        "--section",
+        help="[Future] Restrict search to a labelled section.",
+        show_default=False,
+    ),
+    transposition_invariant: bool = typer.Option(
+        True,
+        "--transposition-invariant/--no-transposition-invariant",
+        help="[Future] Match regardless of key/transposition (default: on).",
+    ),
+    rhythm_invariant: bool = typer.Option(
+        False,
+        "--rhythm-invariant",
+        help="[Future] Match regardless of rhythm/timing.",
+    ),
+    show_commits: bool = typer.Option(
+        False,
+        "--commits",
+        help="Output one commit ID per line (like git grep --name-only).",
+    ),
+    output_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Output results as a JSON array.",
+    ),
+) -> None:
+    """Search for a musical pattern across all commits.
+
+    NOTE: The current implementation searches commit *messages* and *branch
+    names* for the pattern string.  Full MIDI content analysis (note
+    sequences, intervals, chord symbols) is planned for a future release.
+    Flags marked [Future] are accepted now for API stability but have no
+    effect on text-only matching.
+    """
+    root = require_repo()
+
+    # Warn when MIDI-analysis flags are supplied — they are no-ops right now.
+    if track is not None:
+        typer.echo("⚠️  --track is not yet implemented (MIDI analysis is future work).")
+    if section is not None:
+        typer.echo("⚠️  --section is not yet implemented (MIDI analysis is future work).")
+    if rhythm_invariant:
+        typer.echo("⚠️  --rhythm-invariant is not yet implemented (MIDI analysis is future work).")
+
+    async def _run() -> list[GrepMatch]:
+        async with open_session() as session:
+            return await _grep_async(
+                root=root,
+                session=session,
+                pattern=pattern,
+                track=track,
+                section=section,
+                transposition_invariant=transposition_invariant,
+                rhythm_invariant=rhythm_invariant,
+                show_commits=show_commits,
+                output_json=output_json,
+            )
+
+    try:
+        matches = asyncio.run(_run())
+        _render_matches(matches, pattern=pattern, show_commits=show_commits, output_json=output_json)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse grep failed: {exc}")
+        logger.error("❌ muse grep error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/tests/test_muse_grep.py
+++ b/tests/test_muse_grep.py
@@ -1,0 +1,478 @@
+"""Tests for muse grep — pattern search across Muse VCS commits (issue #124).
+
+Verifies:
+- Pattern matching against commit messages (case-insensitive).
+- Pattern matching against branch names.
+- Non-matching commits are excluded.
+- --commits flag produces one commit ID per line.
+- --json flag produces valid JSON array.
+- --track / --section / --rhythm-invariant emit future-work warnings.
+- Empty history produces a graceful no-commits message.
+- Multiple matches across a chain are all returned.
+- Boundary seal (AST).
+"""
+from __future__ import annotations
+
+import ast
+import dataclasses
+import json
+import pathlib
+import textwrap
+from collections.abc import AsyncGenerator
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from maestro.db.database import Base
+from maestro.muse_cli.commands.grep_cmd import (
+    GrepMatch,
+    _grep_async,
+    _load_all_commits,
+    _match_commit,
+    _render_matches,
+)
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def async_session() -> AsyncGenerator[AsyncSession, None]:
+    """In-memory SQLite async session — creates all tables before each test."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+def _utc(year: int = 2026, month: int = 1, day: int = 1) -> datetime:
+    return datetime(year, month, day, tzinfo=timezone.utc)
+
+
+def _snapshot(session: AsyncSession, snap_id: str) -> MuseCliSnapshot:
+    s = MuseCliSnapshot(snapshot_id=snap_id, manifest={})
+    session.add(s)
+    return s
+
+
+def _commit(
+    session: AsyncSession,
+    *,
+    commit_id: str,
+    repo_id: str = "repo-1",
+    branch: str = "main",
+    message: str = "test commit",
+    parent_id: str | None = None,
+    snap_id: str = "snap-0000",
+    ts: datetime | None = None,
+) -> MuseCliCommit:
+    c = MuseCliCommit(
+        commit_id=commit_id,
+        repo_id=repo_id,
+        branch=branch,
+        parent_commit_id=parent_id,
+        parent2_commit_id=None,
+        snapshot_id=snap_id,
+        message=message,
+        author="test-user",
+        committed_at=ts or _utc(),
+    )
+    session.add(c)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _match_commit
+# ---------------------------------------------------------------------------
+
+
+def _make_commit_obj(
+    *,
+    commit_id: str = "abc12345" * 8,
+    branch: str = "main",
+    message: str = "boom bap groove",
+) -> MuseCliCommit:
+    """Build a MuseCliCommit using its normal constructor (no DB session needed).
+
+    SQLAlchemy ORM models can be instantiated without a session by using the
+    regular constructor.  The instance is transient (not associated with any
+    session) which is sufficient for testing ``_match_commit``.
+    """
+    return MuseCliCommit(
+        commit_id=commit_id,
+        repo_id="repo-1",
+        branch=branch,
+        parent_commit_id=None,
+        parent2_commit_id=None,
+        snapshot_id="snap-0000" + "0" * 60,
+        message=message,
+        author="test-user",
+        committed_at=_utc(),
+    )
+
+
+def test_match_commit_finds_pattern_in_message() -> None:
+    """Pattern matched in message → GrepMatch with source='message'."""
+    c = _make_commit_obj(message="add C4 E4 G4 riff to chorus")
+    result = _match_commit(
+        c,
+        "C4 E4 G4",
+        track=None,
+        section=None,
+        transposition_invariant=True,
+        rhythm_invariant=False,
+    )
+    assert result is not None
+    assert result.match_source == "message"
+    assert result.commit_id == c.commit_id
+
+
+def test_match_commit_case_insensitive() -> None:
+    """Pattern matching is case-insensitive."""
+    c = _make_commit_obj(message="Added CM7 chord voicing")
+    result = _match_commit(
+        c,
+        "cm7",
+        track=None,
+        section=None,
+        transposition_invariant=True,
+        rhythm_invariant=False,
+    )
+    assert result is not None
+
+
+def test_match_commit_finds_pattern_in_branch() -> None:
+    """Pattern matched in branch name → GrepMatch with source='branch'."""
+    c = _make_commit_obj(branch="feature/pentatonic-scale", message="initial commit")
+    result = _match_commit(
+        c,
+        "pentatonic",
+        track=None,
+        section=None,
+        transposition_invariant=True,
+        rhythm_invariant=False,
+    )
+    assert result is not None
+    assert result.match_source == "branch"
+
+
+def test_match_commit_no_match_returns_none() -> None:
+    """Commit with no pattern occurrence → None."""
+    c = _make_commit_obj(message="unrelated commit", branch="main")
+    result = _match_commit(
+        c,
+        "Am7",
+        track=None,
+        section=None,
+        transposition_invariant=True,
+        rhythm_invariant=False,
+    )
+    assert result is None
+
+
+def test_match_commit_message_takes_priority_over_branch() -> None:
+    """When message matches, source is 'message' even if branch would also match."""
+    c = _make_commit_obj(message="groove pattern", branch="groove-branch")
+    result = _match_commit(
+        c,
+        "groove",
+        track=None,
+        section=None,
+        transposition_invariant=True,
+        rhythm_invariant=False,
+    )
+    assert result is not None
+    assert result.match_source == "message"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: _load_all_commits + _grep_async (with real in-memory DB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_load_all_commits_walks_chain(async_session: AsyncSession) -> None:
+    """_load_all_commits returns all commits in newest-first order."""
+    snap_id = "snap-aaaa" + "0" * 55
+    _snapshot(async_session, snap_id[:64])
+    c1 = _commit(async_session, commit_id="aaa" + "0" * 61, snap_id=snap_id[:64], message="first")
+    c2 = _commit(
+        async_session,
+        commit_id="bbb" + "0" * 61,
+        snap_id=snap_id[:64],
+        parent_id=c1.commit_id,
+        message="second",
+        ts=_utc(day=2),
+    )
+    await async_session.commit()
+
+    commits = await _load_all_commits(async_session, head_commit_id=c2.commit_id, limit=100)
+    assert len(commits) == 2
+    assert commits[0].commit_id == c2.commit_id  # newest first
+    assert commits[1].commit_id == c1.commit_id
+
+
+@pytest.mark.anyio
+async def test_grep_async_matches_message(
+    async_session: AsyncSession, tmp_path: pathlib.Path
+) -> None:
+    """_grep_async finds commits whose messages contain the pattern."""
+    # Set up a minimal .muse repo structure
+    muse_dir = tmp_path / ".muse"
+    (muse_dir / "refs" / "heads").mkdir(parents=True)
+    head_ref = "refs/heads/main"
+    (muse_dir / "HEAD").write_text(head_ref)
+
+    snap_id = "s" * 64
+    _snapshot(async_session, snap_id)
+    c1 = _commit(
+        async_session,
+        commit_id="c" * 64,
+        snap_id=snap_id,
+        message="add pentatonic riff",
+        ts=_utc(day=2),
+    )
+    await async_session.commit()
+    (muse_dir / head_ref).write_text(c1.commit_id)
+
+    matches = await _grep_async(
+        root=tmp_path,
+        session=async_session,
+        pattern="pentatonic",
+        track=None,
+        section=None,
+        transposition_invariant=True,
+        rhythm_invariant=False,
+        show_commits=False,
+        output_json=False,
+    )
+    assert len(matches) == 1
+    assert matches[0].match_source == "message"
+    assert matches[0].commit_id == c1.commit_id
+
+
+@pytest.mark.anyio
+async def test_grep_async_no_matches(
+    async_session: AsyncSession, tmp_path: pathlib.Path
+) -> None:
+    """_grep_async returns empty list when pattern is not found."""
+    muse_dir = tmp_path / ".muse"
+    (muse_dir / "refs" / "heads").mkdir(parents=True)
+    (muse_dir / "HEAD").write_text("refs/heads/main")
+
+    snap_id = "s" * 64
+    _snapshot(async_session, snap_id)
+    c1 = _commit(
+        async_session,
+        commit_id="c" * 64,
+        snap_id=snap_id,
+        message="unrelated commit",
+    )
+    await async_session.commit()
+    (muse_dir / "refs" / "heads" / "main").write_text(c1.commit_id)
+
+    matches = await _grep_async(
+        root=tmp_path,
+        session=async_session,
+        pattern="Cm7",
+        track=None,
+        section=None,
+        transposition_invariant=True,
+        rhythm_invariant=False,
+        show_commits=False,
+        output_json=False,
+    )
+    assert matches == []
+
+
+@pytest.mark.anyio
+async def test_grep_async_empty_history(
+    async_session: AsyncSession, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """_grep_async handles branches with no commits gracefully."""
+    muse_dir = tmp_path / ".muse"
+    (muse_dir / "refs" / "heads").mkdir(parents=True)
+    (muse_dir / "HEAD").write_text("refs/heads/main")
+    # No HEAD ref file → no commits
+
+    matches = await _grep_async(
+        root=tmp_path,
+        session=async_session,
+        pattern="anything",
+        track=None,
+        section=None,
+        transposition_invariant=True,
+        rhythm_invariant=False,
+        show_commits=False,
+        output_json=False,
+    )
+    assert matches == []
+
+
+@pytest.mark.anyio
+async def test_grep_async_multiple_matches_across_chain(
+    async_session: AsyncSession, tmp_path: pathlib.Path
+) -> None:
+    """All matching commits across a long chain are returned."""
+    muse_dir = tmp_path / ".muse"
+    (muse_dir / "refs" / "heads").mkdir(parents=True)
+    (muse_dir / "HEAD").write_text("refs/heads/main")
+
+    snap_id = "s" * 64
+    _snapshot(async_session, snap_id)
+
+    # 3-commit chain; c1 and c3 match "groove", c2 does not
+    c1 = _commit(async_session, commit_id="1" * 64, snap_id=snap_id, message="groove intro", ts=_utc(day=1))
+    c2 = _commit(async_session, commit_id="2" * 64, snap_id=snap_id, message="bridge section", parent_id=c1.commit_id, ts=_utc(day=2))
+    c3 = _commit(async_session, commit_id="3" * 64, snap_id=snap_id, message="add groove variation", parent_id=c2.commit_id, ts=_utc(day=3))
+    await async_session.commit()
+    (muse_dir / "refs" / "heads" / "main").write_text(c3.commit_id)
+
+    matches = await _grep_async(
+        root=tmp_path,
+        session=async_session,
+        pattern="groove",
+        track=None,
+        section=None,
+        transposition_invariant=True,
+        rhythm_invariant=False,
+        show_commits=False,
+        output_json=False,
+    )
+    assert len(matches) == 2
+    commit_ids = {m.commit_id for m in matches}
+    assert c1.commit_id in commit_ids
+    assert c3.commit_id in commit_ids
+    assert c2.commit_id not in commit_ids
+
+
+# ---------------------------------------------------------------------------
+# Output rendering tests
+# ---------------------------------------------------------------------------
+
+
+def test_render_matches_json_output(capsys: pytest.CaptureFixture[str]) -> None:
+    """--json flag produces a valid JSON array of match dicts."""
+    matches = [
+        GrepMatch(
+            commit_id="abc" * 21 + "a",
+            branch="main",
+            message="pentatonic solo",
+            committed_at="2026-01-01T00:00:00+00:00",
+            match_source="message",
+        )
+    ]
+    _render_matches(matches, pattern="pentatonic", show_commits=False, output_json=True)
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert isinstance(parsed, list)
+    assert len(parsed) == 1
+    assert parsed[0]["match_source"] == "message"
+    assert parsed[0]["branch"] == "main"
+
+
+def test_render_matches_commits_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    """--commits flag outputs one commit ID per line."""
+    commit_ids = ["a" * 64, "b" * 64]
+    matches = [
+        GrepMatch(commit_id=cid, branch="main", message="msg", committed_at="2026-01-01T00:00:00+00:00", match_source="message")
+        for cid in commit_ids
+    ]
+    _render_matches(matches, pattern="msg", show_commits=True, output_json=False)
+    captured = capsys.readouterr()
+    lines = captured.out.strip().splitlines()
+    assert lines == commit_ids
+
+
+def test_render_matches_default_human_output(capsys: pytest.CaptureFixture[str]) -> None:
+    """Default output includes commit ID, branch, date, match source, and message."""
+    matches = [
+        GrepMatch(
+            commit_id="d" * 64,
+            branch="feature/groove",
+            message="add groove pattern",
+            committed_at="2026-02-01T00:00:00+00:00",
+            match_source="message",
+        )
+    ]
+    _render_matches(matches, pattern="groove", show_commits=False, output_json=False)
+    captured = capsys.readouterr()
+    assert "groove" in captured.out
+    assert "feature/groove" in captured.out
+    assert "message" in captured.out
+
+
+def test_render_matches_no_matches_message(capsys: pytest.CaptureFixture[str]) -> None:
+    """When no matches found, a descriptive message is printed."""
+    _render_matches([], pattern="Cm7", show_commits=False, output_json=False)
+    captured = capsys.readouterr()
+    assert "Cm7" in captured.out
+    assert "No commits" in captured.out
+
+
+def test_render_matches_json_empty_list(capsys: pytest.CaptureFixture[str]) -> None:
+    """--json with no matches outputs an empty JSON array."""
+    _render_matches([], pattern="nothing", show_commits=False, output_json=True)
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed == []
+
+
+# ---------------------------------------------------------------------------
+# GrepMatch dataclass integrity
+# ---------------------------------------------------------------------------
+
+
+def test_grep_match_asdict_roundtrip() -> None:
+    """GrepMatch is a plain dataclass — asdict() should be lossless."""
+    m = GrepMatch(
+        commit_id="x" * 64,
+        branch="main",
+        message="test pattern",
+        committed_at="2026-01-01T00:00:00+00:00",
+        match_source="message",
+    )
+    d = dataclasses.asdict(m)
+    assert d["commit_id"] == "x" * 64
+    assert d["branch"] == "main"
+    assert d["match_source"] == "message"
+
+
+# ---------------------------------------------------------------------------
+# Boundary seal — AST checks
+# ---------------------------------------------------------------------------
+
+
+def test_grep_cmd_module_has_future_annotations() -> None:
+    """grep_cmd.py must start with 'from __future__ import annotations'."""
+    src = pathlib.Path(__file__).parent.parent / "maestro" / "muse_cli" / "commands" / "grep_cmd.py"
+    tree = ast.parse(src.read_text())
+    first_import = next(
+        (n for n in ast.walk(tree) if isinstance(n, ast.ImportFrom)),
+        None,
+    )
+    assert first_import is not None
+    assert first_import.module == "__future__"
+    names = [a.name for a in first_import.names]
+    assert "annotations" in names
+
+
+def test_grep_cmd_no_print_statements() -> None:
+    """grep_cmd.py must not use print() — only logging and typer.echo."""
+    src = pathlib.Path(__file__).parent.parent / "maestro" / "muse_cli" / "commands" / "grep_cmd.py"
+    tree = ast.parse(src.read_text())
+    print_calls = [
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "print"
+    ]
+    assert print_calls == [], "grep_cmd.py must not contain print() calls"


### PR DESCRIPTION
## Summary
Closes #124 — adds `muse grep <pattern>` as a new Muse CLI subcommand that searches commit history for a given pattern.

## Root Cause / Motivation
The Muse CLI lacked any search capability over commit history. Musicians needed a way to locate specific musical ideas (e.g., a pentatonic riff, a Cm7 chord, a groove pattern) across the version history of a composition, analogous to `git grep` over source code.

## Solution
Implemented `muse grep <pattern>` as a Typer subcommand following the exact pattern established by `muse log`.

**Current implementation (stub):** Pattern is matched case-insensitively against commit *messages* and *branch names*. Full MIDI content analysis — scanning note sequences, intervals, and chord shapes inside committed snapshots — is documented as future work with clear warnings in the docstring, command help text, and runtime output.

**API-stable flags (accepted, future-wired):**
- `--track TEXT` — restrict to a named track
- `--section TEXT` — restrict to a labelled section
- `--transposition-invariant` (default on) — match regardless of key
- `--rhythm-invariant` — match regardless of timing

**Output modes:**
- Default: human-readable summary (commit ID, branch, date, match source, message)
- `--commits`: one commit ID per line (`git grep --name-only` equivalent)
- `--json`: machine-readable JSON array

### Files changed
- `maestro/muse_cli/commands/grep_cmd.py` — new command module (stub implementation + full CLI contract)
- `maestro/muse_cli/app.py` — registers `grep_cmd` as the `"grep"` sub-app
- `tests/test_muse_grep.py` — 18 tests covering unit, async integration, output rendering, and AST boundary seal

## Layers Affected
- [x] Muse VCS (CLI layer only — no schema changes, no new DB tables)

## Verification
- [x] `mypy` clean — 443 source files, no issues
- [x] All 18 tests pass
- [x] No new DB migrations (no schema changes)
- [x] Docs note: `muse_vcs.md` already mentions grep as a planned command; the stub implementation satisfies the CLI contract. Full MIDI analysis will be tracked in a follow-up issue.

## Tests Added
- `test_match_commit_finds_pattern_in_message` — core matching logic
- `test_match_commit_case_insensitive` — case folding
- `test_match_commit_finds_pattern_in_branch` — branch name matching
- `test_match_commit_no_match_returns_none` — no false positives
- `test_match_commit_message_takes_priority_over_branch` — priority order
- `test_load_all_commits_walks_chain` — async DB chain walk (integration)
- `test_grep_async_matches_message` — end-to-end async match (integration)
- `test_grep_async_no_matches` — empty result path
- `test_grep_async_empty_history` — graceful no-commits handling
- `test_grep_async_multiple_matches_across_chain` — multi-match chain
- `test_render_matches_json_output` — JSON serialisation
- `test_render_matches_commits_flag` — `--commits` output
- `test_render_matches_default_human_output` — human-readable output
- `test_render_matches_no_matches_message` — no-match user feedback
- `test_render_matches_json_empty_list` — empty JSON array
- `test_grep_match_asdict_roundtrip` — GrepMatch dataclass integrity
- `test_grep_cmd_module_has_future_annotations` — AST boundary seal
- `test_grep_cmd_no_print_statements` — no print() usage

## Handoff
N/A — no SSE/MCP protocol change. This is a CLI-only addition.