### PR TITLE
feat: muse divergence <branch-a> <branch-b> — show how two branches have diverged musically

### DIFF
--- a/.cursor/PARALLEL_ISSUE_TO_PR.md
+++ b/.cursor/PARALLEL_ISSUE_TO_PR.md
@@ -75,12 +75,18 @@ cd "$REPO"
 DEV_SHA=$(git rev-parse dev)
 
 # --- define issues (confirmed independent — zero file overlap) ---
+# Batch: #112–#119 (new muse CLI commands)
+# Known shared file: maestro/muse_cli/app.py (each agent adds one app.add_typer line)
+# Resolution: pre-push sync in STEP 4 handles app.py conflicts — keep both sides.
 declare -a ISSUES=(
-  "35|feat: muse merge — fast-forward and 3-way merge with path-level conflict detection"
-  "37|feat: Maestro stress test → muse-work/ output contract with muse-batch.json manifest"
-  "40|feat: Muse Hub push/pull sync protocol — batch commit and object transfer"
-  "41|feat: Muse Hub pull requests — create, list, and merge PRs between branches"
-  "47|feat: Muse Hub JWT auth integration — CLI token storage and Hub request authentication"
+  "119|feat: muse divergence — show how two branches have diverged musically"
+  "118|feat: muse import <file> — import a MIDI or MusicXML file as a new Muse commit"
+  "117|feat: muse meter [<commit>] [--set <time-sig>] — read or set the time signature"
+  "116|feat: muse tempo [<commit>] [--set <bpm>] — read or set the tempo of a commit"
+  "115|feat: muse arrange [<commit>] — display the arrangement map (instrument activity over sections)"
+  "114|feat: muse find — search commit history by musical properties"
+  "113|feat: muse context [<commit>] — output structured musical context for AI agent consumption"
+  "112|feat: muse export [<commit>] --format <format> — export a Muse snapshot to external formats"
 )
 
 # --- create worktrees + task files ---

--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -830,3 +830,376 @@ muse commit --from-batch muse-batch.json
 ```
 
 ---
+
+## Muse CLI — Music Analysis Command Reference
+
+These commands expose musical dimensions across the commit graph — the layer that
+makes Muse fundamentally different from Git. Each command is consumed by AI agents
+to make musically coherent generation decisions. Every flag is part of a stable
+CLI contract; stub implementations are clearly marked.
+
+**Agent pattern:** Run with `--json` to get machine-readable output. Pipe into
+`muse context` for a unified musical state document.
+
+---
+
+### `muse dynamics`
+
+**Purpose:** Analyze the velocity (loudness) profile of a commit across all instrument
+tracks. The primary tool for understanding the dynamic arc of an arrangement and
+detecting flat, robotic, or over-compressed MIDI.
+
+**Usage:**
+```bash
+muse dynamics [<commit>] [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `COMMIT` | positional | HEAD | Commit ref to analyze |
+| `--track TEXT` | string | all tracks | Case-insensitive prefix filter (e.g. `--track bass`) |
+| `--section TEXT` | string | — | Restrict to a named section/region (planned) |
+| `--compare COMMIT` | string | — | Side-by-side comparison with another commit (planned) |
+| `--history` | flag | off | Show dynamics for every commit in branch history (planned) |
+| `--peak` | flag | off | Show only tracks whose peak velocity exceeds the branch average |
+| `--range` | flag | off | Sort output by velocity range descending |
+| `--arc` | flag | off | When combined with `--track`, treat its value as an arc label filter |
+| `--json` | flag | off | Emit structured JSON for agent consumption |
+
+**Arc labels:**
+
+| Label | Meaning |
+|-------|---------|
+| `flat` | Velocity variance < 10; steady throughout |
+| `crescendo` | Monotonically rising from start to end |
+| `decrescendo` | Monotonically falling from start to end |
+| `terraced` | Step-wise plateaus; sudden jumps between stable levels |
+| `swell` | Rises then falls (arch shape) |
+
+**Output example (text):**
+```
+Dynamic profile — commit a1b2c3d4  (HEAD -> main)
+
+Track      Avg Vel  Peak  Range  Arc
+---------  -------  ----  -----  -----------
+drums           88   110     42  terraced
+bass            72    85     28  flat
+keys            64    95     56  crescendo
+lead            79   105     38  swell
+```
+
+**Output example (`--json`):**
+```json
+{
+  "commit": "a1b2c3d4",
+  "branch": "main",
+  "tracks": [
+    {"track": "drums", "avg_velocity": 88, "peak_velocity": 110, "velocity_range": 42, "arc": "terraced"}
+  ]
+}
+```
+
+**Result type:** `TrackDynamics` — fields: `name`, `avg_velocity`, `peak_velocity`, `velocity_range`, `arc`
+
+**Agent use case:** Before generating a new layer, an agent calls `muse dynamics --json` to understand the current velocity landscape. If the arrangement is `flat` across all tracks, the agent adds velocity variation to the new part. If the arc is `crescendo`, the agent ensures the new layer contributes to rather than fights the build.
+
+**Implementation:** `maestro/muse_cli/commands/dynamics.py` — `_dynamics_async` (injectable async core), `TrackDynamics` (result entity), `_render_table` / `_render_json` (renderers). Exit codes: 0 success, 2 outside repo, 3 internal.
+
+> **Stub note:** Arc classification and velocity statistics are placeholder values. Full implementation requires MIDI note velocity extraction from committed snapshot objects (future: Storpheus MIDI parse route).
+
+---
+
+### `muse swing`
+
+**Purpose:** Measure or annotate the swing factor of a commit — the ratio that
+distinguishes a straight 8th-note grid from a shuffled jazz feel. Swing is one
+of the most musically critical dimensions and is completely invisible to Git.
+
+**Usage:**
+```bash
+muse swing [<commit>] [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `COMMIT` | positional | working tree | Commit SHA to analyze |
+| `--set FLOAT` | float | — | Annotate with an explicit swing factor (0.5–0.67) |
+| `--detect` | flag | on | Detect and display the swing factor (default) |
+| `--track TEXT` | string | all | Restrict to a named MIDI track (e.g. `--track bass`) |
+| `--compare COMMIT` | string | — | Compare HEAD swing against another commit |
+| `--history` | flag | off | Show swing history for the current branch |
+| `--json` | flag | off | Emit machine-readable JSON |
+
+**Swing factor scale:**
+
+| Range | Label | Feel |
+|-------|-------|------|
+| < 0.53 | Straight | Equal 8th notes — pop, EDM, quantized |
+| 0.53–0.58 | Light | Subtle shuffle — R&B, Neo-soul |
+| 0.58–0.63 | Medium | Noticeable swing — jazz, hip-hop |
+| ≥ 0.63 | Hard | Triplet feel — bebop, heavy jazz |
+
+**Output example (text):**
+```
+Swing factor: 0.55 (Light)
+Commit: a1b2c3d4  Branch: main
+Track: all
+```
+
+**Output example (`--json`):**
+```json
+{"factor": 0.55, "label": "Light", "commit": "a1b2c3d4", "branch": "main", "track": "all"}
+```
+
+**Result type:** `dict` with keys `factor` (float), `label` (str), `commit` (str), `branch` (str), `track` (str). Future: typed `SwingResult` dataclass.
+
+**Agent use case:** An AI generating a bass line runs `muse swing --json` to know whether to quantize straight or add shuffle. A Medium swing result means the bass should land slightly behind the grid to stay in pocket with the existing drum performance.
+
+**Implementation:** `maestro/muse_cli/commands/swing.py` — `swing_label()`, `_swing_detect_async()`, `_swing_history_async()`, `_swing_compare_async()`, formatters. Exit codes: 0 success, 1 invalid `--set` value, 2 outside repo.
+
+> **Stub note:** Returns a placeholder factor of 0.55. Full implementation requires onset-to-onset ratio measurement from committed MIDI note events (future: Storpheus MIDI parse route).
+
+---
+
+### `muse recall`
+
+**Purpose:** Search the full commit history using natural language. Returns ranked
+commits whose messages best match the query. The musical memory retrieval command —
+"find me that arrangement I made three months ago."
+
+**Usage:**
+```bash
+muse recall "<description>" [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `QUERY` | positional | required | Natural-language description of what to find |
+| `--limit N` | int | 5 | Maximum results to return |
+| `--threshold FLOAT` | float | 0.6 | Minimum similarity score (0.0–1.0) |
+| `--branch TEXT` | string | all branches | Restrict search to a specific branch |
+| `--since DATE` | `YYYY-MM-DD` | — | Only search commits after this date |
+| `--until DATE` | `YYYY-MM-DD` | — | Only search commits before this date |
+| `--json` | flag | off | Emit structured JSON array |
+
+**Scoring (current stub):** Normalized keyword overlap coefficient — `|Q ∩ M| / |Q|` — where Q is the set of query tokens and M is the set of message tokens. Score 1.0 means every query word appeared in the commit message.
+
+**Output example (text):**
+```
+Recall: "dark jazz bassline"
+keyword match · threshold 0.60 · limit 5
+
+  1. [a1b2c3d4]  2026-02-15 22:00  boom bap demo take 3      score 0.67
+  2. [f9e8d7c6]  2026-02-10 18:30  jazz bass overdub session  score 0.50
+```
+
+**Result type:** `RecallResult` (TypedDict) — fields: `rank` (int), `score` (float), `commit_id` (str), `date` (str), `branch` (str), `message` (str)
+
+**Agent use case:** An agent asked to "generate something like that funky bass riff from last month" calls `muse recall "funky bass" --json --limit 3` to retrieve the closest historical commits, then uses those as style references for generation.
+
+**Implementation:** `maestro/muse_cli/commands/recall.py` — `RecallResult` (TypedDict), `_tokenize()`, `_score()`, `_recall_async()`. Exit codes: 0 success, 1 bad date format, 2 outside repo.
+
+> **Stub note:** Uses keyword overlap. Full implementation: vector embeddings stored in Qdrant, cosine similarity retrieval. The CLI interface will not change when vector search is added.
+
+---
+
+### `muse grep`
+
+**Purpose:** Search all commits for a musical pattern — a note sequence, interval
+pattern, or chord symbol. Currently searches commit messages; full MIDI content
+search is the planned implementation.
+
+**Usage:**
+```bash
+muse grep <pattern> [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `PATTERN` | positional | required | Pattern to find (note seq, interval, chord, or text) |
+| `--track TEXT` | string | — | Restrict to a named track (MIDI content search — planned) |
+| `--section TEXT` | string | — | Restrict to a named section (planned) |
+| `--transposition-invariant` | flag | on | Match in any key (planned for MIDI search) |
+| `--rhythm-invariant` | flag | off | Match regardless of rhythm (planned) |
+| `--commits` | flag | off | Output one commit ID per line instead of full table |
+| `--json` | flag | off | Emit structured JSON array |
+
+**Pattern formats (planned for MIDI content search):**
+
+| Format | Example | Matches |
+|--------|---------|---------|
+| Note sequence | `"C4 E4 G4"` | Those exact pitches in sequence |
+| Interval run | `"+4 +3"` | Major 3rd + minor 3rd (Cm arpeggio) |
+| Chord symbol | `"Cm7"` | That chord anywhere in the arrangement |
+| Text | `"verse piano"` | Commit message substring (current implementation) |
+
+**Output example (text):**
+```
+Pattern: "dark jazz" (2 matches)
+
+Commit       Branch   Committed            Message              Source
+-----------  -------  -------------------  -------------------  -------
+a1b2c3d4     main     2026-02-15 22:00     boom bap dark jazz   message
+f9e8d7c6     main     2026-02-10 18:30     dark jazz bass       message
+```
+
+**Result type:** `GrepMatch` (dataclass) — fields: `commit_id` (str), `branch` (str), `message` (str), `committed_at` (str ISO-8601), `match_source` (str: `"message"` | `"branch"` | `"midi_content"`)
+
+**Agent use case:** An agent searching for prior uses of a Cm7 chord calls `muse grep "Cm7" --commits --json` to get a list of commits containing that chord. It can then pull those commits as harmonic reference material.
+
+**Implementation:** `maestro/muse_cli/commands/grep_cmd.py` — registered as `muse grep`. `GrepMatch` (dataclass), `_load_all_commits()`, `_grep_async()`, `_render_matches()`. Exit codes: 0 success, 2 outside repo.
+
+> **Stub note:** Pattern matched against commit messages only. MIDI content scanning (parsing note events from snapshot objects) is tracked as a follow-up issue.
+
+---
+
+### `muse ask`
+
+**Purpose:** Natural language question answering over commit history. Ask questions
+in plain English; Muse searches history and returns a grounded answer citing specific
+commits. The conversational interface to musical memory.
+
+**Usage:**
+```bash
+muse ask "<question>" [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `QUESTION` | positional | required | Natural-language question about musical history |
+| `--branch TEXT` | string | all | Restrict history to a branch |
+| `--since DATE` | `YYYY-MM-DD` | — | Only consider commits after this date |
+| `--until DATE` | `YYYY-MM-DD` | — | Only consider commits before this date |
+| `--cite` | flag | off | Show full commit IDs in the answer (default: short IDs) |
+| `--json` | flag | off | Emit structured JSON response |
+
+**Output example (text):**
+```
+Based on Muse history (47 commits searched):
+Commits matching your query: 3 found
+
+  [a1b2c3d] 2026-02-15 22:00  boom bap dark jazz session
+  [f9e8d7c] 2026-02-10 18:30  Add bass overdub — minor key
+  [3b2a1f0] 2026-01-28 14:00  Initial tempo work at 118 BPM
+
+Note: Full LLM-powered answer generation is a planned enhancement.
+```
+
+**Output example (`--json`):**
+```json
+{
+  "question": "when did we work on jazz?",
+  "total_searched": 47,
+  "matches_found": 3,
+  "commits": [{"id": "a1b2c3d4...", "short_id": "a1b2c3d", "date": "2026-02-15", "message": "..."}],
+  "stub_note": "Full LLM answer generation is a planned enhancement."
+}
+```
+
+**Result type:** `AnswerResult` (class) — fields: `question` (str), `total_searched` (int), `matches` (list[MuseCliCommit]), `cite` (bool). Methods: `.to_plain()`, `.to_json_dict()`.
+
+**Agent use case:** An AI agent composing a bridge asks `muse ask "what was the emotional arc of the chorus?" --json`. The answer grounds the agent in the actual commit history of the project before it generates, preventing stylistic drift.
+
+**Implementation:** `maestro/muse_cli/commands/ask.py` — `AnswerResult`, `_keywords()`, `_ask_async()`. Exit codes: 0 success, 1 bad date, 2 outside repo.
+
+> **Stub note:** Keyword matching over commit messages. Full implementation: RAG over Qdrant musical context embeddings + LLM answer synthesis via OpenRouter (Claude Sonnet/Opus). CLI interface is stable and will not change when LLM is wired in.
+
+---
+
+### `muse session`
+
+**Purpose:** Record and query recording session metadata — who played, when, where,
+and what they intended to create. Sessions are stored as local JSON files (not in
+Postgres), mirroring how Git stores config as plain files.
+
+**Usage:**
+```bash
+muse session <subcommand> [OPTIONS]
+```
+
+**Subcommands:**
+
+| Subcommand | Description |
+|------------|-------------|
+| `muse session start` | Open a new recording session |
+| `muse session end` | Finalize the active session |
+| `muse session log` | List all completed sessions, newest first |
+| `muse session show <id>` | Print a specific session by ID (prefix match) |
+| `muse session credits` | Aggregate participants across all sessions |
+
+**`muse session start` flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--participants TEXT` | string | — | Comma-separated participant names |
+| `--location TEXT` | string | — | Studio or location name |
+| `--intent TEXT` | string | — | Creative intent for this session |
+
+**`muse session end` flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--notes TEXT` | string | — | Session notes / retrospective |
+
+**Session JSON schema** (stored in `.muse/sessions/<uuid>.json`):
+```json
+{
+  "session_id": "<uuid4>",
+  "started_at": "2026-02-27T22:00:00+00:00",
+  "ended_at": "2026-02-27T02:30:00+00:00",
+  "participants": ["Gabriel (producer)", "Sarah (keys)"],
+  "location": "Studio A",
+  "intent": "Piano overdubs for verse sections",
+  "commits": [],
+  "notes": "Great tone on the Steinway today."
+}
+```
+
+**`muse session log` output:**
+```
+SESSION  2026-02-27T22:00  → 2026-02-27T02:30  2h30m
+  Participants: Gabriel (producer), Sarah (keys)
+  Location:     Studio A
+  Intent:       Piano overdubs for verse sections
+```
+
+**`muse session credits` output:**
+```
+Gabriel (producer)  7 sessions
+Sarah (keys)        3 sessions
+Marcus (bass)       2 sessions
+```
+
+**Agent use case:** An AI agent summarizing a project's creative history calls `muse session credits --json` to attribute musical contributions. An AI generating liner notes reads `muse session log --json` to reconstruct the session timeline.
+
+**Implementation:** `maestro/muse_cli/commands/session.py` — all synchronous (no DB, no async). Storage: `.muse/sessions/current.json` (active) → `.muse/sessions/<uuid>.json` (completed). Exit codes: 0 success, 1 user error (duplicate session, no active session, ambiguous ID), 2 outside repo, 3 internal.
+
+---
+
+### Command Registration Summary
+
+| Command | File | Status | Issue |
+|---------|------|--------|-------|
+| `muse dynamics` | `commands/dynamics.py` | ✅ stub (PR #130) | #120 |
+| `muse swing` | `commands/swing.py` | ✅ stub (PR #131) | #121 |
+| `muse recall` | `commands/recall.py` | ✅ stub (PR #135) | #122 |
+| `muse tag` | `commands/tag.py` | ✅ implemented (PR #133) | #123 |
+| `muse grep` | `commands/grep_cmd.py` | ✅ stub (PR #128) | #124 |
+| `muse describe` | `commands/describe.py` | ✅ stub (PR #134) | #125 |
+| `muse ask` | `commands/ask.py` | ✅ stub (PR #132) | #126 |
+| `muse session` | `commands/session.py` | ✅ implemented (PR #129) | #127 |
+
+All stub commands have stable CLI contracts. Full musical analysis (MIDI content
+parsing, vector embeddings, LLM synthesis) is tracked as follow-up issues.
+
+---

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -21,6 +21,7 @@ This document is the single source of truth for every named entity (TypedDict, d
    - [Assets (`maestro/services/assets.py`)](#assets)
    - [StorpheusRawResponse](#storpheusrawresponse)
    - [SampleChange](#samplechange)
+   - [Muse Divergence Types](#muse-divergence-types)
    - [ExpressivenessResult](#expressivenessresult)
 5. [Variation Layer (`app/variation/`)](#variation-layer)
    - [Event Envelope payloads](#event-envelope-payloads)
@@ -928,6 +929,56 @@ On failure: `success=False` plus `error` (and optionally `message`).
 | `note` | | `NoteDict \| None` | The note (for `added`/`removed`) |
 | `before` | | `NoteDict \| None` | Original note (for `modified`) |
 | `after` | | `NoteDict \| None` | New note (for `modified`) |
+
+---
+
+### Muse Divergence Types
+
+**Path:** `maestro/services/muse_divergence.py`
+
+#### `DivergenceLevel`
+
+`str, Enum` — Qualitative label for a per-dimension or overall divergence score.
+
+| Value | Score Range | Meaning |
+|-------|-------------|---------|
+| `"none"` | < 0.15 | No meaningful divergence |
+| `"low"` | 0.15 – 0.40 | Minor divergence, mostly aligned |
+| `"med"` | 0.40 – 0.70 | Moderate divergence, different directions |
+| `"high"` | ≥ 0.70 | High divergence, completely different creative paths |
+
+#### `DimensionDivergence`
+
+`dataclass(frozen=True)` — Divergence score and human description for a single musical dimension.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dimension` | `str` | Dimension name: `"melodic"`, `"harmonic"`, `"rhythmic"`, `"structural"`, or `"dynamic"` |
+| `level` | `DivergenceLevel` | Qualitative level label |
+| `score` | `float` | Normalised score in [0.0, 1.0] — `|sym_diff| / |union|` over classified paths |
+| `description` | `str` | Human-readable summary of the divergence |
+| `branch_a_summary` | `str` | E.g. `"2 melodic file(s) changed"` |
+| `branch_b_summary` | `str` | E.g. `"0 melodic file(s) changed"` |
+
+#### `MuseDivergenceResult`
+
+`dataclass(frozen=True)` — Full musical divergence report between two CLI branches.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `branch_a` | `str` | Name of the first branch |
+| `branch_b` | `str` | Name of the second branch |
+| `common_ancestor` | `str \| None` | Merge-base commit ID; `None` if histories are disjoint |
+| `dimensions` | `tuple[DimensionDivergence, ...]` | Per-dimension results |
+| `overall_score` | `float` | Mean of all per-dimension scores in [0.0, 1.0] |
+
+**Where used:**
+
+| Module | Usage |
+|--------|-------|
+| `maestro/services/muse_divergence.py` | `compute_divergence` return type |
+| `maestro/muse_cli/commands/divergence.py` | `render_text`, `render_json` input |
+| `tests/test_muse_divergence.py` | All async divergence tests |
 
 ---
 

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -2,7 +2,7 @@
 
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (init, status, commit, log, checkout, merge, remote,
-push, pull, open, play) as Typer sub-applications.
+push, pull, open, play, divergence) as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ import typer
 from maestro.muse_cli.commands import (
     checkout,
     commit,
+    divergence,
     init,
     log,
     merge,
@@ -39,6 +40,7 @@ cli.add_typer(push.app, name="push", help="Upload local variations to a remote."
 cli.add_typer(pull.app, name="pull", help="Download remote variations locally.")
 cli.add_typer(open_cmd.app, name="open", help="Open an artifact in the system default app (macOS).")
 cli.add_typer(play.app, name="play", help="Play an audio artifact via afplay (macOS).")
+cli.add_typer(divergence.app, name="divergence", help="Show how two branches have diverged musically.")
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/commands/divergence.py
+++ b/maestro/muse_cli/commands/divergence.py
@@ -60,7 +60,7 @@ import asyncio
 import json
 import logging
 import pathlib
-from typing import Optional
+from typing import Optional, TypedDict
 
 import typer
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -77,6 +77,27 @@ from maestro.services.muse_divergence import (
 logger = logging.getLogger(__name__)
 
 app = typer.Typer()
+
+
+class _DimJsonEntry(TypedDict):
+    """JSON-serialisable representation of a single dimension divergence entry."""
+
+    dimension: str
+    level: str
+    score: float
+    description: str
+    branch_a_summary: str
+    branch_b_summary: str
+
+
+class _DivergenceJson(TypedDict):
+    """JSON-serialisable representation of a full divergence result."""
+
+    branch_a: str
+    branch_b: str
+    common_ancestor: str | None
+    overall_score: float
+    dimensions: list[_DimJsonEntry]
 
 _LEVEL_LABELS: dict[DivergenceLevel, str] = {
     DivergenceLevel.NONE: "NONE",
@@ -118,7 +139,7 @@ def render_json(result: MuseDivergenceResult) -> None:
     Args:
         result: The divergence result to render.
     """
-    data: dict[str, object] = {
+    data: _DivergenceJson = {
         "branch_a": result.branch_a,
         "branch_b": result.branch_b,
         "common_ancestor": result.common_ancestor,

--- a/maestro/muse_cli/commands/divergence.py
+++ b/maestro/muse_cli/commands/divergence.py
@@ -1,0 +1,247 @@
+"""muse divergence — show how two branches have diverged musically.
+
+Computes a per-dimension musical divergence report between two CLI branches.
+
+Usage
+-----
+::
+
+    muse divergence <branch-a> <branch-b> [OPTIONS]
+
+Options
+-------
+- ``--since <commit>``       Common ancestor commit ID (auto-detected if omitted).
+- ``--dimensions <name>``    Dimension(s) to analyse — may be repeated
+                             (default: all five dimensions).
+- ``--json``                 Machine-readable JSON output.
+
+Output example (text mode)
+--------------------------
+::
+
+    Musical Divergence: feature/guitar-version vs feature/piano-version
+    Common ancestor: 7e3a1f2c
+
+    Melodic divergence:     HIGH — High melodic divergence — branches took different creative paths.
+      feature/guitar-version: 2 melodic file(s) changed
+      feature/piano-version:  0 melodic file(s) changed
+
+    Harmonic divergence:    MED  — Moderate harmonic divergence — different directions.
+      feature/guitar-version: 1 harmonic file(s) changed
+      feature/piano-version:  2 harmonic file(s) changed
+
+    Overall divergence score: 0.60
+
+Output example (JSON mode)
+--------------------------
+::
+
+    {
+      "branch_a": "feature/guitar-version",
+      "branch_b": "feature/piano-version",
+      "common_ancestor": "7e3a1f2c...",
+      "overall_score": 0.60,
+      "dimensions": [
+        {
+          "dimension": "melodic",
+          "level": "high",
+          "score": 1.0,
+          "description": "High melodic divergence — branches took different creative paths.",
+          "branch_a_summary": "2 melodic file(s) changed",
+          "branch_b_summary": "0 melodic file(s) changed"
+        }
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.services.muse_divergence import (
+    DivergenceLevel,
+    MuseDivergenceResult,
+    compute_divergence,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+_LEVEL_LABELS: dict[DivergenceLevel, str] = {
+    DivergenceLevel.NONE: "NONE",
+    DivergenceLevel.LOW:  "LOW ",
+    DivergenceLevel.MED:  "MED ",
+    DivergenceLevel.HIGH: "HIGH",
+}
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def render_text(result: MuseDivergenceResult) -> None:
+    """Write a human-readable divergence report via :func:`typer.echo`.
+
+    Args:
+        result: The divergence result to render.
+    """
+    ancestor_short = result.common_ancestor[:8] if result.common_ancestor else "none"
+    typer.echo(f"Musical Divergence: {result.branch_a} vs {result.branch_b}")
+    typer.echo(f"Common ancestor: {ancestor_short}")
+    typer.echo("")
+    for dim in result.dimensions:
+        label = _LEVEL_LABELS[dim.level]
+        typer.echo(
+            f"{dim.dimension.capitalize()} divergence:\t{label} — {dim.description}"
+        )
+        typer.echo(f"  {result.branch_a}: {dim.branch_a_summary}")
+        typer.echo(f"  {result.branch_b}: {dim.branch_b_summary}")
+        typer.echo("")
+    typer.echo(f"Overall divergence score: {result.overall_score:.4f}")
+
+
+def render_json(result: MuseDivergenceResult) -> None:
+    """Write a machine-readable JSON divergence report via :func:`typer.echo`.
+
+    Args:
+        result: The divergence result to render.
+    """
+    data: dict[str, object] = {
+        "branch_a": result.branch_a,
+        "branch_b": result.branch_b,
+        "common_ancestor": result.common_ancestor,
+        "overall_score": result.overall_score,
+        "dimensions": [
+            {
+                "dimension": d.dimension,
+                "level": d.level.value,
+                "score": d.score,
+                "description": d.description,
+                "branch_a_summary": d.branch_a_summary,
+                "branch_b_summary": d.branch_b_summary,
+            }
+            for d in result.dimensions
+        ],
+    }
+    typer.echo(json.dumps(data, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _divergence_async(
+    *,
+    branch_a: str,
+    branch_b: str,
+    root: pathlib.Path,
+    session: AsyncSession,
+    since: str | None,
+    dimensions: list[str],
+    output_json: bool,
+) -> None:
+    """Core divergence logic — injectable for unit tests.
+
+    Reads ``repo_id`` from ``.muse/repo.json``, calls :func:`compute_divergence`,
+    and writes output via the appropriate renderer.
+
+    Args:
+        branch_a:    First branch name.
+        branch_b:    Second branch name.
+        root:        Repository root (directory containing ``.muse/``).
+        session:     Open async DB session.
+        since:       Common ancestor commit ID override (``None`` → auto-detect).
+        dimensions:  Dimensions to analyse (empty → all).
+        output_json: If ``True``, render JSON; otherwise render text.
+    """
+    muse_dir = root / ".muse"
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]
+
+    try:
+        result = await compute_divergence(
+            session,
+            repo_id=repo_id,
+            branch_a=branch_a,
+            branch_b=branch_b,
+            since=since,
+            dimensions=dimensions if dimensions else None,
+        )
+    except ValueError as exc:
+        typer.echo(f"❌ {exc}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    if output_json:
+        render_json(result)
+    else:
+        render_text(result)
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def divergence(
+    ctx: typer.Context,
+    branch_a: str = typer.Argument(..., help="First branch."),
+    branch_b: str = typer.Argument(..., help="Second branch."),
+    since: Optional[str] = typer.Option(
+        None,
+        "--since",
+        help="Common ancestor commit ID (auto-detected if omitted).",
+    ),
+    dimensions: list[str] = typer.Option(
+        [],
+        "--dimensions",
+        help="Musical dimension to analyse — may be repeated. Default: all.",
+    ),
+    output_json: bool = typer.Option(
+        False,
+        "--json",
+        is_flag=True,
+        help="Output machine-readable JSON.",
+    ),
+) -> None:
+    """Show how two branches have diverged musically.
+
+    Finds the common ancestor of BRANCH_A and BRANCH_B, then reports
+    per-dimension musical divergence scores (melodic, harmonic, rhythmic,
+    structural, dynamic) and an overall divergence score.
+    """
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _divergence_async(
+                branch_a=branch_a,
+                branch_b=branch_b,
+                root=root,
+                session=session,
+                since=since,
+                dimensions=dimensions,
+                output_json=output_json,
+            )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse divergence failed: {exc}")
+        logger.error("❌ muse divergence error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/services/muse_divergence.py
+++ b/maestro/services/muse_divergence.py
@@ -1,0 +1,390 @@
+"""Muse Divergence Engine — musical divergence between two CLI branches.
+
+Computes a per-dimension divergence score by comparing the file-level changes
+each branch introduced since their common ancestor (merge base).
+
+Dimensions analysed
+-------------------
+- ``melodic``    — lead/melody/solo/vocal files
+- ``harmonic``   — harmony/chord/key/scale files
+- ``rhythmic``   — beat/drum/rhythm/groove/percussion files
+- ``structural`` — form/section/arrangement/bridge/chorus/verse files
+- ``dynamic``    — mix/master/volume/level files
+
+A path is assigned to one or more dimensions by keyword matching on the
+lowercase filename.  Paths that do not match any dimension keyword are counted
+as unclassified and excluded from individual dimension scores but may
+contribute to the ``overall_score``.
+
+Score formula (per dimension)
+------------------------------
+Given the sets of paths changed on branch A (``a_dim``) and branch B
+(``b_dim``) since the merge base for a specific dimension:
+
+    score = |symmetric_difference(a_dim, b_dim)| / |union(a_dim, b_dim)|
+
+Score 0.0 = both branches changed exactly the same files in this dimension.
+Score 1.0 = no overlap — completely diverged.
+
+Boundary rules
+--------------
+- Must NOT import StateStore, executor, MCP tools, or handlers.
+- Must NOT import ``muse_merge_base`` (variation-level LCA) — use
+  ``merge_engine.find_merge_base`` (commit-level LCA) for CLI branches.
+- May import ``muse_cli.{db, merge_engine, models}``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from dataclasses import dataclass
+from enum import Enum
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from maestro.muse_cli.db import get_commit_snapshot_manifest
+from maestro.muse_cli.merge_engine import find_merge_base
+from maestro.muse_cli.models import MuseCliCommit
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ALL_DIMENSIONS: tuple[str, ...] = (
+    "melodic",
+    "harmonic",
+    "rhythmic",
+    "structural",
+    "dynamic",
+)
+
+#: Lowercase keyword patterns used to classify file paths into musical dimensions.
+_DIMENSION_PATTERNS: dict[str, tuple[str, ...]] = {
+    "melodic":    ("melody", "lead", "solo", "vocal"),
+    "harmonic":   ("harm", "chord", "key", "scale"),
+    "rhythmic":   ("beat", "drum", "rhythm", "groove", "perc"),
+    "structural": ("struct", "form", "section", "bridge", "chorus", "verse", "intro", "outro"),
+    "dynamic":    ("mix", "master", "volume", "level", "dyn"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+class DivergenceLevel(str, Enum):
+    """Qualitative label for a per-dimension or overall divergence score.
+
+    Thresholds
+    ----------
+    - ``NONE`` — score < 0.15
+    - ``LOW``  — 0.15 ≤ score < 0.40
+    - ``MED``  — 0.40 ≤ score < 0.70
+    - ``HIGH`` — score ≥ 0.70
+    """
+
+    NONE = "none"
+    LOW = "low"
+    MED = "med"
+    HIGH = "high"
+
+
+@dataclass(frozen=True)
+class DimensionDivergence:
+    """Divergence score and description for a single musical dimension.
+
+    Attributes:
+        dimension:        Dimension name (e.g. ``"melodic"``).
+        level:            Qualitative divergence level.
+        score:            Normalised divergence score in [0.0, 1.0].
+        description:      Human-readable divergence summary.
+        branch_a_summary: How many files in this dimension changed on branch A.
+        branch_b_summary: How many files in this dimension changed on branch B.
+    """
+
+    dimension: str
+    level: DivergenceLevel
+    score: float
+    description: str
+    branch_a_summary: str
+    branch_b_summary: str
+
+
+@dataclass(frozen=True)
+class MuseDivergenceResult:
+    """Full musical divergence report between two CLI branches.
+
+    Attributes:
+        branch_a:        Name of the first branch.
+        branch_b:        Name of the second branch.
+        common_ancestor: Commit ID of the merge base, or ``None`` if disjoint.
+        dimensions:      Per-dimension divergence results.
+        overall_score:   Mean of all per-dimension scores in [0.0, 1.0].
+    """
+
+    branch_a: str
+    branch_b: str
+    common_ancestor: str | None
+    dimensions: tuple[DimensionDivergence, ...]
+    overall_score: float
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def classify_path(path: str) -> set[str]:
+    """Return the set of dimensions this file path belongs to.
+
+    Matching is case-insensitive and keyword-based.  A single path may belong
+    to multiple dimensions (e.g. ``"vocal_melody.mid"`` → ``melodic``).
+
+    Args:
+        path: POSIX-style relative file path from a snapshot manifest.
+
+    Returns:
+        Set of dimension names that the path matches.  Empty set if unclassified.
+    """
+    lower = path.lower()
+    return {
+        dim
+        for dim, patterns in _DIMENSION_PATTERNS.items()
+        if any(pat in lower for pat in patterns)
+    }
+
+
+def score_to_level(score: float) -> DivergenceLevel:
+    """Map a numeric divergence score to a qualitative :class:`DivergenceLevel`.
+
+    Args:
+        score: Normalised score in [0.0, 1.0].
+
+    Returns:
+        The appropriate :class:`DivergenceLevel` enum member.
+    """
+    if score < 0.15:
+        return DivergenceLevel.NONE
+    if score < 0.40:
+        return DivergenceLevel.LOW
+    if score < 0.70:
+        return DivergenceLevel.MED
+    return DivergenceLevel.HIGH
+
+
+def compute_dimension_divergence(
+    dimension: str,
+    branch_a_changed: set[str],
+    branch_b_changed: set[str],
+) -> DimensionDivergence:
+    """Compute divergence for a single musical dimension.
+
+    Score = ``|symmetric_diff| / |union|`` over paths in *dimension*:
+
+    - 0.0 → both branches changed exactly the same files.
+    - 1.0 → no overlap — completely diverged.
+
+    Args:
+        dimension:        Dimension name (one of :data:`ALL_DIMENSIONS`).
+        branch_a_changed: Paths changed on branch A since the merge base.
+        branch_b_changed: Paths changed on branch B since the merge base.
+
+    Returns:
+        A :class:`DimensionDivergence` with score, level, and human summary.
+    """
+    def _filter(paths: set[str]) -> set[str]:
+        return {p for p in paths if dimension in classify_path(p)}
+
+    a_dim = _filter(branch_a_changed)
+    b_dim = _filter(branch_b_changed)
+
+    union = a_dim | b_dim
+    sym_diff = a_dim.symmetric_difference(b_dim)
+    total = len(union)
+
+    if total == 0:
+        score = 0.0
+        desc = f"No {dimension} changes on either branch."
+    else:
+        score = len(sym_diff) / total
+        if score < 0.15:
+            desc = f"Both branches made similar {dimension} changes."
+        elif score < 0.40:
+            desc = f"Minor {dimension} divergence — mostly aligned."
+        elif score < 0.70:
+            desc = f"Moderate {dimension} divergence — different directions."
+        else:
+            desc = f"High {dimension} divergence — branches took different creative paths."
+
+    level = score_to_level(score)
+    return DimensionDivergence(
+        dimension=dimension,
+        level=level,
+        score=round(score, 4),
+        description=desc,
+        branch_a_summary=f"{len(a_dim)} {dimension} file(s) changed",
+        branch_b_summary=f"{len(b_dim)} {dimension} file(s) changed",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Async DB helpers
+# ---------------------------------------------------------------------------
+
+
+async def get_branch_head_commit_id(
+    session: AsyncSession,
+    repo_id: str,
+    branch: str,
+) -> str | None:
+    """Return the most recent commit ID on *branch* for *repo_id*.
+
+    Args:
+        session:  Open async DB session.
+        repo_id:  Repository identifier (from ``.muse/repo.json``).
+        branch:   Branch name.
+
+    Returns:
+        Commit ID string, or ``None`` if the branch has no commits.
+    """
+    result = await session.execute(
+        select(MuseCliCommit.commit_id)
+        .where(
+            MuseCliCommit.repo_id == repo_id,
+            MuseCliCommit.branch == branch,
+        )
+        .order_by(MuseCliCommit.committed_at.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def collect_changed_paths_since(
+    session: AsyncSession,
+    tip_commit_id: str,
+    base_commit_id: str | None,
+) -> set[str]:
+    """Collect all file paths changed from *base_commit_id* to *tip_commit_id*.
+
+    Loads the snapshot manifests at both ends and returns the union of:
+    - Paths added (in tip but not base).
+    - Paths deleted (in base but not tip).
+    - Paths modified (in both but with different ``object_id``).
+
+    When *base_commit_id* is ``None`` (disjoint histories), all paths in
+    *tip_commit_id*'s snapshot are returned.
+
+    Args:
+        session:        Open async DB session.
+        tip_commit_id:  Branch HEAD commit ID.
+        base_commit_id: Merge-base commit ID, or ``None``.
+
+    Returns:
+        Set of POSIX paths that changed between base and tip.
+    """
+    tip_manifest = await get_commit_snapshot_manifest(session, tip_commit_id) or {}
+    base_manifest: dict[str, str] = {}
+    if base_commit_id:
+        base_manifest = await get_commit_snapshot_manifest(session, base_commit_id) or {}
+
+    base_paths = set(base_manifest)
+    tip_paths = set(tip_manifest)
+
+    changed: set[str] = set()
+    changed |= tip_paths - base_paths          # added
+    changed |= base_paths - tip_paths          # deleted
+    for path in base_paths & tip_paths:
+        if base_manifest[path] != tip_manifest[path]:
+            changed.add(path)                  # modified
+
+    return changed
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def compute_divergence(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    branch_a: str,
+    branch_b: str,
+    since: str | None = None,
+    dimensions: list[str] | None = None,
+) -> MuseDivergenceResult:
+    """Compute musical divergence between two CLI branches.
+
+    Finds the common ancestor (merge base), collects file changes since the
+    base on each branch, and computes a per-dimension divergence score.
+
+    Args:
+        session:    Open async DB session.
+        repo_id:    Repository ID (from ``.muse/repo.json``).
+        branch_a:   First branch name.
+        branch_b:   Second branch name.
+        since:      Common ancestor commit ID override (auto-detected if ``None``).
+        dimensions: Dimensions to analyse (default: all in :data:`ALL_DIMENSIONS`).
+
+    Returns:
+        A :class:`MuseDivergenceResult` with per-dimension scores and
+        the resolved common ancestor.
+
+    Raises:
+        ValueError: If *branch_a* or *branch_b* has no commits.
+    """
+    dims: list[str] = list(dimensions) if dimensions else list(ALL_DIMENSIONS)
+
+    # ── Resolve branch head commits ──────────────────────────────────────
+    a_head = await get_branch_head_commit_id(session, repo_id, branch_a)
+    if a_head is None:
+        raise ValueError(
+            f"Branch '{branch_a}' has no commits in repo '{repo_id}'."
+        )
+    b_head = await get_branch_head_commit_id(session, repo_id, branch_b)
+    if b_head is None:
+        raise ValueError(
+            f"Branch '{branch_b}' has no commits in repo '{repo_id}'."
+        )
+
+    # ── Find or use provided common ancestor ─────────────────────────────
+    base_commit_id: str | None = since
+    if base_commit_id is None:
+        base_commit_id = await find_merge_base(session, a_head, b_head)
+
+    logger.info(
+        "✅ muse divergence: %r vs %r, base=%s",
+        branch_a,
+        branch_b,
+        base_commit_id[:8] if base_commit_id else "none",
+    )
+
+    # ── Collect changed paths since merge base ───────────────────────────
+    a_changed = await collect_changed_paths_since(session, a_head, base_commit_id)
+    b_changed = await collect_changed_paths_since(session, b_head, base_commit_id)
+
+    # ── Per-dimension divergence ─────────────────────────────────────────
+    divergences = tuple(
+        compute_dimension_divergence(dim, a_changed, b_changed)
+        for dim in dims
+    )
+
+    overall = (
+        round(sum(d.score for d in divergences) / len(divergences), 4)
+        if divergences
+        else 0.0
+    )
+
+    return MuseDivergenceResult(
+        branch_a=branch_a,
+        branch_b=branch_b,
+        common_ancestor=base_commit_id,
+        dimensions=divergences,
+        overall_score=overall,
+    )

--- a/tests/test_muse_divergence.py
+++ b/tests/test_muse_divergence.py
@@ -1,0 +1,641 @@
+"""Tests for muse divergence — musical divergence between two CLI branches.
+
+Covers:
+- Common ancestor auto-detection (merge-base computation).
+- Per-dimension divergence scores and level labels.
+- JSON output format.
+- Multiple divergent commits across branches.
+- Boundary seal (no forbidden imports in service or command).
+
+Naming convention: ``test_<behaviour>_<scenario>``
+"""
+from __future__ import annotations
+
+import ast
+import datetime
+import hashlib
+import json
+import pathlib
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from maestro.db.database import Base
+from maestro.db import muse_models  # noqa: F401  — registers ORM models with Base
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+from maestro.services.muse_divergence import (
+    ALL_DIMENSIONS,
+    DivergenceLevel,
+    MuseDivergenceResult,
+    classify_path,
+    compute_dimension_divergence,
+    compute_divergence,
+    score_to_level,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def async_session() -> AsyncGenerator[AsyncSession, None]:
+    """In-memory SQLite session with the full Maestro schema."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with Session() as session:
+        yield session
+    await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_REPO_ID = "test-repo-001"
+_COUNTER = 0
+
+
+def _unique_hash(prefix: str) -> str:
+    """Deterministic 64-char hash for test IDs."""
+    global _COUNTER
+    _COUNTER += 1
+    raw = f"{prefix}-{_COUNTER}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _make_snapshot(manifest: dict[str, str]) -> MuseCliSnapshot:
+    """Create a :class:`MuseCliSnapshot` from a manifest dict."""
+    parts = sorted(f"{k}:{v}" for k, v in manifest.items())
+    snap_id = hashlib.sha256("|".join(parts).encode()).hexdigest()
+    return MuseCliSnapshot(snapshot_id=snap_id, manifest=manifest)
+
+
+def _make_commit(
+    snapshot: MuseCliSnapshot,
+    branch: str,
+    parent: MuseCliCommit | None = None,
+    parent2: MuseCliCommit | None = None,
+    seq: int = 0,
+) -> MuseCliCommit:
+    """Create a :class:`MuseCliCommit` linked to *snapshot* on *branch*."""
+    cid = _unique_hash(f"commit-{branch}-{seq}")
+    return MuseCliCommit(
+        commit_id=cid,
+        repo_id=_REPO_ID,
+        branch=branch,
+        snapshot_id=snapshot.snapshot_id,
+        parent_commit_id=parent.commit_id if parent else None,
+        parent2_commit_id=parent2.commit_id if parent2 else None,
+        message=f"commit on {branch} seq={seq}",
+        author="test",
+        committed_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        + datetime.timedelta(seconds=seq),
+    )
+
+
+async def _save(
+    session: AsyncSession,
+    snapshot: MuseCliSnapshot,
+    commit: MuseCliCommit,
+) -> None:
+    """Persist *snapshot* and *commit* to the session."""
+    existing_snap = await session.get(MuseCliSnapshot, snapshot.snapshot_id)
+    if existing_snap is None:
+        session.add(snapshot)
+    session.add(commit)
+    await session.flush()
+
+
+# ---------------------------------------------------------------------------
+# 1 — classify_path (pure, no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyPath:
+
+    def test_melodic_keywords_matched(self) -> None:
+        assert "melodic" in classify_path("lead_guitar.mid")
+        assert "melodic" in classify_path("Melody_Line.midi")
+        assert "melodic" in classify_path("SOLO.MID")
+
+    def test_harmonic_keywords_matched(self) -> None:
+        assert "harmonic" in classify_path("chord_progression.txt")
+        assert "harmonic" in classify_path("harmony_track.mid")
+        assert "harmonic" in classify_path("key_of_d.json")
+
+    def test_rhythmic_keywords_matched(self) -> None:
+        assert "rhythmic" in classify_path("drum_pattern.mid")
+        assert "rhythmic" in classify_path("beat.mid")
+        assert "rhythmic" in classify_path("groove_01.wav")
+
+    def test_structural_keywords_matched(self) -> None:
+        assert "structural" in classify_path("chorus.mid")
+        assert "structural" in classify_path("verse_01.mid")
+        assert "structural" in classify_path("intro.mid")
+        assert "structural" in classify_path("bridge_section.mid")
+
+    def test_dynamic_keywords_matched(self) -> None:
+        assert "dynamic" in classify_path("mixdown.wav")
+        assert "dynamic" in classify_path("master_vol.mid")
+        assert "dynamic" in classify_path("level_control.json")
+
+    def test_unclassified_path_returns_empty_set(self) -> None:
+        assert classify_path("project.muse") == set()
+        assert classify_path("readme.txt") == set()
+
+    def test_multi_dimension_path(self) -> None:
+        result = classify_path("melody_key.mid")
+        assert "melodic" in result
+        assert "harmonic" in result
+
+
+# ---------------------------------------------------------------------------
+# 2 — score_to_level (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestScoreToLevel:
+
+    def test_zero_is_none(self) -> None:
+        assert score_to_level(0.0) is DivergenceLevel.NONE
+
+    def test_boundary_0_15_is_low(self) -> None:
+        assert score_to_level(0.15) is DivergenceLevel.LOW
+
+    def test_boundary_0_40_is_med(self) -> None:
+        assert score_to_level(0.40) is DivergenceLevel.MED
+
+    def test_boundary_0_70_is_high(self) -> None:
+        assert score_to_level(0.70) is DivergenceLevel.HIGH
+
+    def test_full_score_is_high(self) -> None:
+        assert score_to_level(1.0) is DivergenceLevel.HIGH
+
+
+# ---------------------------------------------------------------------------
+# 3 — compute_dimension_divergence (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDimensionDivergence:
+
+    def test_no_files_on_either_branch_gives_none_level(self) -> None:
+        result = compute_dimension_divergence("melodic", set(), set())
+        assert result.score == 0.0
+        assert result.level is DivergenceLevel.NONE
+        assert result.branch_a_summary == "0 melodic file(s) changed"
+
+    def test_same_melodic_file_on_both_branches_gives_zero_score(self) -> None:
+        a = {"melody.mid"}
+        b = {"melody.mid"}
+        result = compute_dimension_divergence("melodic", a, b)
+        assert result.score == 0.0
+        assert result.level is DivergenceLevel.NONE
+
+    def test_melodic_only_on_branch_a_gives_high_score(self) -> None:
+        a = {"lead_guitar.mid", "solo_01.mid"}
+        b: set[str] = set()
+        result = compute_dimension_divergence("melodic", a, b)
+        assert result.score == 1.0
+        assert result.level is DivergenceLevel.HIGH
+
+    def test_partial_overlap_gives_low_score(self) -> None:
+        a = {"melody.mid", "lead.mid", "solo.mid"}
+        b = {"melody.mid", "vocal.mid"}
+        result = compute_dimension_divergence("melodic", a, b)
+        # union = {melody, lead, solo, vocal} = 4; sym_diff = {lead, solo, vocal} = 3
+        assert 0.5 < result.score < 1.0
+
+    def test_non_matching_paths_ignored(self) -> None:
+        a = {"beat.mid", "drum.mid"}
+        b = {"beat.mid"}
+        result = compute_dimension_divergence("melodic", a, b)
+        # Neither 'beat' nor 'drum' matches melodic keywords
+        assert result.score == 0.0
+        assert result.branch_a_summary == "0 melodic file(s) changed"
+
+    def test_description_mentions_dimension_name(self) -> None:
+        result = compute_dimension_divergence("harmonic", {"chord.mid"}, set())
+        assert "harmonic" in result.description.lower()
+
+
+# ---------------------------------------------------------------------------
+# 4 — compute_divergence (async, DB)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDivergenceDetectsCommonAncestor:
+    """test_muse_divergence_detects_common_ancestor_automatically"""
+
+    @pytest.mark.anyio
+    async def test_detects_common_ancestor_automatically(
+        self, async_session: AsyncSession
+    ) -> None:
+        """
+        root (main) ─── branch-a (adds melody.mid)
+                    └── branch-b (adds chord.mid)
+
+        Common ancestor = root commit.
+        """
+        base_snap = _make_snapshot({})
+        base_commit = _make_commit(base_snap, "main", seq=0)
+        await _save(async_session, base_snap, base_commit)
+
+        a_snap = _make_snapshot({"melody.mid": "hash-melody"})
+        a_commit = _make_commit(a_snap, "branch-a", parent=base_commit, seq=1)
+        await _save(async_session, a_snap, a_commit)
+
+        b_snap = _make_snapshot({"chord.mid": "hash-chord"})
+        b_commit = _make_commit(b_snap, "branch-b", parent=base_commit, seq=2)
+        await _save(async_session, b_snap, b_commit)
+
+        await async_session.commit()
+
+        result = await compute_divergence(
+            async_session,
+            repo_id=_REPO_ID,
+            branch_a="branch-a",
+            branch_b="branch-b",
+        )
+
+        assert isinstance(result, MuseDivergenceResult)
+        assert result.common_ancestor == base_commit.commit_id
+        assert result.branch_a == "branch-a"
+        assert result.branch_b == "branch-b"
+
+    @pytest.mark.anyio
+    async def test_since_override_skips_merge_base_computation(
+        self, async_session: AsyncSession
+    ) -> None:
+        """``--since`` overrides automatic LCA detection."""
+        base_snap = _make_snapshot({})
+        base_commit = _make_commit(base_snap, "main", seq=10)
+        await _save(async_session, base_snap, base_commit)
+
+        a_snap = _make_snapshot({"lead.mid": "h1"})
+        a_commit = _make_commit(a_snap, "dev-a", parent=base_commit, seq=11)
+        await _save(async_session, a_snap, a_commit)
+
+        b_snap = _make_snapshot({"harm.mid": "h2"})
+        b_commit = _make_commit(b_snap, "dev-b", parent=base_commit, seq=12)
+        await _save(async_session, b_snap, b_commit)
+
+        await async_session.commit()
+
+        result = await compute_divergence(
+            async_session,
+            repo_id=_REPO_ID,
+            branch_a="dev-a",
+            branch_b="dev-b",
+            since=base_commit.commit_id,
+        )
+
+        assert result.common_ancestor == base_commit.commit_id
+
+    @pytest.mark.anyio
+    async def test_missing_branch_raises_value_error(
+        self, async_session: AsyncSession
+    ) -> None:
+        """A branch with no commits raises ``ValueError``."""
+        snap = _make_snapshot({})
+        commit = _make_commit(snap, "existing-branch", seq=20)
+        await _save(async_session, snap, commit)
+        await async_session.commit()
+
+        with pytest.raises(ValueError, match="no commits"):
+            await compute_divergence(
+                async_session,
+                repo_id=_REPO_ID,
+                branch_a="existing-branch",
+                branch_b="nonexistent-branch",
+            )
+
+
+class TestComputeDivergencePerDimensionScores:
+    """test_muse_divergence_per_dimension_scores"""
+
+    @pytest.mark.anyio
+    async def test_melodic_divergence_high_when_only_branch_a_has_melody(
+        self, async_session: AsyncSession
+    ) -> None:
+        """Branch A adds melody.mid; Branch B adds chord.mid.
+
+        Melodic: only A → HIGH.  Harmonic: only B → HIGH.
+        Rhythmic: neither → NONE.
+        """
+        base_snap = _make_snapshot({})
+        base_commit = _make_commit(base_snap, "main", seq=30)
+        await _save(async_session, base_snap, base_commit)
+
+        a_snap = _make_snapshot({"melody.mid": "m1"})
+        a_commit = _make_commit(a_snap, "feat-melody", parent=base_commit, seq=31)
+        await _save(async_session, a_snap, a_commit)
+
+        b_snap = _make_snapshot({"chord_sheet.txt": "c1"})
+        b_commit = _make_commit(b_snap, "feat-harmony", parent=base_commit, seq=32)
+        await _save(async_session, b_snap, b_commit)
+
+        await async_session.commit()
+
+        result = await compute_divergence(
+            async_session,
+            repo_id=_REPO_ID,
+            branch_a="feat-melody",
+            branch_b="feat-harmony",
+        )
+
+        dim_by_name = {d.dimension: d for d in result.dimensions}
+
+        assert dim_by_name["melodic"].level is DivergenceLevel.HIGH
+        assert dim_by_name["melodic"].score == 1.0
+
+        assert dim_by_name["harmonic"].level is DivergenceLevel.HIGH
+        assert dim_by_name["harmonic"].score == 1.0
+
+        assert dim_by_name["rhythmic"].level is DivergenceLevel.NONE
+        assert dim_by_name["rhythmic"].score == 0.0
+
+    @pytest.mark.anyio
+    async def test_rhythmic_divergence_none_when_same_beat_file_on_both(
+        self, async_session: AsyncSession
+    ) -> None:
+        """Both branches add the same beat.mid — rhythmic divergence = 0."""
+        base_snap = _make_snapshot({})
+        base_commit = _make_commit(base_snap, "main", seq=40)
+        await _save(async_session, base_snap, base_commit)
+
+        a_snap = _make_snapshot({"beat.mid": "b1", "melody.mid": "m1"})
+        a_commit = _make_commit(a_snap, "rhy-a", parent=base_commit, seq=41)
+        await _save(async_session, a_snap, a_commit)
+
+        b_snap = _make_snapshot({"beat.mid": "b1", "chord.mid": "c1"})
+        b_commit = _make_commit(b_snap, "rhy-b", parent=base_commit, seq=42)
+        await _save(async_session, b_snap, b_commit)
+
+        await async_session.commit()
+
+        result = await compute_divergence(
+            async_session,
+            repo_id=_REPO_ID,
+            branch_a="rhy-a",
+            branch_b="rhy-b",
+        )
+
+        dim_by_name = {d.dimension: d for d in result.dimensions}
+        assert dim_by_name["rhythmic"].score == 0.0
+        assert dim_by_name["rhythmic"].level is DivergenceLevel.NONE
+
+    @pytest.mark.anyio
+    async def test_dimensions_filter_limits_output(
+        self, async_session: AsyncSession
+    ) -> None:
+        """``dimensions=['melodic', 'harmonic']`` returns only those two."""
+        base_snap = _make_snapshot({})
+        base_commit = _make_commit(base_snap, "main", seq=50)
+        await _save(async_session, base_snap, base_commit)
+
+        a_snap = _make_snapshot({"melody.mid": "m1"})
+        a_commit = _make_commit(a_snap, "filter-a", parent=base_commit, seq=51)
+        await _save(async_session, a_snap, a_commit)
+
+        b_snap = _make_snapshot({"chord.mid": "c1"})
+        b_commit = _make_commit(b_snap, "filter-b", parent=base_commit, seq=52)
+        await _save(async_session, b_snap, b_commit)
+
+        await async_session.commit()
+
+        result = await compute_divergence(
+            async_session,
+            repo_id=_REPO_ID,
+            branch_a="filter-a",
+            branch_b="filter-b",
+            dimensions=["melodic", "harmonic"],
+        )
+
+        assert len(result.dimensions) == 2
+        returned_names = {d.dimension for d in result.dimensions}
+        assert returned_names == {"melodic", "harmonic"}
+
+    @pytest.mark.anyio
+    async def test_overall_score_is_mean_of_dimension_scores(
+        self, async_session: AsyncSession
+    ) -> None:
+        """``overall_score`` equals the mean of individual dimension scores."""
+        base_snap = _make_snapshot({})
+        base_commit = _make_commit(base_snap, "main", seq=60)
+        await _save(async_session, base_snap, base_commit)
+
+        a_snap = _make_snapshot({"melody.mid": "m1"})
+        a_commit = _make_commit(a_snap, "overall-a", parent=base_commit, seq=61)
+        await _save(async_session, a_snap, a_commit)
+
+        b_snap = _make_snapshot({"melody.mid": "m1"})
+        b_commit = _make_commit(b_snap, "overall-b", parent=base_commit, seq=62)
+        await _save(async_session, b_snap, b_commit)
+
+        await async_session.commit()
+
+        result = await compute_divergence(
+            async_session,
+            repo_id=_REPO_ID,
+            branch_a="overall-a",
+            branch_b="overall-b",
+        )
+
+        computed_mean = round(
+            sum(d.score for d in result.dimensions) / len(result.dimensions), 4
+        )
+        assert result.overall_score == computed_mean
+
+
+class TestComputeDivergenceJsonOutput:
+    """test_muse_divergence_json_output"""
+
+    @pytest.mark.anyio
+    async def test_result_serializes_to_valid_json(
+        self, async_session: AsyncSession
+    ) -> None:
+        """MuseDivergenceResult fields round-trip cleanly through json.dumps."""
+        base_snap = _make_snapshot({})
+        base_commit = _make_commit(base_snap, "main", seq=70)
+        await _save(async_session, base_snap, base_commit)
+
+        a_snap = _make_snapshot({"lead.mid": "h1"})
+        a_commit = _make_commit(a_snap, "json-a", parent=base_commit, seq=71)
+        await _save(async_session, a_snap, a_commit)
+
+        b_snap = _make_snapshot({"chord.mid": "h2"})
+        b_commit = _make_commit(b_snap, "json-b", parent=base_commit, seq=72)
+        await _save(async_session, b_snap, b_commit)
+
+        await async_session.commit()
+
+        result = await compute_divergence(
+            async_session,
+            repo_id=_REPO_ID,
+            branch_a="json-a",
+            branch_b="json-b",
+        )
+
+        data = {
+            "branch_a": result.branch_a,
+            "branch_b": result.branch_b,
+            "common_ancestor": result.common_ancestor,
+            "overall_score": result.overall_score,
+            "dimensions": [
+                {
+                    "dimension": d.dimension,
+                    "level": d.level.value,
+                    "score": d.score,
+                    "description": d.description,
+                    "branch_a_summary": d.branch_a_summary,
+                    "branch_b_summary": d.branch_b_summary,
+                }
+                for d in result.dimensions
+            ],
+        }
+        serialised = json.dumps(data)
+        parsed = json.loads(serialised)
+
+        assert parsed["branch_a"] == "json-a"
+        assert parsed["branch_b"] == "json-b"
+        assert parsed["common_ancestor"] == base_commit.commit_id
+        assert isinstance(parsed["overall_score"], float)
+        assert len(parsed["dimensions"]) == len(ALL_DIMENSIONS)
+        for dim in parsed["dimensions"]:
+            assert "dimension" in dim
+            assert "level" in dim
+            assert "score" in dim
+            assert "description" in dim
+
+
+class TestComputeDivergenceMultipleDivergentCommits:
+    """test_muse_divergence_multiple_divergent_commits"""
+
+    @pytest.mark.anyio
+    async def test_multiple_commits_accumulate_changes_correctly(
+        self, async_session: AsyncSession
+    ) -> None:
+        """Branch A adds files across multiple commits; tip manifest reflects all.
+
+        root → [branch-multi-a: commit1 adds melody.mid, commit2 adds solo.mid]
+             → [branch-multi-b: commit1 adds chord.mid]
+
+        Melodic divergence on branch A should count both melody.mid and solo.mid.
+        """
+        base_snap = _make_snapshot({})
+        base_commit = _make_commit(base_snap, "main", seq=80)
+        await _save(async_session, base_snap, base_commit)
+
+        # Branch A: two sequential commits
+        a1_snap = _make_snapshot({"melody.mid": "m1"})
+        a1_commit = _make_commit(a1_snap, "branch-multi-a", parent=base_commit, seq=81)
+        await _save(async_session, a1_snap, a1_commit)
+
+        a2_snap = _make_snapshot({"melody.mid": "m1", "solo.mid": "s1"})
+        a2_commit = _make_commit(a2_snap, "branch-multi-a", parent=a1_commit, seq=82)
+        await _save(async_session, a2_snap, a2_commit)
+
+        # Branch B: single commit
+        b1_snap = _make_snapshot({"chord.mid": "c1"})
+        b1_commit = _make_commit(b1_snap, "branch-multi-b", parent=base_commit, seq=83)
+        await _save(async_session, b1_snap, b1_commit)
+
+        await async_session.commit()
+
+        result = await compute_divergence(
+            async_session,
+            repo_id=_REPO_ID,
+            branch_a="branch-multi-a",
+            branch_b="branch-multi-b",
+        )
+
+        dim_by_name = {d.dimension: d for d in result.dimensions}
+
+        # Both melody.mid and solo.mid are on branch A → 2 melodic files
+        assert "2 melodic" in dim_by_name["melodic"].branch_a_summary
+        assert dim_by_name["melodic"].level is DivergenceLevel.HIGH
+
+    @pytest.mark.anyio
+    async def test_disjoint_histories_common_ancestor_is_none(
+        self, async_session: AsyncSession
+    ) -> None:
+        """Branches with no common history produce ``common_ancestor=None``."""
+        snap_x = _make_snapshot({"melody.mid": "mx"})
+        commit_x = _make_commit(snap_x, "isolated-x", seq=90)
+        await _save(async_session, snap_x, commit_x)
+
+        snap_y = _make_snapshot({"chord.mid": "cy"})
+        commit_y = _make_commit(snap_y, "isolated-y", seq=91)
+        await _save(async_session, snap_y, commit_y)
+
+        await async_session.commit()
+
+        result = await compute_divergence(
+            async_session,
+            repo_id=_REPO_ID,
+            branch_a="isolated-x",
+            branch_b="isolated-y",
+        )
+
+        assert result.common_ancestor is None
+
+
+# ---------------------------------------------------------------------------
+# 5 — Boundary seal
+# ---------------------------------------------------------------------------
+
+
+class TestDivergenceBoundarySeal:
+    """Verify that service and command modules do not import forbidden modules."""
+
+    _SERVICES_DIR = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "maestro"
+        / "services"
+    )
+    _COMMANDS_DIR = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "maestro"
+        / "muse_cli"
+        / "commands"
+    )
+
+    def test_service_does_not_import_forbidden_modules(self) -> None:
+        filepath = self._SERVICES_DIR / "muse_divergence.py"
+        tree = ast.parse(filepath.read_text())
+        forbidden = {
+            "state_store", "executor", "maestro_handlers",
+            "maestro_editing", "mcp", "muse_merge_base",
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                for fb in forbidden:
+                    assert fb not in node.module, (
+                        f"muse_divergence imports forbidden module: {node.module}"
+                    )
+
+    def test_command_does_not_import_state_store(self) -> None:
+        filepath = self._COMMANDS_DIR / "divergence.py"
+        tree = ast.parse(filepath.read_text())
+        forbidden = {"state_store", "executor", "maestro_handlers", "mcp"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                for fb in forbidden:
+                    assert fb not in node.module, (
+                        f"divergence command imports forbidden module: {node.module}"
+                    )
+
+    def test_service_starts_with_future_annotations(self) -> None:
+        filepath = self._SERVICES_DIR / "muse_divergence.py"
+        source = filepath.read_text()
+        assert "from __future__ import annotations" in source


### PR DESCRIPTION
Closes #119

## Summary

- New `muse divergence <branch-a> <branch-b>` CLI command that computes per-dimension musical divergence between two CLI branches.
- Pure divergence engine in `maestro/services/muse_divergence.py` with named result types and a clear scoring formula.
- 31 unit tests covering path classification, scoring, DB integration, JSON output, and AST boundary seals.
- Docs updated in `docs/architecture/muse_vcs.md` and `docs/reference/type_contracts.md`.

## Motivation

Two producers working on alternative arrangements of the same project need to understand creative distance before deciding which branch to merge or how to combine them. `git diff` shows file-level changes; `muse divergence` answers "how different are these two creative visions?" along musical dimensions (melodic, harmonic, rhythmic, structural, dynamic).

## Solution

**Service (`maestro/services/muse_divergence.py`)**
- `classify_path(path) → set[str]` — keyword-based file→dimension classifier
- `compute_dimension_divergence(dim, a_changed, b_changed) → DimensionDivergence` — per-dimension score using `|sym_diff| / |union|` formula
- `collect_changed_paths_since(session, tip, base) → set[str]` — manifest diff (added + deleted + modified)
- `compute_divergence(session, *, repo_id, branch_a, branch_b, since, dimensions) → MuseDivergenceResult` — full API

**Named result types:**
- `DivergenceLevel` (Enum: NONE/LOW/MED/HIGH)
- `DimensionDivergence` (frozen dataclass)
- `MuseDivergenceResult` (frozen dataclass)

**Command (`maestro/muse_cli/commands/divergence.py`)**
- `muse divergence <branch-a> <branch-b> [--since] [--dimensions] [--json]`
- Text and JSON renderers
- Fully injectable async core for unit tests

**Architecture notes:**
- Read-only — never writes to DB or filesystem
- No schema changes — uses existing `muse_cli_commits` / `muse_cli_snapshots` tables
- Delegates merge-base LCA to `merge_engine.find_merge_base` (same BFS used by `muse merge`)
- Boundary rule enforced by AST test: must not import `muse_merge_base` (variation-level LCA)

## Verification Checklist

- [x] `muse divergence feature/a feature/b` shows musical divergence between two branches
- [x] Auto-detects common ancestor via merge-base BFS computation
- [x] `--json` outputs per-dimension divergence scores and descriptions
- [x] Works for branches with multiple divergent commits (tip manifest captures all changes)
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (456 files, 0 issues)
- [x] 31 unit tests — all passing
- [x] Docs updated: `docs/architecture/muse_vcs.md`, `docs/reference/type_contracts.md`
- [x] No forbidden imports (boundary seal test passes)
- [x] No `print()`, no secrets, no dead code