### PR TITLE
feat: `muse ask "<question>"` — natural language query over Muse musical history

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -2061,6 +2061,24 @@ Swing comparison between HEAD and a reference commit.
 **Producer:** `_swing_compare_async()`
 **Consumer:** `_format_compare()`
 
+### `AnswerResult`
+
+**Module:** `maestro/muse_cli/commands/ask.py`
+
+Structured result from a `muse ask` query. Carries the matched commits and
+rendering context; rendering is deferred to `to_plain()` / `to_json()` so the
+core logic is testable without touching I/O.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `question` | `str` | Original natural-language question as typed by the user |
+| `total_searched` | `int` | Total number of commits examined (after branch / date filters) |
+| `matches` | `list[MuseCliCommit]` | Commits whose messages contain at least one extracted keyword |
+| `cite` | `bool` | When `True`, full 64-char commit IDs are used; otherwise 8-char prefixes |
+
+**Producer:** `_ask_async()`
+**Consumer:** `ask()` Typer command via `to_plain()` / `to_json()`
+
 ---
 
 ## `Any` Status

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -2,13 +2,14 @@
 
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (init, status, commit, log, checkout, merge, remote,
-push, pull, open, play) as Typer sub-applications.
+push, pull, open, play, ask) as Typer sub-applications.
 """
 from __future__ import annotations
 
 import typer
 
 from maestro.muse_cli.commands import (
+    ask,
     checkout,
     commit,
     init,
@@ -39,6 +40,7 @@ cli.add_typer(push.app, name="push", help="Upload local variations to a remote."
 cli.add_typer(pull.app, name="pull", help="Download remote variations locally.")
 cli.add_typer(open_cmd.app, name="open", help="Open an artifact in the system default app (macOS).")
 cli.add_typer(play.app, name="play", help="Play an audio artifact via afplay (macOS).")
+cli.add_typer(ask.app, name="ask", help="Query musical history in natural language.")
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/commands/ask.py
+++ b/maestro/muse_cli/commands/ask.py
@@ -1,0 +1,238 @@
+"""muse ask — natural language query over Muse musical history.
+
+Searches commit messages for keywords extracted from the user's question
+and returns matching commits in a structured answer.  This is a stub
+implementation: keyword matching over commit messages.  Full LLM-powered
+answer generation is a planned enhancement.
+
+Usage::
+
+    muse ask "what tempo changes did I make last week?"
+    muse ask "boom bap sessions" --branch feature/hip-hop --cite
+    muse ask "piano intro" --since 2026-01-01 --until 2026-02-01 --json
+
+``--cite`` appends the full commit ID to each matching commit entry.
+``--json`` emits a machine-readable JSON response instead of plain text.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from datetime import date, datetime, timezone
+from typing import Annotated, Optional
+
+import typer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+_MAX_COMMITS = 10_000
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+class AnswerResult:
+    """Structured result returned by ``_ask_async`` for testability."""
+
+    def __init__(
+        self,
+        question: str,
+        total_searched: int,
+        matches: list[MuseCliCommit],
+        cite: bool,
+    ) -> None:
+        self.question = question
+        self.total_searched = total_searched
+        self.matches = matches
+        self.cite = cite
+
+    def to_plain(self) -> str:
+        """Format as human-readable plain text."""
+        lines: list[str] = [
+            f"Based on Muse history ({self.total_searched} commits searched):",
+            f"Commits matching your query: {len(self.matches)} found",
+        ]
+        if self.matches:
+            lines.append("")
+            for commit in self.matches:
+                ts = commit.committed_at.strftime("%Y-%m-%d %H:%M")
+                if self.cite:
+                    lines.append(f"  [{commit.commit_id}] {ts}  {commit.message}")
+                else:
+                    lines.append(f"  [{commit.commit_id[:8]}] {ts}  {commit.message}")
+        else:
+            lines.append("  (no matching commits)")
+        lines.append("")
+        lines.append(
+            "Note: Full LLM-powered answer generation is a planned enhancement."
+        )
+        return "\n".join(lines)
+
+    def to_json(self) -> str:
+        """Format as JSON."""
+        payload: dict[str, object] = {
+            "question": self.question,
+            "total_searched": self.total_searched,
+            "matches": [
+                {
+                    "commit_id": c.commit_id if self.cite else c.commit_id[:8],
+                    "branch": c.branch,
+                    "message": c.message,
+                    "committed_at": c.committed_at.isoformat(),
+                }
+                for c in self.matches
+            ],
+            "note": "Full LLM-powered answer generation is a planned enhancement.",
+        }
+        return json.dumps(payload, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+def _keywords(question: str) -> list[str]:
+    """Extract non-trivial lowercase tokens from the question string.
+
+    Strips punctuation and common stop-words so the keyword match focuses
+    on meaningful terms from the user's question.
+    """
+    stop = {
+        "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+        "have", "has", "had", "do", "does", "did", "will", "would", "could",
+        "should", "may", "might", "shall", "can", "need", "dare", "ought",
+        "i", "my", "me", "we", "our", "you", "your", "he", "she", "it",
+        "they", "their", "them", "what", "when", "where", "who", "which",
+        "how", "why", "in", "on", "at", "to", "of", "for", "and", "or",
+        "but", "not", "with", "from", "by", "about", "into", "through",
+        "did", "make", "made", "last", "any", "all", "that", "this",
+    }
+    import re
+    tokens = re.split(r"[\s\W]+", question.lower())
+    return [t for t in tokens if t and t not in stop and len(t) > 1]
+
+
+async def _ask_async(
+    *,
+    question: str,
+    root: pathlib.Path,
+    session: AsyncSession,
+    branch: str | None,
+    since: date | None,
+    until: date | None,
+    cite: bool,
+) -> AnswerResult:
+    """Core ask logic — fully injectable for tests.
+
+    Loads commits from the DB, applies optional filters (branch, date
+    range), and performs keyword search over commit messages.  Returns
+    an :class:`AnswerResult` that can be rendered as plain text or JSON.
+    """
+    muse_dir = root / ".muse"
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]
+
+    # Determine effective branch filter: explicit flag → HEAD branch → all.
+    effective_branch: str | None = branch
+    if effective_branch is None:
+        head_ref_text = (muse_dir / "HEAD").read_text().strip()
+        effective_branch = head_ref_text.rsplit("/", 1)[-1]
+
+    stmt = (
+        select(MuseCliCommit)
+        .where(MuseCliCommit.repo_id == repo_id)
+        .order_by(MuseCliCommit.committed_at.desc())
+        .limit(_MAX_COMMITS)
+    )
+    if effective_branch:
+        stmt = stmt.where(MuseCliCommit.branch == effective_branch)
+    if since is not None:
+        since_dt = datetime(since.year, since.month, since.day, tzinfo=timezone.utc)
+        stmt = stmt.where(MuseCliCommit.committed_at >= since_dt)
+    if until is not None:
+        # inclusive: treat until as end-of-day
+        until_dt = datetime(
+            until.year, until.month, until.day, 23, 59, 59, tzinfo=timezone.utc
+        )
+        stmt = stmt.where(MuseCliCommit.committed_at <= until_dt)
+
+    result = await session.execute(stmt)
+    all_commits: list[MuseCliCommit] = list(result.scalars().all())
+
+    keywords = _keywords(question)
+    if keywords:
+        matches = [
+            c for c in all_commits
+            if any(kw in c.message.lower() for kw in keywords)
+        ]
+    else:
+        # Empty query → return all commits (the question had no useful tokens).
+        matches = list(all_commits)
+
+    return AnswerResult(
+        question=question,
+        total_searched=len(all_commits),
+        matches=matches,
+        cite=cite,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def ask(
+    ctx: typer.Context,
+    question: Annotated[str, typer.Argument(help="Natural language question about your musical history.")],
+    branch: Annotated[Optional[str], typer.Option("--branch", help="Restrict search to this branch name.")] = None,
+    since: Annotated[Optional[datetime], typer.Option("--since", formats=["%Y-%m-%d"], help="Only include commits on or after this date (YYYY-MM-DD).")] = None,
+    until: Annotated[Optional[datetime], typer.Option("--until", formats=["%Y-%m-%d"], help="Only include commits on or before this date (YYYY-MM-DD).")] = None,
+    output_json: Annotated[bool, typer.Option("--json", help="Emit machine-readable JSON.")] = False,
+    cite: Annotated[bool, typer.Option("--cite", help="Show full commit IDs in the answer.")] = False,
+) -> None:
+    """Query your Muse musical history in natural language."""
+    root = require_repo()
+
+    since_date: date | None = since.date() if since is not None else None
+    until_date: date | None = until.date() if until is not None else None
+
+    async def _run() -> None:
+        async with open_session() as session:
+            result = await _ask_async(
+                question=question,
+                root=root,
+                session=session,
+                branch=branch,
+                since=since_date,
+                until=until_date,
+                cite=cite,
+            )
+            if output_json:
+                typer.echo(result.to_json())
+            else:
+                typer.echo(result.to_plain())
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse ask failed: {exc}")
+        logger.error("❌ muse ask error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/muse_cli/commands/ask.py
+++ b/maestro/muse_cli/commands/ask.py
@@ -20,6 +20,7 @@ import asyncio
 import json
 import logging
 import pathlib
+import re
 from datetime import date, datetime, timezone
 from typing import Annotated, Optional
 
@@ -121,7 +122,6 @@ def _keywords(question: str) -> list[str]:
         "but", "not", "with", "from", "by", "about", "into", "through",
         "did", "make", "made", "last", "any", "all", "that", "this",
     }
-    import re
     tokens = re.split(r"[\s\W]+", question.lower())
     return [t for t in tokens if t and t not in stop and len(t) > 1]
 

--- a/tests/muse_cli/test_ask.py
+++ b/tests/muse_cli/test_ask.py
@@ -1,0 +1,451 @@
+"""Tests for ``muse ask``.
+
+All async tests call ``_ask_async`` directly with an in-memory SQLite
+session and a ``tmp_path`` repo root — no real Postgres or running
+process required.  Commits are seeded via ``_commit_async`` so the
+commands are tested as an integrated pair.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import uuid
+from datetime import date, datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.commands.ask import AnswerResult, _ask_async, _keywords
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.errors import ExitCode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _write_workdir(root: pathlib.Path, files: dict[str, bytes]) -> None:
+    workdir = root / "muse-work"
+    workdir.mkdir(exist_ok=True)
+    for name, content in files.items():
+        (workdir / name).write_bytes(content)
+
+
+async def _make_commits(
+    root: pathlib.Path,
+    session: AsyncSession,
+    messages: list[str],
+    file_seed: int = 0,
+) -> list[str]:
+    """Create N commits on the repo, each with unique file content."""
+    commit_ids: list[str] = []
+    for i, msg in enumerate(messages):
+        _write_workdir(root, {f"track_{file_seed + i}.mid": f"MIDI-{file_seed + i}".encode()})
+        cid = await _commit_async(message=msg, root=root, session=session)
+        commit_ids.append(cid)
+    return commit_ids
+
+
+# ---------------------------------------------------------------------------
+# _keywords unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_keywords_extracts_meaningful_tokens() -> None:
+    """Non-trivial keywords are extracted from a natural language question."""
+    tokens = _keywords("what tempo changes did I make last week?")
+    assert "tempo" in tokens
+    assert "changes" in tokens
+    # stop words removed
+    assert "what" not in tokens
+    assert "did" not in tokens
+    assert "last" not in tokens
+
+
+def test_keywords_empty_string_returns_empty() -> None:
+    """Empty input yields no keywords."""
+    assert _keywords("") == []
+
+
+def test_keywords_all_stopwords_returns_empty() -> None:
+    """A question made entirely of stop-words yields no keywords."""
+    result = _keywords("what is the")
+    assert result == []
+
+
+def test_keywords_deduplicates_not_applied_but_all_present() -> None:
+    """Keywords preserves order and includes each meaningful token."""
+    tokens = _keywords("boom bap groove boom")
+    assert "boom" in tokens
+    assert "bap" in tokens
+    assert "groove" in tokens
+
+
+# ---------------------------------------------------------------------------
+# _ask_async — basic matching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ask_matches_keyword_in_commit_message(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``muse ask`` returns commits whose messages contain the keyword."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(
+        tmp_path,
+        muse_cli_db_session,
+        ["boom bap take 1", "jazz piano intro", "boom bap take 2"],
+    )
+
+    result = await _ask_async(
+        question="boom bap",
+        root=tmp_path,
+        session=muse_cli_db_session,
+        branch=None,
+        since=None,
+        until=None,
+        cite=False,
+    )
+
+    assert result.total_searched == 3
+    assert len(result.matches) == 2
+    messages = [c.message for c in result.matches]
+    assert all("boom bap" in m for m in messages)
+
+
+@pytest.mark.anyio
+async def test_ask_no_matches_returns_empty_list(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """A query with no matching commits returns an empty matches list."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(tmp_path, muse_cli_db_session, ["ambient drone take 1"])
+
+    result = await _ask_async(
+        question="hip hop",
+        root=tmp_path,
+        session=muse_cli_db_session,
+        branch=None,
+        since=None,
+        until=None,
+        cite=False,
+    )
+
+    assert result.total_searched == 1
+    assert result.matches == []
+
+
+@pytest.mark.anyio
+async def test_ask_empty_repo_returns_zero_searched(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """On a repo with no commits the answer reports 0 commits searched."""
+    _init_muse_repo(tmp_path)
+
+    result = await _ask_async(
+        question="anything",
+        root=tmp_path,
+        session=muse_cli_db_session,
+        branch=None,
+        since=None,
+        until=None,
+        cite=False,
+    )
+
+    assert result.total_searched == 0
+    assert result.matches == []
+
+
+# ---------------------------------------------------------------------------
+# _ask_async — --branch filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ask_branch_filter_restricts_search(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """``--branch`` restricts the search to commits on that branch."""
+    _init_muse_repo(tmp_path)
+    # Commit on main (default HEAD branch)
+    await _make_commits(tmp_path, muse_cli_db_session, ["groove session main"])
+
+    result = await _ask_async(
+        question="groove",
+        root=tmp_path,
+        session=muse_cli_db_session,
+        branch="other-branch",
+        since=None,
+        until=None,
+        cite=False,
+    )
+
+    # No commits on other-branch → nothing searched
+    assert result.total_searched == 0
+    assert result.matches == []
+
+
+@pytest.mark.anyio
+async def test_ask_branch_filter_returns_matching_branch(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Commits on the specified branch are included in the search."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(tmp_path, muse_cli_db_session, ["groove session on main"])
+
+    result = await _ask_async(
+        question="groove",
+        root=tmp_path,
+        session=muse_cli_db_session,
+        branch="main",
+        since=None,
+        until=None,
+        cite=False,
+    )
+
+    assert result.total_searched == 1
+    assert len(result.matches) == 1
+
+
+# ---------------------------------------------------------------------------
+# _ask_async — --since / --until filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ask_since_filter_excludes_older_commits(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """``--since`` excludes commits before the given date."""
+    from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot, MuseCliObject
+
+    _init_muse_repo(tmp_path)
+    # Seed one commit using the high-level helper (today's date)
+    await _make_commits(tmp_path, muse_cli_db_session, ["new session today"])
+
+    # Use a future date to exclude everything
+    future_date = date(2099, 1, 1)
+    result = await _ask_async(
+        question="session",
+        root=tmp_path,
+        session=muse_cli_db_session,
+        branch=None,
+        since=future_date,
+        until=None,
+        cite=False,
+    )
+
+    assert result.total_searched == 0
+
+
+@pytest.mark.anyio
+async def test_ask_until_filter_excludes_newer_commits(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """``--until`` excludes commits after the given date."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(tmp_path, muse_cli_db_session, ["new session today"])
+
+    # Use a past date so today's commit is excluded
+    past_date = date(2000, 1, 1)
+    result = await _ask_async(
+        question="session",
+        root=tmp_path,
+        session=muse_cli_db_session,
+        branch=None,
+        since=None,
+        until=past_date,
+        cite=False,
+    )
+
+    assert result.total_searched == 0
+
+
+# ---------------------------------------------------------------------------
+# AnswerResult rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ask_plain_output_contains_expected_text(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Plain-text output contains the header and note lines."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(tmp_path, muse_cli_db_session, ["piano loop session"])
+
+    result = await _ask_async(
+        question="piano loop",
+        root=tmp_path,
+        session=muse_cli_db_session,
+        branch=None,
+        since=None,
+        until=None,
+        cite=False,
+    )
+
+    plain = result.to_plain()
+    assert "Based on Muse history" in plain
+    assert "commits searched" in plain
+    assert "Note: Full LLM-powered answer generation" in plain
+    assert "piano loop session" in plain
+
+
+@pytest.mark.anyio
+async def test_ask_cite_flag_shows_full_commit_id(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """``--cite`` flag makes the answer include the full 64-char commit ID."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["synth pad session"])
+
+    result = await _ask_async(
+        question="synth pad",
+        root=tmp_path,
+        session=muse_cli_db_session,
+        branch=None,
+        since=None,
+        until=None,
+        cite=True,
+    )
+
+    plain = result.to_plain()
+    assert cids[0] in plain  # full 64-char ID present
+
+
+@pytest.mark.anyio
+async def test_ask_no_cite_shows_short_commit_id(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Without ``--cite`` only the short (8-char) commit ID appears."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["drum pattern session"])
+
+    result = await _ask_async(
+        question="drum pattern",
+        root=tmp_path,
+        session=muse_cli_db_session,
+        branch=None,
+        since=None,
+        until=None,
+        cite=False,
+    )
+
+    plain = result.to_plain()
+    assert cids[0][:8] in plain
+    # Full ID should NOT appear (only the 8-char prefix is shown)
+    assert cids[0][8:] not in plain
+
+
+@pytest.mark.anyio
+async def test_ask_json_output_is_valid_json(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """``--json`` output is valid JSON with expected top-level keys."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(tmp_path, muse_cli_db_session, ["bass groove take 3"])
+
+    result = await _ask_async(
+        question="bass groove",
+        root=tmp_path,
+        session=muse_cli_db_session,
+        branch=None,
+        since=None,
+        until=None,
+        cite=False,
+    )
+
+    payload = json.loads(result.to_json())
+    assert "question" in payload
+    assert "total_searched" in payload
+    assert "matches" in payload
+    assert "note" in payload
+    assert payload["question"] == "bass groove"
+    assert payload["total_searched"] == 1
+    assert len(payload["matches"]) == 1
+    assert payload["matches"][0]["message"] == "bass groove take 3"
+
+
+@pytest.mark.anyio
+async def test_ask_json_cite_flag_includes_full_id(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """``--json --cite`` shows full commit IDs in the JSON output."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["keys session"])
+
+    result = await _ask_async(
+        question="keys",
+        root=tmp_path,
+        session=muse_cli_db_session,
+        branch=None,
+        since=None,
+        until=None,
+        cite=True,
+    )
+
+    payload = json.loads(result.to_json())
+    assert payload["matches"][0]["commit_id"] == cids[0]
+
+
+# ---------------------------------------------------------------------------
+# CLI interface (CliRunner)
+# ---------------------------------------------------------------------------
+
+
+def test_ask_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse ask`` outside a .muse/ directory exits with code 2."""
+    from typer.testing import CliRunner
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["ask", "anything"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND
+
+
+def test_ask_plain_text_no_matches_message(tmp_path: pathlib.Path) -> None:
+    """Plain text output for zero matches includes '(no matching commits)'."""
+    result = AnswerResult(
+        question="anything",
+        total_searched=5,
+        matches=[],
+        cite=False,
+    )
+    plain = result.to_plain()
+    assert "(no matching commits)" in plain
+    assert "5 commits searched" in plain


### PR DESCRIPTION
## Summary
Closes #126 — adds `muse ask "<question>"` CLI command that performs keyword search over Muse commit messages and returns a structured answer.

## Root Cause / Motivation
There was no way for users to query their musical history in natural language. This command provides a fast, searchable interface over commit messages with filters for branch, date range, and output format.

## Solution

Added `maestro/muse_cli/commands/ask.py` following the same async pattern as `log.py`:

- **`_keywords(question)`** — strips stop-words and punctuation to extract meaningful search tokens from the user's question
- **`_ask_async(...)`** — loads commits from DB with optional `--branch`, `--since`, `--until` filters; performs case-insensitive keyword match over commit messages; returns an `AnswerResult`
- **`AnswerResult`** — typed result class with `.to_plain()` and `.to_json()` renderers
- Stub note in output: "Full LLM-powered answer generation is a planned enhancement."

Flags supported:
- `--branch TEXT` — restrict search to a specific branch (defaults to HEAD branch)
- `--since YYYY-MM-DD` — only include commits on or after this date
- `--until YYYY-MM-DD` — only include commits on or before this date
- `--json` — emit machine-readable JSON
- `--cite` — show full 64-char commit IDs (default: short 8-char prefix)

`maestro/muse_cli/app.py` updated to import and register `ask` as a subcommand.

## Layers Affected
- [x] Muse VCS (muse_cli commands)

## Verification
- [x] `mypy /worktrees/issue-126/maestro/ /worktrees/issue-126/tests/` — 443 files, no issues
- [x] `pytest tests/muse_cli/test_ask.py -v` — 18/18 passed
- [x] No new DB tables (reads existing `muse_cli_commits`)
- [x] No protocol changes

## Tests Added
- `test_keywords_extracts_meaningful_tokens` — keyword extraction from natural language
- `test_keywords_empty_string_returns_empty` — edge case
- `test_keywords_all_stopwords_returns_empty` — edge case
- `test_keywords_deduplicates_not_applied_but_all_present` — keyword presence
- `test_ask_matches_keyword_in_commit_message` — core matching behavior
- `test_ask_no_matches_returns_empty_list` — no-match case
- `test_ask_empty_repo_returns_zero_searched` — empty repo
- `test_ask_branch_filter_restricts_search` — --branch exclusion
- `test_ask_branch_filter_returns_matching_branch` — --branch inclusion
- `test_ask_since_filter_excludes_older_commits` — --since filter
- `test_ask_until_filter_excludes_newer_commits` — --until filter
- `test_ask_plain_output_contains_expected_text` — plain text rendering
- `test_ask_cite_flag_shows_full_commit_id` — --cite mode
- `test_ask_no_cite_shows_short_commit_id` — default short ID
- `test_ask_json_output_is_valid_json` — JSON structure
- `test_ask_json_cite_flag_includes_full_id` — --json --cite
- `test_ask_outside_repo_exits_2` — CLI guard
- `test_ask_plain_text_no_matches_message` — no-matches text

## Handoff
N/A — no protocol change. This is a pure CLI addition with no SSE, MCP, or DAW adapter impact.