### PR TITLE
feat: muse harmony [<commit>] — analyze and query harmonic content across commits

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -1363,6 +1363,101 @@ CLI contract; stub implementations are clearly marked.
 
 ---
 
+### `muse harmony`
+
+**Purpose:** Analyze the harmonic content (key center, mode, chord progression, harmonic
+rhythm, and tension profile) of a commit. The primary tool for understanding what a
+composition is doing harmonically — information that is completely invisible to Git.
+An AI agent calling `muse harmony --json` knows whether the current arrangement is in
+Eb major with a II-V-I progression and moderate tension, and can use this to make
+musically coherent generation decisions.
+
+**Usage:**
+```bash
+muse harmony [<commit>] [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `COMMIT` | positional | HEAD | Commit ref to analyze |
+| `--track TEXT` | string | all tracks | Restrict to a named MIDI track (e.g. `--track keys`) |
+| `--section TEXT` | string | — | Restrict to a named musical section/region (planned) |
+| `--compare COMMIT` | string | — | Compare harmonic content against another commit |
+| `--range FROM..TO` | string | — | Analyze across a commit range (planned) |
+| `--progression` | flag | off | Show only the chord progression sequence |
+| `--key` | flag | off | Show only the detected key center |
+| `--mode` | flag | off | Show only the detected mode |
+| `--tension` | flag | off | Show only the harmonic tension profile |
+| `--json` | flag | off | Emit structured JSON for agent consumption |
+
+**Output example (text):**
+```
+Commit abc1234 — Harmonic Analysis
+(stub — full MIDI analysis pending)
+
+Key: Eb (confidence: 0.92)
+Mode: major
+Chord progression: Ebmaj7 | Fm7 | Bb7sus4 | Bb7 | Ebmaj7 | Abmaj7 | Gm7 | Cm7
+Harmonic rhythm: 2.1 chords/bar avg
+Tension profile: Low → Medium → High → Resolution (textbook tension-release arc)  [0.2 → 0.4 → 0.8 → 0.3]
+```
+
+**Output example (`--json`):**
+```json
+{
+  "commit_id": "abc1234",
+  "branch": "main",
+  "key": "Eb",
+  "mode": "major",
+  "confidence": 0.92,
+  "chord_progression": ["Ebmaj7", "Fm7", "Bb7sus4", "Bb7", "Ebmaj7", "Abmaj7", "Gm7", "Cm7"],
+  "harmonic_rhythm_avg": 2.1,
+  "tension_profile": [0.2, 0.4, 0.8, 0.3],
+  "track": "all",
+  "source": "stub"
+}
+```
+
+**Output example (`--compare <commit> --json`):**
+```json
+{
+  "head": { "commit_id": "abc1234", "key": "Eb", "mode": "major", ... },
+  "compare": { "commit_id": "def5678", "key": "Eb", "mode": "major", ... },
+  "key_changed": false,
+  "mode_changed": false,
+  "chord_progression_delta": []
+}
+```
+
+**Result type:** `HarmonyResult` — fields: `commit_id`, `branch`, `key`, `mode`,
+`confidence`, `chord_progression`, `harmonic_rhythm_avg`, `tension_profile`, `track`, `source`.
+Compare path returns `HarmonyCompareResult` — fields: `head`, `compare`, `key_changed`,
+`mode_changed`, `chord_progression_delta`.
+
+**Agent use case:** Before generating a new instrument layer, an agent calls
+`muse harmony --json` to discover the harmonic context. If the arrangement is in
+Eb major with a II-V-I progression, the agent ensures its generated voicings stay
+diatonic to Eb. If the tension profile shows a build toward the chorus, the agent
+adds chromatic tension at the right moment rather than resolving early.
+`muse harmony --compare HEAD~5 --json` reveals whether the composition has
+modulated, shifted mode, or changed its harmonic rhythm — all decisions an AI
+needs to make coherent musical choices across versions.
+
+**Implementation:** `maestro/muse_cli/commands/harmony.py` — `_harmony_analyze_async`
+(injectable async core), `HarmonyResult` / `HarmonyCompareResult` (TypedDict result
+entities), `_stub_harmony` (placeholder data), `_tension_label` (arc classifier),
+`_render_result_human` / `_render_result_json` / `_render_compare_human` /
+`_render_compare_json` (renderers). Exit codes: 0 success, 2 outside repo, 3 internal.
+
+> **Stub note:** Chord detection, key inference, and tension computation are placeholder
+> values derived from a static Eb major II-V-I template. Full implementation requires
+> MIDI note extraction from committed snapshot objects (future: Storpheus chord detection
+> route). The CLI contract, result types, and flag set are stable.
+
+---
+
 ### `muse dynamics`
 
 **Purpose:** Analyze the velocity (loudness) profile of a commit across all instrument

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -1818,6 +1818,42 @@ These type aliases replace the repeated pattern `dict[str, list[XxxDict]]` that 
 
 > Added: 2026-02-27 | Types used by the `muse` CLI commands — purely local, never serialised over HTTP.
 
+### `HarmonyResult` (`maestro/muse_cli/commands/harmony.py`)
+
+`TypedDict` — harmonic analysis for a single commit returned by `muse harmony`.
+Primary result type for AI agent consumption via `muse harmony --json`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | Short or full commit SHA that was analyzed |
+| `branch` | `str` | Current branch name |
+| `key` | `str \| None` | Detected key center (e.g. `"Eb"`); `None` for drum-only snapshots |
+| `mode` | `str \| None` | Detected mode (e.g. `"major"`, `"dorian"`); `None` for drum-only |
+| `confidence` | `float` | Key/mode detection confidence in [0.0, 1.0] |
+| `chord_progression` | `list[str]` | Ordered chord symbol strings (e.g. `["Ebmaj7", "Fm7"]`) |
+| `harmonic_rhythm_avg` | `float` | Average chord changes per bar |
+| `tension_profile` | `list[float]` | Per-section tension scores in [0.0, 1.0]; 0.0 = consonant, 1.0 = dissonant |
+| `track` | `str` | Instrument track scope (`"all"` unless `--track` specified) |
+| `source` | `str` | `"stub"` until backed by real MIDI analysis |
+
+**Used by:** `_harmony_analyze_async`, `_render_result_human`, `_render_result_json`.
+
+### `HarmonyCompareResult` (`maestro/muse_cli/commands/harmony.py`)
+
+`TypedDict` — comparison between two commits returned by `muse harmony --compare`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `head` | `HarmonyResult` | Harmonic analysis for the HEAD (or specified) commit |
+| `compare` | `HarmonyResult` | Harmonic analysis for the reference commit |
+| `key_changed` | `bool` | `True` if the key center differs between commits |
+| `mode_changed` | `bool` | `True` if the mode differs between commits |
+| `chord_progression_delta` | `list[str]` | Chords present in HEAD but absent in compare |
+
+**Used by:** `_render_compare_human`, `_render_compare_json`.
+
+---
+
 ### `MuseSessionRecord` (`maestro/muse_cli/commands/session.py`)
 
 `TypedDict(total=False)` — wire-format for a single recording session stored as JSON in `.muse/sessions/`.

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -2,9 +2,9 @@
 
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (arrange, ask, checkout, commit, context, describe, divergence,
-dynamics, export, find, grep, import, init, log, merge, meter, open, play,
-pull, push, recall, remote, session, status, swing, tag, tempo) as Typer
-sub-applications.
+dynamics, export, find, grep, harmony, import, init, log, merge, meter,
+open, play, pull, push, recall, remote, session, status, swing, tag, tempo)
+as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -22,6 +22,7 @@ from maestro.muse_cli.commands import (
     export,
     find,
     grep_cmd,
+    harmony,
     import_cmd,
     init,
     log,
@@ -53,6 +54,7 @@ cli.add_typer(commit.app, name="commit", help="Record a new variation in history
 cli.add_typer(grep_cmd.app, name="grep", help="Search for a musical pattern across all commits.")
 cli.add_typer(log.app, name="log", help="Display the variation history graph.")
 cli.add_typer(find.app, name="find", help="Search commit history by musical properties.")
+cli.add_typer(harmony.app, name="harmony", help="Analyze harmonic content (key, mode, chords, tension) of a commit.")
 cli.add_typer(checkout.app, name="checkout", help="Checkout a historical variation.")
 cli.add_typer(merge.app, name="merge", help="Three-way merge two variation branches.")
 cli.add_typer(remote.app, name="remote", help="Manage remote server connections.")

--- a/maestro/muse_cli/commands/harmony.py
+++ b/maestro/muse_cli/commands/harmony.py
@@ -1,0 +1,561 @@
+"""muse harmony — analyze and query harmonic content across commits.
+
+Examines the harmonic profile (key, mode, chord progression, harmonic
+rhythm, and tension) of a given commit (default: HEAD) or a range of
+commits.  Harmonic analysis is one of the most musically significant
+dimensions exposed by Muse VCS — information that Git has no concept of.
+
+An AI agent calling ``muse harmony --json`` receives a structured snapshot
+of the harmonic landscape it can use to make musically coherent generation
+decisions: stay in the same key, continue the same chord progression, or
+intentionally create harmonic contrast.
+
+Command forms
+-------------
+
+Analyze HEAD (default)::
+
+    muse harmony
+
+Analyze a specific commit::
+
+    muse harmony a1b2c3d4
+
+Analyze a commit range::
+
+    muse harmony HEAD~10..HEAD
+
+Compare two commits::
+
+    muse harmony --compare HEAD~5
+
+Extract only the chord progression::
+
+    muse harmony --progression
+
+Show key center::
+
+    muse harmony --key
+
+Show mode::
+
+    muse harmony --mode
+
+Show harmonic tension profile::
+
+    muse harmony --tension
+
+Restrict to a single instrument track::
+
+    muse harmony --track keys
+
+Machine-readable JSON output::
+
+    muse harmony --json
+
+Stub note
+---------
+Full chord detection requires MIDI note extraction from committed snapshot
+objects.  This implementation provides a realistic placeholder in the
+correct schema.  The result type and CLI contract are stable.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing_extensions import Annotated, TypedDict
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+# ---------------------------------------------------------------------------
+# Constants — mode vocabulary
+# ---------------------------------------------------------------------------
+
+KNOWN_MODES: tuple[str, ...] = (
+    "major",
+    "minor",
+    "dorian",
+    "phrygian",
+    "lydian",
+    "mixolydian",
+    "aeolian",
+    "locrian",
+)
+
+KNOWN_MODES_SET: frozenset[str] = frozenset(KNOWN_MODES)
+
+# ---------------------------------------------------------------------------
+# Named result types (stable CLI contract)
+# ---------------------------------------------------------------------------
+
+
+class HarmonyResult(TypedDict):
+    """Harmonic analysis result for a single commit.
+
+    This is the primary result type for ``muse harmony``.  Every field is
+    populated by stub logic today and will be backed by MIDI analysis once
+    the Storpheus inference endpoint exposes a chord detection route.
+
+    Fields
+    ------
+    commit_id : str
+        Short or full commit SHA that was analyzed.
+    branch : str
+        Name of the current branch.
+    key : str | None
+        Detected key center (e.g. ``"Eb"``), or ``None`` for drum-only
+        snapshots with no pitched content.
+    mode : str | None
+        Detected mode (e.g. ``"major"``, ``"dorian"``), or ``None``.
+    confidence : float
+        Key/mode detection confidence in [0.0, 1.0].
+    chord_progression : list[str]
+        Ordered list of chord symbol strings (e.g. ``["Ebmaj7", "Fm7"]``).
+    harmonic_rhythm_avg : float
+        Average number of chord changes per bar.
+    tension_profile : list[float]
+        Per-section tension scores in [0.0, 1.0], where 0.0 = fully
+        consonant and 1.0 = maximally dissonant.
+    track : str
+        Instrument track scope (``"all"`` unless ``--track`` is specified).
+    source : str
+        ``"stub"`` until backed by real MIDI analysis.
+    """
+
+    commit_id: str
+    branch: str
+    key: Optional[str]
+    mode: Optional[str]
+    confidence: float
+    chord_progression: list[str]
+    harmonic_rhythm_avg: float
+    tension_profile: list[float]
+    track: str
+    source: str
+
+
+class HarmonyCompareResult(TypedDict):
+    """Comparison of harmonic content between two commits.
+
+    Fields
+    ------
+    head : HarmonyResult
+        Harmonic analysis for the HEAD (or specified) commit.
+    compare : HarmonyResult
+        Harmonic analysis for the reference commit.
+    key_changed : bool
+        ``True`` if the key center differs between the two commits.
+    mode_changed : bool
+        ``True`` if the mode differs between the two commits.
+    chord_progression_delta : list[str]
+        Chords present in HEAD but absent in compare (new chords).
+    """
+
+    head: HarmonyResult
+    compare: HarmonyResult
+    key_changed: bool
+    mode_changed: bool
+    chord_progression_delta: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Stub data — realistic placeholder until MIDI note data is queryable
+# ---------------------------------------------------------------------------
+
+_STUB_KEY = "Eb"
+_STUB_MODE = "major"
+_STUB_CONFIDENCE = 0.92
+_STUB_CHORD_PROGRESSION = ["Ebmaj7", "Fm7", "Bb7sus4", "Bb7", "Ebmaj7", "Abmaj7", "Gm7", "Cm7"]
+_STUB_HARMONIC_RHYTHM_AVG = 2.1
+_STUB_TENSION_PROFILE = [0.2, 0.4, 0.8, 0.3]
+
+
+def _stub_harmony(commit_id: str, branch: str, track: str = "all") -> HarmonyResult:
+    """Return a realistic placeholder HarmonyResult.
+
+    Produces a II-V-I flavored progression in Eb major — one of the most
+    common key centers in jazz and soul productions.  Confidence and tension
+    values reflect a textbook tension-release arc.
+    """
+    return HarmonyResult(
+        commit_id=commit_id,
+        branch=branch,
+        key=_STUB_KEY,
+        mode=_STUB_MODE,
+        confidence=_STUB_CONFIDENCE,
+        chord_progression=list(_STUB_CHORD_PROGRESSION),
+        harmonic_rhythm_avg=_STUB_HARMONIC_RHYTHM_AVG,
+        tension_profile=list(_STUB_TENSION_PROFILE),
+        track=track,
+        source="stub",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _harmony_analyze_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    commit: Optional[str],
+    track: Optional[str],
+    section: Optional[str],
+    compare: Optional[str],
+    commit_range: Optional[str],
+    show_progression: bool,
+    show_key: bool,
+    show_mode: bool,
+    show_tension: bool,
+    as_json: bool,
+) -> HarmonyResult:
+    """Core harmonic analysis logic — fully injectable for tests.
+
+    Resolves the target commit from the ``.muse/`` layout, produces a
+    ``HarmonyResult`` (stub today, full MIDI analysis in future), and
+    renders it to stdout according to the active flags.
+
+    Returns the ``HarmonyResult`` so callers (tests) can assert on values
+    without parsing stdout.
+
+    Args:
+        root:             Repository root (directory containing ``.muse/``).
+        session:          Open async DB session (reserved for full implementation).
+        commit:           Commit ref to analyse; defaults to HEAD.
+        track:            Restrict to a named MIDI track, or ``None`` for all.
+        section:          Restrict to a named region (stub: noted in output).
+        compare:          Second commit ref for side-by-side comparison.
+        commit_range:     ``from..to`` range string (stub: noted in output).
+        show_progression: If ``True``, show only the chord progression sequence.
+        show_key:         If ``True``, show only the detected key center.
+        show_mode:        If ``True``, show only the detected mode.
+        show_tension:     If ``True``, show only the tension profile.
+        as_json:          Emit JSON instead of human-readable text.
+    """
+    muse_dir = root / ".muse"
+
+    # -- Resolve branch / commit ref --
+    head_ref = (muse_dir / "HEAD").read_text().strip()
+    branch = head_ref.rsplit("/", 1)[-1] if "/" in head_ref else head_ref
+    ref_path = muse_dir / pathlib.Path(head_ref)
+
+    head_sha = ref_path.read_text().strip() if ref_path.exists() else ""
+
+    if not head_sha and not commit:
+        typer.echo(f"No commits yet on branch {branch} — nothing to analyse.")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    resolved_commit = commit or (head_sha[:8] if head_sha else "HEAD")
+    effective_track = track or "all"
+
+    # -- Stub: produce placeholder result --
+    result = _stub_harmony(
+        commit_id=resolved_commit,
+        branch=branch,
+        track=effective_track,
+    )
+
+    # -- Stub boundary notes for unimplemented flags --
+    if commit_range:
+        typer.echo(
+            f"⚠️  --range {commit_range!r}: range analysis not yet implemented. "
+            f"Showing HEAD ({resolved_commit}) only."
+        )
+    if section:
+        typer.echo(f"⚠️  --section {section!r}: region filtering not yet implemented.")
+
+    # -- Render --
+    if compare is not None:
+        compare_result = _stub_harmony(
+            commit_id=compare,
+            branch=branch,
+            track=effective_track,
+        )
+        cmp = HarmonyCompareResult(
+            head=result,
+            compare=compare_result,
+            key_changed=result["key"] != compare_result["key"],
+            mode_changed=result["mode"] != compare_result["mode"],
+            chord_progression_delta=[
+                c
+                for c in result["chord_progression"]
+                if c not in compare_result["chord_progression"]
+            ],
+        )
+        if as_json:
+            _render_compare_json(cmp)
+        else:
+            _render_compare_human(cmp)
+        return result
+
+    # Single-commit render with optional field scoping
+    if as_json:
+        _render_result_json(result, show_progression, show_key, show_mode, show_tension)
+    else:
+        _render_result_human(result, show_progression, show_key, show_mode, show_tension)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+
+def _tension_label(profile: list[float]) -> str:
+    """Classify a tension profile into a human-readable arc description.
+
+    Uses the shape of the profile (monotone rise/fall, arch, valley) to
+    produce vocabulary familiar to producers and music directors.
+    """
+    if not profile:
+        return "unknown"
+    if len(profile) == 1:
+        v = profile[0]
+        if v < 0.3:
+            return "Low"
+        if v < 0.6:
+            return "Medium"
+        return "High"
+
+    rising = all(profile[i] <= profile[i + 1] for i in range(len(profile) - 1))
+    falling = all(profile[i] >= profile[i + 1] for i in range(len(profile) - 1))
+    peak_idx = profile.index(max(profile))
+    valley_idx = profile.index(min(profile))
+
+    if rising:
+        return "Rising (tension build)"
+    if falling:
+        return "Falling (tension release)"
+    if 0 < peak_idx < len(profile) - 1:
+        return "Low → Medium → High → Resolution (textbook tension-release arc)"
+    if 0 < valley_idx < len(profile) - 1:
+        return "High → Resolution → High (bracketed release)"
+    return "Variable"
+
+
+def _render_result_human(
+    result: HarmonyResult,
+    show_progression: bool,
+    show_key: bool,
+    show_mode: bool,
+    show_tension: bool,
+) -> None:
+    """Render a HarmonyResult as human-readable text."""
+    full = not any([show_progression, show_key, show_mode, show_tension])
+
+    if full:
+        typer.echo(f"Commit {result['commit_id']} — Harmonic Analysis")
+        if result["source"] == "stub":
+            typer.echo("(stub — full MIDI analysis pending)")
+        typer.echo("")
+
+    if full or show_key:
+        key_display = result["key"] or "—  (no pitched content)"
+        typer.echo(
+            f"Key: {key_display}"
+            + (f" (confidence: {result['confidence']:.2f})" if result["key"] else "")
+        )
+
+    if full or show_mode:
+        mode_display = result["mode"] or "—"
+        typer.echo(f"Mode: {mode_display}")
+
+    if full or show_progression:
+        if result["chord_progression"]:
+            progression_str = " | ".join(result["chord_progression"])
+        else:
+            progression_str = "(no pitched content — drums only)"
+        typer.echo(f"Chord progression: {progression_str}")
+
+    if full:
+        typer.echo(f"Harmonic rhythm: {result['harmonic_rhythm_avg']:.1f} chords/bar avg")
+
+    if full or show_tension:
+        label = _tension_label(result["tension_profile"])
+        profile_str = " → ".join(f"{v:.1f}" for v in result["tension_profile"])
+        typer.echo(f"Tension profile: {label}  [{profile_str}]")
+
+
+def _render_result_json(
+    result: HarmonyResult,
+    show_progression: bool,
+    show_key: bool,
+    show_mode: bool,
+    show_tension: bool,
+) -> None:
+    """Render a HarmonyResult as JSON, optionally scoped to requested fields."""
+    full = not any([show_progression, show_key, show_mode, show_tension])
+
+    if full:
+        payload: dict[str, object] = dict(result)
+    else:
+        payload = {"commit_id": result["commit_id"], "branch": result["branch"]}
+        if show_key:
+            payload["key"] = result["key"]
+            payload["confidence"] = result["confidence"]
+        if show_mode:
+            payload["mode"] = result["mode"]
+        if show_progression:
+            payload["chord_progression"] = result["chord_progression"]
+        if show_tension:
+            payload["tension_profile"] = result["tension_profile"]
+
+    typer.echo(json.dumps(payload, indent=2))
+
+
+def _render_compare_human(cmp: HarmonyCompareResult) -> None:
+    """Render a HarmonyCompareResult as human-readable text."""
+    head = cmp["head"]
+    ref = cmp["compare"]
+
+    typer.echo(f"Harmonic Comparison — HEAD ({head['commit_id']}) vs {ref['commit_id']}")
+    typer.echo("")
+    typer.echo(f"  Key   HEAD: {head['key'] or '—'}   Compare: {ref['key'] or '—'}")
+    typer.echo(f"  Mode  HEAD: {head['mode'] or '—'}  Compare: {ref['mode'] or '—'}")
+    typer.echo(f"  Key changed:  {'yes' if cmp['key_changed'] else 'no'}")
+    typer.echo(f"  Mode changed: {'yes' if cmp['mode_changed'] else 'no'}")
+    if cmp["chord_progression_delta"]:
+        typer.echo(f"  New chords in HEAD: {' '.join(cmp['chord_progression_delta'])}")
+    else:
+        typer.echo("  Chord progression: unchanged")
+
+
+def _render_compare_json(cmp: HarmonyCompareResult) -> None:
+    """Render a HarmonyCompareResult as JSON."""
+    typer.echo(json.dumps(dict(cmp), indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def harmony(
+    ctx: typer.Context,
+    commit: Annotated[
+        Optional[str],
+        typer.Argument(
+            help="Commit SHA to analyze. Defaults to HEAD.",
+            show_default=False,
+        ),
+    ] = None,
+    track: Annotated[
+        Optional[str],
+        typer.Option(
+            "--track",
+            help="Restrict analysis to a named MIDI track (e.g. 'keys', 'bass').",
+            show_default=False,
+        ),
+    ] = None,
+    section: Annotated[
+        Optional[str],
+        typer.Option(
+            "--section",
+            help="Restrict analysis to a named musical section or region.",
+            show_default=False,
+        ),
+    ] = None,
+    compare: Annotated[
+        Optional[str],
+        typer.Option(
+            "--compare",
+            metavar="COMMIT",
+            help="Compare harmonic content of HEAD against another commit.",
+            show_default=False,
+        ),
+    ] = None,
+    commit_range: Annotated[
+        Optional[str],
+        typer.Option(
+            "--range",
+            metavar="FROM..TO",
+            help="Analyze harmonic content across a commit range (e.g. HEAD~10..HEAD).",
+            show_default=False,
+        ),
+    ] = None,
+    show_progression: Annotated[
+        bool,
+        typer.Option(
+            "--progression",
+            help="Show only the chord progression sequence.",
+        ),
+    ] = False,
+    show_key: Annotated[
+        bool,
+        typer.Option(
+            "--key",
+            help="Show only the detected key center.",
+        ),
+    ] = False,
+    show_mode: Annotated[
+        bool,
+        typer.Option(
+            "--mode",
+            help="Show only the detected mode (major, minor, dorian, etc.).",
+        ),
+    ] = False,
+    show_tension: Annotated[
+        bool,
+        typer.Option(
+            "--tension",
+            help="Show only the harmonic tension profile.",
+        ),
+    ] = False,
+    as_json: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="Emit machine-readable JSON output.",
+        ),
+    ] = False,
+) -> None:
+    """Analyze harmonic content (key, mode, chords, tension) of a commit.
+
+    Without flags, prints a full harmonic summary for the target commit.
+    Use ``--key``, ``--mode``, ``--progression``, or ``--tension`` to
+    scope the output to a single dimension.  Use ``--json`` for structured
+    output suitable for AI agent consumption.
+    """
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _harmony_analyze_async(
+                root=root,
+                session=session,
+                commit=commit,
+                track=track,
+                section=section,
+                compare=compare,
+                commit_range=commit_range,
+                show_progression=show_progression,
+                show_key=show_key,
+                show_mode=show_mode,
+                show_tension=show_tension,
+                as_json=as_json,
+            )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse harmony failed: {exc}")
+        logger.error("❌ muse harmony error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/tests/muse_cli/test_harmony.py
+++ b/tests/muse_cli/test_harmony.py
@@ -1,0 +1,734 @@
+"""Tests for ``muse harmony`` — CLI interface, flag parsing, and stub output format.
+
+All CLI-level tests use ``typer.testing.CliRunner`` against the full ``muse``
+app so that argument parsing, flag handling, and exit codes are exercised
+end-to-end.
+
+Async core tests call ``_harmony_analyze_async`` directly with an in-memory
+SQLite session (the stub does not query the DB, so the session satisfies
+the signature contract only).
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import uuid
+
+import pytest
+import pytest_asyncio
+from collections.abc import AsyncGenerator
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+from typer.testing import CliRunner
+
+from maestro.db.database import Base
+import maestro.muse_cli.models  # noqa: F401  — registers MuseCli* with Base.metadata
+from maestro.muse_cli.app import cli
+from maestro.muse_cli.commands.harmony import (
+    KNOWN_MODES,
+    KNOWN_MODES_SET,
+    HarmonyCompareResult,
+    HarmonyResult,
+    _harmony_analyze_async,
+    _render_compare_human,
+    _render_compare_json,
+    _render_result_human,
+    _render_result_json,
+    _stub_harmony,
+    _tension_label,
+)
+from maestro.muse_cli.errors import ExitCode
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, branch: str = "main") -> str:
+    """Create a minimal .muse/ layout with one empty commit ref."""
+    rid = str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(json.dumps({"repo_id": rid, "schema_version": "1"}))
+    (muse / "HEAD").write_text(f"refs/heads/{branch}")
+    (muse / "refs" / "heads" / branch).write_text("")
+    return rid
+
+
+def _commit_ref(root: pathlib.Path, branch: str = "main") -> None:
+    """Write a fake commit ID into the branch ref so HEAD is non-empty."""
+    muse = root / ".muse"
+    (muse / "refs" / "heads" / branch).write_text("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    """In-memory SQLite session (stub harmony does not actually query it)."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(bind=engine, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Unit — constants and helpers
+# ---------------------------------------------------------------------------
+
+
+def test_known_modes_set_matches_tuple() -> None:
+    """KNOWN_MODES_SET and KNOWN_MODES tuple are in sync."""
+    assert set(KNOWN_MODES) == KNOWN_MODES_SET
+
+
+def test_known_modes_contains_standard_modes() -> None:
+    """All seven standard modes plus major/minor are present."""
+    for mode in ("major", "minor", "dorian", "mixolydian", "lydian"):
+        assert mode in KNOWN_MODES_SET
+
+
+def test_tension_label_rising() -> None:
+    """Monotonically rising profile is labeled as 'Rising'."""
+    label = _tension_label([0.1, 0.3, 0.6, 0.9])
+    assert "Rising" in label
+
+
+def test_tension_label_falling() -> None:
+    """Monotonically falling profile is labeled as 'Falling'."""
+    label = _tension_label([0.9, 0.6, 0.3, 0.1])
+    assert "Falling" in label
+
+
+def test_tension_label_arch() -> None:
+    """Low-high-low arc produces a 'tension-release' label."""
+    label = _tension_label([0.2, 0.4, 0.8, 0.3])
+    assert "Resolution" in label or "release" in label.lower()
+
+
+def test_tension_label_single_value_low() -> None:
+    label = _tension_label([0.1])
+    assert label == "Low"
+
+
+def test_tension_label_single_value_high() -> None:
+    label = _tension_label([0.8])
+    assert label == "High"
+
+
+def test_tension_label_empty() -> None:
+    assert _tension_label([]) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Unit — stub data
+# ---------------------------------------------------------------------------
+
+
+def test_stub_harmony_returns_harmony_result() -> None:
+    """_stub_harmony returns a HarmonyResult with the expected fields."""
+    result = _stub_harmony(commit_id="a1b2c3d4", branch="main")
+    assert result["commit_id"] == "a1b2c3d4"
+    assert result["branch"] == "main"
+    assert result["key"] is not None
+    assert result["mode"] in KNOWN_MODES_SET
+    assert 0.0 <= result["confidence"] <= 1.0
+    assert isinstance(result["chord_progression"], list)
+    assert len(result["chord_progression"]) > 0
+    assert result["harmonic_rhythm_avg"] > 0
+    assert isinstance(result["tension_profile"], list)
+    assert result["track"] == "all"
+    assert result["source"] == "stub"
+
+
+def test_stub_harmony_track_scope() -> None:
+    """_stub_harmony respects the track argument."""
+    result = _stub_harmony(commit_id="a1b2c3d4", branch="main", track="keys")
+    assert result["track"] == "keys"
+
+
+def test_stub_harmony_chord_progression_are_strings() -> None:
+    """Every chord in the stub progression is a non-empty string."""
+    result = _stub_harmony(commit_id="a1b2c3d4", branch="main")
+    for chord in result["chord_progression"]:
+        assert isinstance(chord, str)
+        assert len(chord) > 0
+
+
+# ---------------------------------------------------------------------------
+# Unit — renderers
+# ---------------------------------------------------------------------------
+
+
+def test_render_result_human_full(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_result_human with no flags shows key, mode, chords, and tension."""
+    result = _stub_harmony(commit_id="a1b2c3d4", branch="main")
+    _render_result_human(result, False, False, False, False)
+    out = capsys.readouterr().out
+    assert "Harmonic Analysis" in out
+    assert "Key:" in out
+    assert "Mode:" in out
+    assert "Chord progression:" in out
+    assert "Tension profile:" in out
+
+
+def test_render_result_human_key_only(capsys: pytest.CaptureFixture[str]) -> None:
+    """--key shows only the key line."""
+    result = _stub_harmony(commit_id="a1b2c3d4", branch="main")
+    _render_result_human(result, False, True, False, False)
+    out = capsys.readouterr().out
+    assert "Key:" in out
+    assert "Mode:" not in out
+    assert "Chord progression:" not in out
+    assert "Tension profile:" not in out
+
+
+def test_render_result_human_mode_only(capsys: pytest.CaptureFixture[str]) -> None:
+    """--mode shows only the mode line."""
+    result = _stub_harmony(commit_id="a1b2c3d4", branch="main")
+    _render_result_human(result, False, False, True, False)
+    out = capsys.readouterr().out
+    assert "Mode:" in out
+    assert "Key:" not in out
+
+
+def test_render_result_human_progression_only(capsys: pytest.CaptureFixture[str]) -> None:
+    """--progression shows only the chord progression line."""
+    result = _stub_harmony(commit_id="a1b2c3d4", branch="main")
+    _render_result_human(result, True, False, False, False)
+    out = capsys.readouterr().out
+    assert "Chord progression:" in out
+    assert "Key:" not in out
+    assert "Tension profile:" not in out
+
+
+def test_render_result_human_tension_only(capsys: pytest.CaptureFixture[str]) -> None:
+    """--tension shows only the tension profile line."""
+    result = _stub_harmony(commit_id="a1b2c3d4", branch="main")
+    _render_result_human(result, False, False, False, True)
+    out = capsys.readouterr().out
+    assert "Tension profile:" in out
+    assert "Key:" not in out
+    assert "Chord progression:" not in out
+
+
+def test_render_result_json_full(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_result_json with no flags emits all HarmonyResult fields."""
+    result = _stub_harmony(commit_id="a1b2c3d4", branch="main")
+    _render_result_json(result, False, False, False, False)
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    for field in ("commit_id", "branch", "key", "mode", "confidence",
+                  "chord_progression", "harmonic_rhythm_avg", "tension_profile"):
+        assert field in payload, f"Missing field: {field}"
+
+
+def test_render_result_json_key_only(capsys: pytest.CaptureFixture[str]) -> None:
+    """--key JSON includes only key and confidence."""
+    result = _stub_harmony(commit_id="a1b2c3d4", branch="main")
+    _render_result_json(result, False, True, False, False)
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    assert "key" in payload
+    assert "confidence" in payload
+    assert "mode" not in payload
+    assert "chord_progression" not in payload
+
+
+def test_render_result_json_progression_only(capsys: pytest.CaptureFixture[str]) -> None:
+    """--progression JSON includes only chord_progression."""
+    result = _stub_harmony(commit_id="a1b2c3d4", branch="main")
+    _render_result_json(result, True, False, False, False)
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    assert "chord_progression" in payload
+    assert "key" not in payload
+
+
+def test_render_compare_human(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_compare_human shows both commits and change flags."""
+    head = _stub_harmony(commit_id="a1b2c3d4", branch="main")
+    ref = _stub_harmony(commit_id="deadbeef", branch="main")
+    cmp: HarmonyCompareResult = HarmonyCompareResult(
+        head=head,
+        compare=ref,
+        key_changed=False,
+        mode_changed=False,
+        chord_progression_delta=[],
+    )
+    _render_compare_human(cmp)
+    out = capsys.readouterr().out
+    assert "a1b2c3d4" in out
+    assert "deadbeef" in out
+    assert "Key changed" in out
+
+
+def test_render_compare_json(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_compare_json emits valid JSON with head/compare/delta keys."""
+    head = _stub_harmony(commit_id="a1b2c3d4", branch="main")
+    ref = _stub_harmony(commit_id="deadbeef", branch="main")
+    cmp: HarmonyCompareResult = HarmonyCompareResult(
+        head=head,
+        compare=ref,
+        key_changed=False,
+        mode_changed=False,
+        chord_progression_delta=[],
+    )
+    _render_compare_json(cmp)
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    assert "head" in payload
+    assert "compare" in payload
+    assert "key_changed" in payload
+    assert "chord_progression_delta" in payload
+
+
+# ---------------------------------------------------------------------------
+# Async core — _harmony_analyze_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_harmony_async_default_output(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_harmony_analyze_async with no flags shows full harmonic summary."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    result = await _harmony_analyze_async(
+        root=tmp_path,
+        session=db_session,
+        commit=None,
+        track=None,
+        section=None,
+        compare=None,
+        commit_range=None,
+        show_progression=False,
+        show_key=False,
+        show_mode=False,
+        show_tension=False,
+        as_json=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "Harmonic Analysis" in out
+    assert "Key:" in out
+    assert "Mode:" in out
+    assert "Chord progression:" in out
+    assert "Tension profile:" in out
+    assert result["source"] == "stub"
+
+
+@pytest.mark.anyio
+async def test_harmony_async_json_mode(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_harmony_analyze_async --json emits valid JSON with all HarmonyResult fields."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _harmony_analyze_async(
+        root=tmp_path,
+        session=db_session,
+        commit=None,
+        track=None,
+        section=None,
+        compare=None,
+        commit_range=None,
+        show_progression=False,
+        show_key=False,
+        show_mode=False,
+        show_tension=False,
+        as_json=True,
+    )
+
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    for field in ("commit_id", "branch", "key", "mode", "confidence",
+                  "chord_progression", "harmonic_rhythm_avg", "tension_profile"):
+        assert field in payload, f"Missing field: {field}"
+
+
+@pytest.mark.anyio
+async def test_harmony_async_no_commits_exits_success(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """With no commits and no explicit commit arg, exits 0 with informative message."""
+    _init_muse_repo(tmp_path)
+    # No _commit_ref call — branch ref is empty.
+
+    import typer
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _harmony_analyze_async(
+            root=tmp_path,
+            session=db_session,
+            commit=None,
+            track=None,
+            section=None,
+            compare=None,
+            commit_range=None,
+            show_progression=False,
+            show_key=False,
+            show_mode=False,
+            show_tension=False,
+            as_json=False,
+        )
+    assert exc_info.value.exit_code == int(ExitCode.SUCCESS)
+    out = capsys.readouterr().out
+    assert "No commits yet" in out
+
+
+@pytest.mark.anyio
+async def test_harmony_async_explicit_commit_ref(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An explicit commit ref appears in the output."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    result = await _harmony_analyze_async(
+        root=tmp_path,
+        session=db_session,
+        commit="deadbeef",
+        track=None,
+        section=None,
+        compare=None,
+        commit_range=None,
+        show_progression=False,
+        show_key=False,
+        show_mode=False,
+        show_tension=False,
+        as_json=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "deadbeef" in out
+    assert result["commit_id"] == "deadbeef"
+
+
+@pytest.mark.anyio
+async def test_harmony_async_track_scoped(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--track is reflected in the result track field."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    result = await _harmony_analyze_async(
+        root=tmp_path,
+        session=db_session,
+        commit=None,
+        track="keys",
+        section=None,
+        compare=None,
+        commit_range=None,
+        show_progression=False,
+        show_key=False,
+        show_mode=False,
+        show_tension=False,
+        as_json=False,
+    )
+
+    assert result["track"] == "keys"
+
+
+@pytest.mark.anyio
+async def test_harmony_async_progression_flag(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--progression shows chord progression and suppresses other fields."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _harmony_analyze_async(
+        root=tmp_path,
+        session=db_session,
+        commit=None,
+        track=None,
+        section=None,
+        compare=None,
+        commit_range=None,
+        show_progression=True,
+        show_key=False,
+        show_mode=False,
+        show_tension=False,
+        as_json=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "Chord progression:" in out
+    assert "Key:" not in out
+    assert "Tension profile:" not in out
+
+
+@pytest.mark.anyio
+async def test_harmony_async_key_flag(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--key shows key center and suppresses other fields."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _harmony_analyze_async(
+        root=tmp_path,
+        session=db_session,
+        commit=None,
+        track=None,
+        section=None,
+        compare=None,
+        commit_range=None,
+        show_progression=False,
+        show_key=True,
+        show_mode=False,
+        show_tension=False,
+        as_json=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "Key:" in out
+    assert "Mode:" not in out
+
+
+@pytest.mark.anyio
+async def test_harmony_async_mode_flag(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--mode shows mode and suppresses other fields."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _harmony_analyze_async(
+        root=tmp_path,
+        session=db_session,
+        commit=None,
+        track=None,
+        section=None,
+        compare=None,
+        commit_range=None,
+        show_progression=False,
+        show_key=False,
+        show_mode=True,
+        show_tension=False,
+        as_json=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "Mode:" in out
+    assert "Key:" not in out
+
+
+@pytest.mark.anyio
+async def test_harmony_async_tension_flag(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--tension shows tension profile and suppresses other fields."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _harmony_analyze_async(
+        root=tmp_path,
+        session=db_session,
+        commit=None,
+        track=None,
+        section=None,
+        compare=None,
+        commit_range=None,
+        show_progression=False,
+        show_key=False,
+        show_mode=False,
+        show_tension=True,
+        as_json=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "Tension profile:" in out
+    assert "Key:" not in out
+
+
+@pytest.mark.anyio
+async def test_harmony_async_compare_mode(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--compare renders a comparison between HEAD and the reference commit."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _harmony_analyze_async(
+        root=tmp_path,
+        session=db_session,
+        commit=None,
+        track=None,
+        section=None,
+        compare="deadbeef",
+        commit_range=None,
+        show_progression=False,
+        show_key=False,
+        show_mode=False,
+        show_tension=False,
+        as_json=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "deadbeef" in out
+    assert "Harmonic Comparison" in out
+
+
+@pytest.mark.anyio
+async def test_harmony_async_compare_json(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--compare --json emits a HarmonyCompareResult as JSON."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _harmony_analyze_async(
+        root=tmp_path,
+        session=db_session,
+        commit=None,
+        track=None,
+        section=None,
+        compare="deadbeef",
+        commit_range=None,
+        show_progression=False,
+        show_key=False,
+        show_mode=False,
+        show_tension=False,
+        as_json=True,
+    )
+
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    assert "head" in payload
+    assert "compare" in payload
+    assert "key_changed" in payload
+    assert "mode_changed" in payload
+    assert "chord_progression_delta" in payload
+
+
+@pytest.mark.anyio
+async def test_harmony_async_range_flag_warns(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--range emits a stub boundary warning but still renders HEAD result."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _harmony_analyze_async(
+        root=tmp_path,
+        session=db_session,
+        commit=None,
+        track=None,
+        section=None,
+        compare=None,
+        commit_range="HEAD~10..HEAD",
+        show_progression=False,
+        show_key=False,
+        show_mode=False,
+        show_tension=False,
+        as_json=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "--range" in out
+    assert "Harmonic Analysis" in out
+
+
+@pytest.mark.anyio
+async def test_harmony_async_section_flag_warns(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--section emits a stub boundary warning but still renders HEAD result."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _harmony_analyze_async(
+        root=tmp_path,
+        session=db_session,
+        commit=None,
+        track=None,
+        section="verse",
+        compare=None,
+        commit_range=None,
+        show_progression=False,
+        show_key=False,
+        show_mode=False,
+        show_tension=False,
+        as_json=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "--section" in out
+    assert "Harmonic Analysis" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — CliRunner
+# ---------------------------------------------------------------------------
+
+
+def test_cli_harmony_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse harmony`` exits 2 when invoked outside a Muse repository."""
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["harmony"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == int(ExitCode.REPO_NOT_FOUND)
+    assert "not a muse repository" in result.output.lower()
+
+
+def test_cli_harmony_help_lists_flags() -> None:
+    """``muse harmony --help`` shows all documented flags."""
+    result = runner.invoke(cli, ["harmony", "--help"])
+    assert result.exit_code == 0
+    for flag in ("--track", "--section", "--compare", "--range", "--progression",
+                 "--key", "--mode", "--tension", "--json"):
+        assert flag in result.output, f"Flag '{flag}' not found in help output"
+
+
+def test_cli_harmony_appears_in_muse_help() -> None:
+    """``muse --help`` lists the harmony subcommand."""
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "harmony" in result.output


### PR DESCRIPTION
## Summary
Closes #103 — Implement \`muse harmony\` command to analyze and query harmonic content across commits.

## Root Cause / Motivation
No harmonic analysis capability existed in the Muse VCS CLI. An AI agent had no way to discover the key center, mode, chord progression, or harmonic tension of a committed musical arrangement — the most fundamental harmonic dimensions of music.

## Solution
Implement \`muse harmony [<commit>]\` following established Muse CLI patterns (\`muse dynamics\`, \`muse swing\`):

- **Injectable async core:** \`_harmony_analyze_async\` — fully testable without CLI invocation
- **Stable named result types:** \`HarmonyResult\` and \`HarmonyCompareResult\` (TypedDict)
- **Stub placeholder data:** Realistic Eb major II-V-I template with correct schema
- **Tension arc classifier:** \`_tension_label\` maps tension profiles to producer vocabulary
- **Separated renderers:** \`_render_result_human/json\` and \`_render_compare_human/json\`

**Flags implemented:**
\`--track\`, \`--section\`, \`--compare\`, \`--range\`, \`--progression\`, \`--key\`, \`--mode\`, \`--tension\`, \`--json\`

## Layers Affected
- [x] Muse VCS (new \`muse harmony\` command)

## Verification
- [x] \`docker compose exec maestro mypy maestro/ tests/\` — clean (482 files)
- [x] 37 tests pass — constants, helpers, renderers, async core, CLI integration
- [x] Docs updated: \`docs/architecture/muse_vcs.md\` + \`docs/reference/type_contracts.md\`

## Tests Added
- \`test_known_modes_set_matches_tuple\` — constant sync
- \`test_tension_label_*\` (5 cases) — arc classifier coverage
- \`test_stub_harmony_*\` (3 cases) — stub data contract
- \`test_render_result_human_*\` (5 cases) — field scoping per flag
- \`test_render_result_json_*\` (3 cases) — JSON field scoping
- \`test_render_compare_*\` (2 cases) — compare renderers
- \`test_harmony_async_*\` (13 async cases) — core logic: all flags, no-commits graceful exit, compare mode, range/section stub warnings
- \`test_cli_harmony_*\` (3 CLI cases) — outside-repo exit, help flags, muse --help listing

## Handoff
N/A — no SSE protocol or MCP tool schema change.