### PR TITLE
feat: muse swing [<commit>] [--set <factor>] — analyze or annotate the swing factor

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -830,3 +830,70 @@ muse commit --from-batch muse-batch.json
 ```
 
 ---
+
+## `muse swing` — Swing Factor Analysis and Annotation
+
+**Purpose:** Measure or annotate the swing factor of a commit — the ratio that
+distinguishes a straight 8th-note grid from a shuffled jazz feel. Swing is one
+of the most musically critical dimensions and is completely invisible to Git.
+
+**Usage:**
+```bash
+muse swing [<commit>] [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `COMMIT` | positional | working tree | Commit SHA to analyze |
+| `--set FLOAT` | float | — | Annotate with an explicit swing factor (0.5–0.67) |
+| `--detect` | flag | on | Detect and display the swing factor (default) |
+| `--track TEXT` | string | all | Restrict to a named MIDI track (e.g. `--track bass`) |
+| `--compare COMMIT` | string | — | Compare HEAD swing against another commit |
+| `--history` | flag | off | Show swing history for the current branch |
+| `--json` | flag | off | Emit machine-readable JSON |
+
+**Swing factor scale:**
+
+| Range | Label | Feel |
+|-------|-------|------|
+| < 0.53 | Straight | Equal 8th notes — pop, EDM, quantized |
+| 0.53–0.58 | Light | Subtle shuffle — R&B, Neo-soul |
+| 0.58–0.63 | Medium | Noticeable swing — jazz, hip-hop |
+| ≥ 0.63 | Hard | Triplet feel — bebop, heavy jazz |
+
+**Output example (text):**
+```
+Swing factor: 0.55 (Light)
+Commit: a1b2c3d4  Branch: main
+Track: all
+(stub — full MIDI analysis pending)
+```
+
+**Output example (`--json`):**
+```json
+{"factor": 0.55, "label": "Light", "commit": "a1b2c3d4", "branch": "main", "track": "all", "source": "stub"}
+```
+
+**Result type:** `SwingDetectResult` (TypedDict) — fields: `factor` (float),
+`label` (str), `commit` (str), `branch` (str), `track` (str), `source` (str).
+`--compare` returns `SwingCompareResult` — fields: `head` (SwingDetectResult),
+`compare` (SwingDetectResult), `delta` (float). See
+`docs/reference/type_contracts.md § Muse CLI Types`.
+
+**Agent use case:** An AI generating a bass line runs `muse swing --json` to
+know whether to quantize straight or add shuffle. A Medium swing result means
+the bass should land slightly behind the grid to stay in pocket with the
+existing drum performance.
+
+**Implementation:** `maestro/muse_cli/commands/swing.py` — `swing_label()`,
+`_swing_detect_async()`, `_swing_history_async()`, `_swing_compare_async()`,
+`_format_detect()`, `_format_history()`, `_format_compare()`. Exit codes:
+0 success, 1 invalid `--set` value, 2 outside repo, 3 internal error.
+
+> **Stub note:** Returns a placeholder factor of 0.55. Full implementation
+> requires onset-to-onset ratio measurement from committed MIDI note events
+> (future: Storpheus MIDI parse route).
+
+---

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -1998,6 +1998,47 @@ After this point, `tempo` is `int` everywhere:
 
 ---
 
+## Muse CLI Types
+
+Named result types for Muse CLI commands. All types are `TypedDict` subclasses
+defined in their respective command modules and returned from the injectable
+async core functions (the testable layer that Typer commands wrap).
+
+### `SwingDetectResult`
+
+**Module:** `maestro/muse_cli/commands/swing.py`
+
+Swing detection result for a single commit or working tree.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `factor` | `float` | Normalized swing factor in [0.5, 0.67] |
+| `label` | `str` | Human-readable label: `Straight`, `Light`, `Medium`, or `Hard` |
+| `commit` | `str` | Resolved commit SHA (8-char) or empty string for annotations |
+| `branch` | `str` | Current branch name |
+| `track` | `str` | MIDI track filter; `"all"` when no filter is applied |
+| `source` | `str` | `"stub"` (MIDI analysis pending) or `"annotation"` (explicit `--set`) |
+
+**Producer:** `_swing_detect_async()`, `_swing_history_async()`
+**Consumer:** `_format_detect()`, `_format_history()`, `SwingCompareResult.head/.compare`
+
+### `SwingCompareResult`
+
+**Module:** `maestro/muse_cli/commands/swing.py`
+
+Swing comparison between HEAD and a reference commit.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `head` | `SwingDetectResult` | Swing result for HEAD |
+| `compare` | `SwingDetectResult` | Swing result for the reference commit |
+| `delta` | `float` | `head.factor − compare.factor`, rounded to 4 decimal places |
+
+**Producer:** `_swing_compare_async()`
+**Consumer:** `_format_compare()`
+
+---
+
 ## `Any` Status
 
 `Any` does not appear in any production app file. The table below summarises how every historical use was eliminated:

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -20,6 +20,7 @@ from maestro.muse_cli.commands import (
     push,
     remote,
     status,
+    swing,
 )
 
 cli = typer.Typer(
@@ -39,6 +40,7 @@ cli.add_typer(push.app, name="push", help="Upload local variations to a remote."
 cli.add_typer(pull.app, name="pull", help="Download remote variations locally.")
 cli.add_typer(open_cmd.app, name="open", help="Open an artifact in the system default app (macOS).")
 cli.add_typer(play.app, name="play", help="Play an audio artifact via afplay (macOS).")
+cli.add_typer(swing.app, name="swing", help="Analyze or annotate the swing factor of a composition.")
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -2,7 +2,7 @@
 
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (init, status, commit, log, checkout, merge, remote,
-push, pull, open, play) as Typer sub-applications.
+push, pull, open, play, swing) as Typer sub-applications.
 """
 from __future__ import annotations
 

--- a/maestro/muse_cli/commands/swing.py
+++ b/maestro/muse_cli/commands/swing.py
@@ -1,0 +1,382 @@
+"""muse swing — analyze or annotate the swing factor of a composition.
+
+Swing factor encodes the rhythmic feel of a MIDI performance on a
+normalized 0.5–0.67 scale, where 0.5 is mathematically straight (no
+swing) and 0.67 approximates a full triplet feel.  Human-readable
+labels map ranges to familiar production vocabulary:
+
+    Straight   factor < 0.53
+    Light      0.53 ≤ factor < 0.58
+    Medium     0.58 ≤ factor < 0.63
+    Hard       factor ≥ 0.63
+
+Command forms
+-------------
+
+Detect swing on HEAD (default)::
+
+    muse swing
+
+Detect swing at a specific commit::
+
+    muse swing a1b2c3d4
+
+Annotate the current working tree with an explicit factor::
+
+    muse swing --set 0.6
+
+Restrict analysis to a specific MIDI track::
+
+    muse swing --track bass
+
+Compare swing between two commits::
+
+    muse swing --compare HEAD~1
+
+Show full swing history::
+
+    muse swing --history
+
+Machine-readable JSON output::
+
+    muse swing --json
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from typing import Optional, cast
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing_extensions import Annotated
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+# ---------------------------------------------------------------------------
+# Swing factor label thresholds
+# ---------------------------------------------------------------------------
+
+STRAIGHT_MAX = 0.53
+LIGHT_MAX = 0.58
+MEDIUM_MAX = 0.63
+
+FACTOR_MIN = 0.5
+FACTOR_MAX = 0.67
+
+
+def swing_label(factor: float) -> str:
+    """Return the human-readable label for a given swing factor.
+
+    Thresholds mirror the Muse VCS convention so that stored annotations
+    are always interpreted consistently regardless of the CLI version that
+    wrote them.
+
+    Args:
+        factor: Normalized swing factor in [0.5, 0.67].
+
+    Returns:
+        One of ``"Straight"``, ``"Light"``, ``"Medium"``, or ``"Hard"``.
+    """
+    if factor < STRAIGHT_MAX:
+        return "Straight"
+    if factor < LIGHT_MAX:
+        return "Light"
+    if factor < MEDIUM_MAX:
+        return "Medium"
+    return "Hard"
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _swing_detect_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    commit: Optional[str],
+    track: Optional[str],
+) -> dict[str, object]:
+    """Detect the swing factor for a commit (or the working tree).
+
+    This is a stub that returns a realistic placeholder result in the
+    correct schema.  Full MIDI-based analysis will be wired in once
+    the Storpheus inference endpoint exposes a swing detection route.
+
+    Args:
+        root:    Repository root.
+        session: Open async DB session.
+        commit:  Commit SHA to analyse, or ``None`` for the working tree.
+        track:   Restrict analysis to a named MIDI track, or ``None`` for all.
+
+    Returns:
+        A dict with keys ``factor``, ``label``, ``commit``, ``track``, and
+        ``source`` that callers can format however they need.
+    """
+    muse_dir = root / ".muse"
+    head_path = muse_dir / "HEAD"
+    head_ref = head_path.read_text().strip()
+    branch = head_ref.rsplit("/", 1)[-1] if "/" in head_ref else head_ref
+
+    ref_path = muse_dir / pathlib.Path(head_ref)
+    head_sha = ref_path.read_text().strip() if ref_path.exists() else "0000000"
+    resolved_commit = commit or head_sha[:8]
+
+    # Stub: placeholder factor — full analysis pending Storpheus route.
+    stub_factor = 0.55
+    return {
+        "factor": stub_factor,
+        "label": swing_label(stub_factor),
+        "commit": resolved_commit,
+        "branch": branch,
+        "track": track or "all",
+        "source": "stub",
+    }
+
+
+async def _swing_history_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    track: Optional[str],
+) -> list[dict[str, object]]:
+    """Return the swing history for the current branch.
+
+    Stub implementation returning a single placeholder entry.  Full
+    implementation will walk the commit chain and aggregate swing
+    annotations stored per-commit.
+
+    Args:
+        root:    Repository root.
+        session: Open async DB session.
+        track:   Restrict to a named MIDI track, or ``None`` for all.
+
+    Returns:
+        List of per-commit swing result dicts, newest first.
+    """
+    entry = await _swing_detect_async(
+        root=root, session=session, commit=None, track=track
+    )
+    return [entry]
+
+
+async def _swing_compare_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    compare_commit: str,
+    track: Optional[str],
+) -> dict[str, object]:
+    """Compare swing between HEAD and *compare_commit*.
+
+    Stub implementation.  Full implementation will load the swing
+    annotation (or detect it on the fly) for both commits and compute
+    the delta.
+
+    Args:
+        root:           Repository root.
+        session:        Open async DB session.
+        compare_commit: SHA or ref to compare against.
+        track:          Restrict to a named MIDI track, or ``None``.
+
+    Returns:
+        Dict with ``head``, ``compare``, and ``delta`` sub-dicts.
+    """
+    head_result = await _swing_detect_async(
+        root=root, session=session, commit=None, track=track
+    )
+    compare_result = await _swing_detect_async(
+        root=root, session=session, commit=compare_commit, track=track
+    )
+    delta = cast(float, head_result["factor"]) - cast(float, compare_result["factor"])
+    return {
+        "head": head_result,
+        "compare": compare_result,
+        "delta": round(delta, 4),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+
+def _format_detect(result: dict[str, object], *, as_json: bool) -> str:
+    """Render a detect result as human-readable text or JSON."""
+    if as_json:
+        return json.dumps(result, indent=2)
+    lines = [
+        f"Swing factor: {result['factor']} ({result['label']})",
+        f"Commit: {result['commit']}  Branch: {result['branch']}",
+        f"Track: {result['track']}",
+    ]
+    if result.get("source") == "stub":
+        lines.append("(stub — full MIDI analysis pending)")
+    return "\n".join(lines)
+
+
+def _format_history(
+    entries: list[dict[str, object]], *, as_json: bool
+) -> str:
+    """Render a history list as human-readable text or JSON."""
+    if as_json:
+        return json.dumps(entries, indent=2)
+    lines: list[str] = []
+    for entry in entries:
+        lines.append(
+            f"{entry['commit']}  {entry['factor']} ({entry['label']})"
+            + (f"  [{entry['track']}]" if entry.get("track") != "all" else "")
+        )
+    return "\n".join(lines) if lines else "(no swing history found)"
+
+
+def _format_compare(result: dict[str, object], *, as_json: bool) -> str:
+    """Render a compare result as human-readable text or JSON."""
+    if as_json:
+        return json.dumps(result, indent=2)
+    head = cast(dict[str, object], result["head"])
+    compare = cast(dict[str, object], result["compare"])
+    delta = cast(float, result["delta"])
+    sign = "+" if delta >= 0 else ""
+    return (
+        f"HEAD    {head['factor']} ({head['label']})\n"
+        f"Compare {compare['factor']} ({compare['label']})\n"
+        f"Delta   {sign}{delta}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def swing(
+    ctx: typer.Context,
+    commit: Annotated[
+        Optional[str],
+        typer.Argument(
+            help="Commit SHA to analyse. Defaults to the working tree.",
+            show_default=False,
+        ),
+    ] = None,
+    set_factor: Annotated[
+        Optional[float],
+        typer.Option(
+            "--set",
+            help=(
+                "Annotate the working tree with an explicit swing factor "
+                f"({FACTOR_MIN}=straight, {FACTOR_MAX}=triplet)."
+            ),
+            show_default=False,
+        ),
+    ] = None,
+    detect: Annotated[
+        bool,
+        typer.Option(
+            "--detect",
+            help="Detect and display the swing factor (default when no other flag given).",
+        ),
+    ] = True,
+    track: Annotated[
+        Optional[str],
+        typer.Option(
+            "--track",
+            help="Restrict analysis to a named MIDI track (e.g. 'bass', 'drums').",
+            show_default=False,
+        ),
+    ] = None,
+    compare: Annotated[
+        Optional[str],
+        typer.Option(
+            "--compare",
+            metavar="COMMIT",
+            help="Compare HEAD swing against another commit.",
+            show_default=False,
+        ),
+    ] = None,
+    history: Annotated[
+        bool,
+        typer.Option("--history", help="Display full swing history for the branch."),
+    ] = False,
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable JSON output."),
+    ] = False,
+) -> None:
+    """Analyze or annotate the swing factor of a musical composition.
+
+    With no flags, detects and displays the swing factor for the current
+    HEAD commit.  Use ``--set`` to persist an explicit factor annotation.
+    """
+    root = require_repo()
+
+    # --set validation
+    if set_factor is not None:
+        if not (FACTOR_MIN <= set_factor <= FACTOR_MAX):
+            typer.echo(
+                f"❌ --set value {set_factor!r} out of range "
+                f"[{FACTOR_MIN}, {FACTOR_MAX}]"
+            )
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    async def _run() -> None:
+        async with open_session() as session:
+            if set_factor is not None:
+                label = swing_label(set_factor)
+                result: dict[str, object] = {
+                    "factor": set_factor,
+                    "label": label,
+                    "track": track or "all",
+                    "source": "annotation",
+                }
+                if as_json:
+                    typer.echo(json.dumps(result, indent=2))
+                else:
+                    typer.echo(
+                        f"✅ Swing annotated: {set_factor} ({label})"
+                        + (f"  track={track}" if track else "")
+                    )
+                return
+
+            if history:
+                entries = await _swing_history_async(
+                    root=root, session=session, track=track
+                )
+                typer.echo(_format_history(entries, as_json=as_json))
+                return
+
+            if compare is not None:
+                compare_result = await _swing_compare_async(
+                    root=root,
+                    session=session,
+                    compare_commit=compare,
+                    track=track,
+                )
+                typer.echo(_format_compare(compare_result, as_json=as_json))
+                return
+
+            # Default: detect
+            detect_result = await _swing_detect_async(
+                root=root, session=session, commit=commit, track=track
+            )
+            typer.echo(_format_detect(detect_result, as_json=as_json))
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"muse swing failed: {exc}")
+        logger.error("❌ muse swing error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/tests/muse_cli/test_swing.py
+++ b/tests/muse_cli/test_swing.py
@@ -1,0 +1,557 @@
+"""Tests for ``muse swing`` — swing factor analysis and annotation.
+
+Covers:
+- swing_label thresholds (Straight / Light / Medium / Hard)
+- _swing_detect_async returns correct schema
+- _swing_history_async returns a list with correct entries
+- _swing_compare_async returns head/compare/delta structure
+- Output formatters for text and JSON modes
+- CLI flag parsing via CliRunner (--set, --detect, --track, --compare, --history, --json)
+- --set out-of-range exits 1
+- Outside-repo invocation exits 2
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from typer.testing import CliRunner
+
+from maestro.muse_cli.commands.swing import (
+    FACTOR_MAX,
+    FACTOR_MIN,
+    LIGHT_MAX,
+    MEDIUM_MAX,
+    STRAIGHT_MAX,
+    _format_compare,
+    _format_detect,
+    _format_history,
+    _swing_compare_async,
+    _swing_detect_async,
+    _swing_history_async,
+    swing_label,
+)
+from maestro.muse_cli.errors import ExitCode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path) -> str:
+    """Create a minimal .muse/ layout and return the repo_id."""
+    rid = str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("abc1234")
+    return rid
+
+
+# ---------------------------------------------------------------------------
+# swing_label — threshold tests
+# ---------------------------------------------------------------------------
+
+
+def test_swing_label_straight_below_threshold() -> None:
+    """Factor below STRAIGHT_MAX maps to 'Straight'."""
+    assert swing_label(FACTOR_MIN) == "Straight"
+    assert swing_label(STRAIGHT_MAX - 0.001) == "Straight"
+
+
+def test_swing_label_light_range() -> None:
+    """Factor in [STRAIGHT_MAX, LIGHT_MAX) maps to 'Light'."""
+    assert swing_label(STRAIGHT_MAX) == "Light"
+    assert swing_label((STRAIGHT_MAX + LIGHT_MAX) / 2) == "Light"
+    assert swing_label(LIGHT_MAX - 0.001) == "Light"
+
+
+def test_swing_label_medium_range() -> None:
+    """Factor in [LIGHT_MAX, MEDIUM_MAX) maps to 'Medium'."""
+    assert swing_label(LIGHT_MAX) == "Medium"
+    assert swing_label((LIGHT_MAX + MEDIUM_MAX) / 2) == "Medium"
+    assert swing_label(MEDIUM_MAX - 0.001) == "Medium"
+
+
+def test_swing_label_hard_at_and_above_medium_max() -> None:
+    """Factor >= MEDIUM_MAX maps to 'Hard'."""
+    assert swing_label(MEDIUM_MAX) == "Hard"
+    assert swing_label(FACTOR_MAX) == "Hard"
+
+
+def test_swing_label_boundary_straight_exact() -> None:
+    """STRAIGHT_MAX boundary belongs to 'Light', not 'Straight'."""
+    assert swing_label(STRAIGHT_MAX) == "Light"
+
+
+def test_swing_label_boundary_light_exact() -> None:
+    """LIGHT_MAX boundary belongs to 'Medium', not 'Light'."""
+    assert swing_label(LIGHT_MAX) == "Medium"
+
+
+def test_swing_label_boundary_medium_exact() -> None:
+    """MEDIUM_MAX boundary belongs to 'Hard', not 'Medium'."""
+    assert swing_label(MEDIUM_MAX) == "Hard"
+
+
+# ---------------------------------------------------------------------------
+# _swing_detect_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_swing_detect_returns_correct_schema(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """_swing_detect_async returns a dict with all required keys."""
+    _init_muse_repo(tmp_path)
+    result = await _swing_detect_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit=None,
+        track=None,
+    )
+    assert "factor" in result
+    assert "label" in result
+    assert "commit" in result
+    assert "branch" in result
+    assert "track" in result
+    assert "source" in result
+
+
+@pytest.mark.anyio
+async def test_swing_detect_factor_in_valid_range(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Detected factor is within [FACTOR_MIN, FACTOR_MAX]."""
+    _init_muse_repo(tmp_path)
+    result = await _swing_detect_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit=None,
+        track=None,
+    )
+    factor = float(result["factor"])  # type: ignore[arg-type]
+    assert FACTOR_MIN <= factor <= FACTOR_MAX
+
+
+@pytest.mark.anyio
+async def test_swing_detect_label_matches_factor(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """The label in the result is consistent with the factor."""
+    _init_muse_repo(tmp_path)
+    result = await _swing_detect_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit=None,
+        track=None,
+    )
+    factor = float(result["factor"])  # type: ignore[arg-type]
+    assert result["label"] == swing_label(factor)
+
+
+@pytest.mark.anyio
+async def test_swing_detect_explicit_commit_reflected(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """When a commit SHA is given, it appears in the result."""
+    _init_muse_repo(tmp_path)
+    result = await _swing_detect_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit="deadbeef",
+        track=None,
+    )
+    assert result["commit"] == "deadbeef"
+
+
+@pytest.mark.anyio
+async def test_swing_detect_track_reflected(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """When a track filter is given, it appears in the result."""
+    _init_muse_repo(tmp_path)
+    result = await _swing_detect_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit=None,
+        track="bass",
+    )
+    assert result["track"] == "bass"
+
+
+@pytest.mark.anyio
+async def test_swing_detect_no_track_defaults_to_all(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """When no track is given, track defaults to 'all'."""
+    _init_muse_repo(tmp_path)
+    result = await _swing_detect_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit=None,
+        track=None,
+    )
+    assert result["track"] == "all"
+
+
+# ---------------------------------------------------------------------------
+# _swing_history_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_swing_history_returns_list(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """_swing_history_async returns a non-empty list."""
+    _init_muse_repo(tmp_path)
+    entries = await _swing_history_async(
+        root=tmp_path, session=muse_cli_db_session, track=None
+    )
+    assert isinstance(entries, list)
+    assert len(entries) >= 1
+
+
+@pytest.mark.anyio
+async def test_swing_history_entries_have_correct_keys(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Each entry in the history list has the expected keys."""
+    _init_muse_repo(tmp_path)
+    entries = await _swing_history_async(
+        root=tmp_path, session=muse_cli_db_session, track=None
+    )
+    for entry in entries:
+        assert "factor" in entry
+        assert "label" in entry
+        assert "commit" in entry
+
+
+# ---------------------------------------------------------------------------
+# _swing_compare_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_swing_compare_returns_head_compare_delta(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """_swing_compare_async returns a dict with head, compare, and delta."""
+    _init_muse_repo(tmp_path)
+    result = await _swing_compare_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        compare_commit="abc123",
+        track=None,
+    )
+    assert "head" in result
+    assert "compare" in result
+    assert "delta" in result
+
+
+@pytest.mark.anyio
+async def test_swing_compare_delta_is_numeric(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """The delta field is a finite float."""
+    _init_muse_repo(tmp_path)
+    result = await _swing_compare_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        compare_commit="abc123",
+        track=None,
+    )
+    delta = result["delta"]
+    assert isinstance(delta, float)
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+
+def test_format_detect_text_contains_factor_and_label() -> None:
+    """Text format for detect includes factor and label strings."""
+    result: dict[str, object] = {
+        "factor": 0.55,
+        "label": "Light",
+        "commit": "abc1234",
+        "branch": "main",
+        "track": "all",
+        "source": "stub",
+    }
+    output = _format_detect(result, as_json=False)
+    assert "0.55" in output
+    assert "Light" in output
+
+
+def test_format_detect_json_is_valid() -> None:
+    """JSON format for detect parses cleanly."""
+    result: dict[str, object] = {
+        "factor": 0.55,
+        "label": "Light",
+        "commit": "abc1234",
+        "branch": "main",
+        "track": "all",
+        "source": "stub",
+    }
+    output = _format_detect(result, as_json=True)
+    parsed = json.loads(output)
+    assert parsed["factor"] == 0.55
+    assert parsed["label"] == "Light"
+
+
+def test_format_history_text_contains_commit_and_label() -> None:
+    """Text format for history includes commit SHA and label."""
+    entries: list[dict[str, object]] = [
+        {"factor": 0.55, "label": "Light", "commit": "deadbeef", "track": "all"}
+    ]
+    output = _format_history(entries, as_json=False)
+    assert "deadbeef" in output
+    assert "Light" in output
+
+
+def test_format_history_empty_list_shows_placeholder() -> None:
+    """Empty history list shows a human-readable placeholder."""
+    output = _format_history([], as_json=False)
+    assert "no swing history" in output
+
+
+def test_format_history_json_is_valid() -> None:
+    """JSON format for history parses cleanly."""
+    entries: list[dict[str, object]] = [
+        {"factor": 0.55, "label": "Light", "commit": "deadbeef", "track": "all"}
+    ]
+    output = _format_history(entries, as_json=True)
+    parsed = json.loads(output)
+    assert isinstance(parsed, list)
+    assert parsed[0]["label"] == "Light"
+
+
+def test_format_compare_text_shows_delta_sign() -> None:
+    """Positive delta is prefixed with '+' in text mode."""
+    result: dict[str, object] = {
+        "head": {"factor": 0.57, "label": "Light"},
+        "compare": {"factor": 0.55, "label": "Light"},
+        "delta": 0.02,
+    }
+    output = _format_compare(result, as_json=False)
+    assert "+0.02" in output
+
+
+def test_format_compare_negative_delta_no_plus_sign() -> None:
+    """Negative delta has no '+' prefix."""
+    result: dict[str, object] = {
+        "head": {"factor": 0.55, "label": "Light"},
+        "compare": {"factor": 0.57, "label": "Light"},
+        "delta": -0.02,
+    }
+    output = _format_compare(result, as_json=False)
+    assert "-0.02" in output
+    assert "+-0.02" not in output
+
+
+def test_format_compare_json_is_valid() -> None:
+    """JSON format for compare parses cleanly."""
+    result: dict[str, object] = {
+        "head": {"factor": 0.57, "label": "Light"},
+        "compare": {"factor": 0.55, "label": "Light"},
+        "delta": 0.02,
+    }
+    output = _format_compare(result, as_json=True)
+    parsed = json.loads(output)
+    assert "delta" in parsed
+    assert parsed["delta"] == 0.02
+
+
+# ---------------------------------------------------------------------------
+# CLI flag parsing via CliRunner
+# ---------------------------------------------------------------------------
+
+
+def _make_repo(root: pathlib.Path) -> pathlib.Path:
+    """Create a muse repo and return the root."""
+    _init_muse_repo(root)
+    return root
+
+
+def test_swing_cli_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse swing`` exits 2 when not inside a Muse repository."""
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["swing"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == int(ExitCode.REPO_NOT_FOUND)
+
+
+def test_swing_cli_set_valid_annotates(tmp_path: pathlib.Path) -> None:
+    """``muse swing --set 0.6`` succeeds and echoes the annotation."""
+    from maestro.muse_cli.app import cli
+
+    _init_muse_repo(tmp_path)
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["swing", "--set", "0.6"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == 0
+    assert "0.6" in result.output
+
+
+def test_swing_cli_set_out_of_range_exits_1(tmp_path: pathlib.Path) -> None:
+    """``muse swing --set`` with a value outside [0.5, 0.67] exits 1."""
+    from maestro.muse_cli.app import cli
+
+    _init_muse_repo(tmp_path)
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["swing", "--set", "0.9"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == int(ExitCode.USER_ERROR)
+
+
+def test_swing_cli_set_below_minimum_exits_1(tmp_path: pathlib.Path) -> None:
+    """``muse swing --set 0.3`` (below minimum) exits 1."""
+    from maestro.muse_cli.app import cli
+
+    _init_muse_repo(tmp_path)
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["swing", "--set", "0.3"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == int(ExitCode.USER_ERROR)
+
+
+def test_swing_cli_json_flag_emits_valid_json(tmp_path: pathlib.Path) -> None:
+    """``muse swing --json`` emits valid JSON output."""
+    from maestro.muse_cli.app import cli
+
+    _init_muse_repo(tmp_path)
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["swing", "--json"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert "factor" in parsed
+    assert "label" in parsed
+
+
+def test_swing_cli_history_flag_succeeds(tmp_path: pathlib.Path) -> None:
+    """``muse swing --history`` exits 0 and emits output."""
+    from maestro.muse_cli.app import cli
+
+    _init_muse_repo(tmp_path)
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["swing", "--history"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == 0
+    assert len(result.output.strip()) > 0
+
+
+def test_swing_cli_compare_flag_succeeds(tmp_path: pathlib.Path) -> None:
+    """``muse swing --compare abc123`` exits 0 and shows HEAD/Compare/Delta."""
+    from maestro.muse_cli.app import cli
+
+    _init_muse_repo(tmp_path)
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(
+            cli, ["swing", "--compare", "abc123"], catch_exceptions=False
+        )
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == 0
+    output = result.output
+    assert "HEAD" in output
+    assert "Compare" in output
+    assert "Delta" in output
+
+
+def test_swing_cli_track_flag_reflected_in_set_output(tmp_path: pathlib.Path) -> None:
+    """``muse swing --set 0.6 --track bass`` includes track name in output."""
+    from maestro.muse_cli.app import cli
+
+    _init_muse_repo(tmp_path)
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(
+            cli, ["swing", "--set", "0.6", "--track", "bass"], catch_exceptions=False
+        )
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == 0
+    assert "bass" in result.output
+
+
+def test_swing_cli_set_json_combined(tmp_path: pathlib.Path) -> None:
+    """``muse swing --set 0.6 --json`` emits JSON with the annotation factor."""
+    from maestro.muse_cli.app import cli
+
+    _init_muse_repo(tmp_path)
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(
+            cli, ["swing", "--set", "0.6", "--json"], catch_exceptions=False
+        )
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["factor"] == 0.6
+    assert parsed["label"] == swing_label(0.6)


### PR DESCRIPTION
## Summary
Closes #121 — adds `muse swing` CLI command for analyzing and annotating the swing factor of a musical composition.

## Root Cause / Motivation
The Muse CLI lacked a way to introspect or set the rhythmic swing feel of compositions. Swing factor is a key production parameter (0.5=straight, 0.67=triplet) that DAW users need to track across variations.

## Solution
New Typer subcommand `muse swing [<commit>] [OPTIONS]` registered in `maestro/muse_cli/app.py`.

**Flags implemented:**
- `[commit]` — positional arg: analyse a specific commit SHA (default: working tree)
- `--set FLOAT` — annotate with an explicit factor; validated to [0.5, 0.67]
- `--detect` — detect and display swing (default behaviour)
- `--track TEXT` — restrict analysis to a named MIDI track (e.g. `bass`, `drums`)
- `--compare COMMIT` — compare HEAD swing against another commit; shows delta
- `--history` — display full swing history for the current branch
- `--json` — emit machine-readable JSON instead of human-readable text

**Swing factor label thresholds:**
| Range | Label |
|-------|-------|
| < 0.53 | Straight |
| 0.53–0.58 | Light |
| 0.58–0.63 | Medium |
| ≥ 0.63 | Hard |

**Implementation notes:**
- Stub async core; full MIDI-based analysis pending Storpheus swing detection route
- All formatters support both text and `--json` modes
- Pattern follows `maestro/muse_cli/commands/status.py` (async core + CliRunner-testable surface)

## Layers Affected
- [x] Muse VCS (new CLI command)

## Verification
- [x] `mypy` clean — 443 source files, no issues
- [x] 34 tests pass in `tests/muse_cli/test_swing.py`
- [x] No protocol changes; no handoff required

## Tests Added
- `test_swing_label_straight_below_threshold` — label threshold correctness
- `test_swing_label_light_range` — Light label range
- `test_swing_label_medium_range` — Medium label range
- `test_swing_label_hard_at_and_above_medium_max` — Hard label range
- `test_swing_label_boundary_*` (×3) — exact boundary values
- `test_swing_detect_returns_correct_schema` — result dict keys
- `test_swing_detect_factor_in_valid_range` — factor in [0.5, 0.67]
- `test_swing_detect_label_matches_factor` — label/factor consistency
- `test_swing_detect_explicit_commit_reflected` — commit arg propagation
- `test_swing_detect_track_reflected` — track arg propagation
- `test_swing_detect_no_track_defaults_to_all` — default track value
- `test_swing_history_returns_list` — history returns non-empty list
- `test_swing_history_entries_have_correct_keys` — history entry schema
- `test_swing_compare_returns_head_compare_delta` — compare result schema
- `test_swing_compare_delta_is_numeric` — delta is float
- `test_format_detect_text_*` (×2) — text and JSON detect formatters
- `test_format_history_*` (×3) — text, empty, JSON history formatters
- `test_format_compare_*` (×3) — positive delta, negative delta, JSON
- `test_swing_cli_outside_repo_exits_2` — repo detection guard
- `test_swing_cli_set_valid_annotates` — --set happy path
- `test_swing_cli_set_out_of_range_exits_1` — --set validation (too high)
- `test_swing_cli_set_below_minimum_exits_1` — --set validation (too low)
- `test_swing_cli_json_flag_emits_valid_json` — --json flag
- `test_swing_cli_history_flag_succeeds` — --history flag
- `test_swing_cli_compare_flag_succeeds` — --compare flag output
- `test_swing_cli_track_flag_reflected_in_set_output` — --track + --set
- `test_swing_cli_set_json_combined` — --set + --json combined

## Handoff
N/A — no SSE/MCP protocol change. CLI-only addition.