### PR TITLE
feat: muse describe — generate a natural language description of what changed musically

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -349,6 +349,10 @@ Note: Full harmonic/melodic analysis requires muse harmony and muse motif (plann
 
 `_describe_async` is the injectable async core (tested directly without a running server).  Exit codes: 0 success, 1 user error (bad commit ID or wrong `--compare` count), 2 outside a Muse repo, 3 internal error.
 
+**Result type:** `DescribeResult` (class) — fields: `commit_id` (str), `message` (str), `depth` (DescribeDepth), `parent_id` (str | None), `compare_commit_id` (str | None), `changed_files` (list[str]), `added_files` (list[str]), `removed_files` (list[str]), `dimensions` (list[str]), `auto_tag` (str | None). Methods: `.file_count()` → int, `.to_dict()` → dict[str, object]. See `docs/reference/type_contracts.md § DescribeResult`.
+
+**Agent use case:** Before generating new material, an agent calls `muse describe --json` to understand what changed in the most recent commit. If a bass and melody file were both modified, the agent knows a harmonic rewrite occurred and adjusts generation accordingly. `--auto-tag` provides a quick `minor-revision` / `major-revision` signal without full MIDI analysis.
+
 > **Planned enhancement:** Full harmonic, melodic, and rhythmic analysis (chord progression diffs, motif tracking, groove scoring) is tracked as a follow-up. Current output is purely structural — file-level snapshot diffs with no MIDI parsing.
 
 ---

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -2080,6 +2080,31 @@ directly for JSON serialisation without any additional mapping step.
 **Producer:** `_match_commit()`, `_grep_async()`
 **Consumer:** `_render_matches()`, callers using `--json` output
 
+### `DescribeResult`
+
+**Module:** `maestro/muse_cli/commands/describe.py`
+
+Structured description of what changed between two commits. Implemented as a
+plain class (not `TypedDict`) to support methods (`.file_count()`, `.to_dict()`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | Full 64-char SHA of the target commit |
+| `message` | `str` | Commit message |
+| `depth` | `DescribeDepth` | Output verbosity level (`brief`, `standard`, `verbose`) |
+| `parent_id` | `str \| None` | Parent commit SHA; `None` for root commits |
+| `compare_commit_id` | `str \| None` | Explicitly compared commit (`--compare A B`); `None` in single-commit mode |
+| `changed_files` | `list[str]` | Relative paths with differing `object_id` between parent and target |
+| `added_files` | `list[str]` | Paths present in target but not parent |
+| `removed_files` | `list[str]` | Paths present in parent but not target |
+| `dimensions` | `list[str]` | Inferred or user-supplied musical dimension labels |
+| `auto_tag` | `str \| None` | Heuristic tag (`no-change`, `single-file-edit`, `minor-revision`, `major-revision`); `None` when `--auto-tag` not set |
+
+**Methods:** `.file_count() → int` (sum of all three file lists), `.to_dict() → dict[str, object]` (JSON-safe serialisation for `--json` output).
+
+**Producer:** `_describe_async()`
+**Consumer:** `_render_brief()`, `_render_standard()`, `_render_verbose()`, `_render_result()`
+
 ---
 
 ## `Any` Status

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -11,6 +11,7 @@ import typer
 from maestro.muse_cli.commands import (
     checkout,
     commit,
+    describe,
     init,
     log,
     merge,
@@ -37,6 +38,7 @@ cli.add_typer(merge.app, name="merge", help="Three-way merge two variation branc
 cli.add_typer(remote.app, name="remote", help="Manage remote server connections.")
 cli.add_typer(push.app, name="push", help="Upload local variations to a remote.")
 cli.add_typer(pull.app, name="pull", help="Download remote variations locally.")
+cli.add_typer(describe.app, name="describe", help="Describe what changed musically in a commit.")
 cli.add_typer(open_cmd.app, name="open", help="Open an artifact in the system default app (macOS).")
 cli.add_typer(play.app, name="play", help="Play an audio artifact via afplay (macOS).")
 

--- a/maestro/muse_cli/commands/describe.py
+++ b/maestro/muse_cli/commands/describe.py
@@ -1,0 +1,516 @@
+"""muse describe — generate a structured description of what changed musically.
+
+Compares a commit against its parent (or two commits via ``--compare``) and
+produces a structured description of the snapshot diff: which files changed
+and how many.  Depth controls verbosity:
+
+- **brief**    — one-line summary (commit ID + file count)
+- **standard** — commit message, changed files list, dimensions (default)
+- **verbose**  — standard plus parent commit info and full file paths
+
+NOTE: Full harmonic/melodic analysis (identifying chord progressions, melodic
+motifs, rhythmic changes) requires ``muse harmony`` and ``muse motif`` — both
+planned enhancements tracked in follow-up issues.  This implementation uses
+the snapshot manifest diff as a structural proxy: the set of files added,
+removed, or modified between two commits.
+
+Output formats
+--------------
+Default (human-readable)::
+
+    Commit abc1234: "Add piano melody to verse"
+    Changed files: 2 (beat.mid, keys.mid)
+    Dimensions analyzed: structural (2 files modified)
+    Note: Full harmonic/melodic analysis requires muse harmony and muse motif (planned)
+
+JSON (``--json``)::
+
+    {
+      "commit": "abc1234...",
+      "message": "Add piano melody to verse",
+      "depth": "standard",
+      "changed_files": ["beat.mid", "keys.mid"],
+      "added_files": [],
+      "removed_files": [],
+      "dimensions": ["structural"],
+      "file_count": 2,
+      "parent": "def5678...",
+      "note": "Full harmonic/melodic analysis requires muse harmony and muse motif (planned)"
+    }
+
+Auto-tag (``--auto-tag``)
+--------------------------
+When ``--auto-tag`` is given, a suggested tag is printed (or included in JSON)
+based on the file count and dimensions.  This is a heuristic stub — a full
+tagger would classify by musical dimension (rhythm, harmony, melody, etc.)
+using instrument metadata.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from enum import Enum
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+_LLM_NOTE = (
+    "Full harmonic/melodic analysis requires muse harmony and muse motif (planned)"
+)
+
+
+# ---------------------------------------------------------------------------
+# Depth enum
+# ---------------------------------------------------------------------------
+
+
+class DescribeDepth(str, Enum):
+    """Verbosity level for ``muse describe`` output."""
+
+    brief = "brief"
+    standard = "standard"
+    verbose = "verbose"
+
+
+# ---------------------------------------------------------------------------
+# Core data types
+# ---------------------------------------------------------------------------
+
+
+class DescribeResult:
+    """Structured description of what changed between two commits.
+
+    Returned by ``_describe_async`` and consumed by both the human-readable
+    renderer and the JSON serialiser.
+    """
+
+    def __init__(
+        self,
+        *,
+        commit_id: str,
+        message: str,
+        depth: DescribeDepth,
+        parent_id: str | None,
+        compare_commit_id: str | None,
+        changed_files: list[str],
+        added_files: list[str],
+        removed_files: list[str],
+        dimensions: list[str],
+        auto_tag: str | None,
+    ) -> None:
+        self.commit_id = commit_id
+        self.message = message
+        self.depth = depth
+        self.parent_id = parent_id
+        self.compare_commit_id = compare_commit_id
+        self.changed_files = changed_files
+        self.added_files = added_files
+        self.removed_files = removed_files
+        self.dimensions = dimensions
+        self.auto_tag = auto_tag
+
+    def file_count(self) -> int:
+        return len(self.changed_files) + len(self.added_files) + len(self.removed_files)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialise to a JSON-compatible dict."""
+        result: dict[str, object] = {
+            "commit": self.commit_id,
+            "message": self.message,
+            "depth": self.depth.value,
+            "changed_files": self.changed_files,
+            "added_files": self.added_files,
+            "removed_files": self.removed_files,
+            "dimensions": self.dimensions,
+            "file_count": self.file_count(),
+            "parent": self.parent_id,
+            "note": _LLM_NOTE,
+        }
+        if self.compare_commit_id is not None:
+            result["compare_commit"] = self.compare_commit_id
+        if self.auto_tag is not None:
+            result["auto_tag"] = self.auto_tag
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Snapshot diff helpers
+# ---------------------------------------------------------------------------
+
+
+def _diff_manifests(
+    base: dict[str, str],
+    target: dict[str, str],
+) -> tuple[list[str], list[str], list[str]]:
+    """Compute the diff between two snapshot manifests.
+
+    Returns ``(changed, added, removed)`` where each entry is a relative
+    file path (as stored in the manifest keys).
+
+    - *changed*  — path exists in both manifests but object_id differs
+    - *added*    — path exists in *target* but not *base*
+    - *removed*  — path exists in *base* but not *target*
+    """
+    all_paths = set(base) | set(target)
+    changed: list[str] = []
+    added: list[str] = []
+    removed: list[str] = []
+    for path in sorted(all_paths):
+        base_obj = base.get(path)
+        target_obj = target.get(path)
+        if base_obj is None:
+            added.append(path)
+        elif target_obj is None:
+            removed.append(path)
+        elif base_obj != target_obj:
+            changed.append(path)
+    return changed, added, removed
+
+
+def _infer_dimensions(
+    changed: list[str],
+    added: list[str],
+    removed: list[str],
+    requested: list[str],
+) -> list[str]:
+    """Infer musical dimensions from the file diff.
+
+    This is a heuristic stub — always returns ``["structural"]`` with the
+    file count as context.  A full implementation would inspect MIDI metadata
+    to classify changes as rhythmic, harmonic, or melodic.
+    """
+    if requested:
+        return [d.strip() for d in requested if d.strip()]
+    total = len(changed) + len(added) + len(removed)
+    if total == 0:
+        return []
+    return [f"structural ({total} file{'s' if total != 1 else ''} modified)"]
+
+
+def _suggest_tag(dimensions: list[str], file_count: int) -> str:
+    """Return a heuristic tag based on dimensions and file count.
+
+    Stub implementation — a full tagger would classify by instrument and
+    MIDI content.
+    """
+    if file_count == 0:
+        return "no-change"
+    if file_count == 1:
+        return "single-file-edit"
+    if file_count <= 3:
+        return "minor-revision"
+    return "major-revision"
+
+
+# ---------------------------------------------------------------------------
+# Async core — fully injectable for tests
+# ---------------------------------------------------------------------------
+
+
+async def _load_commit_with_snapshot(
+    session: AsyncSession,
+    commit_id: str,
+) -> tuple[MuseCliCommit, dict[str, str]] | None:
+    """Load a commit and its snapshot manifest.
+
+    Returns ``None`` when either the commit or its snapshot is missing from
+    the database (e.g. the repo is in a partially-consistent state).
+    """
+    commit = await session.get(MuseCliCommit, commit_id)
+    if commit is None:
+        return None
+    snapshot = await session.get(MuseCliSnapshot, commit.snapshot_id)
+    if snapshot is None:
+        logger.warning(
+            "⚠️ Snapshot %s for commit %s not found",
+            commit.snapshot_id[:8],
+            commit_id[:8],
+        )
+        return None
+    return commit, dict(snapshot.manifest)
+
+
+async def _resolve_head_commit_id(root: pathlib.Path) -> str | None:
+    """Read the HEAD commit ID from the ``.muse/`` directory."""
+    muse_dir = root / ".muse"
+    head_ref = (muse_dir / "HEAD").read_text().strip()
+    ref_path = muse_dir / pathlib.Path(head_ref)
+    if not ref_path.exists():
+        return None
+    value = ref_path.read_text().strip()
+    return value or None
+
+
+async def _describe_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    commit_id: str | None,
+    compare_a: str | None,
+    compare_b: str | None,
+    depth: DescribeDepth,
+    dimensions_raw: str | None,
+    as_json: bool,
+    auto_tag: bool,
+) -> DescribeResult:
+    """Core describe logic — fully injectable for tests.
+
+    Resolution order for which commits to diff:
+
+    1. ``--compare A B`` — compare A against B explicitly.
+    2. ``<commit>`` positional argument — compare that commit against its parent.
+    3. No argument — compare HEAD against its parent.
+
+    Raises ``typer.Exit`` with an appropriate exit code on error.
+    """
+    requested_dimensions = [d.strip() for d in (dimensions_raw or "").split(",") if d.strip()]
+
+    # --- resolve target commit ------------------------------------------
+    if compare_a and compare_b:
+        # Explicit compare mode: diff A → B
+        pair_a = await _load_commit_with_snapshot(session, compare_a)
+        if pair_a is None:
+            typer.echo(f"❌ Commit not found: {compare_a}")
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+
+        pair_b = await _load_commit_with_snapshot(session, compare_b)
+        if pair_b is None:
+            typer.echo(f"❌ Commit not found: {compare_b}")
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+
+        commit_a, manifest_a = pair_a
+        commit_b, manifest_b = pair_b
+
+        changed, added, removed = _diff_manifests(manifest_a, manifest_b)
+        dims = _infer_dimensions(changed, added, removed, requested_dimensions)
+        tag = _suggest_tag(dims, len(changed) + len(added) + len(removed)) if auto_tag else None
+
+        return DescribeResult(
+            commit_id=commit_b.commit_id,
+            message=commit_b.message,
+            depth=depth,
+            parent_id=commit_a.commit_id,
+            compare_commit_id=commit_a.commit_id,
+            changed_files=changed,
+            added_files=added,
+            removed_files=removed,
+            dimensions=dims,
+            auto_tag=tag,
+        )
+
+    # --- single commit (or HEAD) mode -----------------------------------
+    target_id = commit_id or await _resolve_head_commit_id(root)
+    if not target_id:
+        typer.echo("No commits yet on this branch.")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    pair_target = await _load_commit_with_snapshot(session, target_id)
+    if pair_target is None:
+        typer.echo(f"❌ Commit not found: {target_id}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    target_commit, target_manifest = pair_target
+    parent_id = target_commit.parent_commit_id
+
+    if parent_id:
+        pair_parent = await _load_commit_with_snapshot(session, parent_id)
+        if pair_parent is None:
+            # Parent referenced but missing — treat as empty base
+            logger.warning("⚠️ Parent commit %s not found; treating as empty", parent_id[:8])
+            parent_manifest: dict[str, str] = {}
+        else:
+            _, parent_manifest = pair_parent
+    else:
+        # Root commit — everything in the snapshot is "added"
+        parent_manifest = {}
+
+    changed, added, removed = _diff_manifests(parent_manifest, target_manifest)
+    dims = _infer_dimensions(changed, added, removed, requested_dimensions)
+    tag = _suggest_tag(dims, len(changed) + len(added) + len(removed)) if auto_tag else None
+
+    return DescribeResult(
+        commit_id=target_commit.commit_id,
+        message=target_commit.message,
+        depth=depth,
+        parent_id=parent_id,
+        compare_commit_id=None,
+        changed_files=changed,
+        added_files=added,
+        removed_files=removed,
+        dimensions=dims,
+        auto_tag=tag,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def _render_brief(result: DescribeResult) -> None:
+    """One-line summary: short commit ID + total file count."""
+    short_id = result.commit_id[:8]
+    count = result.file_count()
+    typer.echo(f"Commit {short_id}: {count} file change{'s' if count != 1 else ''}")
+    if result.auto_tag:
+        typer.echo(f"Tag: {result.auto_tag}")
+
+
+def _render_standard(result: DescribeResult) -> None:
+    """Standard output: commit message, changed files, dimensions."""
+    short_id = result.commit_id[:8]
+    count = result.file_count()
+    typer.echo(f'Commit {short_id}: "{result.message}"')
+
+    # Collect all changed paths for display
+    all_changed = result.changed_files + result.added_files + result.removed_files
+    file_names = [pathlib.Path(p).name for p in all_changed]
+    files_str = (", ".join(file_names)) if file_names else "none"
+    typer.echo(f"Changed files: {count} ({files_str})")
+
+    dims_str = ", ".join(result.dimensions) if result.dimensions else "none"
+    typer.echo(f"Dimensions analyzed: {dims_str}")
+
+    if result.auto_tag:
+        typer.echo(f"Tag: {result.auto_tag}")
+
+    typer.echo(f"Note: {_LLM_NOTE}")
+
+
+def _render_verbose(result: DescribeResult) -> None:
+    """Verbose output: adds parent commit and full file paths."""
+    typer.echo(f"Commit:  {result.commit_id}")
+    typer.echo(f'Message: "{result.message}"')
+    if result.parent_id:
+        typer.echo(f"Parent:  {result.parent_id}")
+    if result.compare_commit_id:
+        typer.echo(f"Compare: {result.compare_commit_id} → {result.commit_id}")
+
+    typer.echo("")
+    count = result.file_count()
+    typer.echo(f"Changed files ({count}):")
+    for p in result.changed_files:
+        typer.echo(f"  M  {p}")
+    for p in result.added_files:
+        typer.echo(f"  A  {p}")
+    for p in result.removed_files:
+        typer.echo(f"  D  {p}")
+    if count == 0:
+        typer.echo("  (no changes)")
+
+    typer.echo("")
+    dims_str = ", ".join(result.dimensions) if result.dimensions else "none"
+    typer.echo(f"Dimensions: {dims_str}")
+
+    if result.auto_tag:
+        typer.echo(f"Tag:        {result.auto_tag}")
+
+    typer.echo(f"\nNote: {_LLM_NOTE}")
+
+
+def _render_result(result: DescribeResult, *, as_json: bool) -> None:
+    """Dispatch to the appropriate renderer."""
+    if as_json:
+        typer.echo(json.dumps(result.to_dict(), indent=2))
+        return
+
+    if result.depth == DescribeDepth.brief:
+        _render_brief(result)
+    elif result.depth == DescribeDepth.verbose:
+        _render_verbose(result)
+    else:
+        _render_standard(result)
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def describe(
+    ctx: typer.Context,
+    commit: Optional[str] = typer.Argument(
+        default=None,
+        help="Commit ID to describe. Defaults to HEAD.",
+    ),
+    compare: Optional[list[str]] = typer.Option(
+        default=None,
+        help="Compare two commits: --compare COMMIT_A COMMIT_B.",
+    ),
+    depth: DescribeDepth = typer.Option(
+        DescribeDepth.standard,
+        "--depth",
+        help="Output verbosity: brief, standard (default), or verbose.",
+    ),
+    dimensions: Optional[str] = typer.Option(
+        None,
+        "--dimensions",
+        help="Comma-separated dimensions to analyze (e.g. 'rhythm,harmony'). "
+        "Currently informational; full analysis is a planned enhancement.",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Output as JSON.",
+    ),
+    auto_tag: bool = typer.Option(
+        False,
+        "--auto-tag",
+        help="Suggest a heuristic tag based on the change scope.",
+    ),
+) -> None:
+    """Describe what changed musically in a commit.
+
+    Compares the specified commit (default: HEAD) against its parent and
+    outputs a structured description of the snapshot diff.
+
+    NOTE: Full harmonic/melodic analysis is a planned enhancement.
+    Current output is based on file-level snapshot diffs only.
+    """
+    root = require_repo()
+
+    # Validate --compare: exactly 0 or 2 values
+    compare_a: str | None = None
+    compare_b: str | None = None
+    if compare:
+        if len(compare) != 2:
+            typer.echo("❌ --compare requires exactly two commit IDs: --compare A B")
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+        compare_a, compare_b = compare[0], compare[1]
+
+    async def _run() -> None:
+        async with open_session() as session:
+            result = await _describe_async(
+                root=root,
+                session=session,
+                commit_id=commit,
+                compare_a=compare_a,
+                compare_b=compare_b,
+                depth=depth,
+                dimensions_raw=dimensions,
+                as_json=json_output,
+                auto_tag=auto_tag,
+            )
+            _render_result(result, as_json=json_output)
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse describe failed: {exc}")
+        logger.error("❌ muse describe error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/tests/muse_cli/test_describe.py
+++ b/tests/muse_cli/test_describe.py
@@ -1,0 +1,643 @@
+"""Tests for ``muse describe``.
+
+All async tests call ``_describe_async`` directly with an in-memory SQLite
+session and a ``tmp_path`` repo root — no real Postgres or running process
+required.  Commits are seeded via ``_commit_async`` so the two commands
+are tested as an integrated pair.
+
+Coverage:
+- HEAD describe with no parent (root commit)
+- HEAD describe with parent (diff shows changed files)
+- Explicit commit ID describe
+- --compare A B mode
+- --depth brief / standard / verbose output
+- --json output format
+- --dimensions passthrough
+- --auto-tag heuristic
+- No commits → clean exit
+- Outside repo → exit code 2
+- --compare with wrong arg count → exit code 1
+- Commit not found → exit code 1
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import uuid
+
+import pytest
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.commands.describe import (
+    DescribeDepth,
+    DescribeResult,
+    _describe_async,
+    _diff_manifests,
+    _infer_dimensions,
+    _suggest_tag,
+)
+from maestro.muse_cli.errors import ExitCode
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_log.py pattern)
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _write_workdir(root: pathlib.Path, files: dict[str, bytes]) -> None:
+    workdir = root / "muse-work"
+    workdir.mkdir(exist_ok=True)
+    for name, content in files.items():
+        (workdir / name).write_bytes(content)
+
+
+async def _make_commit(
+    root: pathlib.Path,
+    session: AsyncSession,
+    message: str,
+    files: dict[str, bytes],
+) -> str:
+    """Create one commit with the given files and message."""
+    _write_workdir(root, files)
+    return await _commit_async(message=message, root=root, session=session)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — pure functions
+# ---------------------------------------------------------------------------
+
+
+class TestDiffManifests:
+    def test_diff_manifests_identical(self) -> None:
+        m = {"a.mid": "aaa", "b.mid": "bbb"}
+        changed, added, removed = _diff_manifests(m, m)
+        assert changed == []
+        assert added == []
+        assert removed == []
+
+    def test_diff_manifests_modified(self) -> None:
+        base = {"a.mid": "old"}
+        target = {"a.mid": "new"}
+        changed, added, removed = _diff_manifests(base, target)
+        assert changed == ["a.mid"]
+        assert added == []
+        assert removed == []
+
+    def test_diff_manifests_added(self) -> None:
+        base: dict[str, str] = {}
+        target = {"new.mid": "hash"}
+        changed, added, removed = _diff_manifests(base, target)
+        assert changed == []
+        assert added == ["new.mid"]
+        assert removed == []
+
+    def test_diff_manifests_removed(self) -> None:
+        base = {"gone.mid": "hash"}
+        target: dict[str, str] = {}
+        changed, added, removed = _diff_manifests(base, target)
+        assert changed == []
+        assert added == []
+        assert removed == ["gone.mid"]
+
+    def test_diff_manifests_mixed(self) -> None:
+        base = {"a.mid": "1", "b.mid": "2", "c.mid": "3"}
+        target = {"a.mid": "changed", "c.mid": "3", "d.mid": "4"}
+        changed, added, removed = _diff_manifests(base, target)
+        assert changed == ["a.mid"]
+        assert added == ["d.mid"]
+        assert removed == ["b.mid"]
+
+    def test_diff_manifests_sorted_output(self) -> None:
+        base = {"z.mid": "1"}
+        target = {"a.mid": "2", "z.mid": "1"}
+        _, added, _ = _diff_manifests(base, target)
+        assert added == ["a.mid"]
+
+
+class TestInferDimensions:
+    def test_infer_dimensions_no_changes(self) -> None:
+        dims = _infer_dimensions([], [], [], [])
+        assert dims == []
+
+    def test_infer_dimensions_structural_singular(self) -> None:
+        dims = _infer_dimensions(["a.mid"], [], [], [])
+        assert len(dims) == 1
+        assert "1 file" in dims[0]
+
+    def test_infer_dimensions_structural_plural(self) -> None:
+        dims = _infer_dimensions(["a.mid", "b.mid"], [], [], [])
+        assert "2 files" in dims[0]
+
+    def test_infer_dimensions_requested_passthrough(self) -> None:
+        dims = _infer_dimensions(["a.mid"], [], [], ["rhythm", "harmony"])
+        assert dims == ["rhythm", "harmony"]
+
+    def test_infer_dimensions_requested_strips_whitespace(self) -> None:
+        dims = _infer_dimensions([], [], [], [" rhythm ", " harmony "])
+        assert dims == ["rhythm", "harmony"]
+
+
+class TestSuggestTag:
+    def test_suggest_tag_no_change(self) -> None:
+        assert _suggest_tag([], 0) == "no-change"
+
+    def test_suggest_tag_single_file(self) -> None:
+        assert _suggest_tag(["structural"], 1) == "single-file-edit"
+
+    def test_suggest_tag_minor(self) -> None:
+        assert _suggest_tag(["structural"], 3) == "minor-revision"
+
+    def test_suggest_tag_major(self) -> None:
+        assert _suggest_tag(["structural"], 10) == "major-revision"
+
+
+class TestDescribeResult:
+    def _make_result(self, **kwargs: object) -> DescribeResult:
+        defaults: dict[str, object] = dict(
+            commit_id="a" * 64,
+            message="test msg",
+            depth=DescribeDepth.standard,
+            parent_id=None,
+            compare_commit_id=None,
+            changed_files=[],
+            added_files=[],
+            removed_files=[],
+            dimensions=[],
+            auto_tag=None,
+        )
+        defaults.update(kwargs)
+        return DescribeResult(**defaults)  # type: ignore[arg-type]
+
+    def test_file_count_empty(self) -> None:
+        r = self._make_result()
+        assert r.file_count() == 0
+
+    def test_file_count_sum(self) -> None:
+        r = self._make_result(
+            changed_files=["a.mid"],
+            added_files=["b.mid", "c.mid"],
+            removed_files=[],
+        )
+        assert r.file_count() == 3
+
+    def test_to_dict_has_required_keys(self) -> None:
+        r = self._make_result(changed_files=["x.mid"])
+        d = r.to_dict()
+        assert "commit" in d
+        assert "message" in d
+        assert "depth" in d
+        assert "changed_files" in d
+        assert "added_files" in d
+        assert "removed_files" in d
+        assert "dimensions" in d
+        assert "file_count" in d
+        assert "parent" in d
+        assert "note" in d
+
+    def test_to_dict_compare_commit_included_when_set(self) -> None:
+        r = self._make_result(compare_commit_id="b" * 64)
+        d = r.to_dict()
+        assert "compare_commit" in d
+
+    def test_to_dict_auto_tag_included_when_set(self) -> None:
+        r = self._make_result(auto_tag="minor-revision")
+        d = r.to_dict()
+        assert d["auto_tag"] == "minor-revision"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — _describe_async with real DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_describe_root_commit_no_parent(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Root commit (no parent) shows all files as added."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(
+        tmp_path, muse_cli_db_session, "init session",
+        {"beat.mid": b"MIDI1", "keys.mid": b"MIDI2"}
+    )
+
+    result = await _describe_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit_id=None,
+        compare_a=None,
+        compare_b=None,
+        depth=DescribeDepth.standard,
+        dimensions_raw=None,
+        as_json=False,
+        auto_tag=False,
+    )
+
+    # Root commit: no parent, so all files are "added"
+    assert result.parent_id is None
+    assert result.file_count() == 2
+    assert len(result.added_files) == 2
+    assert result.changed_files == []
+    assert result.removed_files == []
+
+
+@pytest.mark.anyio
+async def test_describe_head_shows_diff_from_parent(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """HEAD describe shows files changed relative to its parent."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(
+        tmp_path, muse_cli_db_session, "first take",
+        {"beat.mid": b"v1", "keys.mid": b"v1"}
+    )
+    await _make_commit(
+        tmp_path, muse_cli_db_session, "update beat",
+        {"beat.mid": b"v2", "keys.mid": b"v1"}  # keys unchanged, beat modified
+    )
+
+    result = await _describe_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit_id=None,
+        compare_a=None,
+        compare_b=None,
+        depth=DescribeDepth.standard,
+        dimensions_raw=None,
+        as_json=False,
+        auto_tag=False,
+    )
+
+    # Only beat.mid changed between first and second commit
+    # Manifest keys are relative to muse-work/ directory (not the repo root)
+    assert result.changed_files == ["beat.mid"]
+    assert result.added_files == []
+    assert result.removed_files == []
+    assert result.file_count() == 1
+    assert result.message == "update beat"
+
+
+@pytest.mark.anyio
+async def test_describe_explicit_commit_id(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Describing an explicit commit ID works correctly."""
+    _init_muse_repo(tmp_path)
+    cid1 = await _make_commit(
+        tmp_path, muse_cli_db_session, "take one",
+        {"track_1.mid": b"data"}
+    )
+    # Make a second commit so HEAD != cid1
+    await _make_commit(
+        tmp_path, muse_cli_db_session, "take two",
+        {"track_1.mid": b"data", "track_2.mid": b"more"}
+    )
+
+    result = await _describe_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit_id=cid1,
+        compare_a=None,
+        compare_b=None,
+        depth=DescribeDepth.standard,
+        dimensions_raw=None,
+        as_json=False,
+        auto_tag=False,
+    )
+
+    assert result.commit_id == cid1
+    assert result.message == "take one"
+
+
+@pytest.mark.anyio
+async def test_describe_compare_mode(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """--compare A B produces a diff between two explicit commits."""
+    _init_muse_repo(tmp_path)
+    cid_a = await _make_commit(
+        tmp_path, muse_cli_db_session, "baseline",
+        {"beat.mid": b"v1"}
+    )
+    cid_b = await _make_commit(
+        tmp_path, muse_cli_db_session, "add melody",
+        {"beat.mid": b"v1", "melody.mid": b"new"}
+    )
+
+    result = await _describe_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit_id=None,
+        compare_a=cid_a,
+        compare_b=cid_b,
+        depth=DescribeDepth.standard,
+        dimensions_raw=None,
+        as_json=False,
+        auto_tag=False,
+    )
+
+    assert result.commit_id == cid_b
+    assert result.compare_commit_id == cid_a
+    # Manifest keys are relative to muse-work/ directory
+    assert "melody.mid" in result.added_files
+    assert result.file_count() == 1
+
+
+@pytest.mark.anyio
+async def test_describe_depth_brief(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--depth brief produces a one-line summary."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(
+        tmp_path, muse_cli_db_session, "init",
+        {"beat.mid": b"data"}
+    )
+
+    result = await _describe_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit_id=None,
+        compare_a=None,
+        compare_b=None,
+        depth=DescribeDepth.brief,
+        dimensions_raw=None,
+        as_json=False,
+        auto_tag=False,
+    )
+
+    from maestro.muse_cli.commands.describe import _render_brief
+    _render_brief(result)
+    out = capsys.readouterr().out
+
+    # Brief: short commit ID and file count, no commit message
+    assert result.commit_id[:8] in out
+    assert "file change" in out
+    # No verbose detail
+    assert "Note:" not in out
+
+
+@pytest.mark.anyio
+async def test_describe_depth_standard(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--depth standard includes message, files, dimensions, and note."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(
+        tmp_path, muse_cli_db_session, "add chorus",
+        {"chorus.mid": b"x"}
+    )
+
+    result = await _describe_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit_id=None,
+        compare_a=None,
+        compare_b=None,
+        depth=DescribeDepth.standard,
+        dimensions_raw=None,
+        as_json=False,
+        auto_tag=False,
+    )
+
+    from maestro.muse_cli.commands.describe import _render_standard
+    _render_standard(result)
+    out = capsys.readouterr().out
+
+    assert "add chorus" in out
+    assert "chorus.mid" in out
+    assert "Dimensions analyzed:" in out
+    assert "Note:" in out
+
+
+@pytest.mark.anyio
+async def test_describe_depth_verbose(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--depth verbose includes full commit ID and parent."""
+    _init_muse_repo(tmp_path)
+    cid1 = await _make_commit(
+        tmp_path, muse_cli_db_session, "first",
+        {"a.mid": b"1"}
+    )
+    await _make_commit(
+        tmp_path, muse_cli_db_session, "second",
+        {"a.mid": b"2"}
+    )
+
+    result = await _describe_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit_id=None,
+        compare_a=None,
+        compare_b=None,
+        depth=DescribeDepth.verbose,
+        dimensions_raw=None,
+        as_json=False,
+        auto_tag=False,
+    )
+
+    from maestro.muse_cli.commands.describe import _render_verbose
+    _render_verbose(result)
+    out = capsys.readouterr().out
+
+    # Full commit ID visible
+    assert result.commit_id in out
+    # Parent shown
+    assert cid1 in out
+    # File status prefix
+    assert "M  " in out
+
+
+@pytest.mark.anyio
+async def test_describe_json_output(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--json outputs valid JSON with the expected structure."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(
+        tmp_path, muse_cli_db_session, "json test",
+        {"track.mid": b"data"}
+    )
+
+    result = await _describe_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit_id=None,
+        compare_a=None,
+        compare_b=None,
+        depth=DescribeDepth.standard,
+        dimensions_raw=None,
+        as_json=True,
+        auto_tag=False,
+    )
+
+    from maestro.muse_cli.commands.describe import _render_result
+    capsys.readouterr()  # discard ✅ output from _commit_async calls
+    _render_result(result, as_json=True)
+    out = capsys.readouterr().out
+    data = json.loads(out)
+
+    assert "commit" in data
+    assert "message" in data
+    assert data["message"] == "json test"
+    assert "changed_files" in data
+    assert "added_files" in data
+    assert "removed_files" in data
+    assert "file_count" in data
+    assert "note" in data
+
+
+@pytest.mark.anyio
+async def test_describe_dimensions_passthrough(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """--dimensions passes user-specified dimensions through to result."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(
+        tmp_path, muse_cli_db_session, "dim test",
+        {"beat.mid": b"x"}
+    )
+
+    result = await _describe_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit_id=None,
+        compare_a=None,
+        compare_b=None,
+        depth=DescribeDepth.standard,
+        dimensions_raw="rhythm,harmony",
+        as_json=False,
+        auto_tag=False,
+    )
+
+    assert "rhythm" in result.dimensions
+    assert "harmony" in result.dimensions
+
+
+@pytest.mark.anyio
+async def test_describe_auto_tag(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """--auto-tag adds a non-empty tag to the result."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(
+        tmp_path, muse_cli_db_session, "tagged commit",
+        {"x.mid": b"y"}
+    )
+
+    result = await _describe_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        commit_id=None,
+        compare_a=None,
+        compare_b=None,
+        depth=DescribeDepth.standard,
+        dimensions_raw=None,
+        as_json=False,
+        auto_tag=True,
+    )
+
+    assert result.auto_tag is not None
+    assert len(result.auto_tag) > 0
+
+
+@pytest.mark.anyio
+async def test_describe_no_commits_exits_zero(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``muse describe`` on a repo with no commits exits 0 with a message."""
+    _init_muse_repo(tmp_path)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _describe_async(
+            root=tmp_path,
+            session=muse_cli_db_session,
+            commit_id=None,
+            compare_a=None,
+            compare_b=None,
+            depth=DescribeDepth.standard,
+            dimensions_raw=None,
+            as_json=False,
+            auto_tag=False,
+        )
+
+    assert exc_info.value.exit_code == ExitCode.SUCCESS
+    out = capsys.readouterr().out
+    assert "No commits" in out
+
+
+@pytest.mark.anyio
+async def test_describe_unknown_commit_exits_user_error(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Passing an unknown commit ID exits with USER_ERROR."""
+    _init_muse_repo(tmp_path)
+
+    bogus_id = "d" * 64
+    with pytest.raises(typer.Exit) as exc_info:
+        await _describe_async(
+            root=tmp_path,
+            session=muse_cli_db_session,
+            commit_id=bogus_id,
+            compare_a=None,
+            compare_b=None,
+            depth=DescribeDepth.standard,
+            dimensions_raw=None,
+            as_json=False,
+            auto_tag=False,
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+    out = capsys.readouterr().out
+    assert "not found" in out.lower()
+
+
+def test_describe_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse describe`` outside a .muse/ directory exits with code 2."""
+    from typer.testing import CliRunner
+
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["describe"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND


### PR DESCRIPTION
## Summary
Closes #125 — Add `muse describe [<commit>] [OPTIONS]` command that generates a structured description of what changed musically between commits.

## Root Cause / Motivation
The Muse CLI lacked a way to answer "what changed?" in human-readable terms. `muse log` shows which commits exist; `muse describe` explains what each commit changed — a critical gap for producers reviewing session history.

## Solution

### New command: `maestro/muse_cli/commands/describe.py`

Follows the same pattern as `muse log` — injectable async core (`_describe_async`) tested directly with an in-memory SQLite session.

**Flags:**
- `<commit>` (positional) — commit to describe; defaults to HEAD
- `--compare A B` — diff two explicit commits
- `--depth brief|standard|verbose` (default: `standard`)
- `--dimensions TEXT` — comma-separated dimension labels (informational passthrough)
- `--json` — JSON output
- `--auto-tag` — heuristic tag based on change scope (file count)

**Stub implementation:** compares snapshot manifests to compute a file-level structural diff (changed / added / removed files). Full harmonic/melodic analysis (chord progressions, motifs, groove scoring) is clearly documented as a planned enhancement requiring `muse harmony` and `muse motif`.

**Standard output example:**
```
Commit abc1234: "Add piano melody to verse"
Changed files: 2 (beat.mid, keys.mid)
Dimensions analyzed: structural (2 files modified)
Note: Full harmonic/melodic analysis requires muse harmony and muse motif (planned)
```

### Registration: `maestro/muse_cli/app.py`
Added `describe` import and `cli.add_typer(describe.app, ...)`.

### Docs: `docs/architecture/muse_vcs.md`
Added `muse describe` section with flag table, depth mode table, implementation layer table, and planned-enhancement note.

## Layers Affected
- [x] Muse VCS (new CLI command)

## Verification
- [x] `mypy /worktrees/issue-125/maestro/ /worktrees/issue-125/tests/` — clean (443 files)
- [x] `docker compose exec storpheus mypy .` — unaffected
- [x] 33 tests pass in `tests/muse_cli/test_describe.py`
- [x] Docs updated

## Tests Added
- `TestDiffManifests` — 6 unit tests for `_diff_manifests` (identical, modified, added, removed, mixed, sorted output)
- `TestInferDimensions` — 4 unit tests for dimension inference (no changes, singular, plural, passthrough)
- `TestSuggestTag` — 4 unit tests for `_suggest_tag` heuristic
- `TestDescribeResult` — 5 unit tests for `DescribeResult` (file count, to_dict structure)
- `test_describe_root_commit_no_parent` — root commit shows all files as added
- `test_describe_head_shows_diff_from_parent` — HEAD diff correctly identifies changed files
- `test_describe_explicit_commit_id` — explicit commit ID resolve
- `test_describe_compare_mode` — `--compare A B` produces correct diff
- `test_describe_depth_brief/standard/verbose` — depth output format validation
- `test_describe_json_output` — valid JSON with expected structure
- `test_describe_dimensions_passthrough` — user-supplied dimensions flow through
- `test_describe_auto_tag` — auto-tag produces non-empty result
- `test_describe_no_commits_exits_zero` — clean exit on empty repo
- `test_describe_unknown_commit_exits_user_error` — exit code 1 for bad commit ID
- `test_describe_outside_repo_exits_2` — exit code 2 outside `.muse/` repo

## Handoff
N/A — no SSE/MCP protocol change. Pure CLI addition.