### PR TITLE
feat: muse recall — keyword search over musical commit history

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -2097,6 +2097,27 @@ directly for JSON serialisation without any additional mapping step.
 **Producer:** `_match_commit()`, `_grep_async()`
 **Consumer:** `_render_matches()`, callers using `--json` output
 
+### `RecallResult`
+
+**Module:** `maestro/muse_cli/commands/recall.py`
+
+Ranked result entry returned by `muse recall`. Each entry represents one
+commit that scored at or above the `--threshold` keyword-overlap cutoff.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rank` | `int` | 1-based rank within the result set (1 = highest score) |
+| `score` | `float` | Keyword overlap coefficient ∈ [0, 1], rounded to 4 decimal places |
+| `commit_id` | `str` | Full 64-char SHA of the matching commit |
+| `date` | `str` | Commit timestamp formatted as `"YYYY-MM-DD HH:MM:SS"` |
+| `branch` | `str` | Branch the commit belongs to |
+| `message` | `str` | Full commit message |
+
+**Producer:** `_recall_async()`
+**Consumer:** `_render_results()`, callers using `--json` output
+
+---
+
 ### `DescribeResult`
 
 **Module:** `maestro/muse_cli/commands/describe.py`

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -2,7 +2,7 @@
 
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (init, status, commit, log, checkout, merge, remote,
-push, pull, open, play) as Typer sub-applications.
+push, pull, open, play, recall) as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -18,6 +18,7 @@ from maestro.muse_cli.commands import (
     play,
     pull,
     push,
+    recall,
     remote,
     status,
 )
@@ -39,6 +40,7 @@ cli.add_typer(push.app, name="push", help="Upload local variations to a remote."
 cli.add_typer(pull.app, name="pull", help="Download remote variations locally.")
 cli.add_typer(open_cmd.app, name="open", help="Open an artifact in the system default app (macOS).")
 cli.add_typer(play.app, name="play", help="Play an audio artifact via afplay (macOS).")
+cli.add_typer(recall.app, name="recall", help="Search commit history by natural-language description.")
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/commands/recall.py
+++ b/maestro/muse_cli/commands/recall.py
@@ -1,0 +1,312 @@
+"""muse recall — keyword search over musical commit history.
+
+Accepts a natural-language query string and returns the top-N commits from
+history ranked by keyword overlap against commit messages.
+
+Usage::
+
+    muse recall "dark jazz bassline"
+    muse recall "drum fill" --limit 3 --threshold 0.5 --branch main
+    muse recall "piano" --since 2026-01-01 --until 2026-02-01 --json
+
+Scoring algorithm (stub — vector search planned):
+    Each commit message is tokenized (lowercase, split on whitespace/punctuation).
+    The score is the normalised overlap coefficient between the query tokens and
+    the message tokens:
+
+        score = |query_tokens ∩ message_tokens| / |query_tokens|
+
+    This gives 1.0 when every query word appears in the message, and 0.0 when
+    none do.  Commits with score < ``--threshold`` are excluded.
+
+Note:
+    Full vector embedding search via Qdrant is a planned enhancement (see muse
+    context / issue backlog).  When implemented, the scoring function will be
+    replaced by cosine similarity over pre-computed embeddings, with no change
+    to the CLI interface.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+import re
+from datetime import datetime, timezone
+from typing import Annotated, TypedDict
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+_TOKEN_RE = re.compile(r"[a-zA-Z0-9]+")
+
+
+class RecallResult(TypedDict):
+    """A single ranked recall result entry."""
+
+    rank: int
+    score: float
+    commit_id: str
+    date: str
+    branch: str
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Scoring helpers
+# ---------------------------------------------------------------------------
+
+
+def _tokenize(text: str) -> set[str]:
+    """Return a set of lowercase word tokens from *text*."""
+    return {m.group().lower() for m in _TOKEN_RE.finditer(text)}
+
+
+def _score(query_tokens: set[str], message: str) -> float:
+    """Return a [0, 1] keyword overlap score.
+
+    Uses the overlap coefficient: |Q ∩ M| / |Q| so that a short, precise
+    query can match a verbose commit message without penalty.
+
+    Returns 0.0 when *query_tokens* is empty (avoids division by zero).
+    """
+    if not query_tokens:
+        return 0.0
+    message_tokens = _tokenize(message)
+    return len(query_tokens & message_tokens) / len(query_tokens)
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_commits(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    branch: str | None,
+    since: datetime | None,
+    until: datetime | None,
+) -> list[MuseCliCommit]:
+    """Fetch all candidate commits from the DB, optionally filtered.
+
+    Filters are applied at the SQL level to minimise in-memory work.  The
+    caller ranks and limits the result set.
+    """
+    stmt = select(MuseCliCommit).where(MuseCliCommit.repo_id == repo_id)
+
+    if branch is not None:
+        stmt = stmt.where(MuseCliCommit.branch == branch)
+    if since is not None:
+        stmt = stmt.where(MuseCliCommit.committed_at >= since)
+    if until is not None:
+        stmt = stmt.where(MuseCliCommit.committed_at <= until)
+
+    stmt = stmt.order_by(MuseCliCommit.committed_at.desc())
+
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def _recall_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    query: str,
+    limit: int,
+    threshold: float,
+    branch: str | None,
+    since: datetime | None,
+    until: datetime | None,
+    as_json: bool,
+) -> list[RecallResult]:
+    """Core recall logic — fully injectable for tests.
+
+    Returns the list of ranked result dicts (also echoed to stdout).
+    """
+    muse_dir = root / ".muse"
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]
+
+    # When no branch filter is given, default to current branch from HEAD.
+    effective_branch: str | None = branch
+    if effective_branch is None:
+        head_ref = (muse_dir / "HEAD").read_text().strip()
+        effective_branch = head_ref.rsplit("/", 1)[-1]
+
+    commits = await _fetch_commits(
+        session,
+        repo_id=repo_id,
+        branch=effective_branch,
+        since=since,
+        until=until,
+    )
+
+    query_tokens = _tokenize(query)
+    scored: list[tuple[float, MuseCliCommit]] = []
+    for commit in commits:
+        score = _score(query_tokens, commit.message)
+        if score >= threshold:
+            scored.append((score, commit))
+
+    # Sort by score descending, then by recency (committed_at desc) for ties.
+    scored.sort(key=lambda x: (x[0], x[1].committed_at.timestamp()), reverse=True)
+    top = scored[:limit]
+
+    results: list[RecallResult] = [
+        RecallResult(
+            rank=i + 1,
+            score=round(score, 4),
+            commit_id=commit.commit_id,
+            date=commit.committed_at.strftime("%Y-%m-%d %H:%M:%S"),
+            branch=commit.branch,
+            message=commit.message,
+        )
+        for i, (score, commit) in enumerate(top)
+    ]
+
+    if as_json:
+        typer.echo(json.dumps(results, indent=2))
+    else:
+        _render_results(query=query, results=results, threshold=threshold)
+
+    return results
+
+
+def _render_results(
+    *,
+    query: str,
+    results: list[RecallResult],
+    threshold: float,
+) -> None:
+    """Print ranked recall results in human-readable format.
+
+    Note: similarity scores are keyword-overlap estimates, not semantic
+    embeddings.  Vector search via Qdrant is a planned enhancement.
+    """
+    typer.echo(f'Recall: "{query}"')
+    typer.echo(f"(keyword match · threshold {threshold:.2f} · "
+               "vector search is a planned enhancement)")
+    typer.echo("")
+
+    if not results:
+        typer.echo("  No matching commits found.")
+        return
+
+    for entry in results:
+        typer.echo(
+            f"  #{entry['rank']}  score={entry['score']:.4f}  "
+            f"commit {entry['commit_id']}  [{entry['date']}]"
+        )
+        typer.echo(f"       {entry['message']}")
+        typer.echo("")
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def recall(
+    ctx: typer.Context,
+    query: Annotated[str, typer.Argument(help="Natural-language description to search for.")],
+    limit: int = typer.Option(
+        5,
+        "--limit",
+        "-n",
+        help="Maximum number of results to return.",
+        min=1,
+    ),
+    threshold: float = typer.Option(
+        0.6,
+        "--threshold",
+        help="Minimum similarity score (0–1) to include a commit.",
+        min=0.0,
+        max=1.0,
+    ),
+    branch: str | None = typer.Option(
+        None,
+        "--branch",
+        help="Filter by branch name (defaults to current branch).",
+    ),
+    since: str | None = typer.Option(
+        None,
+        "--since",
+        help="Only include commits on or after this date (YYYY-MM-DD).",
+    ),
+    until: str | None = typer.Option(
+        None,
+        "--until",
+        help="Only include commits on or before this date (YYYY-MM-DD).",
+    ),
+    as_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Output results as JSON.",
+    ),
+) -> None:
+    """Search commit history by description (keyword match over messages).
+
+    Returns the top ``--limit`` commits whose messages best match the query,
+    sorted by keyword overlap score.  Commits below ``--threshold`` are
+    excluded.
+
+    Note:
+        Full semantic vector search via Qdrant is a planned enhancement
+        (see muse context).  Until then, scoring is based on keyword overlap
+        between the query and commit messages.
+    """
+    # Validate date args first — fail fast before touching the filesystem.
+    since_dt: datetime | None = None
+    until_dt: datetime | None = None
+
+    if since:
+        try:
+            since_dt = datetime.strptime(since, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        except ValueError:
+            typer.echo(f"❌ --since: invalid date format '{since}' — expected YYYY-MM-DD")
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    if until:
+        try:
+            until_dt = datetime.strptime(until, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        except ValueError:
+            typer.echo(f"❌ --until: invalid date format '{until}' — expected YYYY-MM-DD")
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _recall_async(
+                root=root,
+                session=session,
+                query=query,
+                limit=limit,
+                threshold=threshold,
+                branch=branch,
+                since=since_dt,
+                until=until_dt,
+                as_json=as_json,
+            )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse recall failed: {exc}")
+        logger.error("❌ muse recall error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/tests/muse_cli/test_recall.py
+++ b/tests/muse_cli/test_recall.py
@@ -1,0 +1,491 @@
+"""Tests for ``muse recall``.
+
+All async tests call ``_recall_async`` directly with an in-memory SQLite
+session and a ``tmp_path`` repo root — no real Postgres or running process
+required.  Commits are seeded via ``_commit_async`` so the two commands
+are exercised as an integrated pair.
+
+Covers:
+- Keyword match returns top-N results sorted by score (highest first).
+- ``--limit`` restricts result count.
+- ``--threshold`` filters low-scoring commits.
+- ``--since`` / ``--until`` date filters.
+- ``--json`` emits valid JSON with the expected schema.
+- Query with zero matches returns empty result set (not an error).
+- CLI invocation outside a repo exits with code 2.
+- ``--since`` / ``--until`` with bad date strings exits with code 1.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.commands.recall import _recall_async, _score, _tokenize
+from maestro.muse_cli.errors import ExitCode
+
+
+# ---------------------------------------------------------------------------
+# Repo / workdir helpers (mirror test_log.py pattern)
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _write_workdir(root: pathlib.Path, files: dict[str, bytes]) -> None:
+    workdir = root / "muse-work"
+    workdir.mkdir(exist_ok=True)
+    for name, content in files.items():
+        (workdir / name).write_bytes(content)
+
+
+async def _make_commits(
+    root: pathlib.Path,
+    session: AsyncSession,
+    messages: list[str],
+    file_seed: int = 0,
+) -> list[str]:
+    """Create N commits on the repo, each with unique file content."""
+    commit_ids: list[str] = []
+    for i, msg in enumerate(messages):
+        _write_workdir(root, {f"track_{file_seed + i}.mid": f"MIDI-{file_seed + i}".encode()})
+        cid = await _commit_async(message=msg, root=root, session=session)
+        commit_ids.append(cid)
+    return commit_ids
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for scoring helpers
+# ---------------------------------------------------------------------------
+
+
+class TestScoringHelpers:
+    """Unit tests for ``_tokenize`` and ``_score`` — no DB required."""
+
+    def test_tokenize_splits_on_whitespace(self) -> None:
+        assert _tokenize("dark jazz bassline") == {"dark", "jazz", "bassline"}
+
+    def test_tokenize_is_lowercase(self) -> None:
+        assert _tokenize("DARK Jazz") == {"dark", "jazz"}
+
+    def test_tokenize_ignores_punctuation(self) -> None:
+        tokens = _tokenize("boom, bap! drum-fill")
+        assert "boom" in tokens
+        assert "bap" in tokens
+        assert "drum" in tokens
+        assert "fill" in tokens
+
+    def test_score_full_match_returns_one(self) -> None:
+        q = _tokenize("jazz bassline")
+        score = _score(q, "this is a jazz bassline")
+        assert score == 1.0
+
+    def test_score_no_match_returns_zero(self) -> None:
+        q = _tokenize("jazz bassline")
+        score = _score(q, "rock guitar solo")
+        assert score == 0.0
+
+    def test_score_partial_match(self) -> None:
+        q = _tokenize("jazz drum fill")
+        score = _score(q, "a cool jazz moment")
+        assert 0.0 < score < 1.0
+        assert score == pytest.approx(1 / 3, rel=1e-6)
+
+    def test_score_empty_query_returns_zero(self) -> None:
+        score = _score(set(), "anything")
+        assert score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# test_recall_returns_top_n_by_score
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_recall_returns_top_n_by_score(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Commits with higher keyword overlap rank before those with lower overlap."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(
+        tmp_path,
+        muse_cli_db_session,
+        [
+            "boom bap drum pattern",
+            "jazz piano chord voicing",
+            "boom bap jazz fusion groove",
+            "classical string quartet",
+        ],
+    )
+
+    results = await _recall_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        query="boom bap jazz",
+        limit=5,
+        threshold=0.0,
+        branch=None,
+        since=None,
+        until=None,
+        as_json=False,
+    )
+
+    assert len(results) > 0
+    assert results[0]["message"] == "boom bap jazz fusion groove"
+    assert results[0]["score"] == pytest.approx(1.0)
+
+    scores = [r["score"] for r in results]
+    assert scores == sorted(scores, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# test_recall_limit_restricts_result_count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_recall_limit_restricts_result_count(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--limit 2`` returns at most 2 results even if more match."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(
+        tmp_path,
+        muse_cli_db_session,
+        [
+            "jazz piano solo",
+            "jazz drum groove",
+            "jazz bass walk",
+            "jazz chord progression",
+        ],
+    )
+
+    results = await _recall_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        query="jazz",
+        limit=2,
+        threshold=0.0,
+        branch=None,
+        since=None,
+        until=None,
+        as_json=False,
+    )
+
+    assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# test_recall_threshold_filters_low_scores
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_recall_threshold_filters_low_scores(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Commits with score < threshold are excluded from results."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(
+        tmp_path,
+        muse_cli_db_session,
+        [
+            "jazz piano solo",
+            "classical strings",
+        ],
+    )
+
+    results = await _recall_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        query="jazz",
+        limit=5,
+        threshold=0.6,
+        branch=None,
+        since=None,
+        until=None,
+        as_json=False,
+    )
+
+    assert all(r["score"] >= 0.6 for r in results)
+    messages = [r["message"] for r in results]
+    assert "jazz piano solo" in messages
+    assert "classical strings" not in messages
+
+
+# ---------------------------------------------------------------------------
+# test_recall_no_matches_returns_empty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_recall_no_matches_returns_empty(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A query that matches nothing returns an empty list (not an error)."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(tmp_path, muse_cli_db_session, ["rock guitar riff"])
+
+    results = await _recall_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        query="jazz bassline",
+        limit=5,
+        threshold=0.6,
+        branch=None,
+        since=None,
+        until=None,
+        as_json=False,
+    )
+
+    assert results == []
+    out = capsys.readouterr().out
+    assert "No matching commits found" in out
+
+
+# ---------------------------------------------------------------------------
+# test_recall_json_output_valid_schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_recall_json_output_valid_schema(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--json`` output is valid JSON with expected fields."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(tmp_path, muse_cli_db_session, ["jazz drum groove"])
+    capsys.readouterr()  # discard commit output before testing recall JSON
+
+    await _recall_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        query="jazz drum",
+        limit=5,
+        threshold=0.0,
+        branch=None,
+        since=None,
+        until=None,
+        as_json=True,
+    )
+
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert isinstance(parsed, list)
+    assert len(parsed) >= 1
+
+    entry = parsed[0]
+    assert "rank" in entry
+    assert "score" in entry
+    assert "commit_id" in entry
+    assert "date" in entry
+    assert "branch" in entry
+    assert "message" in entry
+    assert entry["rank"] == 1
+    assert isinstance(entry["score"], float)
+    assert entry["branch"] == "main"
+
+
+# ---------------------------------------------------------------------------
+# test_recall_rank_field_is_sequential
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_recall_rank_field_is_sequential(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``rank`` starts at 1 and increments sequentially."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(
+        tmp_path,
+        muse_cli_db_session,
+        ["jazz piano", "jazz drums", "jazz bass"],
+    )
+
+    results = await _recall_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        query="jazz",
+        limit=5,
+        threshold=0.0,
+        branch=None,
+        since=None,
+        until=None,
+        as_json=False,
+    )
+
+    assert [r["rank"] for r in results] == list(range(1, len(results) + 1))
+
+
+# ---------------------------------------------------------------------------
+# test_recall_since_filter_excludes_older_commits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_recall_since_filter_excludes_older_commits(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--since`` set to the future excludes all commits."""
+    from datetime import datetime, timezone
+
+    _init_muse_repo(tmp_path)
+    await _make_commits(tmp_path, muse_cli_db_session, ["jazz rhythm section"])
+
+    future = datetime(2099, 1, 1, tzinfo=timezone.utc)
+
+    results = await _recall_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        query="jazz",
+        limit=5,
+        threshold=0.0,
+        branch=None,
+        since=future,
+        until=None,
+        as_json=False,
+    )
+
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# test_recall_until_filter_excludes_newer_commits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_recall_until_filter_excludes_newer_commits(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--until`` set in the past excludes all commits."""
+    from datetime import datetime, timezone
+
+    _init_muse_repo(tmp_path)
+    await _make_commits(tmp_path, muse_cli_db_session, ["jazz rhythm section"])
+
+    past = datetime(2000, 1, 1, tzinfo=timezone.utc)
+
+    results = await _recall_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        query="jazz",
+        limit=5,
+        threshold=0.0,
+        branch=None,
+        since=None,
+        until=past,
+        as_json=False,
+    )
+
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# test_recall_outside_repo_exits_2
+# ---------------------------------------------------------------------------
+
+
+def test_recall_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse recall`` outside a .muse/ directory exits with code 2."""
+    from typer.testing import CliRunner
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["recall", "jazz"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# test_recall_bad_since_date_exits_1
+# ---------------------------------------------------------------------------
+
+
+def test_recall_bad_since_date_exits_1() -> None:
+    """``--since`` with a non-YYYY-MM-DD value exits with code 1.
+
+    Date validation occurs before repo discovery so no repo setup is needed.
+    """
+    import typer
+    from maestro.muse_cli.commands.recall import recall as recall_cmd
+
+    with pytest.raises(typer.Exit) as exc_info:
+        recall_cmd(
+            ctx=None,  # type: ignore[arg-type]
+            query="jazz",
+            limit=5,
+            threshold=0.6,
+            branch=None,
+            since="not-a-date",
+            until=None,
+            as_json=False,
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+
+# ---------------------------------------------------------------------------
+# test_recall_bad_until_date_exits_1
+# ---------------------------------------------------------------------------
+
+
+def test_recall_bad_until_date_exits_1() -> None:
+    """``--until`` with a non-YYYY-MM-DD value exits with code 1.
+
+    Date validation occurs before repo discovery so no repo setup is needed.
+    """
+    import typer
+    from maestro.muse_cli.commands.recall import recall as recall_cmd
+
+    with pytest.raises(typer.Exit) as exc_info:
+        recall_cmd(
+            ctx=None,  # type: ignore[arg-type]
+            query="jazz",
+            limit=5,
+            threshold=0.6,
+            branch=None,
+            since=None,
+            until="2026/01/01",
+            as_json=False,
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR


### PR DESCRIPTION
## Summary
Closes #122 — implements \`muse recall \"<description>\" [OPTIONS]\` command for searching commit history by natural-language description.

## Root Cause / Motivation
The Muse CLI lacked any way to search commit history by content. Users had to scroll through \`muse log\` output to find relevant commits. This command provides a fast keyword-based recall mechanism as the foundation for future vector-based semantic search.

## Solution
Added \`maestro/muse_cli/commands/recall.py\` following the exact pattern of \`log.py\`:

- **Scoring**: overlap coefficient \`|Q ∩ M| / |Q|\` between query tokens and commit message tokens — scores 1.0 when every query word appears in the message
- **Flags**: \`--limit N\` (default 5), \`--threshold FLOAT\` (default 0.6), \`--branch TEXT\`, \`--since DATE\`, \`--until DATE\`, \`--json\`
- **TypedDict**: \`RecallResult\` with typed fields \`rank\`, \`score\`, \`commit_id\`, \`date\`, \`branch\`, \`message\` — clean mypy boundary
- **Date validation**: occurs before \`require_repo()\` (fail-fast UX)
- **Stub note**: docstring and output clearly state vector search via Qdrant is a planned enhancement

Registered in \`maestro/muse_cli/app.py\` alongside existing commands.

## Layers Affected
- [x] Muse VCS (CLI commands)

## Verification
- [x] \`mypy\` clean (443 source files, no issues)
- [x] 18 tests pass: \`tests/muse_cli/test_recall.py\`
- [x] No new DB tables — reads existing \`muse_cli_commits\`
- [x] No new dependencies

## Tests Added
- \`TestScoringHelpers\` — 7 unit tests for \`_tokenize\` / \`_score\`
- \`test_recall_returns_top_n_by_score\` — ranking correctness
- \`test_recall_limit_restricts_result_count\` — \`--limit\` flag
- \`test_recall_threshold_filters_low_scores\` — \`--threshold\` flag
- \`test_recall_no_matches_returns_empty\` — zero-result case (not an error)
- \`test_recall_json_output_valid_schema\` — \`--json\` schema validation
- \`test_recall_rank_field_is_sequential\` — rank ordering
- \`test_recall_since_filter_excludes_older_commits\` — \`--since\` filter
- \`test_recall_until_filter_excludes_newer_commits\` — \`--until\` filter
- \`test_recall_outside_repo_exits_2\` — repo detection failure
- \`test_recall_bad_since_date_exits_1\` — bad \`--since\` date format
- \`test_recall_bad_until_date_exits_1\` — bad \`--until\` date format

## Handoff
N/A — no protocol change (no SSE events, no MCP tool schema changes, no API endpoint changes).

## Follow-up
The \`--threshold\` and scoring are keyword-based. Full semantic vector search via Qdrant (embedding commit messages at commit time, querying by cosine similarity) is the planned next step documented in the command's docstring.