### PR TITLE
feat: muse import <file> — import a MIDI or MusicXML file as a new Muse commit

### DIFF
--- a/.cursor/PARALLEL_ISSUE_TO_PR.md
+++ b/.cursor/PARALLEL_ISSUE_TO_PR.md
@@ -75,12 +75,18 @@ cd "$REPO"
 DEV_SHA=$(git rev-parse dev)
 
 # --- define issues (confirmed independent — zero file overlap) ---
+# Batch: #112–#119 (new muse CLI commands)
+# Known shared file: maestro/muse_cli/app.py (each agent adds one app.add_typer line)
+# Resolution: pre-push sync in STEP 4 handles app.py conflicts — keep both sides.
 declare -a ISSUES=(
-  "35|feat: muse merge — fast-forward and 3-way merge with path-level conflict detection"
-  "37|feat: Maestro stress test → muse-work/ output contract with muse-batch.json manifest"
-  "40|feat: Muse Hub push/pull sync protocol — batch commit and object transfer"
-  "41|feat: Muse Hub pull requests — create, list, and merge PRs between branches"
-  "47|feat: Muse Hub JWT auth integration — CLI token storage and Hub request authentication"
+  "119|feat: muse divergence — show how two branches have diverged musically"
+  "118|feat: muse import <file> — import a MIDI or MusicXML file as a new Muse commit"
+  "117|feat: muse meter [<commit>] [--set <time-sig>] — read or set the time signature"
+  "116|feat: muse tempo [<commit>] [--set <bpm>] — read or set the tempo of a commit"
+  "115|feat: muse arrange [<commit>] — display the arrangement map (instrument activity over sections)"
+  "114|feat: muse find — search commit history by musical properties"
+  "113|feat: muse context [<commit>] — output structured musical context for AI agent consumption"
+  "112|feat: muse export [<commit>] --format <format> — export a Muse snapshot to external formats"
 )
 
 # --- create worktrees + task files ---

--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -830,3 +830,376 @@ muse commit --from-batch muse-batch.json
 ```
 
 ---
+
+## Muse CLI — Music Analysis Command Reference
+
+These commands expose musical dimensions across the commit graph — the layer that
+makes Muse fundamentally different from Git. Each command is consumed by AI agents
+to make musically coherent generation decisions. Every flag is part of a stable
+CLI contract; stub implementations are clearly marked.
+
+**Agent pattern:** Run with `--json` to get machine-readable output. Pipe into
+`muse context` for a unified musical state document.
+
+---
+
+### `muse dynamics`
+
+**Purpose:** Analyze the velocity (loudness) profile of a commit across all instrument
+tracks. The primary tool for understanding the dynamic arc of an arrangement and
+detecting flat, robotic, or over-compressed MIDI.
+
+**Usage:**
+```bash
+muse dynamics [<commit>] [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `COMMIT` | positional | HEAD | Commit ref to analyze |
+| `--track TEXT` | string | all tracks | Case-insensitive prefix filter (e.g. `--track bass`) |
+| `--section TEXT` | string | — | Restrict to a named section/region (planned) |
+| `--compare COMMIT` | string | — | Side-by-side comparison with another commit (planned) |
+| `--history` | flag | off | Show dynamics for every commit in branch history (planned) |
+| `--peak` | flag | off | Show only tracks whose peak velocity exceeds the branch average |
+| `--range` | flag | off | Sort output by velocity range descending |
+| `--arc` | flag | off | When combined with `--track`, treat its value as an arc label filter |
+| `--json` | flag | off | Emit structured JSON for agent consumption |
+
+**Arc labels:**
+
+| Label | Meaning |
+|-------|---------|
+| `flat` | Velocity variance < 10; steady throughout |
+| `crescendo` | Monotonically rising from start to end |
+| `decrescendo` | Monotonically falling from start to end |
+| `terraced` | Step-wise plateaus; sudden jumps between stable levels |
+| `swell` | Rises then falls (arch shape) |
+
+**Output example (text):**
+```
+Dynamic profile — commit a1b2c3d4  (HEAD -> main)
+
+Track      Avg Vel  Peak  Range  Arc
+---------  -------  ----  -----  -----------
+drums           88   110     42  terraced
+bass            72    85     28  flat
+keys            64    95     56  crescendo
+lead            79   105     38  swell
+```
+
+**Output example (`--json`):**
+```json
+{
+  "commit": "a1b2c3d4",
+  "branch": "main",
+  "tracks": [
+    {"track": "drums", "avg_velocity": 88, "peak_velocity": 110, "velocity_range": 42, "arc": "terraced"}
+  ]
+}
+```
+
+**Result type:** `TrackDynamics` — fields: `name`, `avg_velocity`, `peak_velocity`, `velocity_range`, `arc`
+
+**Agent use case:** Before generating a new layer, an agent calls `muse dynamics --json` to understand the current velocity landscape. If the arrangement is `flat` across all tracks, the agent adds velocity variation to the new part. If the arc is `crescendo`, the agent ensures the new layer contributes to rather than fights the build.
+
+**Implementation:** `maestro/muse_cli/commands/dynamics.py` — `_dynamics_async` (injectable async core), `TrackDynamics` (result entity), `_render_table` / `_render_json` (renderers). Exit codes: 0 success, 2 outside repo, 3 internal.
+
+> **Stub note:** Arc classification and velocity statistics are placeholder values. Full implementation requires MIDI note velocity extraction from committed snapshot objects (future: Storpheus MIDI parse route).
+
+---
+
+### `muse swing`
+
+**Purpose:** Measure or annotate the swing factor of a commit — the ratio that
+distinguishes a straight 8th-note grid from a shuffled jazz feel. Swing is one
+of the most musically critical dimensions and is completely invisible to Git.
+
+**Usage:**
+```bash
+muse swing [<commit>] [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `COMMIT` | positional | working tree | Commit SHA to analyze |
+| `--set FLOAT` | float | — | Annotate with an explicit swing factor (0.5–0.67) |
+| `--detect` | flag | on | Detect and display the swing factor (default) |
+| `--track TEXT` | string | all | Restrict to a named MIDI track (e.g. `--track bass`) |
+| `--compare COMMIT` | string | — | Compare HEAD swing against another commit |
+| `--history` | flag | off | Show swing history for the current branch |
+| `--json` | flag | off | Emit machine-readable JSON |
+
+**Swing factor scale:**
+
+| Range | Label | Feel |
+|-------|-------|------|
+| < 0.53 | Straight | Equal 8th notes — pop, EDM, quantized |
+| 0.53–0.58 | Light | Subtle shuffle — R&B, Neo-soul |
+| 0.58–0.63 | Medium | Noticeable swing — jazz, hip-hop |
+| ≥ 0.63 | Hard | Triplet feel — bebop, heavy jazz |
+
+**Output example (text):**
+```
+Swing factor: 0.55 (Light)
+Commit: a1b2c3d4  Branch: main
+Track: all
+```
+
+**Output example (`--json`):**
+```json
+{"factor": 0.55, "label": "Light", "commit": "a1b2c3d4", "branch": "main", "track": "all"}
+```
+
+**Result type:** `dict` with keys `factor` (float), `label` (str), `commit` (str), `branch` (str), `track` (str). Future: typed `SwingResult` dataclass.
+
+**Agent use case:** An AI generating a bass line runs `muse swing --json` to know whether to quantize straight or add shuffle. A Medium swing result means the bass should land slightly behind the grid to stay in pocket with the existing drum performance.
+
+**Implementation:** `maestro/muse_cli/commands/swing.py` — `swing_label()`, `_swing_detect_async()`, `_swing_history_async()`, `_swing_compare_async()`, formatters. Exit codes: 0 success, 1 invalid `--set` value, 2 outside repo.
+
+> **Stub note:** Returns a placeholder factor of 0.55. Full implementation requires onset-to-onset ratio measurement from committed MIDI note events (future: Storpheus MIDI parse route).
+
+---
+
+### `muse recall`
+
+**Purpose:** Search the full commit history using natural language. Returns ranked
+commits whose messages best match the query. The musical memory retrieval command —
+"find me that arrangement I made three months ago."
+
+**Usage:**
+```bash
+muse recall "<description>" [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `QUERY` | positional | required | Natural-language description of what to find |
+| `--limit N` | int | 5 | Maximum results to return |
+| `--threshold FLOAT` | float | 0.6 | Minimum similarity score (0.0–1.0) |
+| `--branch TEXT` | string | all branches | Restrict search to a specific branch |
+| `--since DATE` | `YYYY-MM-DD` | — | Only search commits after this date |
+| `--until DATE` | `YYYY-MM-DD` | — | Only search commits before this date |
+| `--json` | flag | off | Emit structured JSON array |
+
+**Scoring (current stub):** Normalized keyword overlap coefficient — `|Q ∩ M| / |Q|` — where Q is the set of query tokens and M is the set of message tokens. Score 1.0 means every query word appeared in the commit message.
+
+**Output example (text):**
+```
+Recall: "dark jazz bassline"
+keyword match · threshold 0.60 · limit 5
+
+  1. [a1b2c3d4]  2026-02-15 22:00  boom bap demo take 3      score 0.67
+  2. [f9e8d7c6]  2026-02-10 18:30  jazz bass overdub session  score 0.50
+```
+
+**Result type:** `RecallResult` (TypedDict) — fields: `rank` (int), `score` (float), `commit_id` (str), `date` (str), `branch` (str), `message` (str)
+
+**Agent use case:** An agent asked to "generate something like that funky bass riff from last month" calls `muse recall "funky bass" --json --limit 3` to retrieve the closest historical commits, then uses those as style references for generation.
+
+**Implementation:** `maestro/muse_cli/commands/recall.py` — `RecallResult` (TypedDict), `_tokenize()`, `_score()`, `_recall_async()`. Exit codes: 0 success, 1 bad date format, 2 outside repo.
+
+> **Stub note:** Uses keyword overlap. Full implementation: vector embeddings stored in Qdrant, cosine similarity retrieval. The CLI interface will not change when vector search is added.
+
+---
+
+### `muse grep`
+
+**Purpose:** Search all commits for a musical pattern — a note sequence, interval
+pattern, or chord symbol. Currently searches commit messages; full MIDI content
+search is the planned implementation.
+
+**Usage:**
+```bash
+muse grep <pattern> [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `PATTERN` | positional | required | Pattern to find (note seq, interval, chord, or text) |
+| `--track TEXT` | string | — | Restrict to a named track (MIDI content search — planned) |
+| `--section TEXT` | string | — | Restrict to a named section (planned) |
+| `--transposition-invariant` | flag | on | Match in any key (planned for MIDI search) |
+| `--rhythm-invariant` | flag | off | Match regardless of rhythm (planned) |
+| `--commits` | flag | off | Output one commit ID per line instead of full table |
+| `--json` | flag | off | Emit structured JSON array |
+
+**Pattern formats (planned for MIDI content search):**
+
+| Format | Example | Matches |
+|--------|---------|---------|
+| Note sequence | `"C4 E4 G4"` | Those exact pitches in sequence |
+| Interval run | `"+4 +3"` | Major 3rd + minor 3rd (Cm arpeggio) |
+| Chord symbol | `"Cm7"` | That chord anywhere in the arrangement |
+| Text | `"verse piano"` | Commit message substring (current implementation) |
+
+**Output example (text):**
+```
+Pattern: "dark jazz" (2 matches)
+
+Commit       Branch   Committed            Message              Source
+-----------  -------  -------------------  -------------------  -------
+a1b2c3d4     main     2026-02-15 22:00     boom bap dark jazz   message
+f9e8d7c6     main     2026-02-10 18:30     dark jazz bass       message
+```
+
+**Result type:** `GrepMatch` (dataclass) — fields: `commit_id` (str), `branch` (str), `message` (str), `committed_at` (str ISO-8601), `match_source` (str: `"message"` | `"branch"` | `"midi_content"`)
+
+**Agent use case:** An agent searching for prior uses of a Cm7 chord calls `muse grep "Cm7" --commits --json` to get a list of commits containing that chord. It can then pull those commits as harmonic reference material.
+
+**Implementation:** `maestro/muse_cli/commands/grep_cmd.py` — registered as `muse grep`. `GrepMatch` (dataclass), `_load_all_commits()`, `_grep_async()`, `_render_matches()`. Exit codes: 0 success, 2 outside repo.
+
+> **Stub note:** Pattern matched against commit messages only. MIDI content scanning (parsing note events from snapshot objects) is tracked as a follow-up issue.
+
+---
+
+### `muse ask`
+
+**Purpose:** Natural language question answering over commit history. Ask questions
+in plain English; Muse searches history and returns a grounded answer citing specific
+commits. The conversational interface to musical memory.
+
+**Usage:**
+```bash
+muse ask "<question>" [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `QUESTION` | positional | required | Natural-language question about musical history |
+| `--branch TEXT` | string | all | Restrict history to a branch |
+| `--since DATE` | `YYYY-MM-DD` | — | Only consider commits after this date |
+| `--until DATE` | `YYYY-MM-DD` | — | Only consider commits before this date |
+| `--cite` | flag | off | Show full commit IDs in the answer (default: short IDs) |
+| `--json` | flag | off | Emit structured JSON response |
+
+**Output example (text):**
+```
+Based on Muse history (47 commits searched):
+Commits matching your query: 3 found
+
+  [a1b2c3d] 2026-02-15 22:00  boom bap dark jazz session
+  [f9e8d7c] 2026-02-10 18:30  Add bass overdub — minor key
+  [3b2a1f0] 2026-01-28 14:00  Initial tempo work at 118 BPM
+
+Note: Full LLM-powered answer generation is a planned enhancement.
+```
+
+**Output example (`--json`):**
+```json
+{
+  "question": "when did we work on jazz?",
+  "total_searched": 47,
+  "matches_found": 3,
+  "commits": [{"id": "a1b2c3d4...", "short_id": "a1b2c3d", "date": "2026-02-15", "message": "..."}],
+  "stub_note": "Full LLM answer generation is a planned enhancement."
+}
+```
+
+**Result type:** `AnswerResult` (class) — fields: `question` (str), `total_searched` (int), `matches` (list[MuseCliCommit]), `cite` (bool). Methods: `.to_plain()`, `.to_json_dict()`.
+
+**Agent use case:** An AI agent composing a bridge asks `muse ask "what was the emotional arc of the chorus?" --json`. The answer grounds the agent in the actual commit history of the project before it generates, preventing stylistic drift.
+
+**Implementation:** `maestro/muse_cli/commands/ask.py` — `AnswerResult`, `_keywords()`, `_ask_async()`. Exit codes: 0 success, 1 bad date, 2 outside repo.
+
+> **Stub note:** Keyword matching over commit messages. Full implementation: RAG over Qdrant musical context embeddings + LLM answer synthesis via OpenRouter (Claude Sonnet/Opus). CLI interface is stable and will not change when LLM is wired in.
+
+---
+
+### `muse session`
+
+**Purpose:** Record and query recording session metadata — who played, when, where,
+and what they intended to create. Sessions are stored as local JSON files (not in
+Postgres), mirroring how Git stores config as plain files.
+
+**Usage:**
+```bash
+muse session <subcommand> [OPTIONS]
+```
+
+**Subcommands:**
+
+| Subcommand | Description |
+|------------|-------------|
+| `muse session start` | Open a new recording session |
+| `muse session end` | Finalize the active session |
+| `muse session log` | List all completed sessions, newest first |
+| `muse session show <id>` | Print a specific session by ID (prefix match) |
+| `muse session credits` | Aggregate participants across all sessions |
+
+**`muse session start` flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--participants TEXT` | string | — | Comma-separated participant names |
+| `--location TEXT` | string | — | Studio or location name |
+| `--intent TEXT` | string | — | Creative intent for this session |
+
+**`muse session end` flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--notes TEXT` | string | — | Session notes / retrospective |
+
+**Session JSON schema** (stored in `.muse/sessions/<uuid>.json`):
+```json
+{
+  "session_id": "<uuid4>",
+  "started_at": "2026-02-27T22:00:00+00:00",
+  "ended_at": "2026-02-27T02:30:00+00:00",
+  "participants": ["Gabriel (producer)", "Sarah (keys)"],
+  "location": "Studio A",
+  "intent": "Piano overdubs for verse sections",
+  "commits": [],
+  "notes": "Great tone on the Steinway today."
+}
+```
+
+**`muse session log` output:**
+```
+SESSION  2026-02-27T22:00  → 2026-02-27T02:30  2h30m
+  Participants: Gabriel (producer), Sarah (keys)
+  Location:     Studio A
+  Intent:       Piano overdubs for verse sections
+```
+
+**`muse session credits` output:**
+```
+Gabriel (producer)  7 sessions
+Sarah (keys)        3 sessions
+Marcus (bass)       2 sessions
+```
+
+**Agent use case:** An AI agent summarizing a project's creative history calls `muse session credits --json` to attribute musical contributions. An AI generating liner notes reads `muse session log --json` to reconstruct the session timeline.
+
+**Implementation:** `maestro/muse_cli/commands/session.py` — all synchronous (no DB, no async). Storage: `.muse/sessions/current.json` (active) → `.muse/sessions/<uuid>.json` (completed). Exit codes: 0 success, 1 user error (duplicate session, no active session, ambiguous ID), 2 outside repo, 3 internal.
+
+---
+
+### Command Registration Summary
+
+| Command | File | Status | Issue |
+|---------|------|--------|-------|
+| `muse dynamics` | `commands/dynamics.py` | ✅ stub (PR #130) | #120 |
+| `muse swing` | `commands/swing.py` | ✅ stub (PR #131) | #121 |
+| `muse recall` | `commands/recall.py` | ✅ stub (PR #135) | #122 |
+| `muse tag` | `commands/tag.py` | ✅ implemented (PR #133) | #123 |
+| `muse grep` | `commands/grep_cmd.py` | ✅ stub (PR #128) | #124 |
+| `muse describe` | `commands/describe.py` | ✅ stub (PR #134) | #125 |
+| `muse ask` | `commands/ask.py` | ✅ stub (PR #132) | #126 |
+| `muse session` | `commands/session.py` | ✅ implemented (PR #129) | #127 |
+
+All stub commands have stable CLI contracts. Full musical analysis (MIDI content
+parsing, vector embeddings, LLM synthesis) is tracked as follow-up issues.
+
+---

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -3545,3 +3545,58 @@ classDiagram
     parse_prompt ..> MaestroPrompt : produces
     parse_prompt ..> PromptParseError : raises
 ```
+
+---
+
+### Diagram 20 — Muse Import Types (`maestro/muse_cli/midi_parser.py`)
+
+`NoteEvent` is the atomic unit of parsed music data — one sounding note with pitch, timing, velocity, and track assignment. `MuseImportData` groups all notes extracted from a single file along with format metadata. Both types are produced by `parse_file()` and its format-specific delegates (`parse_midi_file`, `parse_musicxml_file`). `apply_track_map()` returns a new list of `NoteEvent` objects with `channel_name` fields remapped; it never mutates its input.
+
+```mermaid
+classDiagram
+    direction TB
+
+    class NoteEvent {
+        <<dataclass>>
+        +pitch : int
+        +velocity : int
+        +start_tick : int
+        +duration_ticks : int
+        +channel : int
+        +channel_name : str
+    }
+
+    class MuseImportData {
+        <<dataclass>>
+        +source_path : pathlib.Path
+        +format : str
+        +ticks_per_beat : int
+        +tempo_bpm : float
+        +notes : list~NoteEvent~
+        +tracks : list~str~
+        +raw_meta : dict~str, Any~
+    }
+
+    class parse_file {
+        <<function>>
+        pathlib.Path → MuseImportData
+    }
+    class parse_midi_file {
+        <<function>>
+        pathlib.Path → MuseImportData
+    }
+    class parse_musicxml_file {
+        <<function>>
+        pathlib.Path → MuseImportData
+    }
+    class apply_track_map {
+        <<function>>
+        list~NoteEvent~, dict~str,str~ → list~NoteEvent~
+    }
+
+    MuseImportData --> NoteEvent : notes list
+    parse_file ..> MuseImportData : produces
+    parse_midi_file ..> MuseImportData : produces
+    parse_musicxml_file ..> MuseImportData : produces
+    apply_track_map ..> NoteEvent : returns remapped copies
+```

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -2,7 +2,7 @@
 
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (init, status, commit, log, checkout, merge, remote,
-push, pull, open, play) as Typer sub-applications.
+push, pull, open, play, import) as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ import typer
 from maestro.muse_cli.commands import (
     checkout,
     commit,
+    import_cmd,
     init,
     log,
     merge,
@@ -39,6 +40,7 @@ cli.add_typer(push.app, name="push", help="Upload local variations to a remote."
 cli.add_typer(pull.app, name="pull", help="Download remote variations locally.")
 cli.add_typer(open_cmd.app, name="open", help="Open an artifact in the system default app (macOS).")
 cli.add_typer(play.app, name="play", help="Play an audio artifact via afplay (macOS).")
+cli.add_typer(import_cmd.app, name="import", help="Import a MIDI or MusicXML file as a new Muse commit.")
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/commands/import_cmd.py
+++ b/maestro/muse_cli/commands/import_cmd.py
@@ -1,0 +1,258 @@
+"""muse import — import a MIDI or MusicXML file as a new Muse commit.
+
+Workflow
+--------
+1. Validate the file extension (supported: .mid, .midi, .xml, .musicxml).
+2. Parse the file into Muse's internal :class:`MuseImportData` representation.
+3. Apply any ``--track-map`` channel→name remapping.
+4. Copy the source file into ``muse-work/imports/<filename>``.
+5. Write a ``muse-work/imports/<filename>.meta.json`` with note count, tracks,
+   and tempo metadata (for downstream processing and commit diffs).
+6. Run :func:`_commit_async` to create the Muse commit.
+7. If ``--analyze``, print a multi-dimensional analysis of the imported content.
+
+Flags
+-----
+``<file>``            File to import (.mid/.midi/.xml/.musicxml).
+``--message TEXT``    Commit message (default: "Import <filename>").
+``--track-map TEXT``  Channel→name mapping, e.g. ``ch0=bass,ch1=piano,ch9=drums``.
+``--section TEXT``    Section tag stored in the commit metadata JSON.
+``--analyze``         Run analysis and display results after importing.
+``--dry-run``         Validate only — do not write files or create a commit.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+import shutil
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.midi_parser import (
+    MuseImportData,
+    analyze_import,
+    apply_track_map,
+    parse_file,
+    parse_track_map_arg,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _import_async(
+    *,
+    file_path: pathlib.Path,
+    root: pathlib.Path,
+    session: AsyncSession,
+    message: str | None = None,
+    track_map: dict[str, str] | None = None,
+    section: str | None = None,
+    analyze: bool = False,
+    dry_run: bool = False,
+) -> str | None:
+    """Core import pipeline — fully injectable for tests.
+
+    Parses, copies, commits, and optionally analyses the given file.
+
+    Returns:
+        The new ``commit_id`` on success, or ``None`` when ``dry_run=True``.
+
+    Raises:
+        ``typer.Exit`` with the appropriate exit code on validation failures so
+        the Typer callback surfaces a clean message instead of a traceback.
+    """
+    # ── Validate and parse ───────────────────────────────────────────────
+    try:
+        data: MuseImportData = parse_file(file_path)
+    except FileNotFoundError:
+        typer.echo(f"❌ File not found: {file_path}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+    except ValueError as exc:
+        typer.echo(f"❌ {exc}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+    except RuntimeError as exc:
+        typer.echo(f"❌ {exc}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # ── Apply track map ──────────────────────────────────────────────────
+    if track_map:
+        data = MuseImportData(
+            source_path=data.source_path,
+            format=data.format,
+            ticks_per_beat=data.ticks_per_beat,
+            tempo_bpm=data.tempo_bpm,
+            notes=apply_track_map(data.notes, track_map),
+            tracks=list({n.channel_name for n in apply_track_map(data.notes, track_map)}),
+            raw_meta=data.raw_meta,
+        )
+        # Preserve insertion order for tracks
+        seen: set[str] = set()
+        ordered_tracks: list[str] = []
+        for n in data.notes:
+            if n.channel_name not in seen:
+                seen.add(n.channel_name)
+                ordered_tracks.append(n.channel_name)
+        data = MuseImportData(
+            source_path=data.source_path,
+            format=data.format,
+            ticks_per_beat=data.ticks_per_beat,
+            tempo_bpm=data.tempo_bpm,
+            notes=data.notes,
+            tracks=ordered_tracks,
+            raw_meta=data.raw_meta,
+        )
+
+    effective_message = message or f"Import {file_path.name}"
+
+    # ── Dry-run: validate only ────────────────────────────────────────────
+    if dry_run:
+        typer.echo(f"✅ Dry run: '{file_path.name}' is valid ({data.format})")
+        typer.echo(f"   Notes: {len(data.notes)}, Tracks: {len(data.tracks)}, Tempo: {data.tempo_bpm:.1f} BPM")
+        typer.echo(f"   Would commit: {effective_message!r}")
+        if section:
+            typer.echo(f"   Section: {section!r}")
+        if analyze:
+            typer.echo("\nAnalysis:")
+            typer.echo(analyze_import(data))
+        return None
+
+    # ── Copy file into muse-work/imports/ ────────────────────────────────
+    imports_dir = root / "muse-work" / "imports"
+    imports_dir.mkdir(parents=True, exist_ok=True)
+
+    dest = imports_dir / file_path.name
+    shutil.copy2(str(file_path), str(dest))
+    logger.debug("✅ Copied %s → %s", file_path, dest)
+
+    # ── Write metadata JSON ───────────────────────────────────────────────
+    meta: dict[str, object] = {
+        "source": str(file_path),
+        "format": data.format,
+        "ticks_per_beat": data.ticks_per_beat,
+        "tempo_bpm": round(data.tempo_bpm, 3),
+        "note_count": len(data.notes),
+        "tracks": data.tracks,
+        "track_map": track_map or {},
+        "section": section,
+        "raw_meta": data.raw_meta,
+    }
+    meta_path = imports_dir / f"{file_path.name}.meta.json"
+    meta_path.write_text(json.dumps(meta, indent=2))
+
+    # ── Commit ────────────────────────────────────────────────────────────
+    commit_id = await _commit_async(
+        message=effective_message,
+        root=root,
+        session=session,
+    )
+
+    typer.echo(f"✅ Imported '{file_path.name}' as commit {commit_id[:8]}")
+    if section:
+        typer.echo(f"   Section: {section!r}")
+
+    # ── Analysis ─────────────────────────────────────────────────────────
+    if analyze:
+        typer.echo("\nAnalysis:")
+        typer.echo(analyze_import(data))
+
+    return commit_id
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def import_file(
+    ctx: typer.Context,
+    file: str = typer.Argument(..., help="Path to the MIDI or MusicXML file to import."),
+    message: Optional[str] = typer.Option(
+        None,
+        "--message",
+        "-m",
+        help='Commit message (default: "Import <filename>").',
+    ),
+    track_map: Optional[str] = typer.Option(
+        None,
+        "--track-map",
+        help='Map MIDI channels to track names, e.g. "ch0=bass,ch1=piano,ch9=drums".',
+    ),
+    section: Optional[str] = typer.Option(
+        None,
+        "--section",
+        help="Tag the imported content as a specific section.",
+    ),
+    analyze: bool = typer.Option(
+        False,
+        "--analyze",
+        help="Run multi-dimensional analysis on the imported content and display it.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Validate the import without committing.",
+    ),
+) -> None:
+    """Import a MIDI or MusicXML file as a new Muse commit."""
+    file_path = pathlib.Path(file).expanduser().resolve()
+
+    parsed_track_map: dict[str, str] | None = None
+    if track_map is not None:
+        try:
+            parsed_track_map = parse_track_map_arg(track_map)
+        except ValueError as exc:
+            typer.echo(f"❌ --track-map: {exc}")
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    root = require_repo()
+
+    async def _run() -> None:
+        if dry_run:
+            # Dry-run does not need a DB session
+            await _import_async(
+                file_path=file_path,
+                root=root,
+                session=None,  # type: ignore[arg-type]
+                message=message,
+                track_map=parsed_track_map,
+                section=section,
+                analyze=analyze,
+                dry_run=True,
+            )
+        else:
+            async with open_session() as session:
+                await _import_async(
+                    file_path=file_path,
+                    root=root,
+                    session=session,
+                    message=message,
+                    track_map=parsed_track_map,
+                    section=section,
+                    analyze=analyze,
+                    dry_run=False,
+                )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse import failed: {exc}")
+        logger.error("❌ muse import error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/muse_cli/midi_parser.py
+++ b/maestro/muse_cli/midi_parser.py
@@ -1,0 +1,393 @@
+"""MIDI and MusicXML parsing for ``muse import``.
+
+Converts standard music file formats into Muse's internal note representation:
+a list of :class:`NoteEvent` objects and a :class:`MuseImportData` container.
+
+Supported formats
+-----------------
+- ``.mid`` / ``.midi`` — Standard MIDI File via ``mido``
+- ``.xml`` / ``.musicxml`` — MusicXML via Python's built-in ``xml.etree.ElementTree``
+
+Named result types registered in ``docs/reference/type_contracts.md``:
+- ``MuseImportData``
+- ``NoteEvent``
+"""
+from __future__ import annotations
+
+import dataclasses
+import logging
+import pathlib
+import xml.etree.ElementTree as ET
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: File extensions accepted by this module.
+SUPPORTED_MIDI_EXTENSIONS = {".mid", ".midi"}
+SUPPORTED_XML_EXTENSIONS = {".xml", ".musicxml"}
+SUPPORTED_EXTENSIONS = SUPPORTED_MIDI_EXTENSIONS | SUPPORTED_XML_EXTENSIONS
+
+
+@dataclasses.dataclass
+class NoteEvent:
+    """A single sounding note extracted from an imported file."""
+
+    pitch: int
+    velocity: int
+    start_tick: int
+    duration_ticks: int
+    channel: int
+    channel_name: str
+
+
+@dataclasses.dataclass
+class MuseImportData:
+    """All data extracted from a single imported music file."""
+
+    source_path: pathlib.Path
+    format: str
+    ticks_per_beat: int
+    tempo_bpm: float
+    notes: list[NoteEvent]
+    tracks: list[str]
+    raw_meta: dict[str, Any]
+
+
+def parse_file(path: pathlib.Path) -> MuseImportData:
+    """Dispatch to the correct parser based on file extension.
+
+    Raises:
+        ValueError: When the extension is not in :data:`SUPPORTED_EXTENSIONS`.
+        FileNotFoundError: When the file does not exist.
+        RuntimeError: When the file is malformed.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+    ext = path.suffix.lower()
+    if ext in SUPPORTED_MIDI_EXTENSIONS:
+        return parse_midi_file(path)
+    if ext in SUPPORTED_XML_EXTENSIONS:
+        return parse_musicxml_file(path)
+    supported = ", ".join(sorted(SUPPORTED_EXTENSIONS))
+    raise ValueError(
+        f"Unsupported file extension '{path.suffix}'.  Supported: {supported}"
+    )
+
+
+def parse_midi_file(path: pathlib.Path) -> MuseImportData:
+    """Parse a Standard MIDI File into a :class:`MuseImportData`.
+
+    Uses ``mido``.  Note-on with velocity=0 is treated as note-off.
+
+    Raises:
+        RuntimeError: When ``mido`` cannot read the file.
+    """
+    try:
+        import mido
+    except ImportError:
+        raise RuntimeError(
+            "mido is required for MIDI import.  "
+            "It is pre-installed in the Maestro Docker image."
+        )
+
+    try:
+        mid = mido.MidiFile(str(path))
+    except Exception as exc:
+        raise RuntimeError(f"Cannot parse MIDI file '{path}': {exc}") from exc
+
+    ticks_per_beat = int(mid.ticks_per_beat)
+    tempo_us: int = 500_000  # 120 BPM default
+    notes: list[NoteEvent] = []
+    # (channel, pitch) -> (start_tick, velocity)
+    active: dict[tuple[int, int], tuple[int, int]] = {}
+
+    for track in mid.tracks:
+        abs_tick = 0
+        for msg in track:
+            abs_tick += msg.time
+            if msg.type == "set_tempo":
+                tempo_us = msg.tempo
+            elif msg.type == "note_on" and msg.velocity > 0:
+                active[(msg.channel, msg.note)] = (abs_tick, msg.velocity)
+            elif msg.type == "note_off" or (
+                msg.type == "note_on" and msg.velocity == 0
+            ):
+                key = (msg.channel, msg.note)
+                if key in active:
+                    start, vel = active.pop(key)
+                    notes.append(
+                        NoteEvent(
+                            pitch=msg.note,
+                            velocity=vel,
+                            start_tick=start,
+                            duration_ticks=max(abs_tick - start, 1),
+                            channel=msg.channel,
+                            channel_name=f"ch{msg.channel}",
+                        )
+                    )
+
+    # Notes never closed — truncate to duration 1
+    for (ch, pitch), (start, vel) in active.items():
+        notes.append(
+            NoteEvent(
+                pitch=pitch,
+                velocity=vel,
+                start_tick=start,
+                duration_ticks=1,
+                channel=ch,
+                channel_name=f"ch{ch}",
+            )
+        )
+
+    tempo_bpm = 60_000_000 / tempo_us
+    tracks = _unique_ordered([n.channel_name for n in notes])
+
+    logger.debug(
+        "✅ Parsed MIDI %s: %d notes, %d tracks, %.1f BPM",
+        path.name, len(notes), len(tracks), tempo_bpm,
+    )
+    return MuseImportData(
+        source_path=path,
+        format="midi",
+        ticks_per_beat=ticks_per_beat,
+        tempo_bpm=tempo_bpm,
+        notes=notes,
+        tracks=tracks,
+        raw_meta={"num_tracks": len(mid.tracks)},
+    )
+
+
+def parse_musicxml_file(path: pathlib.Path) -> MuseImportData:
+    """Parse a MusicXML ``<score-partwise>`` file into a :class:`MuseImportData`.
+
+    Raises:
+        RuntimeError: When the XML is invalid or not a recognisable MusicXML document.
+    """
+    try:
+        tree = ET.parse(str(path))
+    except ET.ParseError as exc:
+        raise RuntimeError(f"Cannot parse MusicXML file '{path}': {exc}") from exc
+
+    root = tree.getroot()
+
+    # Strip XML namespace prefix, e.g. {http://www.musicxml.org/…}element → element
+    ns = ""
+    if root.tag.startswith("{"):
+        ns = root.tag[: root.tag.index("}") + 1]
+
+    def t(name: str) -> str:
+        return f"{ns}{name}"
+
+    if root.tag not in (t("score-partwise"), "score-partwise"):
+        raise RuntimeError(
+            f"Unrecognised MusicXML root element '{root.tag}'.  "
+            "Expected <score-partwise>."
+        )
+
+    tempo_bpm = 120.0
+    for direction in root.iter(t("direction")):
+        sound = direction.find(t("sound"))
+        if sound is not None:
+            raw = sound.get("tempo")
+            if raw is not None:
+                try:
+                    tempo_bpm = float(raw)
+                    break
+                except ValueError:
+                    pass
+
+    ticks_per_beat = 480  # internal default for MusicXML
+
+    part_names: list[str] = []
+    for pn in root.iter(t("part-name")):
+        name = (pn.text or "").strip()
+        part_names.append(name or f"Part {len(part_names) + 1}")
+
+    _STEP_SEMITONE: dict[str, int] = {
+        "C": 0, "D": 2, "E": 4, "F": 5, "G": 7, "A": 9, "B": 11,
+    }
+
+    notes: list[NoteEvent] = []
+    parts = root.findall(t("part"))
+
+    for ch_idx, part_el in enumerate(parts):
+        channel_name = part_names[ch_idx] if ch_idx < len(part_names) else f"ch{ch_idx}"
+        abs_tick = 0
+        divisions = 1
+
+        for measure_el in part_el.findall(t("measure")):
+            attrs = measure_el.find(t("attributes"))
+            if attrs is not None:
+                div_el = attrs.find(t("divisions"))
+                if div_el is not None and div_el.text:
+                    try:
+                        divisions = int(div_el.text)
+                    except ValueError:
+                        pass
+
+            measure_tick = abs_tick
+
+            for note_el in measure_el.findall(t("note")):
+                dur_el = note_el.find(t("duration"))
+                dur_xml = int(dur_el.text) if dur_el is not None and dur_el.text else 0
+                dur_ticks = int(dur_xml * ticks_per_beat / max(divisions, 1))
+
+                if note_el.find(t("rest")) is not None:
+                    measure_tick += dur_ticks
+                    continue
+
+                pitch_el = note_el.find(t("pitch"))
+                if pitch_el is None:
+                    measure_tick += dur_ticks
+                    continue
+
+                step_el = pitch_el.find(t("step"))
+                oct_el = pitch_el.find(t("octave"))
+                alt_el = pitch_el.find(t("alter"))
+
+                step = (step_el.text or "C").strip() if step_el is not None else "C"
+                octave = int(oct_el.text or "4") if oct_el is not None else 4
+                alter = int(float(alt_el.text or "0")) if alt_el is not None else 0
+
+                pitch = max(0, min(127, (octave + 1) * 12 + _STEP_SEMITONE.get(step, 0) + alter))
+                is_chord = note_el.find(t("chord")) is not None
+                note_start = measure_tick
+                if not is_chord:
+                    measure_tick += dur_ticks
+
+                notes.append(
+                    NoteEvent(
+                        pitch=pitch,
+                        velocity=80,
+                        start_tick=note_start,
+                        duration_ticks=max(dur_ticks, 1),
+                        channel=ch_idx,
+                        channel_name=channel_name,
+                    )
+                )
+
+            abs_tick = measure_tick
+
+    tracks = _unique_ordered([n.channel_name for n in notes])
+    logger.debug(
+        "✅ Parsed MusicXML %s: %d notes, %d parts, %.1f BPM",
+        path.name, len(notes), len(parts), tempo_bpm,
+    )
+    return MuseImportData(
+        source_path=path,
+        format="musicxml",
+        ticks_per_beat=ticks_per_beat,
+        tempo_bpm=tempo_bpm,
+        notes=notes,
+        tracks=tracks,
+        raw_meta={"num_parts": len(parts), "part_names": part_names},
+    )
+
+
+def apply_track_map(notes: list[NoteEvent], track_map: dict[str, str]) -> list[NoteEvent]:
+    """Return notes with ``channel_name`` fields remapped per *track_map*.
+
+    Keys may be ``"ch<N>"`` or bare channel number strings.
+    Notes for unmapped channels are returned unchanged.
+    """
+    normalised: dict[int, str] = {}
+    for key, name in track_map.items():
+        k = key.strip()
+        try:
+            ch = int(k[2:]) if k.startswith("ch") else int(k)
+            normalised[ch] = name
+        except ValueError:
+            logger.warning("⚠️ Ignoring invalid track-map key %r", key)
+
+    result: list[NoteEvent] = []
+    for note in notes:
+        if note.channel in normalised:
+            result.append(dataclasses.replace(note, channel_name=normalised[note.channel]))
+        else:
+            result.append(note)
+    return result
+
+
+def parse_track_map_arg(raw: str) -> dict[str, str]:
+    """Parse ``"ch0=bass,ch1=piano"`` into ``{"ch0": "bass", "ch1": "piano"}``.
+
+    Raises:
+        ValueError: When any pair is not in ``KEY=VALUE`` format.
+    """
+    result: dict[str, str] = {}
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if not pair:
+            continue
+        if "=" not in pair:
+            raise ValueError(
+                f"Invalid track-map entry {pair!r}.  Expected KEY=VALUE (e.g. ch0=bass)."
+            )
+        key, _, value = pair.partition("=")
+        result[key.strip()] = value.strip()
+    return result
+
+
+def analyze_import(data: MuseImportData) -> str:
+    """Return a multi-line analysis of *data* covering harmonic, rhythmic, and dynamic dimensions."""
+    notes = data.notes
+    if not notes:
+        return "  (no notes found — file may be empty or contain only meta events)"
+
+    _NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+    pitches = [n.pitch for n in notes]
+    pitch_counts: dict[int, int] = {}
+    for p in pitches:
+        pitch_counts[p] = pitch_counts.get(p, 0) + 1
+    top_pitches = sorted(pitch_counts, key=lambda p: -pitch_counts[p])[:5]
+    top_str = ", ".join(
+        f"{_NOTE_NAMES[p % 12]}{p // 12 - 1}({pitch_counts[p]}x)" for p in top_pitches
+    )
+    pitch_min, pitch_max = min(pitches), max(pitches)
+
+    total = len(notes)
+    span_ticks = max(n.start_tick + n.duration_ticks for n in notes)
+    span_beats = span_ticks / max(data.ticks_per_beat, 1)
+    density = total / max(span_beats, 0.001)
+
+    velocities = [n.velocity for n in notes]
+    avg_vel = sum(velocities) / len(velocities)
+    vel_min, vel_max = min(velocities), max(velocities)
+
+    def _band(v: float) -> str:
+        if v < 40: return "pp (very soft)"
+        if v < 65: return "p (soft)"
+        if v < 85: return "mp/mf (medium)"
+        if v < 105: return "f (loud)"
+        return "ff (very loud)"
+
+    track_summary = ", ".join(data.tracks) if data.tracks else "(none)"
+    return "\n".join([
+        f"  Format:      {data.format}",
+        f"  Tempo:       {data.tempo_bpm:.1f} BPM",
+        f"  Tracks:      {track_summary}",
+        "",
+        "  ── Harmonic ──────────────────────────────────",
+        f"  Pitch range: {_NOTE_NAMES[pitch_min % 12]}{pitch_min // 12 - 1}"
+        f"–{_NOTE_NAMES[pitch_max % 12]}{pitch_max // 12 - 1}",
+        f"  Top pitches: {top_str}",
+        "",
+        "  ── Rhythmic ──────────────────────────────────",
+        f"  Notes:       {total}",
+        f"  Span:        {span_beats:.1f} beats",
+        f"  Density:     {density:.1f} notes/beat",
+        "",
+        "  ── Dynamic ───────────────────────────────────",
+        f"  Velocity:    avg={avg_vel:.0f}, min={vel_min}, max={vel_max}",
+        f"  Character:   {_band(avg_vel)}",
+    ])
+
+
+def _unique_ordered(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result

--- a/tests/muse_cli/test_import.py
+++ b/tests/muse_cli/test_import.py
@@ -1,0 +1,470 @@
+"""Tests for ``muse import`` — MIDI and MusicXML import pipeline.
+
+All async tests use ``@pytest.mark.anyio``.
+The ``muse_cli_db_session`` fixture (in tests/muse_cli/conftest.py) provides
+an isolated in-memory SQLite session; no real Postgres instance is required.
+
+Test MIDI fixtures are synthesised in-memory using ``mido`` so no binary
+files need to be committed to the repository.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import struct
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from maestro.muse_cli.commands.import_cmd import _import_async
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.midi_parser import (
+    MuseImportData,
+    NoteEvent,
+    analyze_import,
+    apply_track_map,
+    parse_file,
+    parse_midi_file,
+    parse_musicxml_file,
+    parse_track_map_arg,
+)
+from maestro.muse_cli.models import MuseCliCommit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    """Create a minimal .muse/ layout compatible with _commit_async."""
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(json.dumps({"repo_id": rid, "schema_version": "1"}))
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _make_minimal_midi(path: pathlib.Path) -> None:
+    """Write a minimal but valid Type-0 MIDI file using raw bytes.
+
+    Contains a single track with: tempo (120 BPM), note-on C4 ch0, note-off C4 ch0.
+    Using raw bytes avoids requiring mido at test-fixture-creation time.
+    """
+    # MIDI header: MThd, length=6, format=0, ntracks=1, division=480
+    header = b"MThd" + struct.pack(">IHHH", 6, 0, 1, 480)
+
+    # Track events (delta_time, event):
+    # 0   FF 51 03 07 A1 20  — set_tempo: 500000 µs = 120 BPM
+    # 0   90 3C 64           — note_on ch0 pitch=60 vel=100
+    # 240 80 3C 00           — note_off ch0 pitch=60
+    # 0   FF 2F 00           — end_of_track
+    track_data = (
+        b"\x00\xFF\x51\x03\x07\xA1\x20"   # tempo
+        b"\x00\x90\x3C\x64"               # note_on C4
+        b"\x81\x70\x80\x3C\x00"           # delta=240 (varint), note_off
+        b"\x00\xFF\x2F\x00"               # end_of_track
+    )
+    track = b"MTrk" + struct.pack(">I", len(track_data)) + track_data
+    path.write_bytes(header + track)
+
+
+def _make_minimal_musicxml(path: pathlib.Path) -> None:
+    """Write a minimal valid MusicXML file with one part and two notes."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC
+    "-//Recordare//DTD MusicXML 3.1 Partwise//EN"
+    "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <direction placement="above">
+        <direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>120</per-minute></metronome></direction-type>
+        <sound tempo="120"/>
+      </direction>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>
+"""
+    path.write_text(xml)
+
+
+# ---------------------------------------------------------------------------
+# midi_parser unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_midi_file_returns_note_data(tmp_path: pathlib.Path) -> None:
+    """parse_midi_file extracts at least one NoteEvent from a valid MIDI file."""
+    mid = tmp_path / "song.mid"
+    _make_minimal_midi(mid)
+    data = parse_midi_file(mid)
+    assert data.format == "midi"
+    assert len(data.notes) >= 1
+    assert data.ticks_per_beat == 480
+    assert data.tempo_bpm == pytest.approx(120.0, abs=1.0)
+
+
+def test_parse_musicxml_creates_commit(tmp_path: pathlib.Path) -> None:
+    """parse_musicxml_file returns a MuseImportData with notes for a valid MusicXML."""
+    xml = tmp_path / "song.musicxml"
+    _make_minimal_musicxml(xml)
+    data = parse_musicxml_file(xml)
+    assert data.format == "musicxml"
+    assert len(data.notes) >= 1
+    assert data.tempo_bpm == pytest.approx(120.0, abs=1.0)
+    assert "Piano" in data.tracks
+
+
+def test_parse_file_dispatches_by_extension(tmp_path: pathlib.Path) -> None:
+    """`parse_file` dispatches to the correct parser via extension."""
+    mid = tmp_path / "x.mid"
+    _make_minimal_midi(mid)
+    data = parse_file(mid)
+    assert data.format == "midi"
+
+    xml = tmp_path / "x.musicxml"
+    _make_minimal_musicxml(xml)
+    data2 = parse_file(xml)
+    assert data2.format == "musicxml"
+
+
+def test_import_unsupported_extension_raises_error(tmp_path: pathlib.Path) -> None:
+    """parse_file raises ValueError for unsupported extensions."""
+    bad = tmp_path / "song.mp3"
+    bad.write_bytes(b"not midi")
+    with pytest.raises(ValueError, match="Unsupported file extension"):
+        parse_file(bad)
+
+
+def test_import_malformed_midi_raises_clear_error(tmp_path: pathlib.Path) -> None:
+    """Malformed MIDI content raises RuntimeError with a clear message (regression test)."""
+    bad = tmp_path / "bad.mid"
+    bad.write_bytes(b"not a midi file at all")
+    with pytest.raises(RuntimeError, match="Cannot parse MIDI file"):
+        parse_midi_file(bad)
+
+
+def test_import_track_map_assigns_named_tracks(tmp_path: pathlib.Path) -> None:
+    """apply_track_map renames channel_name fields per the provided mapping."""
+    mid = tmp_path / "song.mid"
+    _make_minimal_midi(mid)
+    data = parse_midi_file(mid)
+
+    remapped = apply_track_map(data.notes, {"ch0": "bass", "ch1": "piano"})
+    ch0_notes = [n for n in remapped if n.channel == 0]
+    assert all(n.channel_name == "bass" for n in ch0_notes)
+
+
+def test_apply_track_map_bare_channel_key(tmp_path: pathlib.Path) -> None:
+    """apply_track_map accepts bare channel numbers as keys (e.g. '0' not 'ch0')."""
+    notes = [NoteEvent(pitch=60, velocity=80, start_tick=0, duration_ticks=100, channel=0, channel_name="ch0")]
+    remapped = apply_track_map(notes, {"0": "bass"})
+    assert remapped[0].channel_name == "bass"
+
+
+def test_apply_track_map_does_not_mutate_original() -> None:
+    """apply_track_map returns new NoteEvent objects; originals are unchanged."""
+    note = NoteEvent(pitch=60, velocity=80, start_tick=0, duration_ticks=100, channel=0, channel_name="ch0")
+    apply_track_map([note], {"ch0": "bass"})
+    assert note.channel_name == "ch0"
+
+
+def test_parse_track_map_arg_valid() -> None:
+    """parse_track_map_arg parses comma-separated KEY=VALUE pairs."""
+    result = parse_track_map_arg("ch0=bass,ch1=piano,ch9=drums")
+    assert result == {"ch0": "bass", "ch1": "piano", "ch9": "drums"}
+
+
+def test_parse_track_map_arg_invalid_raises() -> None:
+    """parse_track_map_arg raises ValueError for malformed entries."""
+    with pytest.raises(ValueError, match="KEY=VALUE"):
+        parse_track_map_arg("ch0=bass,nodivider")
+
+
+def test_analyze_import_returns_string(tmp_path: pathlib.Path) -> None:
+    """analyze_import produces a non-empty multi-line analysis string."""
+    mid = tmp_path / "song.mid"
+    _make_minimal_midi(mid)
+    data = parse_midi_file(mid)
+    analysis = analyze_import(data)
+    assert "Harmonic" in analysis
+    assert "Rhythmic" in analysis
+    assert "Dynamic" in analysis
+
+
+def test_analyze_import_empty_notes() -> None:
+    """analyze_import handles empty note lists gracefully."""
+    data = MuseImportData(
+        source_path=pathlib.Path("/tmp/empty.mid"),
+        format="midi",
+        ticks_per_beat=480,
+        tempo_bpm=120.0,
+        notes=[],
+        tracks=[],
+        raw_meta={},
+    )
+    result = analyze_import(data)
+    assert "no notes found" in result
+
+
+def test_musicxml_part_name_becomes_track(tmp_path: pathlib.Path) -> None:
+    """MusicXML <part-name> elements are used as channel_name values."""
+    xml = tmp_path / "song.xml"
+    _make_minimal_musicxml(xml)
+    data = parse_musicxml_file(xml)
+    assert "Piano" in data.tracks
+    assert all(n.channel_name == "Piano" for n in data.notes if n.channel == 0)
+
+
+def test_parse_musicxml_malformed_raises(tmp_path: pathlib.Path) -> None:
+    """Malformed XML raises RuntimeError with a clear message."""
+    bad = tmp_path / "bad.xml"
+    bad.write_text("not xml at all <unclosed")
+    with pytest.raises(RuntimeError, match="Cannot parse MusicXML file"):
+        parse_musicxml_file(bad)
+
+
+# ---------------------------------------------------------------------------
+# _import_async integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_import_midi_creates_commit_with_note_data(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """_import_async creates a MuseCliCommit with correct message and copies the file."""
+    _init_muse_repo(tmp_path)
+    mid = tmp_path / "session.mid"
+    _make_minimal_midi(mid)
+
+    commit_id = await _import_async(
+        file_path=mid,
+        root=tmp_path,
+        session=muse_cli_db_session,
+        message="Import original session MIDI",
+    )
+
+    assert commit_id is not None
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == commit_id)
+    )
+    row = result.scalar_one_or_none()
+    assert row is not None
+    assert row.message == "Import original session MIDI"
+
+    # File was copied into muse-work/imports/
+    dest = tmp_path / "muse-work" / "imports" / "session.mid"
+    assert dest.exists()
+
+    # Metadata JSON was written
+    meta_path = tmp_path / "muse-work" / "imports" / "session.mid.meta.json"
+    assert meta_path.exists()
+    meta = json.loads(meta_path.read_text())
+    assert meta["format"] == "midi"
+    assert meta["note_count"] >= 1
+
+
+@pytest.mark.anyio
+async def test_import_default_message_is_import_filename(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """When no --message is given the commit message defaults to 'Import <filename>'."""
+    _init_muse_repo(tmp_path)
+    mid = tmp_path / "groove.mid"
+    _make_minimal_midi(mid)
+
+    commit_id = await _import_async(
+        file_path=mid,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    assert commit_id is not None
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == commit_id)
+    )
+    row = result.scalar_one()
+    assert row.message == "Import groove.mid"
+
+
+@pytest.mark.anyio
+async def test_import_track_map_recorded_in_metadata(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--track-map is persisted in the .meta.json file."""
+    _init_muse_repo(tmp_path)
+    mid = tmp_path / "band.mid"
+    _make_minimal_midi(mid)
+
+    await _import_async(
+        file_path=mid,
+        root=tmp_path,
+        session=muse_cli_db_session,
+        track_map={"ch0": "bass", "ch1": "piano", "ch9": "drums"},
+    )
+
+    meta = json.loads(
+        (tmp_path / "muse-work" / "imports" / "band.mid.meta.json").read_text()
+    )
+    assert meta["track_map"] == {"ch0": "bass", "ch1": "piano", "ch9": "drums"}
+
+
+@pytest.mark.anyio
+async def test_import_dry_run_no_commit_created(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--dry-run returns None and does not create a commit or copy files."""
+    _init_muse_repo(tmp_path)
+    mid = tmp_path / "check.mid"
+    _make_minimal_midi(mid)
+
+    result = await _import_async(
+        file_path=mid,
+        root=tmp_path,
+        session=muse_cli_db_session,
+        dry_run=True,
+    )
+
+    assert result is None
+
+    # No file copied
+    dest = tmp_path / "muse-work" / "imports" / "check.mid"
+    assert not dest.exists()
+
+    # No commit row in DB
+    rows = await muse_cli_db_session.execute(select(MuseCliCommit))
+    assert rows.scalars().all() == []
+
+
+@pytest.mark.anyio
+async def test_import_musicxml_creates_commit(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """_import_async handles .musicxml files and creates a valid commit."""
+    _init_muse_repo(tmp_path)
+    xml = tmp_path / "score.musicxml"
+    _make_minimal_musicxml(xml)
+
+    commit_id = await _import_async(
+        file_path=xml,
+        root=tmp_path,
+        session=muse_cli_db_session,
+        message="Import MusicXML score",
+    )
+
+    assert commit_id is not None
+    meta = json.loads(
+        (tmp_path / "muse-work" / "imports" / "score.musicxml.meta.json").read_text()
+    )
+    assert meta["format"] == "musicxml"
+
+
+@pytest.mark.anyio
+async def test_import_analyze_runs_context_analysis(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--analyze prints harmonic, rhythmic, and dynamic analysis after import."""
+    _init_muse_repo(tmp_path)
+    mid = tmp_path / "song.mid"
+    _make_minimal_midi(mid)
+
+    await _import_async(
+        file_path=mid,
+        root=tmp_path,
+        session=muse_cli_db_session,
+        analyze=True,
+    )
+
+    captured = capsys.readouterr()
+    assert "Harmonic" in captured.out
+    assert "Rhythmic" in captured.out
+    assert "Dynamic" in captured.out
+
+
+@pytest.mark.anyio
+async def test_import_missing_file_exits_user_error(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Importing a nonexistent file exits with USER_ERROR."""
+    import typer
+
+    _init_muse_repo(tmp_path)
+    missing = tmp_path / "ghost.mid"
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _import_async(
+            file_path=missing,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_import_unsupported_extension_exits_user_error(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Importing an unsupported file extension exits with USER_ERROR."""
+    import typer
+
+    _init_muse_repo(tmp_path)
+    bad = tmp_path / "song.mp3"
+    bad.write_bytes(b"not midi")
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _import_async(
+            file_path=bad,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_import_section_recorded_in_metadata(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--section is persisted in the .meta.json file."""
+    _init_muse_repo(tmp_path)
+    mid = tmp_path / "intro.mid"
+    _make_minimal_midi(mid)
+
+    await _import_async(
+        file_path=mid,
+        root=tmp_path,
+        session=muse_cli_db_session,
+        section="verse",
+    )
+
+    meta = json.loads(
+        (tmp_path / "muse-work" / "imports" / "intro.mid.meta.json").read_text()
+    )
+    assert meta["section"] == "verse"


### PR DESCRIPTION
## Summary
Closes #118 — adds `muse import <file>` command to import an external MIDI or MusicXML file as a new Muse VCS commit.

## Root Cause / Motivation
Muse VCS had no way to ingest external musical files into the commit history, blocking workflows that start from existing MIDI or notation files.

## Solution
Implemented `muse import <file>` with format detection (MIDI/MusicXML), manifest generation, commit creation with source metadata, and structured result types.

## Verification
- [x] mypy clean (460 source files, no issues)
- [x] Tests pass (23/23)
- [x] Merge conflict resolved (kept all `add_typer` lines from both sides)
- [x] Docs updated