### PR TITLE
feat: muse tag — add music-semantic tags to commits and query by tag

### DIFF
--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -2,7 +2,7 @@
 
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (init, status, commit, grep, log, checkout, merge, remote,
-push, pull, open, play, dynamics, session, swing, ask) as Typer sub-applications.
+push, pull, open, play, dynamics, session, swing, ask, tag) as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -25,6 +25,7 @@ from maestro.muse_cli.commands import (
     session,
     status,
     swing,
+    tag,
 )
 
 cli = typer.Typer(
@@ -49,6 +50,7 @@ cli.add_typer(play.app, name="play", help="Play an audio artifact via afplay (ma
 cli.add_typer(swing.app, name="swing", help="Analyze or annotate the swing factor of a composition.")
 cli.add_typer(session.app, name="session", help="Record and query recording session metadata.")
 cli.add_typer(ask.app, name="ask", help="Query musical history in natural language.")
+cli.add_typer(tag.app, name="tag", help="Attach and query music-semantic tags on commits.")
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/commands/tag.py
+++ b/maestro/muse_cli/commands/tag.py
@@ -1,0 +1,338 @@
+"""muse tag — attach and query music-semantic tags on commits.
+
+Subcommands
+-----------
+``muse tag add <tag> [<commit>]``
+    Attach a tag to a commit (default: branch HEAD).
+
+``muse tag remove <tag> [<commit>]``
+    Remove a tag from a commit.
+
+``muse tag list [<commit>]``
+    List all tags on a commit (default: branch HEAD).
+
+``muse tag search <tag>``
+    List commits in the current repo that carry a given tag.
+    Supports prefix matching so ``emotion:`` finds all emotion tags.
+
+Tag namespaces
+--------------
+Tags are free-form strings. Conventional namespace prefixes:
+
+- ``emotion:*``  — emotional character, e.g. ``emotion:melancholic``
+- ``stage:*``    — production stage, e.g. ``stage:rough-mix``
+- ``ref:*``      — reference source, e.g. ``ref:beatles``
+- ``key:*``      — musical key, e.g. ``key:Am``
+- ``tempo:*``    — tempo annotation, e.g. ``tempo:120bpm``
+- free-form      — any other descriptive label
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliTag
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(no_args_is_help=True)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_commit_id(root: pathlib.Path, commit_ref: str | None) -> str:
+    """Resolve a commit reference to a full commit ID.
+
+    When *commit_ref* is ``None`` the current branch HEAD is used.
+    Raises ``typer.Exit`` with ``USER_ERROR`` if the ref cannot be resolved.
+    """
+    muse_dir = root / ".muse"
+    if commit_ref is not None:
+        return commit_ref
+
+    # Resolve HEAD from .muse/HEAD → .muse/refs/heads/<branch>
+    head_file = muse_dir / "HEAD"
+    if not head_file.exists():
+        typer.echo("❌ .muse/HEAD not found — is this a valid Muse repository?")
+        raise typer.Exit(code=ExitCode.REPO_NOT_FOUND)
+
+    head_ref = head_file.read_text().strip()  # "refs/heads/main"
+    ref_path = muse_dir / pathlib.Path(head_ref)
+    if not ref_path.exists() or not ref_path.read_text().strip():
+        typer.echo("❌ No commits yet on this branch. Create a commit first.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    return ref_path.read_text().strip()
+
+
+async def _get_repo_id(root: pathlib.Path) -> str:
+    """Read repo_id from .muse/repo.json."""
+    repo_json = root / ".muse" / "repo.json"
+    data: dict[str, str] = json.loads(repo_json.read_text())
+    return data["repo_id"]
+
+
+# ---------------------------------------------------------------------------
+# Testable async cores
+# ---------------------------------------------------------------------------
+
+
+async def _tag_add_async(
+    *,
+    tag: str,
+    commit_ref: str | None,
+    root: pathlib.Path,
+    session: AsyncSession,
+) -> None:
+    """Attach *tag* to the target commit.
+
+    No-ops silently when the same tag already exists on that commit so that
+    ``muse tag add`` is idempotent and safe to re-run.
+    """
+    commit_id = _resolve_commit_id(root, commit_ref)
+    repo_id = await _get_repo_id(root)
+
+    # Guard: commit must exist in the DB
+    commit_row = await session.get(MuseCliCommit, commit_id)
+    if commit_row is None:
+        typer.echo(f"❌ Commit {commit_id[:8]} not found in database.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # Idempotency check
+    existing = await session.execute(
+        select(MuseCliTag).where(
+            MuseCliTag.repo_id == repo_id,
+            MuseCliTag.commit_id == commit_id,
+            MuseCliTag.tag == tag,
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        typer.echo(f"⚠️  Tag {tag!r} already exists on commit {commit_id[:8]} — skipped.")
+        return
+
+    session.add(MuseCliTag(repo_id=repo_id, commit_id=commit_id, tag=tag))
+    typer.echo(f"✅ Tagged commit {commit_id[:8]} with {tag!r}")
+    logger.info("✅ muse tag add %r on commit %s", tag, commit_id[:8])
+
+
+async def _tag_remove_async(
+    *,
+    tag: str,
+    commit_ref: str | None,
+    root: pathlib.Path,
+    session: AsyncSession,
+) -> None:
+    """Remove *tag* from the target commit.
+
+    Exits with ``USER_ERROR`` when the tag does not exist.
+    """
+    commit_id = _resolve_commit_id(root, commit_ref)
+    repo_id = await _get_repo_id(root)
+
+    existing_result = await session.execute(
+        select(MuseCliTag).where(
+            MuseCliTag.repo_id == repo_id,
+            MuseCliTag.commit_id == commit_id,
+            MuseCliTag.tag == tag,
+        )
+    )
+    existing_tag = existing_result.scalar_one_or_none()
+    if existing_tag is None:
+        typer.echo(f"❌ Tag {tag!r} not found on commit {commit_id[:8]}.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+    await session.delete(existing_tag)
+
+    typer.echo(f"✅ Removed tag {tag!r} from commit {commit_id[:8]}")
+    logger.info("✅ muse tag remove %r from commit %s", tag, commit_id[:8])
+
+
+async def _tag_list_async(
+    *,
+    commit_ref: str | None,
+    root: pathlib.Path,
+    session: AsyncSession,
+) -> list[str]:
+    """Return the sorted list of tags on the target commit."""
+    commit_id = _resolve_commit_id(root, commit_ref)
+    repo_id = await _get_repo_id(root)
+
+    result = await session.execute(
+        select(MuseCliTag.tag)
+        .where(
+            MuseCliTag.repo_id == repo_id,
+            MuseCliTag.commit_id == commit_id,
+        )
+        .order_by(MuseCliTag.tag)
+    )
+    tags = [row[0] for row in result.all()]
+
+    if not tags:
+        typer.echo(f"No tags on commit {commit_id[:8]}.")
+    else:
+        typer.echo(f"Tags on commit {commit_id[:8]}:")
+        for t in tags:
+            typer.echo(f"  {t}")
+
+    return tags
+
+
+async def _tag_search_async(
+    *,
+    tag: str,
+    root: pathlib.Path,
+    session: AsyncSession,
+) -> list[tuple[str, str]]:
+    """Return (commit_id, tag) pairs matching *tag* within the current repo.
+
+    Supports prefix matching: passing ``emotion:`` returns all emotion tags.
+    An exact tag string matches only that exact tag.
+    """
+    repo_id = await _get_repo_id(root)
+
+    if tag.endswith(":"):
+        # Prefix match — find all tags in the namespace
+        result = await session.execute(
+            select(MuseCliTag.commit_id, MuseCliTag.tag)
+            .where(
+                MuseCliTag.repo_id == repo_id,
+                MuseCliTag.tag.like(f"{tag}%"),
+            )
+            .order_by(MuseCliTag.commit_id, MuseCliTag.tag)
+        )
+    else:
+        result = await session.execute(
+            select(MuseCliTag.commit_id, MuseCliTag.tag)
+            .where(
+                MuseCliTag.repo_id == repo_id,
+                MuseCliTag.tag == tag,
+            )
+            .order_by(MuseCliTag.commit_id)
+        )
+
+    pairs = [(row[0], row[1]) for row in result.all()]
+
+    if not pairs:
+        typer.echo(f"No commits tagged with {tag!r}.")
+    else:
+        typer.echo(f"Commits tagged with {tag!r}:")
+        for commit_id, matched_tag in pairs:
+            typer.echo(f"  {commit_id[:8]}  {matched_tag}")
+
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Typer subcommands
+# ---------------------------------------------------------------------------
+
+
+@app.command("add")
+def tag_add(
+    tag: str = typer.Argument(..., help="Tag string (e.g. emotion:melancholic, stage:rough-mix)."),
+    commit: Optional[str] = typer.Argument(
+        None, help="Commit ID to tag. Defaults to current branch HEAD."
+    ),
+) -> None:
+    """Attach a music-semantic tag to a commit."""
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _tag_add_async(tag=tag, commit_ref=commit, root=root, session=session)
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse tag add failed: {exc}")
+        logger.error("❌ muse tag add error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+
+@app.command("remove")
+def tag_remove(
+    tag: str = typer.Argument(..., help="Tag string to remove."),
+    commit: Optional[str] = typer.Argument(
+        None, help="Commit ID to untag. Defaults to current branch HEAD."
+    ),
+) -> None:
+    """Remove a tag from a commit."""
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _tag_remove_async(tag=tag, commit_ref=commit, root=root, session=session)
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse tag remove failed: {exc}")
+        logger.error("❌ muse tag remove error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+
+@app.command("list")
+def tag_list(
+    commit: Optional[str] = typer.Argument(
+        None, help="Commit ID to inspect. Defaults to current branch HEAD."
+    ),
+) -> None:
+    """List all tags on a commit."""
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _tag_list_async(commit_ref=commit, root=root, session=session)
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse tag list failed: {exc}")
+        logger.error("❌ muse tag list error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+
+@app.command("search")
+def tag_search(
+    tag: str = typer.Argument(
+        ...,
+        help=(
+            "Tag or namespace prefix to search for. "
+            "Use 'emotion:' (with colon) for prefix search; "
+            "exact string for exact match."
+        ),
+    ),
+) -> None:
+    """Search commits by tag or tag-namespace prefix."""
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _tag_search_async(tag=tag, root=root, session=session)
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse tag search failed: {exc}")
+        logger.error("❌ muse tag search error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/muse_cli/models.py
+++ b/maestro/muse_cli/models.py
@@ -4,6 +4,7 @@ Tables:
 - muse_cli_objects: content-addressed file blobs (sha256 keyed)
 - muse_cli_snapshots: snapshot manifests mapping paths to object IDs
 - muse_cli_commits: commit history with parent linkage and branch tracking
+- muse_cli_tags: music-semantic tags attached to commits
 
 These tables are owned by the Muse CLI (``muse commit``) and are
 distinct from the Muse VCS variation tables (``variations``, ``phrases``,
@@ -12,6 +13,8 @@ distinct from the Muse VCS variation tables (``variations``, ``phrases``,
 from __future__ import annotations
 
 from datetime import datetime, timezone
+
+import uuid
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
@@ -104,3 +107,39 @@ class MuseCliCommit(Base):
             f"<MuseCliCommit {self.commit_id[:8]} branch={self.branch!r}"
             f" msg={self.message[:30]!r}>"
         )
+
+
+class MuseCliTag(Base):
+    """A music-semantic tag attached to a Muse CLI commit.
+
+    Tags are free-form strings supporting namespaced conventions:
+    - ``emotion:*``  — emotional character (e.g. emotion:melancholic)
+    - ``stage:*``    — production stage (e.g. stage:rough-mix)
+    - ``ref:*``      — reference track or external source (e.g. ref:beatles)
+    - ``key:*``      — musical key (e.g. key:Am)
+    - ``tempo:*``    — tempo annotation (e.g. tempo:120bpm)
+    - free-form      — any other descriptive label
+
+    Multiple tags can be attached to the same commit. Tags are scoped to a
+    repo so that different local repos can use independent tag spaces.
+    """
+
+    __tablename__ = "muse_cli_tags"
+
+    tag_id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    repo_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    commit_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("muse_cli_commits.commit_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    tag: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    def __repr__(self) -> str:
+        return f"<MuseCliTag {self.tag!r} commit={self.commit_id[:8]}>"

--- a/tests/test_muse_tag.py
+++ b/tests/test_muse_tag.py
@@ -1,0 +1,473 @@
+"""Tests for ``muse tag`` — music-semantic tagging of commits.
+
+Verifies:
+- tag add: attaches a tag to a commit; idempotent on duplicate.
+- tag remove: removes an existing tag; exits USER_ERROR when not found.
+- tag list: returns sorted tags; prints "No tags" when empty.
+- tag search: exact match and prefix (namespace) match.
+- tag add: exits USER_ERROR when commit does not exist.
+- tag add on HEAD resolved from .muse/HEAD when no commit_ref is given.
+- Boundary seal (AST): ``from __future__ import annotations`` present.
+"""
+from __future__ import annotations
+
+import ast
+import datetime
+import json
+import pathlib
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from maestro.db.database import Base
+from maestro.muse_cli import models as cli_models  # noqa: F401 — register tables
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliObject, MuseCliSnapshot, MuseCliTag
+from maestro.muse_cli.commands.tag import (
+    _tag_add_async,
+    _tag_list_async,
+    _tag_remove_async,
+    _tag_search_async,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def async_session() -> AsyncGenerator[AsyncSession, None]:
+    """In-memory SQLite session with all CLI tables created."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with Session() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture
+def repo_root(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a minimal Muse repo structure under *tmp_path*."""
+    muse_dir = tmp_path / ".muse"
+    muse_dir.mkdir()
+    (muse_dir / "HEAD").write_text("refs/heads/main")
+    refs_dir = muse_dir / "refs" / "heads"
+    refs_dir.mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture
+def repo_id() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def write_repo_json(repo_root: pathlib.Path, repo_id: str) -> None:
+    """Write .muse/repo.json with a stable repo_id."""
+    (repo_root / ".muse" / "repo.json").write_text(json.dumps({"repo_id": repo_id}))
+
+
+async def _insert_commit(
+    session: AsyncSession,
+    repo_id: str,
+    repo_root: pathlib.Path,
+) -> str:
+    """Insert a minimal MuseCliCommit and return its commit_id.
+
+    Also updates .muse/refs/heads/main so HEAD resolution works.
+    """
+    snapshot_id = "a" * 64
+    commit_id = "b" * 64
+
+    session.add(MuseCliObject(object_id="c" * 64, size_bytes=1))
+    session.add(MuseCliSnapshot(snapshot_id=snapshot_id, manifest={"f.mid": "c" * 64}))
+    await session.flush()
+
+    session.add(
+        MuseCliCommit(
+            commit_id=commit_id,
+            repo_id=repo_id,
+            branch="main",
+            parent_commit_id=None,
+            parent2_commit_id=None,
+            snapshot_id=snapshot_id,
+            message="initial",
+            author="",
+            committed_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+    )
+    await session.flush()
+
+    # Update HEAD pointer so _resolve_commit_id works without explicit ref
+    ref_path = repo_root / ".muse" / "refs" / "heads" / "main"
+    ref_path.write_text(commit_id)
+
+    return commit_id
+
+
+# ---------------------------------------------------------------------------
+# tag add
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_tag_add_attaches_tag(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """tag add stores a MuseCliTag row for the target commit."""
+    commit_id = await _insert_commit(async_session, repo_id, repo_root)
+
+    await _tag_add_async(
+        tag="emotion:melancholic",
+        commit_ref=commit_id,
+        root=repo_root,
+        session=async_session,
+    )
+    await async_session.flush()
+
+    from sqlalchemy import select
+
+    result = await async_session.execute(
+        select(MuseCliTag).where(MuseCliTag.commit_id == commit_id)
+    )
+    tags = result.scalars().all()
+    assert len(tags) == 1
+    assert tags[0].tag == "emotion:melancholic"
+    assert tags[0].repo_id == repo_id
+
+
+@pytest.mark.anyio
+async def test_tag_add_is_idempotent(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """Adding the same tag twice must not create a duplicate row."""
+    commit_id = await _insert_commit(async_session, repo_id, repo_root)
+
+    await _tag_add_async(
+        tag="stage:rough-mix",
+        commit_ref=commit_id,
+        root=repo_root,
+        session=async_session,
+    )
+    await _tag_add_async(
+        tag="stage:rough-mix",
+        commit_ref=commit_id,
+        root=repo_root,
+        session=async_session,
+    )
+    await async_session.flush()
+
+    from sqlalchemy import select
+
+    result = await async_session.execute(
+        select(MuseCliTag).where(
+            MuseCliTag.commit_id == commit_id, MuseCliTag.tag == "stage:rough-mix"
+        )
+    )
+    assert len(result.scalars().all()) == 1
+
+
+@pytest.mark.anyio
+async def test_tag_add_missing_commit_exits_user_error(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """tag add on a non-existent commit must exit with USER_ERROR."""
+    import typer
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _tag_add_async(
+            tag="tempo:120bpm",
+            commit_ref="d" * 64,
+            root=repo_root,
+            session=async_session,
+        )
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_tag_add_uses_head_when_no_commit_ref(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """When commit_ref is None, the current HEAD commit is tagged."""
+    commit_id = await _insert_commit(async_session, repo_id, repo_root)
+
+    await _tag_add_async(
+        tag="key:Am",
+        commit_ref=None,  # use HEAD
+        root=repo_root,
+        session=async_session,
+    )
+    await async_session.flush()
+
+    from sqlalchemy import select
+
+    result = await async_session.execute(
+        select(MuseCliTag).where(MuseCliTag.commit_id == commit_id, MuseCliTag.tag == "key:Am")
+    )
+    assert result.scalar_one_or_none() is not None
+
+
+# ---------------------------------------------------------------------------
+# tag remove
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_tag_remove_deletes_existing_tag(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """tag remove deletes the row and succeeds."""
+    commit_id = await _insert_commit(async_session, repo_id, repo_root)
+
+    await _tag_add_async(
+        tag="ref:beatles",
+        commit_ref=commit_id,
+        root=repo_root,
+        session=async_session,
+    )
+    await async_session.flush()
+
+    await _tag_remove_async(
+        tag="ref:beatles",
+        commit_ref=commit_id,
+        root=repo_root,
+        session=async_session,
+    )
+    await async_session.flush()
+
+    from sqlalchemy import select
+
+    result = await async_session.execute(
+        select(MuseCliTag).where(MuseCliTag.commit_id == commit_id, MuseCliTag.tag == "ref:beatles")
+    )
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.anyio
+async def test_tag_remove_missing_tag_exits_user_error(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """Removing a tag that was never added must exit with USER_ERROR."""
+    import typer
+
+    commit_id = await _insert_commit(async_session, repo_id, repo_root)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _tag_remove_async(
+            tag="nonexistent",
+            commit_ref=commit_id,
+            root=repo_root,
+            session=async_session,
+        )
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# tag list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_tag_list_returns_sorted_tags(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """tag list returns all tags sorted alphabetically."""
+    commit_id = await _insert_commit(async_session, repo_id, repo_root)
+
+    for t in ["stage:master", "emotion:hopeful", "tempo:90bpm"]:
+        await _tag_add_async(
+            tag=t,
+            commit_ref=commit_id,
+            root=repo_root,
+            session=async_session,
+        )
+    await async_session.flush()
+
+    tags = await _tag_list_async(commit_ref=commit_id, root=repo_root, session=async_session)
+    assert tags == sorted(["stage:master", "emotion:hopeful", "tempo:90bpm"])
+
+
+@pytest.mark.anyio
+async def test_tag_list_empty_commit(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """tag list on a commit with no tags returns an empty list."""
+    commit_id = await _insert_commit(async_session, repo_id, repo_root)
+
+    tags = await _tag_list_async(commit_ref=commit_id, root=repo_root, session=async_session)
+    assert tags == []
+
+
+# ---------------------------------------------------------------------------
+# tag search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_tag_search_exact_match(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """tag search with an exact string returns matching (commit_id, tag) pairs."""
+    commit_id = await _insert_commit(async_session, repo_id, repo_root)
+
+    await _tag_add_async(
+        tag="emotion:melancholic",
+        commit_ref=commit_id,
+        root=repo_root,
+        session=async_session,
+    )
+    await _tag_add_async(
+        tag="stage:rough-mix",
+        commit_ref=commit_id,
+        root=repo_root,
+        session=async_session,
+    )
+    await async_session.flush()
+
+    pairs = await _tag_search_async(
+        tag="emotion:melancholic", root=repo_root, session=async_session
+    )
+    assert pairs == [(commit_id, "emotion:melancholic")]
+
+
+@pytest.mark.anyio
+async def test_tag_search_prefix_match(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """tag search with a namespace prefix (trailing colon) finds all matching tags."""
+    commit_id = await _insert_commit(async_session, repo_id, repo_root)
+
+    for t in ["emotion:melancholic", "emotion:hopeful", "stage:rough-mix"]:
+        await _tag_add_async(
+            tag=t,
+            commit_ref=commit_id,
+            root=repo_root,
+            session=async_session,
+        )
+    await async_session.flush()
+
+    pairs = await _tag_search_async(tag="emotion:", root=repo_root, session=async_session)
+    found_tags = {tag for _, tag in pairs}
+    assert found_tags == {"emotion:melancholic", "emotion:hopeful"}
+
+
+@pytest.mark.anyio
+async def test_tag_search_no_results(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """tag search returns empty list when no commits carry the requested tag."""
+    await _insert_commit(async_session, repo_id, repo_root)
+
+    pairs = await _tag_search_async(tag="ref:nobody", root=repo_root, session=async_session)
+    assert pairs == []
+
+
+@pytest.mark.anyio
+async def test_tag_search_scoped_to_repo(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    write_repo_json: None,
+) -> None:
+    """Tags from a different repo are not returned by search."""
+    # Tag under first repo (already set up via write_repo_json)
+    repo_id_1: str = json.loads((repo_root / ".muse" / "repo.json").read_text())["repo_id"]
+    commit_id_1 = await _insert_commit(async_session, repo_id_1, repo_root)
+    await _tag_add_async(
+        tag="stage:master",
+        commit_ref=commit_id_1,
+        root=repo_root,
+        session=async_session,
+    )
+    await async_session.flush()
+
+    # Switch repo.json to a different repo_id, insert a second commit
+    repo_id_2 = str(uuid.uuid4())
+    (repo_root / ".muse" / "repo.json").write_text(json.dumps({"repo_id": repo_id_2}))
+
+    snapshot_id_2 = "e" * 64
+    commit_id_2 = "f" * 64
+    async_session.add(MuseCliObject(object_id="g" * 64, size_bytes=1))
+    async_session.add(MuseCliSnapshot(snapshot_id=snapshot_id_2, manifest={"x.mid": "g" * 64}))
+    await async_session.flush()
+    async_session.add(
+        MuseCliCommit(
+            commit_id=commit_id_2,
+            repo_id=repo_id_2,
+            branch="main",
+            parent_commit_id=None,
+            parent2_commit_id=None,
+            snapshot_id=snapshot_id_2,
+            message="second repo initial",
+            author="",
+            committed_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+    )
+    await async_session.flush()
+
+    # Search from second repo — should NOT find the tag belonging to first repo
+    pairs = await _tag_search_async(tag="stage:master", root=repo_root, session=async_session)
+    assert pairs == []
+
+
+# ---------------------------------------------------------------------------
+# Boundary seal
+# ---------------------------------------------------------------------------
+
+
+def test_tag_module_future_annotations_present() -> None:
+    """tag.py must start with 'from __future__ import annotations'."""
+    import maestro.muse_cli.commands.tag as tag_module
+
+    assert tag_module.__file__ is not None
+    source_path = pathlib.Path(tag_module.__file__)
+    tree = ast.parse(source_path.read_text())
+    first_import = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            and node.module == "__future__"
+        ),
+        None,
+    )
+    assert first_import is not None, "Missing 'from __future__ import annotations'"
+    names = [alias.name for alias in first_import.names]
+    assert "annotations" in names


### PR DESCRIPTION
## Summary
Closes #123 — implements `muse tag` with four subcommands: `add`, `remove`, `list`, and `search`.

## Root Cause / Motivation
Muse commits had no semantic annotation layer. Producers could not label variations with musical metadata (emotional character, production stage, key, tempo, reference sources) and could not retrieve commits by such labels. The `muse tag` command fills this gap.

## Solution

### New files
- **`maestro/muse_cli/commands/tag.py`** — Typer sub-application with async core functions (`_tag_add_async`, `_tag_remove_async`, `_tag_list_async`, `_tag_search_async`). Each subcommand delegates to its async core so tests can inject an in-memory session without touching the real DB.
- **`tests/test_muse_tag.py`** — 13 tests covering all four subcommands, idempotency, missing-commit guard, HEAD resolution, repo scoping, and module boundary seal.

### Modified files
- **`maestro/muse_cli/models.py`** — `MuseCliTag` ORM model (`muse_cli_tags` table, FK → `muse_cli_commits` with CASCADE DELETE).
- **`alembic/versions/0001_consolidated_schema.py`** — `muse_cli_tags` table added to `upgrade()` and `downgrade()`. No new migration file created.
- **`maestro/muse_cli/app.py`** — `tag.app` registered as `tag` subcommand.
- **`docs/architecture/muse_vcs.md`** — `muse tag` section documenting subcommands, tag namespaces, and schema layout.

### Tag namespaces documented
`emotion:*`, `stage:*`, `ref:*`, `key:*`, `tempo:*`, plus free-form labels.
Search supports exact match and namespace prefix match via trailing `:` (e.g. `emotion:` finds all emotion tags).

## Layers Affected
- [x] Muse VCS (CLI layer)

## Verification
- [x] `mypy` clean — 0 errors across 443 files
- [x] 13/13 tests pass
- [x] Docs updated (`docs/architecture/muse_vcs.md`)

## Tests Added
- `test_tag_add_attaches_tag` — basic add stores a row
- `test_tag_add_is_idempotent` — duplicate add produces no second row
- `test_tag_add_missing_commit_exits_user_error` — guard on non-existent commit
- `test_tag_add_uses_head_when_no_commit_ref` — HEAD resolution path
- `test_tag_remove_deletes_existing_tag` — delete succeeds
- `test_tag_remove_missing_tag_exits_user_error` — USER_ERROR on absent tag
- `test_tag_list_returns_sorted_tags` — alphabetical ordering
- `test_tag_list_empty_commit` — empty list on untagged commit
- `test_tag_search_exact_match` — exact string search
- `test_tag_search_prefix_match` — namespace prefix (`emotion:`) search
- `test_tag_search_no_results` — empty result when no match
- `test_tag_search_scoped_to_repo` — cross-repo isolation
- `test_tag_module_future_annotations_present` — boundary seal

## Handoff
N/A — no SSE/MCP protocol change.