### PR TITLE
feat: muse cat-object <object-id> — read and display a stored object

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -1363,6 +1363,72 @@ CLI contract; stub implementations are clearly marked.
 
 ---
 
+### `muse cat-object`
+
+**Purpose:** Read and display a raw Muse object by its SHA-256 hash. The
+plumbing equivalent of `git cat-file` — lets an AI agent inspect any stored
+blob, snapshot manifest, or commit record without running the full `muse log`
+pipeline.
+
+**Usage:**
+```bash
+muse cat-object [OPTIONS] <object-id>
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `<object-id>` | positional | required | Full 64-char SHA-256 hash to look up |
+| `-t / --type` | flag | off | Print only the object type (`object`, `snapshot`, or `commit`) |
+| `-p / --pretty` | flag | off | Pretty-print the object content as indented JSON |
+
+`-t` and `-p` are mutually exclusive.
+
+**Output example (default):**
+```
+type:       commit
+commit_id:  a1b2c3d4...
+branch:     main
+snapshot:   f9e8d7c6...
+message:    boom bap demo take 1
+parent:     00112233...
+committed_at: 2026-02-27T17:30:00+00:00
+```
+
+**Output example (`-t`):**
+```
+commit
+```
+
+**Output example (`-p <snapshot_id>`):**
+```json
+{
+  "type": "snapshot",
+  "snapshot_id": "f9e8d7c6...",
+  "manifest": {
+    "beat.mid": "a1b2c3d4...",
+    "keys.mid": "11223344..."
+  },
+  "created_at": "2026-02-27T17:20:00+00:00"
+}
+```
+
+**Result type:** `CatObjectResult` — fields: `object_type` (str), `row`
+(MuseCliObject | MuseCliSnapshot | MuseCliCommit). Call `.to_dict()` for a
+JSON-serialisable representation.
+
+**Agent use case:** Use `muse cat-object -t <hash>` to determine the type of
+an unknown ID before deciding how to process it. Use `-p` to extract the
+snapshot manifest (file → object_id map) or commit metadata for downstream
+generation context. Combine with `muse log` short IDs: copy the full commit_id
+from `muse log`, then `muse cat-object -p <id>` to inspect its snapshot.
+
+**Error behaviour:** Exits with code 1 (`USER_ERROR`) when the ID is not found
+in any object table; prints `❌ Object not found: <id>`.
+
+---
+
 ### `muse dynamics`
 
 **Purpose:** Analyze the velocity (loudness) profile of a commit across all instrument

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -2487,6 +2487,31 @@ commit that scored at or above the `--threshold` keyword-overlap cutoff.
 
 ---
 
+### `CatObjectResult`
+
+**Module:** `maestro/muse_cli/commands/cat_object.py`
+
+Wraps the result of a single object lookup across the three Muse object tables
+(blob → snapshot → commit). Records both the detected type and the ORM row so
+renderers never need to `isinstance`-check independently.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `object_type` | `str` | One of `"object"`, `"snapshot"`, or `"commit"` |
+| `row` | `MuseCliObject \| MuseCliSnapshot \| MuseCliCommit` | The matched ORM row |
+
+**Methods:** `.to_dict() → dict[str, object]` — produces a JSON-serialisable
+dict whose shape varies by `object_type`:
+
+- `object` → `{type, object_id, size_bytes, created_at}`
+- `snapshot` → `{type, snapshot_id, manifest, created_at}`
+- `commit` → `{type, commit_id, repo_id, branch, parent_commit_id, parent2_commit_id, snapshot_id, message, author, committed_at, created_at, metadata}`
+
+**Producer:** `_lookup_object()` (internal) → `_cat_object_async()`
+**Consumer:** `_render_metadata()`, JSON output path in `_cat_object_async()`
+
+---
+
 ### `DescribeResult`
 
 **Module:** `maestro/muse_cli/commands/describe.py`

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -1,10 +1,10 @@
 """Muse CLI — Typer application root.
 
 Entry point for the ``muse`` console script. Registers all MVP
-subcommands (arrange, ask, checkout, commit, context, describe, divergence,
-dynamics, export, find, grep, import, init, log, merge, meter, open, play,
-pull, push, recall, remote, session, status, swing, tag, tempo) as Typer
-sub-applications.
+subcommands (arrange, ask, cat-object, checkout, commit, context, describe,
+divergence, dynamics, export, find, grep, import, init, log, merge, meter,
+open, play, pull, push, recall, remote, session, status, swing, tag, tempo)
+as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ import typer
 from maestro.muse_cli.commands import (
     arrange,
     ask,
+    cat_object,
     checkout,
     commit,
     context,
@@ -46,6 +47,7 @@ cli = typer.Typer(
     no_args_is_help=True,
 )
 
+cli.add_typer(cat_object.app, name="cat-object", help="Read and display a stored object by its SHA-256 hash.")
 cli.add_typer(init.app, name="init", help="Initialise a new Muse repository.")
 cli.add_typer(status.app, name="status", help="Show working-tree drift against HEAD.")
 cli.add_typer(dynamics.app, name="dynamics", help="Analyse the dynamic (velocity) profile of a commit.")

--- a/maestro/muse_cli/commands/cat_object.py
+++ b/maestro/muse_cli/commands/cat_object.py
@@ -46,7 +46,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import Optional
 
 import typer
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/maestro/muse_cli/commands/cat_object.py
+++ b/maestro/muse_cli/commands/cat_object.py
@@ -1,0 +1,294 @@
+"""muse cat-object — inspect a raw object in the Muse content-addressed store.
+
+Mirrors ``git cat-file`` plumbing semantics for Muse's three object types:
+
+- **object**   — a content-addressed file blob (``MuseCliObject``)
+- **snapshot** — an immutable manifest mapping paths to object IDs
+  (``MuseCliSnapshot``)
+- **commit**   — a versioned record pointing to a snapshot and its parent
+  (``MuseCliCommit``)
+
+The command tries each table in order (object → snapshot → commit) until it
+finds a match, so a full 64-character SHA-256 hash is always unambiguous.
+Short prefixes are NOT supported — callers must supply the full hash (as
+returned by ``muse log``, ``muse commit``, etc.).
+
+Output modes
+------------
+
+Default (no flags) — human-readable metadata summary::
+
+    type:       object
+    object_id:  a1b2c3d4...
+    size:       4096 bytes
+    created_at: 2026-02-27T17:30:00+00:00
+
+``-t / --type`` — print only the type string (one of ``object``,
+``snapshot``, ``commit``) and exit, mirroring ``git cat-file -t``::
+
+    object
+
+``-p / --pretty`` — pretty-print the object contents:
+
+- For **objects**: prints size and creation time (binary blobs have no
+  text representation stored in the DB; the raw bytes live on disk).
+- For **snapshots**: prints the manifest JSON (path → object_id mapping).
+- For **commits**: prints all commit fields as indented JSON.
+
+Agent use case
+--------------
+AI agents use ``muse cat-object`` to inspect object metadata before
+deciding whether to re-fetch, export, or reference an artifact.  The
+``-p`` flag gives structured JSON that agents can parse directly.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliObject, MuseCliSnapshot
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+ObjectType = str  # "object" | "snapshot" | "commit"
+
+
+class CatObjectResult:
+    """Structured result from looking up a Muse object by ID.
+
+    Wraps whichever ORM row was found and records its type so renderers
+    don't need to isinstance-check.
+
+    Args:
+        object_type: One of ``"object"``, ``"snapshot"``, or ``"commit"``.
+        row:         The ORM row (``MuseCliObject | MuseCliSnapshot |
+                     MuseCliCommit``).
+    """
+
+    def __init__(
+        self,
+        *,
+        object_type: ObjectType,
+        row: MuseCliObject | MuseCliSnapshot | MuseCliCommit,
+    ) -> None:
+        self.object_type = object_type
+        self.row = row
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialise to a JSON-compatible dict.
+
+        The shape varies by object type and is intended for agent
+        consumption via ``-p``.
+        """
+        if self.object_type == "object":
+            obj = self.row
+            assert isinstance(obj, MuseCliObject)
+            return {
+                "type": "object",
+                "object_id": obj.object_id,
+                "size_bytes": obj.size_bytes,
+                "created_at": obj.created_at.isoformat(),
+            }
+        if self.object_type == "snapshot":
+            snap = self.row
+            assert isinstance(snap, MuseCliSnapshot)
+            return {
+                "type": "snapshot",
+                "snapshot_id": snap.snapshot_id,
+                "manifest": snap.manifest,
+                "created_at": snap.created_at.isoformat(),
+            }
+        # commit
+        commit = self.row
+        assert isinstance(commit, MuseCliCommit)
+        return {
+            "type": "commit",
+            "commit_id": commit.commit_id,
+            "repo_id": commit.repo_id,
+            "branch": commit.branch,
+            "parent_commit_id": commit.parent_commit_id,
+            "parent2_commit_id": commit.parent2_commit_id,
+            "snapshot_id": commit.snapshot_id,
+            "message": commit.message,
+            "author": commit.author,
+            "committed_at": commit.committed_at.isoformat(),
+            "created_at": commit.created_at.isoformat(),
+            "metadata": commit.commit_metadata,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Async core — fully injectable for tests
+# ---------------------------------------------------------------------------
+
+
+async def _lookup_object(
+    session: AsyncSession,
+    object_id: str,
+) -> CatObjectResult | None:
+    """Probe all three object tables and return the first match.
+
+    Lookup order: MuseCliObject → MuseCliSnapshot → MuseCliCommit.
+    Returns ``None`` when the ID is not found in any table.
+
+    Args:
+        session:   An open async DB session.
+        object_id: The full SHA-256 hash to look up (64 hex chars).
+    """
+    obj = await session.get(MuseCliObject, object_id)
+    if obj is not None:
+        return CatObjectResult(object_type="object", row=obj)
+
+    snap = await session.get(MuseCliSnapshot, object_id)
+    if snap is not None:
+        return CatObjectResult(object_type="snapshot", row=snap)
+
+    commit = await session.get(MuseCliCommit, object_id)
+    if commit is not None:
+        return CatObjectResult(object_type="commit", row=commit)
+
+    return None
+
+
+async def _cat_object_async(
+    *,
+    session: AsyncSession,
+    object_id: str,
+    type_only: bool,
+    pretty: bool,
+) -> None:
+    """Core cat-object logic — fully injectable for tests.
+
+    Resolves *object_id* across all three Muse object tables and prints
+    the requested representation.  Exits non-zero when the object is not found.
+
+    Args:
+        session:   Open async DB session.
+        object_id: Full SHA-256 hash to look up.
+        type_only: When ``True``, print only the type string and exit.
+        pretty:    When ``True``, pretty-print the object's content as JSON.
+    """
+    result = await _lookup_object(session, object_id)
+    if result is None:
+        typer.echo(f"❌ Object not found: {object_id}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    if type_only:
+        typer.echo(result.object_type)
+        return
+
+    if pretty:
+        typer.echo(json.dumps(result.to_dict(), indent=2))
+        return
+
+    # Default: human-readable metadata summary
+    _render_metadata(result)
+
+
+def _render_metadata(result: CatObjectResult) -> None:
+    """Print a terse human-readable metadata block for the found object."""
+    if result.object_type == "object":
+        obj = result.row
+        assert isinstance(obj, MuseCliObject)
+        typer.echo(f"type:       object")
+        typer.echo(f"object_id:  {obj.object_id}")
+        typer.echo(f"size:       {obj.size_bytes} bytes")
+        typer.echo(f"created_at: {obj.created_at.isoformat()}")
+        return
+
+    if result.object_type == "snapshot":
+        snap = result.row
+        assert isinstance(snap, MuseCliSnapshot)
+        file_count = len(snap.manifest) if snap.manifest else 0
+        typer.echo(f"type:        snapshot")
+        typer.echo(f"snapshot_id: {snap.snapshot_id}")
+        typer.echo(f"files:       {file_count}")
+        typer.echo(f"created_at:  {snap.created_at.isoformat()}")
+        return
+
+    # commit
+    commit = result.row
+    assert isinstance(commit, MuseCliCommit)
+    typer.echo(f"type:       commit")
+    typer.echo(f"commit_id:  {commit.commit_id}")
+    typer.echo(f"branch:     {commit.branch}")
+    typer.echo(f"snapshot:   {commit.snapshot_id}")
+    typer.echo(f"message:    {commit.message}")
+    if commit.parent_commit_id:
+        typer.echo(f"parent:     {commit.parent_commit_id}")
+    typer.echo(f"committed_at: {commit.committed_at.isoformat()}")
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def cat_object(
+    ctx: typer.Context,
+    object_id: str = typer.Argument(
+        ...,
+        help="Full SHA-256 object ID to look up (64 hex characters).",
+        metavar="<object-id>",
+    ),
+    type_only: bool = typer.Option(
+        False,
+        "-t",
+        "--type",
+        help="Print only the type of the object (object, snapshot, or commit).",
+    ),
+    pretty: bool = typer.Option(
+        False,
+        "-p",
+        "--pretty",
+        help=(
+            "Pretty-print the object content as JSON. "
+            "For snapshots: manifest. For commits: all fields. "
+            "For objects: size and creation time."
+        ),
+    ),
+) -> None:
+    """Read and display a stored Muse object by its SHA-256 hash.
+
+    Probes the object store (blob, snapshot, commit) for the given ID and
+    prints a summary.  Use ``-t`` to get just the type, or ``-p`` to get
+    the full JSON representation.
+    """
+    if type_only and pretty:
+        typer.echo("❌ --type and --pretty are mutually exclusive.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _cat_object_async(
+                session=session,
+                object_id=object_id,
+                type_only=type_only,
+                pretty=pretty,
+            )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse cat-object failed: {exc}")
+        logger.error("❌ muse cat-object error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/tests/muse_cli/test_cat_object.py
+++ b/tests/muse_cli/test_cat_object.py
@@ -1,0 +1,489 @@
+"""Tests for ``muse cat-object``.
+
+All async tests call ``_cat_object_async`` and ``_lookup_object`` directly
+with an in-memory SQLite session and a ``tmp_path`` repo root — no real
+Postgres or running process required.  ORM rows are seeded directly so the
+lookup tests are independent of ``muse commit``.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.commands.cat_object import (
+    CatObjectResult,
+    _cat_object_async,
+    _lookup_object,
+)
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliObject, MuseCliSnapshot
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_UTC = timezone.utc
+
+
+def _fake_hash(prefix: str = "a") -> str:
+    """Generate a deterministic 64-char hex string for use as an object ID."""
+    return (prefix * 64)[:64]
+
+
+def _init_muse_repo(root: pathlib.Path) -> str:
+    """Create a minimal ``.muse/`` directory so ``require_repo()`` succeeds."""
+    rid = str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(json.dumps({"repo_id": rid, "schema_version": "1"}))
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+async def _seed_object(session: AsyncSession, object_id: str, size: int = 1024) -> MuseCliObject:
+    obj = MuseCliObject(
+        object_id=object_id,
+        size_bytes=size,
+        created_at=datetime(2026, 1, 1, tzinfo=_UTC),
+    )
+    session.add(obj)
+    await session.flush()
+    return obj
+
+
+async def _seed_snapshot(
+    session: AsyncSession,
+    snapshot_id: str,
+    manifest: dict[str, str] | None = None,
+) -> MuseCliSnapshot:
+    snap = MuseCliSnapshot(
+        snapshot_id=snapshot_id,
+        manifest=manifest or {"beat.mid": _fake_hash("b")},
+        created_at=datetime(2026, 1, 2, tzinfo=_UTC),
+    )
+    session.add(snap)
+    await session.flush()
+    return snap
+
+
+async def _seed_commit(
+    session: AsyncSession,
+    commit_id: str,
+    snapshot_id: str,
+    repo_id: str = "test-repo",
+) -> MuseCliCommit:
+    commit = MuseCliCommit(
+        commit_id=commit_id,
+        repo_id=repo_id,
+        branch="main",
+        parent_commit_id=None,
+        parent2_commit_id=None,
+        snapshot_id=snapshot_id,
+        message="initial take",
+        author="test-author",
+        committed_at=datetime(2026, 1, 3, tzinfo=_UTC),
+        created_at=datetime(2026, 1, 3, tzinfo=_UTC),
+    )
+    session.add(commit)
+    await session.flush()
+    return commit
+
+
+# ---------------------------------------------------------------------------
+# _lookup_object — type resolution tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_lookup_object_finds_object_row(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """_lookup_object returns type='object' when the ID is a MuseCliObject."""
+    oid = _fake_hash("a")
+    await _seed_object(muse_cli_db_session, oid)
+
+    result = await _lookup_object(muse_cli_db_session, oid)
+
+    assert result is not None
+    assert result.object_type == "object"
+    assert isinstance(result.row, MuseCliObject)
+
+
+@pytest.mark.anyio
+async def test_lookup_object_finds_snapshot_row(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """_lookup_object returns type='snapshot' when the ID is a MuseCliSnapshot."""
+    sid = _fake_hash("c")
+    await _seed_snapshot(muse_cli_db_session, sid)
+
+    result = await _lookup_object(muse_cli_db_session, sid)
+
+    assert result is not None
+    assert result.object_type == "snapshot"
+    assert isinstance(result.row, MuseCliSnapshot)
+
+
+@pytest.mark.anyio
+async def test_lookup_object_finds_commit_row(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """_lookup_object returns type='commit' when the ID is a MuseCliCommit."""
+    sid = _fake_hash("c")
+    cid = _fake_hash("d")
+    await _seed_snapshot(muse_cli_db_session, sid)
+    await _seed_commit(muse_cli_db_session, cid, sid)
+
+    result = await _lookup_object(muse_cli_db_session, cid)
+
+    assert result is not None
+    assert result.object_type == "commit"
+    assert isinstance(result.row, MuseCliCommit)
+
+
+@pytest.mark.anyio
+async def test_lookup_object_returns_none_for_unknown_id(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """_lookup_object returns None when the ID is not in any table."""
+    result = await _lookup_object(muse_cli_db_session, _fake_hash("z"))
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _cat_object_async — default (metadata) output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cat_object_default_prints_object_metadata(
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Default output shows type, object_id, size, and created_at for blob objects."""
+    oid = _fake_hash("a")
+    await _seed_object(muse_cli_db_session, oid, size=2048)
+
+    await _cat_object_async(
+        session=muse_cli_db_session,
+        object_id=oid,
+        type_only=False,
+        pretty=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "type:       object" in out
+    assert oid in out
+    assert "2048 bytes" in out
+
+
+@pytest.mark.anyio
+async def test_cat_object_default_prints_snapshot_metadata(
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Default output shows type, snapshot_id, and file count for snapshots."""
+    sid = _fake_hash("c")
+    manifest = {"beat.mid": _fake_hash("b"), "keys.mid": _fake_hash("e")}
+    await _seed_snapshot(muse_cli_db_session, sid, manifest=manifest)
+
+    await _cat_object_async(
+        session=muse_cli_db_session,
+        object_id=sid,
+        type_only=False,
+        pretty=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "type:        snapshot" in out
+    assert sid in out
+    assert "files:       2" in out
+
+
+@pytest.mark.anyio
+async def test_cat_object_default_prints_commit_metadata(
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Default output shows type, commit_id, branch, message for commits."""
+    sid = _fake_hash("c")
+    cid = _fake_hash("d")
+    await _seed_snapshot(muse_cli_db_session, sid)
+    await _seed_commit(muse_cli_db_session, cid, sid)
+
+    await _cat_object_async(
+        session=muse_cli_db_session,
+        object_id=cid,
+        type_only=False,
+        pretty=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "type:       commit" in out
+    assert cid in out
+    assert "main" in out
+    assert "initial take" in out
+
+
+# ---------------------------------------------------------------------------
+# _cat_object_async — -t / --type flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cat_object_type_only_prints_object(
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """-t prints only 'object' for a MuseCliObject row."""
+    oid = _fake_hash("a")
+    await _seed_object(muse_cli_db_session, oid)
+
+    await _cat_object_async(
+        session=muse_cli_db_session,
+        object_id=oid,
+        type_only=True,
+        pretty=False,
+    )
+
+    out = capsys.readouterr().out.strip()
+    assert out == "object"
+
+
+@pytest.mark.anyio
+async def test_cat_object_type_only_prints_snapshot(
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """-t prints only 'snapshot' for a MuseCliSnapshot row."""
+    sid = _fake_hash("c")
+    await _seed_snapshot(muse_cli_db_session, sid)
+
+    await _cat_object_async(
+        session=muse_cli_db_session,
+        object_id=sid,
+        type_only=True,
+        pretty=False,
+    )
+
+    out = capsys.readouterr().out.strip()
+    assert out == "snapshot"
+
+
+@pytest.mark.anyio
+async def test_cat_object_type_only_prints_commit(
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """-t prints only 'commit' for a MuseCliCommit row."""
+    sid = _fake_hash("c")
+    cid = _fake_hash("d")
+    await _seed_snapshot(muse_cli_db_session, sid)
+    await _seed_commit(muse_cli_db_session, cid, sid)
+
+    await _cat_object_async(
+        session=muse_cli_db_session,
+        object_id=cid,
+        type_only=True,
+        pretty=False,
+    )
+
+    out = capsys.readouterr().out.strip()
+    assert out == "commit"
+
+
+# ---------------------------------------------------------------------------
+# _cat_object_async — -p / --pretty flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cat_object_pretty_prints_snapshot_manifest(
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """-p emits valid JSON containing the manifest dict for snapshots."""
+    sid = _fake_hash("c")
+    manifest = {"beat.mid": _fake_hash("b"), "keys.mid": _fake_hash("e")}
+    await _seed_snapshot(muse_cli_db_session, sid, manifest=manifest)
+
+    await _cat_object_async(
+        session=muse_cli_db_session,
+        object_id=sid,
+        type_only=False,
+        pretty=True,
+    )
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["type"] == "snapshot"
+    assert data["snapshot_id"] == sid
+    assert data["manifest"] == manifest
+
+
+@pytest.mark.anyio
+async def test_cat_object_pretty_prints_commit_fields(
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """-p emits valid JSON with all commit fields."""
+    sid = _fake_hash("c")
+    cid = _fake_hash("d")
+    await _seed_snapshot(muse_cli_db_session, sid)
+    await _seed_commit(muse_cli_db_session, cid, sid)
+
+    await _cat_object_async(
+        session=muse_cli_db_session,
+        object_id=cid,
+        type_only=False,
+        pretty=True,
+    )
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["type"] == "commit"
+    assert data["commit_id"] == cid
+    assert data["branch"] == "main"
+    assert data["message"] == "initial take"
+    assert data["snapshot_id"] == sid
+
+
+@pytest.mark.anyio
+async def test_cat_object_pretty_prints_object_fields(
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """-p emits valid JSON with size and created_at for blob objects."""
+    oid = _fake_hash("a")
+    await _seed_object(muse_cli_db_session, oid, size=512)
+
+    await _cat_object_async(
+        session=muse_cli_db_session,
+        object_id=oid,
+        type_only=False,
+        pretty=True,
+    )
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["type"] == "object"
+    assert data["object_id"] == oid
+    assert data["size_bytes"] == 512
+
+
+# ---------------------------------------------------------------------------
+# _cat_object_async — not found error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cat_object_not_found_exits_user_error(
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Unknown object ID exits with USER_ERROR and a clear message."""
+    with pytest.raises(typer.Exit) as exc_info:
+        await _cat_object_async(
+            session=muse_cli_db_session,
+            object_id=_fake_hash("z"),
+            type_only=False,
+            pretty=False,
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+    out = capsys.readouterr().out
+    assert "Object not found" in out
+
+
+# ---------------------------------------------------------------------------
+# CatObjectResult.to_dict — serialisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cat_object_result_to_dict_object(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """CatObjectResult.to_dict() includes all expected keys for an object row."""
+    oid = _fake_hash("a")
+    obj = await _seed_object(muse_cli_db_session, oid, size=128)
+    result = CatObjectResult(object_type="object", row=obj)
+    d = result.to_dict()
+    assert set(d.keys()) == {"type", "object_id", "size_bytes", "created_at"}
+    assert d["type"] == "object"
+    assert d["size_bytes"] == 128
+
+
+@pytest.mark.anyio
+async def test_cat_object_result_to_dict_commit(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """CatObjectResult.to_dict() includes all expected keys for a commit row."""
+    sid = _fake_hash("c")
+    cid = _fake_hash("d")
+    await _seed_snapshot(muse_cli_db_session, sid)
+    commit = await _seed_commit(muse_cli_db_session, cid, sid)
+    result = CatObjectResult(object_type="commit", row=commit)
+    d = result.to_dict()
+    assert "commit_id" in d
+    assert "branch" in d
+    assert "message" in d
+    assert "snapshot_id" in d
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — mutually exclusive flags
+# ---------------------------------------------------------------------------
+
+
+def test_cat_object_type_and_pretty_mutually_exclusive(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Passing both -t and -p exits with USER_ERROR."""
+    import os
+    from typer.testing import CliRunner
+    from maestro.muse_cli.app import cli
+
+    _init_muse_repo(tmp_path)
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(
+            cli,
+            ["cat-object", "-t", "-p", _fake_hash("a")],
+            catch_exceptions=False,
+        )
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == ExitCode.USER_ERROR
+
+
+def test_cat_object_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse cat-object`` outside a .muse/ directory exits with code 2."""
+    import os
+    from typer.testing import CliRunner
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(
+            cli,
+            ["cat-object", _fake_hash("a")],
+            catch_exceptions=False,
+        )
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND


### PR DESCRIPTION
## Summary
Closes #88 — implements `muse cat-object <object-id>`, a plumbing command that reads and displays any stored Muse object (blob, snapshot, or commit) by its SHA-256 hash.

## Root Cause / Motivation
No way to inspect raw objects in the Muse content-addressed store. Without this command, AI agents and developers cannot verify what is stored under a given hash without querying the database directly.

## Solution

Implemented `maestro/muse_cli/commands/cat_object.py` following the `git cat-file` plumbing pattern:

- **Lookup order:** probes `MuseCliObject` → `MuseCliSnapshot` → `MuseCliCommit` in sequence, returns the first match.
- **Default output:** human-readable metadata block (type, id, size/file-count/message, created_at).
- **`-t / --type`:** prints only the type string (`object`, `snapshot`, or `commit`) — machine-parseable, mirrors `git cat-file -t`.
- **`-p / --pretty`:** prints the full object as indented JSON. For snapshots: the manifest dict. For commits: all fields. For blobs: size and timestamp.
- **`-t` and `-p` are mutually exclusive** — exits USER_ERROR if both supplied.
- **Not found** exits with code 1 and a clear `❌ Object not found: <id>` message.

New named result type `CatObjectResult` with `.to_dict()` registered in `docs/reference/type_contracts.md`.

## Layers Affected
- [x] Muse VCS (new CLI command)

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (481 source files)
- [x] `docker compose exec storpheus mypy .` — clean
- [x] 18 targeted tests pass
- [x] Docs updated (`docs/architecture/muse_vcs.md`, `docs/reference/type_contracts.md`)

## Tests Added
- `test_lookup_object_finds_object_row` — type resolution for blobs
- `test_lookup_object_finds_snapshot_row` — type resolution for snapshots
- `test_lookup_object_finds_commit_row` — type resolution for commits
- `test_lookup_object_returns_none_for_unknown_id` — not-found path
- `test_cat_object_default_prints_object_metadata` — default renderer for objects
- `test_cat_object_default_prints_snapshot_metadata` — default renderer for snapshots
- `test_cat_object_default_prints_commit_metadata` — default renderer for commits
- `test_cat_object_type_only_prints_object/snapshot/commit` — `-t` flag (×3)
- `test_cat_object_pretty_prints_snapshot_manifest` — `-p` JSON for snapshots
- `test_cat_object_pretty_prints_commit_fields` — `-p` JSON for commits
- `test_cat_object_pretty_prints_object_fields` — `-p` JSON for blobs
- `test_cat_object_not_found_exits_user_error` — exit code 1 + message
- `test_cat_object_result_to_dict_object/commit` — serialisation (×2)
- `test_cat_object_type_and_pretty_mutually_exclusive` — CLI guard
- `test_cat_object_outside_repo_exits_2` — repo-not-found guard

## Handoff
N/A — no protocol change (CLI-only, no SSE events, no MCP tool schemas affected).