### PR TITLE
feat: muse contour — analyze melodic contour and phrase shape

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -1309,3 +1309,107 @@ texture — letting the agent reuse, invert, or contrast those ideas.  The
 > scoring function will be replaced with no change to the CLI interface.
 
 ---
+
+## `muse contour` — Melodic Contour and Phrase Shape Analysis
+
+**Purpose:** Determines whether a melody rises, falls, arches, or waves — the
+fundamental expressive character that distinguishes two otherwise similar
+melodies.  An AI generation agent uses `muse contour --json HEAD` to
+understand the melodic shape of the current arrangement before layering a
+countermelody, ensuring complementary (not identical) contour.
+
+**Usage:**
+```bash
+muse contour [<commit>] [OPTIONS]
+```
+
+**Flags:**
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `[<commit>]` | string | HEAD | Target commit SHA to analyse |
+| `--track TEXT` | string | all tracks | Restrict to a named melodic track (e.g. `keys`, `lead`) |
+| `--section TEXT` | string | full piece | Scope analysis to a named section (e.g. `verse`, `chorus`) |
+| `--compare COMMIT` | string | — | Compare contour between HEAD (or `[<commit>]`) and this ref |
+| `--history` | flag | off | Show contour evolution across all commits |
+| `--shape` | flag | off | Print the overall shape label only (one line) |
+| `--json` | flag | off | Emit structured JSON for agent consumption |
+
+**Shape vocabulary:**
+| Label | Description |
+|-------|-------------|
+| `ascending` | Net upward movement across the full phrase |
+| `descending` | Net downward movement across the full phrase |
+| `arch` | Rises then falls (single peak) |
+| `inverted-arch` | Falls then rises (valley shape) |
+| `wave` | Multiple peaks; alternating rise and fall |
+| `static` | Narrow pitch range (< 2 semitones spread) |
+
+**Output example (text):**
+```
+Shape: Arch | Range: 2 octaves | Phrases: 4 avg 8 bars
+Commit: a1b2c3d4  Branch: main
+Track: keys  Section: all
+Angularity: 2.5 st avg interval
+(stub — full MIDI analysis pending)
+```
+
+**Output example (`--shape`):**
+```
+Shape: arch
+```
+
+**Output example (`--compare`, text):**
+```
+A (a1b2c3d4)  Shape: arch | Angularity: 2.5 st
+B (HEAD~10)   Shape: arch | Angularity: 2.5 st
+Delta  angularity +0.0 st | tessitura +0 st
+```
+
+**Output example (`--json`):**
+```json
+{
+  "shape": "arch",
+  "tessitura": 24,
+  "avg_interval": 2.5,
+  "phrase_count": 4,
+  "avg_phrase_bars": 8.0,
+  "commit": "a1b2c3d4",
+  "branch": "main",
+  "track": "keys",
+  "section": "all",
+  "source": "stub"
+}
+```
+
+**Result types:**
+- `ContourResult` — fields: `shape` (str), `tessitura` (int, semitones),
+  `avg_interval` (float, semitones), `phrase_count` (int), `avg_phrase_bars`
+  (float), `commit` (str), `branch` (str), `track` (str), `section` (str),
+  `source` (str).
+- `ContourCompareResult` — fields: `commit_a` (ContourResult), `commit_b`
+  (ContourResult), `shape_changed` (bool), `angularity_delta` (float),
+  `tessitura_delta` (int).
+
+See `docs/reference/type_contracts.md § ContourResult`.
+
+**Agent use case:** Before generating a countermelody, an agent calls
+`muse contour --json HEAD --track keys` to determine whether the existing
+melody is arch-shaped with a wide tessitura (high angularity).  It then
+generates a countermelody that is descending and narrow — complementary, not
+imitative.  The `--compare` flag lets the agent detect whether recent edits
+made a melody more angular (fragmented) or smoother (stepwise), informing
+whether the next variation should introduce or reduce leaps.
+
+**Implementation stub note:** `source: "stub"` in the JSON output indicates
+that full MIDI pitch-trajectory analysis is pending a Storpheus pitch-detection
+route.  The CLI contract (flags, output shape, result types) is stable — only
+the computed values will change when the full implementation is wired in.
+
+**Implementation:** `maestro/muse_cli/commands/contour.py` —
+`ContourResult` (TypedDict), `ContourCompareResult` (TypedDict),
+`_contour_detect_async()`, `_contour_compare_async()`,
+`_contour_history_async()`, `_format_detect()`, `_format_compare()`,
+`_format_history()`.  Exit codes: 0 success, 2 outside repo
+(`REPO_NOT_FOUND`), 3 internal error (`INTERNAL_ERROR`).
+
+---

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -3692,3 +3692,51 @@ classDiagram
     parse_prompt ..> MaestroPrompt : produces
     parse_prompt ..> PromptParseError : raises
 ```
+
+---
+
+### `ContourResult`
+
+**Module:** `maestro/muse_cli/commands/contour.py`
+
+Melodic contour analysis for a single commit or working tree.  Captures the
+overall pitch trajectory shape, effective range, average interval size, and
+phrase statistics.  Used by AI agents to understand a melody's expressive
+character before generating countermelodies or variations.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `shape` | `str` | Overall shape label: `ascending`, `descending`, `arch`, `inverted-arch`, `wave`, or `static` |
+| `tessitura` | `int` | Effective pitch range in semitones (e.g. 24 = 2 octaves) |
+| `avg_interval` | `float` | Mean absolute note-to-note interval in semitones; higher = more angular |
+| `phrase_count` | `int` | Number of detected melodic phrases |
+| `avg_phrase_bars` | `float` | Mean phrase length in bars |
+| `commit` | `str` | 8-char commit SHA analysed |
+| `branch` | `str` | Current branch name |
+| `track` | `str` | Track name analysed, or `"all"` |
+| `section` | `str` | Section name scoped, or `"all"` |
+| `source` | `str` | `"stub"` until full MIDI analysis is wired; `"midi"` when live |
+
+**Producer:** `_contour_detect_async()`
+**Consumer:** `_format_detect()`, `_format_history()`, `ContourCompareResult.commit_a/.commit_b`
+
+---
+
+### `ContourCompareResult`
+
+**Module:** `maestro/muse_cli/commands/contour.py`
+
+Comparison of melodic contour between two commits.  Exposes delta metrics
+that let an agent detect whether a melody became more angular (fragmented)
+or smoother (stepwise) between two points in history.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_a` | `ContourResult` | Contour result for the first commit (or HEAD) |
+| `commit_b` | `ContourResult` | Contour result for the reference commit |
+| `shape_changed` | `bool` | `True` when the overall shape label differs between commits |
+| `angularity_delta` | `float` | Change in `avg_interval` (positive = more angular at A) |
+| `tessitura_delta` | `int` | Change in tessitura semitones (positive = wider range at A) |
+
+**Producer:** `_contour_compare_async()`
+**Consumer:** `_format_compare()`

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -3,7 +3,7 @@
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (init, status, commit, describe, grep, log, checkout, merge,
 remote, push, pull, open, play, dynamics, session, swing, ask, tag,
-recall) as Typer sub-applications.
+recall, contour) as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ from maestro.muse_cli.commands import (
     ask,
     checkout,
     commit,
+    contour,
     describe,
     dynamics,
     grep_cmd,
@@ -39,6 +40,7 @@ cli = typer.Typer(
 
 cli.add_typer(init.app, name="init", help="Initialise a new Muse repository.")
 cli.add_typer(status.app, name="status", help="Show working-tree drift against HEAD.")
+cli.add_typer(contour.app, name="contour", help="Analyze melodic contour and phrase shape of a commit.")
 cli.add_typer(dynamics.app, name="dynamics", help="Analyse the dynamic (velocity) profile of a commit.")
 cli.add_typer(commit.app, name="commit", help="Record a new variation in history.")
 cli.add_typer(grep_cmd.app, name="grep", help="Search for a musical pattern across all commits.")

--- a/maestro/muse_cli/commands/contour.py
+++ b/maestro/muse_cli/commands/contour.py
@@ -1,0 +1,489 @@
+"""muse contour — analyze the melodic contour and phrase shape of a composition.
+
+Melodic contour encodes whether a melody rises, falls, arches, or waves — a
+fundamental expressive quality that distinguishes two otherwise similar melodies.
+This command computes the pitch trajectory, classifies the overall shape, and
+reports phrase statistics for a target commit (default HEAD).
+
+Shape vocabulary
+----------------
+- ascending       — net upward movement across the full phrase
+- descending      — net downward movement across the full phrase
+- arch            — rises then falls (single peak)
+- inverted-arch   — falls then rises (valley shape)
+- wave            — multiple peaks; alternating rise and fall
+- static          — narrow pitch range (< 2 semitones spread)
+
+Command forms
+-------------
+
+Analyse melodic contour at HEAD (default)::
+
+    muse contour
+
+Analyse at a specific commit::
+
+    muse contour a1b2c3d4
+
+Restrict to a named melodic track::
+
+    muse contour --track keys
+
+Scope to a section::
+
+    muse contour --section verse
+
+Compare contour between two commits::
+
+    muse contour --compare HEAD~10 HEAD
+
+Show overall shape label only::
+
+    muse contour --shape
+
+Show contour evolution across all commits::
+
+    muse contour --history
+
+Machine-readable JSON output::
+
+    muse contour --json
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing_extensions import Annotated, TypedDict
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+# ---------------------------------------------------------------------------
+# Shape label constants
+# ---------------------------------------------------------------------------
+
+ShapeLabel = str  # one of the SHAPE_LABELS values
+
+SHAPE_LABELS: tuple[str, ...] = (
+    "ascending",
+    "descending",
+    "arch",
+    "inverted-arch",
+    "wave",
+    "static",
+)
+
+VALID_SHAPES: frozenset[str] = frozenset(SHAPE_LABELS)
+
+# ---------------------------------------------------------------------------
+# Named result types — stable CLI contract
+# ---------------------------------------------------------------------------
+
+
+class ContourResult(TypedDict):
+    """Melodic contour analysis for a single commit or working tree.
+
+    Fields
+    ------
+    shape:         Overall melodic shape label (ascending, descending, arch, …).
+    tessitura:     Effective pitch range in semitones.
+    avg_interval:  Mean absolute note-to-note interval (semitones).  Higher
+                   values indicate more angular, wider-leaping melodies.
+    phrase_count:  Number of detected melodic phrases.
+    avg_phrase_bars: Mean phrase length in bars.
+    commit:        Commit SHA analysed (8-char prefix).
+    branch:        Current branch name.
+    track:         Track name analysed, or "all".
+    section:       Section name scoped, or "all".
+    source:        "stub" until MIDI analysis is wired in.
+    """
+
+    shape: str
+    tessitura: int
+    avg_interval: float
+    phrase_count: int
+    avg_phrase_bars: float
+    commit: str
+    branch: str
+    track: str
+    section: str
+    source: str
+
+
+class ContourCompareResult(TypedDict):
+    """Comparison of melodic contour between two commits.
+
+    Fields
+    ------
+    commit_a:         ContourResult for the first commit (or HEAD).
+    commit_b:         ContourResult for the reference commit.
+    shape_changed:    True when the overall shape label differs.
+    angularity_delta: Change in avg_interval (positive = more angular).
+    tessitura_delta:  Change in tessitura semitones (positive = wider).
+    """
+
+    commit_a: ContourResult
+    commit_b: ContourResult
+    shape_changed: bool
+    angularity_delta: float
+    tessitura_delta: int
+
+
+# ---------------------------------------------------------------------------
+# Stub data
+# ---------------------------------------------------------------------------
+
+_STUB_SHAPE: ShapeLabel = "arch"
+_STUB_TESSITURA = 24  # 2 octaves
+_STUB_AVG_INTERVAL = 2.5  # semitones
+_STUB_PHRASE_COUNT = 4
+_STUB_AVG_PHRASE_BARS = 8.0
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_head(root: pathlib.Path) -> tuple[str, str]:
+    """Return (branch, head_sha) from the .muse/ layout.
+
+    Reads HEAD → ref → SHA, returning empty string for the SHA when no commits
+    exist yet.  Called by every analysis function to avoid duplicating file I/O.
+
+    Args:
+        root: Repository root (directory that contains ``.muse/``).
+
+    Returns:
+        Tuple of (branch_name, head_sha_or_empty).
+    """
+    muse_dir = root / ".muse"
+    head_ref = (muse_dir / "HEAD").read_text().strip()
+    branch = head_ref.rsplit("/", 1)[-1] if "/" in head_ref else head_ref
+    ref_path = muse_dir / pathlib.Path(head_ref)
+    head_sha = ref_path.read_text().strip() if ref_path.exists() else ""
+    return branch, head_sha
+
+
+async def _contour_detect_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    commit: Optional[str],
+    track: Optional[str],
+    section: Optional[str],
+) -> ContourResult:
+    """Compute the melodic contour for a single commit (or working tree).
+
+    Stub implementation: resolves branch/commit metadata from ``.muse/`` and
+    returns a realistic placeholder result in the correct schema.  Full MIDI
+    analysis will be wired once Storpheus exposes a pitch-trajectory route.
+
+    Args:
+        root:    Repository root.
+        session: Open async DB session (reserved for full implementation).
+        commit:  Commit SHA to analyse, or ``None`` for HEAD.
+        track:   Named MIDI track to analyse, or ``None`` for all tracks.
+        section: Named section to scope analysis, or ``None`` for the full piece.
+
+    Returns:
+        A :class:`ContourResult` describing shape, tessitura, angularity,
+        phrase statistics, and provenance metadata.
+    """
+    branch, head_sha = await _resolve_head(root)
+    resolved_commit = commit or (head_sha[:8] if head_sha else "HEAD")
+
+    return ContourResult(
+        shape=_STUB_SHAPE,
+        tessitura=_STUB_TESSITURA,
+        avg_interval=_STUB_AVG_INTERVAL,
+        phrase_count=_STUB_PHRASE_COUNT,
+        avg_phrase_bars=_STUB_AVG_PHRASE_BARS,
+        commit=resolved_commit,
+        branch=branch,
+        track=track or "all",
+        section=section or "all",
+        source="stub",
+    )
+
+
+async def _contour_compare_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    commit_a: Optional[str],
+    commit_b: str,
+    track: Optional[str],
+    section: Optional[str],
+) -> ContourCompareResult:
+    """Compare melodic contour between two commits.
+
+    Stub implementation: both sides share the same placeholder metric values,
+    so shape_changed is always False and deltas are always 0.  Full implementation
+    will load per-commit pitch trajectories from Storpheus.
+
+    Args:
+        root:     Repository root.
+        session:  Open async DB session.
+        commit_a: First commit ref (defaults to HEAD when ``None``).
+        commit_b: Reference commit ref to compare against.
+        track:    Named MIDI track, or ``None`` for all.
+        section:  Named section, or ``None`` for the full piece.
+
+    Returns:
+        A :class:`ContourCompareResult` with both sides and diff metrics.
+    """
+    result_a = await _contour_detect_async(
+        root=root, session=session, commit=commit_a, track=track, section=section
+    )
+    result_b = await _contour_detect_async(
+        root=root, session=session, commit=commit_b, track=track, section=section
+    )
+    result_b = ContourResult(**{**result_b, "commit": commit_b})
+
+    return ContourCompareResult(
+        commit_a=result_a,
+        commit_b=result_b,
+        shape_changed=result_a["shape"] != result_b["shape"],
+        angularity_delta=round(result_a["avg_interval"] - result_b["avg_interval"], 4),
+        tessitura_delta=result_a["tessitura"] - result_b["tessitura"],
+    )
+
+
+async def _contour_history_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    track: Optional[str],
+    section: Optional[str],
+) -> list[ContourResult]:
+    """Return the contour history for the current branch.
+
+    Stub implementation: returns a single entry for HEAD.  Full implementation
+    will walk the commit chain and return one :class:`ContourResult` per commit,
+    newest first.
+
+    Args:
+        root:    Repository root.
+        session: Open async DB session.
+        track:   Named MIDI track, or ``None`` for all.
+        section: Named section, or ``None`` for the full piece.
+
+    Returns:
+        List of :class:`ContourResult` entries, newest first.
+    """
+    entry = await _contour_detect_async(
+        root=root, session=session, commit=None, track=track, section=section
+    )
+    return [entry]
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+
+def _format_detect(result: ContourResult, *, as_json: bool, shape_only: bool) -> str:
+    """Render a detect result as human-readable text or JSON.
+
+    When *shape_only* is True, only the shape label line is printed (useful
+    for quick scripting).  When *as_json* is True, the full :class:`ContourResult`
+    is serialised as indented JSON.
+
+    Args:
+        result:     Analysis result to render.
+        as_json:    Emit JSON instead of human-readable text.
+        shape_only: Emit the shape label line only (ignored when as_json=True).
+
+    Returns:
+        Formatted string ready for ``typer.echo``.
+    """
+    if as_json:
+        return json.dumps(dict(result), indent=2)
+    if shape_only:
+        return f"Shape: {result['shape']}"
+    octaves = result["tessitura"] // 12
+    semitones_rem = result["tessitura"] % 12
+    range_str = f"{octaves} octave{'s' if octaves != 1 else ''}"
+    if semitones_rem:
+        range_str += f" + {semitones_rem} st"
+    lines = [
+        f"Shape: {result['shape']} | Range: {range_str} | "
+        f"Phrases: {result['phrase_count']} avg {result['avg_phrase_bars']:.0f} bars",
+        f"Commit: {result['commit']}  Branch: {result['branch']}",
+        f"Track: {result['track']}  Section: {result['section']}",
+        f"Angularity: {result['avg_interval']} st avg interval",
+    ]
+    if result.get("source") == "stub":
+        lines.append("(stub — full MIDI analysis pending)")
+    return "\n".join(lines)
+
+
+def _format_compare(result: ContourCompareResult, *, as_json: bool) -> str:
+    """Render a compare result as human-readable text or JSON.
+
+    Args:
+        result:  Comparison result to render.
+        as_json: Emit JSON instead of human-readable text.
+
+    Returns:
+        Formatted string ready for ``typer.echo``.
+    """
+    if as_json:
+        return json.dumps(
+            {
+                "commit_a": dict(result["commit_a"]),
+                "commit_b": dict(result["commit_b"]),
+                "shape_changed": result["shape_changed"],
+                "angularity_delta": result["angularity_delta"],
+                "tessitura_delta": result["tessitura_delta"],
+            },
+            indent=2,
+        )
+    a = result["commit_a"]
+    b = result["commit_b"]
+    ang_delta = result["angularity_delta"]
+    sign = "+" if ang_delta >= 0 else ""
+    shape_note = " (shape changed)" if result["shape_changed"] else ""
+    return (
+        f"A ({a['commit']})  Shape: {a['shape']} | Angularity: {a['avg_interval']} st\n"
+        f"B ({b['commit']})  Shape: {b['shape']} | Angularity: {b['avg_interval']} st\n"
+        f"Delta  angularity {sign}{ang_delta} st | tessitura {result['tessitura_delta']:+d} st"
+        + shape_note
+    )
+
+
+def _format_history(entries: list[ContourResult], *, as_json: bool) -> str:
+    """Render a contour history list as human-readable text or JSON.
+
+    Args:
+        entries: History entries, newest first.
+        as_json: Emit JSON instead of human-readable text.
+
+    Returns:
+        Formatted string ready for ``typer.echo``.
+    """
+    if as_json:
+        return json.dumps([dict(e) for e in entries], indent=2)
+    if not entries:
+        return "(no contour history found)"
+    lines: list[str] = []
+    for entry in entries:
+        lines.append(
+            f"{entry['commit']}  {entry['shape']} | "
+            f"range {entry['tessitura']} st | "
+            f"ang {entry['avg_interval']} st"
+            + (f"  [{entry['track']}]" if entry["track"] != "all" else "")
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def contour(
+    ctx: typer.Context,
+    commit: Annotated[
+        Optional[str],
+        typer.Argument(
+            help="Commit SHA to analyse. Defaults to HEAD.",
+            show_default=False,
+        ),
+    ] = None,
+    track: Annotated[
+        Optional[str],
+        typer.Option(
+            "--track",
+            metavar="TEXT",
+            help="Restrict analysis to a named melodic track (e.g. 'keys', 'lead').",
+            show_default=False,
+        ),
+    ] = None,
+    section: Annotated[
+        Optional[str],
+        typer.Option(
+            "--section",
+            metavar="TEXT",
+            help="Scope analysis to a named section (e.g. 'verse', 'chorus').",
+            show_default=False,
+        ),
+    ] = None,
+    compare: Annotated[
+        Optional[str],
+        typer.Option(
+            "--compare",
+            metavar="COMMIT",
+            help="Compare contour against another commit.",
+            show_default=False,
+        ),
+    ] = None,
+    history: Annotated[
+        bool,
+        typer.Option("--history", help="Show contour evolution across all commits."),
+    ] = False,
+    shape: Annotated[
+        bool,
+        typer.Option("--shape", help="Print the overall shape label only."),
+    ] = False,
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable JSON output."),
+    ] = False,
+) -> None:
+    """Analyze melodic contour and phrase shape for a composition commit.
+
+    With no flags, analyses HEAD and prints shape, range, phrase count, and
+    angularity.  Use ``--compare`` to diff two commits, ``--history`` to see
+    how melodic character evolved, and ``--shape`` for a one-line shape label.
+    """
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            if history:
+                entries = await _contour_history_async(
+                    root=root, session=session, track=track, section=section
+                )
+                typer.echo(_format_history(entries, as_json=as_json))
+                return
+
+            if compare is not None:
+                compare_result = await _contour_compare_async(
+                    root=root,
+                    session=session,
+                    commit_a=commit,
+                    commit_b=compare,
+                    track=track,
+                    section=section,
+                )
+                typer.echo(_format_compare(compare_result, as_json=as_json))
+                return
+
+            # Default: detect
+            detect_result = await _contour_detect_async(
+                root=root, session=session, commit=commit, track=track, section=section
+            )
+            typer.echo(_format_detect(detect_result, as_json=as_json, shape_only=shape))
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse contour failed: {exc}")
+        logger.error("❌ muse contour error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/tests/test_muse_contour.py
+++ b/tests/test_muse_contour.py
@@ -1,0 +1,438 @@
+"""Tests for ``muse contour`` — CLI interface, flag parsing, and stub output format.
+
+All CLI-level tests use ``typer.testing.CliRunner`` against the full ``muse``
+app so that argument parsing, flag handling, and exit codes are exercised end-to-end.
+
+Async core tests call the internal async functions directly with an in-memory
+SQLite session (the stub does not query the DB, so the session is injected only
+to satisfy the signature contract).
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+from typer.testing import CliRunner
+
+from maestro.db.database import Base
+import maestro.muse_cli.models  # noqa: F401  — registers MuseCli* with Base.metadata
+from maestro.muse_cli.app import cli
+from maestro.muse_cli.commands.contour import (
+    SHAPE_LABELS,
+    VALID_SHAPES,
+    ContourCompareResult,
+    ContourResult,
+    _contour_compare_async,
+    _contour_detect_async,
+    _contour_history_async,
+    _format_compare,
+    _format_detect,
+    _format_history,
+)
+from maestro.muse_cli.errors import ExitCode
+
+runner = CliRunner()
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, branch: str = "main") -> str:
+    """Create a minimal .muse/ layout with one empty commit ref."""
+    rid = str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(json.dumps({"repo_id": rid, "schema_version": "1"}))
+    (muse / "HEAD").write_text(f"refs/heads/{branch}")
+    (muse / "refs" / "heads" / branch).write_text("")
+    return rid
+
+
+def _commit_ref(root: pathlib.Path, branch: str = "main") -> None:
+    """Write a fake commit ID into the branch ref so HEAD is non-empty."""
+    muse = root / ".muse"
+    (muse / "refs" / "heads" / branch).write_text("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    """In-memory SQLite session (stub contour does not actually query it)."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(bind=engine, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Unit — constants
+# ---------------------------------------------------------------------------
+
+
+def test_shape_labels_constant_matches_valid_shapes() -> None:
+    """SHAPE_LABELS tuple and VALID_SHAPES frozenset are in sync."""
+    assert set(SHAPE_LABELS) == VALID_SHAPES
+
+
+def test_valid_shapes_contains_expected_labels() -> None:
+    """All six canonical shape labels are present in VALID_SHAPES."""
+    expected = {"ascending", "descending", "arch", "inverted-arch", "wave", "static"}
+    assert expected == VALID_SHAPES
+
+
+# ---------------------------------------------------------------------------
+# Unit — formatters
+# ---------------------------------------------------------------------------
+
+
+def _make_result(
+    *,
+    shape: str = "arch",
+    tessitura: int = 24,
+    avg_interval: float = 2.5,
+    phrase_count: int = 4,
+    avg_phrase_bars: float = 8.0,
+    commit: str = "a1b2c3d4",
+    branch: str = "main",
+    track: str = "all",
+    section: str = "all",
+    source: str = "stub",
+) -> ContourResult:
+    return ContourResult(
+        shape=shape,
+        tessitura=tessitura,
+        avg_interval=avg_interval,
+        phrase_count=phrase_count,
+        avg_phrase_bars=avg_phrase_bars,
+        commit=commit,
+        branch=branch,
+        track=track,
+        section=section,
+        source=source,
+    )
+
+
+def test_format_detect_human_readable_contains_shape() -> None:
+    """_format_detect (human mode) includes shape, range, phrase info."""
+    result = _make_result()
+    out = _format_detect(result, as_json=False, shape_only=False)
+    assert "Shape: arch" in out
+    assert "Phrases: 4" in out
+    assert "Angularity:" in out
+    assert "stub" in out
+
+
+def test_format_detect_shape_only() -> None:
+    """_format_detect with shape_only=True returns just the shape line."""
+    result = _make_result(shape="wave")
+    out = _format_detect(result, as_json=False, shape_only=True)
+    assert out == "Shape: wave"
+
+
+def test_format_detect_json_is_valid() -> None:
+    """_format_detect with as_json=True returns valid parseable JSON."""
+    result = _make_result()
+    raw = _format_detect(result, as_json=True, shape_only=False)
+    payload = json.loads(raw)
+    assert payload["shape"] == "arch"
+    assert payload["tessitura"] == 24
+    assert payload["phrase_count"] == 4
+    assert payload["source"] == "stub"
+
+
+def test_format_detect_range_octaves() -> None:
+    """_format_detect converts tessitura semitones to octave string correctly."""
+    result = _make_result(tessitura=24)
+    out = _format_detect(result, as_json=False, shape_only=False)
+    assert "2 octaves" in out
+
+    result_one_octave = _make_result(tessitura=12)
+    out2 = _format_detect(result_one_octave, as_json=False, shape_only=False)
+    assert "1 octave" in out2
+
+
+def test_format_history_human_readable() -> None:
+    """_format_history renders commit, shape, range, and angularity per entry."""
+    entries = [_make_result(commit="deadbeef")]
+    out = _format_history(entries, as_json=False)
+    assert "deadbeef" in out
+    assert "arch" in out
+    assert "24 st" in out
+
+
+def test_format_history_empty() -> None:
+    """_format_history returns a helpful message when entries list is empty."""
+    out = _format_history([], as_json=False)
+    assert "no contour history" in out.lower()
+
+
+def test_format_history_json() -> None:
+    """_format_history with as_json=True emits a JSON array."""
+    entries = [_make_result()]
+    raw = _format_history(entries, as_json=True)
+    payload = json.loads(raw)
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    assert payload[0]["shape"] == "arch"
+
+
+def test_format_compare_human_readable() -> None:
+    """_format_compare renders commit refs, shapes, and delta line."""
+    result = ContourCompareResult(
+        commit_a=_make_result(commit="aaaa1111"),
+        commit_b=_make_result(commit="bbbb2222", shape="ascending"),
+        shape_changed=True,
+        angularity_delta=0.5,
+        tessitura_delta=4,
+    )
+    out = _format_compare(result, as_json=False)
+    assert "aaaa1111" in out
+    assert "bbbb2222" in out
+    assert "shape changed" in out
+    assert "Delta" in out
+
+
+def test_format_compare_json() -> None:
+    """_format_compare with as_json=True emits parseable JSON."""
+    result = ContourCompareResult(
+        commit_a=_make_result(commit="aaa"),
+        commit_b=_make_result(commit="bbb"),
+        shape_changed=False,
+        angularity_delta=0.0,
+        tessitura_delta=0,
+    )
+    raw = _format_compare(result, as_json=True)
+    payload = json.loads(raw)
+    assert "commit_a" in payload
+    assert "commit_b" in payload
+    assert payload["shape_changed"] is False
+    assert payload["angularity_delta"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Async core — _contour_detect_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_contour_detect_async_returns_contour_result(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """_contour_detect_async returns a ContourResult with all expected keys."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    result = await _contour_detect_async(
+        root=tmp_path, session=db_session, commit=None, track=None, section=None
+    )
+
+    assert result["shape"] in VALID_SHAPES
+    assert isinstance(result["tessitura"], int)
+    assert result["tessitura"] > 0
+    assert isinstance(result["avg_interval"], float)
+    assert result["phrase_count"] > 0
+    assert result["branch"] == "main"
+    assert result["track"] == "all"
+    assert result["section"] == "all"
+
+
+@pytest.mark.anyio
+async def test_contour_detect_async_uses_explicit_commit(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """When commit is provided, it appears as the commit field in the result."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    result = await _contour_detect_async(
+        root=tmp_path, session=db_session, commit="deadbeef", track=None, section=None
+    )
+    assert result["commit"] == "deadbeef"
+
+
+@pytest.mark.anyio
+async def test_contour_detect_async_track_filter(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """Track name is propagated into the result when specified."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    result = await _contour_detect_async(
+        root=tmp_path, session=db_session, commit=None, track="keys", section=None
+    )
+    assert result["track"] == "keys"
+
+
+@pytest.mark.anyio
+async def test_contour_detect_async_section_filter(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """Section name is propagated into the result when specified."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    result = await _contour_detect_async(
+        root=tmp_path, session=db_session, commit=None, track=None, section="verse"
+    )
+    assert result["section"] == "verse"
+
+
+@pytest.mark.anyio
+async def test_contour_classifies_arch_shape(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """Stub contour returns 'arch' as the default shape label."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    result = await _contour_detect_async(
+        root=tmp_path, session=db_session, commit=None, track=None, section=None
+    )
+    assert result["shape"] == "arch"
+
+
+# ---------------------------------------------------------------------------
+# Async core — _contour_compare_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_contour_compare_detects_angularity_change(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """_contour_compare_async returns a ContourCompareResult with delta fields."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    result = await _contour_compare_async(
+        root=tmp_path,
+        session=db_session,
+        commit_a=None,
+        commit_b="HEAD~10",
+        track=None,
+        section=None,
+    )
+
+    assert "commit_a" in result
+    assert "commit_b" in result
+    assert "angularity_delta" in result
+    assert "tessitura_delta" in result
+    assert isinstance(result["shape_changed"], bool)
+    assert result["commit_b"]["commit"] == "HEAD~10"
+
+
+@pytest.mark.anyio
+async def test_contour_compare_shape_changed_flag(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """shape_changed is False when both sides return the same stub shape."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    result = await _contour_compare_async(
+        root=tmp_path,
+        session=db_session,
+        commit_a=None,
+        commit_b="some-ref",
+        track=None,
+        section=None,
+    )
+    assert result["shape_changed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Async core — _contour_history_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_contour_history_returns_evolution(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """_contour_history_async returns a non-empty list of ContourResult entries."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    entries = await _contour_history_async(
+        root=tmp_path, session=db_session, track=None, section=None
+    )
+
+    assert len(entries) >= 1
+    for entry in entries:
+        assert entry["shape"] in VALID_SHAPES
+        assert isinstance(entry["tessitura"], int)
+
+
+@pytest.mark.anyio
+async def test_contour_history_with_track(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """_contour_history_async propagates track into all returned entries."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    entries = await _contour_history_async(
+        root=tmp_path, session=db_session, track="lead", section=None
+    )
+
+    for entry in entries:
+        assert entry["track"] == "lead"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — CliRunner
+# ---------------------------------------------------------------------------
+
+
+def test_cli_contour_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse contour`` exits 2 when invoked outside a Muse repository."""
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["contour"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == int(ExitCode.REPO_NOT_FOUND)
+    assert "not a muse repository" in result.output.lower()
+
+
+def test_cli_contour_help_lists_flags() -> None:
+    """``muse contour --help`` shows all documented flags."""
+    result = runner.invoke(cli, ["contour", "--help"])
+    assert result.exit_code == 0
+    for flag in ("--track", "--section", "--compare", "--history", "--shape", "--json"):
+        assert flag in result.output, f"Flag '{flag}' not found in help output"
+
+
+def test_cli_contour_appears_in_muse_help() -> None:
+    """``muse --help`` lists the contour subcommand."""
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "contour" in result.output


### PR DESCRIPTION
## Summary
Closes #105 — adds `muse contour [<commit>]` command for melodic contour analysis and phrase shape classification.

## Root Cause / Motivation
No Muse command tracked melodic contour across commit history. Melodic contour — whether a melody rises, falls, arches, or waves — is a fundamental expressive quality that distinguishes two otherwise similar melodies and is essential context for AI-driven countermelody generation.

## Solution
Added a new `muse contour` command following the same pattern as `muse swing` and `muse dynamics`. The command classifies overall melodic shape into six labels (ascending, descending, arch, inverted-arch, wave, static), reports tessitura (semitones), average note-to-note interval (angularity), and phrase statistics. Stub implementation returns consistent placeholder values in the correct schema; full MIDI pitch-trajectory analysis is wired once Storpheus exposes the relevant route.

### New files
- `maestro/muse_cli/commands/contour.py` — `ContourResult` (TypedDict), `ContourCompareResult` (TypedDict), `_contour_detect_async()`, `_contour_compare_async()`, `_contour_history_async()`, formatters, and the Typer command with all flags from the issue.
- `tests/test_muse_contour.py` — 23 tests covering constants, formatters, async core (detect/compare/history), and CLI integration.

### Updated files
- `maestro/muse_cli/app.py` — registers `contour` subcommand.
- `docs/architecture/muse_vcs.md` — full `muse contour` command reference section.
- `docs/reference/type_contracts.md` — `ContourResult` and `ContourCompareResult` entries.

## Layers Affected
- [x] Muse VCS

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (482 source files)
- [x] `docker compose exec storpheus mypy .` — clean
- [x] Relevant tests pass (23/23)
- [x] Affected docs updated

## Tests Added
- `test_shape_labels_constant_matches_valid_shapes` — constant sync check
- `test_valid_shapes_contains_expected_labels` — all six labels present
- `test_format_detect_human_readable_contains_shape` — human output format
- `test_format_detect_shape_only` — --shape flag renders one line
- `test_format_detect_json_is_valid` — JSON output parseable and correct
- `test_format_detect_range_octaves` — tessitura → octave string conversion
- `test_format_history_human_readable` — history entry format
- `test_format_history_empty` — empty history message
- `test_format_history_json` — JSON array output
- `test_format_compare_human_readable` — compare diff output
- `test_format_compare_json` — compare JSON output
- `test_contour_detect_async_returns_contour_result` — unit: detect result shape
- `test_contour_detect_async_uses_explicit_commit` — explicit commit propagated
- `test_contour_detect_async_track_filter` — track propagated to result
- `test_contour_detect_async_section_filter` — section propagated to result
- `test_contour_classifies_arch_shape` — stub returns "arch" shape (regression)
- `test_contour_compare_detects_angularity_change` — compare result has delta fields
- `test_contour_compare_shape_changed_flag` — shape_changed is False for same stub shape
- `test_contour_history_returns_evolution` — history returns non-empty list
- `test_contour_history_with_track` — track propagated into all history entries
- `test_cli_contour_outside_repo_exits_2` — CLI exits REPO_NOT_FOUND outside repo
- `test_cli_contour_help_lists_flags` — all flags present in --help output
- `test_cli_contour_appears_in_muse_help` — contour listed in muse --help

## Handoff
N/A — no protocol change. Pure Muse CLI addition, no SSE event or MCP tool schema changes.