### PR TITLE
feat: muse write-tree — write the current muse-work/ state as a snapshot (tree) object

### DIFF
--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -3,8 +3,8 @@
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (arrange, ask, checkout, commit, context, describe, divergence,
 dynamics, export, find, grep, import, init, log, merge, meter, open, play,
-pull, push, recall, remote, session, status, swing, tag, tempo) as Typer
-sub-applications.
+pull, push, recall, remote, session, status, swing, tag, tempo,
+write_tree) as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -38,6 +38,7 @@ from maestro.muse_cli.commands import (
     swing,
     tag,
     tempo,
+    write_tree,
 )
 
 cli = typer.Typer(
@@ -73,6 +74,7 @@ cli.add_typer(tempo.app, name="tempo", help="Read or set the tempo (BPM) of a co
 cli.add_typer(recall.app, name="recall", help="Search commit history by natural-language description.")
 cli.add_typer(context.app, name="context", help="Output structured musical context for AI agent consumption.")
 cli.add_typer(divergence.app, name="divergence", help="Show how two branches have diverged musically.")
+cli.add_typer(write_tree.app, name="write-tree", help="Write the current muse-work/ state as a snapshot (tree) object.")
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/commands/write_tree.py
+++ b/maestro/muse_cli/commands/write_tree.py
@@ -1,0 +1,191 @@
+"""muse write-tree — write the current muse-work/ state as a snapshot (tree) object.
+
+Plumbing command that mirrors ``git write-tree``. It scans ``muse-work/``,
+hashes all files, builds a deterministic snapshot manifest, persists both
+the individual object rows and the snapshot row to Postgres, and prints the
+``snapshot_id``.
+
+Why this exists
+---------------
+Porcelain commands like ``muse commit`` bundle snapshot creation with commit
+creation and branch-pointer updates.  Agents and tooling sometimes need the
+snapshot object alone — e.g. to compare the current working tree against a
+reference snapshot without recording history, or to pre-hash the tree before
+deciding whether to commit.  ``muse write-tree`` exposes that primitive.
+
+Key properties
+--------------
+- **Deterministic / idempotent**: same files → same ``snapshot_id``.  Running
+  the command twice without changing any files outputs the same ID and makes
+  exactly zero new DB writes (the upsert is a no-op).
+- **No commit**: the HEAD pointer and branch refs are never modified.
+- **Prefix filter**: ``--prefix PATH`` restricts the snapshot to files whose
+  relative path starts with *PATH*, enabling per-instrument or per-section
+  snapshots without committing unrelated work.
+- **Empty-tree handling**: by default the command exits 1 when ``muse-work/``
+  is absent or empty.  Pass ``--missing-ok`` to suppress the error and still
+  emit a valid (empty) ``snapshot_id``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session, upsert_object, upsert_snapshot
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.snapshot import (
+    build_snapshot_manifest,
+    compute_snapshot_id,
+    hash_file,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _write_tree_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    prefix: str | None = None,
+    missing_ok: bool = False,
+) -> str:
+    """Hash the working tree, persist snapshot objects, and return the ``snapshot_id``.
+
+    Args:
+        root: Repo root directory (must contain ``muse-work/``).
+        session: Open async DB session.  The caller is responsible for
+            committing.  ``open_session()`` commits on clean exit.
+        prefix: When set, restrict the snapshot to files whose repo-relative
+            path starts with *prefix*.  The prefix is matched against paths
+            of the form ``<prefix>/<rest>`` (no leading slash).
+        missing_ok: When ``True``, an absent or empty ``muse-work/`` is not
+            an error — the command writes an empty snapshot and exits 0.
+            When ``False`` (default), an absent or empty tree exits 1.
+
+    Returns:
+        The 64-character sha256 hex digest that uniquely identifies this
+        snapshot.  The same content always returns the same ID.
+
+    Raises:
+        typer.Exit: With ``USER_ERROR`` (1) when ``muse-work/`` is missing or
+            empty and *missing_ok* is ``False``.
+    """
+    workdir = root / "muse-work"
+
+    # ── Build manifest ───────────────────────────────────────────────────
+    if not workdir.exists():
+        if not missing_ok:
+            typer.echo(
+                "⚠️  No muse-work/ directory found. Generate some artifacts first.\n"
+                "     Tip: run the Maestro stress test to populate muse-work/.\n"
+                "     Or pass --missing-ok to allow an empty tree."
+            )
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+        manifest: dict[str, str] = {}
+    else:
+        manifest = build_snapshot_manifest(workdir)
+
+        # Apply prefix filter when requested.
+        if prefix is not None:
+            # Normalise: strip leading/trailing slashes so callers can pass
+            # either "drums" or "drums/" and get identical results.
+            norm_prefix = prefix.strip("/")
+            manifest = {
+                path: oid
+                for path, oid in manifest.items()
+                if path == norm_prefix or path.startswith(norm_prefix + "/")
+            }
+
+        if not manifest and not missing_ok:
+            if prefix is not None:
+                typer.echo(
+                    f"⚠️  No files found under prefix '{prefix}' in muse-work/.\n"
+                    "     Pass --missing-ok to allow an empty snapshot."
+                )
+            else:
+                typer.echo(
+                    "⚠️  muse-work/ is empty — no files to snapshot.\n"
+                    "     Pass --missing-ok to allow an empty snapshot."
+                )
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    snapshot_id = compute_snapshot_id(manifest)
+
+    # ── Persist object rows (content-addressed, deduped by upsert) ───────
+    for rel_path, object_id in manifest.items():
+        file_path = workdir / rel_path
+        size = file_path.stat().st_size
+        await upsert_object(session, object_id=object_id, size_bytes=size)
+
+    # ── Persist snapshot row ─────────────────────────────────────────────
+    await upsert_snapshot(session, manifest=manifest, snapshot_id=snapshot_id)
+
+    logger.info("✅ muse write-tree snapshot_id=%s files=%d", snapshot_id[:8], len(manifest))
+    return snapshot_id
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def write_tree(
+    ctx: typer.Context,
+    prefix: Optional[str] = typer.Option(
+        None,
+        "--prefix",
+        help=(
+            "Only include files whose path (relative to muse-work/) starts "
+            "with this prefix.  Example: --prefix drums/ snapshots only the "
+            "drums sub-directory."
+        ),
+    ),
+    missing_ok: bool = typer.Option(
+        False,
+        "--missing-ok",
+        help=(
+            "Do not fail when muse-work/ is absent or empty (or when --prefix "
+            "matches no files).  The empty snapshot_id is still printed."
+        ),
+    ),
+) -> None:
+    """Write the current muse-work/ state as a snapshot (tree) object.
+
+    Hashes all files in muse-work/, persists the object and snapshot rows,
+    and prints the snapshot_id.  Does NOT create a commit or modify any
+    branch ref.
+    """
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            snapshot_id = await _write_tree_async(
+                root=root,
+                session=session,
+                prefix=prefix,
+                missing_ok=missing_ok,
+            )
+            typer.echo(snapshot_id)
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse write-tree failed: {exc}")
+        logger.error("❌ muse write-tree error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/tests/muse_cli/test_write_tree.py
+++ b/tests/muse_cli/test_write_tree.py
@@ -1,0 +1,381 @@
+"""Tests for ``muse write-tree``.
+
+``_write_tree_async`` is exercised directly with an in-memory SQLite session
+(via the ``muse_cli_db_session`` fixture) so no real Postgres instance is
+needed.  The Typer CLI runner covers the command surface (repo detection,
+exit codes, flag handling).
+
+All async tests use ``@pytest.mark.anyio``.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+
+import pytest
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from maestro.muse_cli.commands.write_tree import _write_tree_async
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliObject, MuseCliSnapshot
+from maestro.muse_cli.snapshot import build_snapshot_manifest, compute_snapshot_id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    """Create a minimal .muse/ layout without any commits."""
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _populate_workdir(
+    root: pathlib.Path,
+    files: dict[str, bytes] | None = None,
+    subdir: str | None = None,
+) -> None:
+    """Create muse-work/ with the given files (defaults to two sample files)."""
+    workdir = root / "muse-work"
+    if subdir:
+        workdir = workdir / subdir
+    workdir.mkdir(parents=True, exist_ok=True)
+    if files is None:
+        files = {"beat.mid": b"MIDI-DATA", "lead.mp3": b"MP3-DATA"}
+    for name, content in files.items():
+        (workdir / name).write_bytes(content)
+
+
+# ---------------------------------------------------------------------------
+# Core behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_write_tree_returns_snapshot_id(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """_write_tree_async returns a 64-char hex snapshot_id."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path)
+
+    snapshot_id = await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+
+    assert len(snapshot_id) == 64
+    assert all(c in "0123456789abcdef" for c in snapshot_id)
+
+
+@pytest.mark.anyio
+async def test_write_tree_idempotent_same_content_same_id(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Calling write-tree twice on identical content yields the same snapshot_id."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"track.mid": b"CONSTANT"})
+
+    id1 = await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+    id2 = await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+
+    assert id1 == id2
+
+
+@pytest.mark.anyio
+async def test_write_tree_different_content_different_id(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Changing a file produces a different snapshot_id."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"track.mid": b"VERSION1"})
+
+    id1 = await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+
+    (tmp_path / "muse-work" / "track.mid").write_bytes(b"VERSION2")
+
+    id2 = await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+
+    assert id1 != id2
+
+
+@pytest.mark.anyio
+async def test_write_tree_snapshot_id_matches_snapshot_module(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """snapshot_id returned by _write_tree_async equals compute_snapshot_id(manifest)."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"a.mid": b"ALPHA", "b.mp3": b"BETA"})
+
+    snapshot_id = await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+
+    manifest = build_snapshot_manifest(tmp_path / "muse-work")
+    expected = compute_snapshot_id(manifest)
+
+    assert snapshot_id == expected
+
+
+# ---------------------------------------------------------------------------
+# DB persistence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_write_tree_persists_snapshot_row(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """A MuseCliSnapshot row is written to the DB."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"MIDI"})
+
+    snapshot_id = await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+    await muse_cli_db_session.flush()
+
+    snap = await muse_cli_db_session.get(MuseCliSnapshot, snapshot_id)
+    assert snap is not None
+    assert "beat.mid" in snap.manifest
+
+
+@pytest.mark.anyio
+async def test_write_tree_persists_object_rows(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """A MuseCliObject row is written for every unique file."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"drums.mid": b"DRUM-BYTES", "bass.mid": b"BASS-BYTES"})
+
+    await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+    await muse_cli_db_session.flush()
+
+    result = await muse_cli_db_session.execute(select(MuseCliObject))
+    objects = result.scalars().all()
+    assert len(objects) == 2
+
+
+@pytest.mark.anyio
+async def test_write_tree_objects_are_deduplicated(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Running write-tree twice does not create duplicate object rows."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"track.mid": b"SHARED-CONTENT"})
+
+    await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+    await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+    await muse_cli_db_session.flush()
+
+    result = await muse_cli_db_session.execute(select(MuseCliObject))
+    objects = result.scalars().all()
+    # Only one unique file → only one object row
+    assert len(objects) == 1
+
+
+@pytest.mark.anyio
+async def test_write_tree_does_not_create_commit(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """write-tree must NOT create a MuseCliCommit row."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path)
+
+    await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+    await muse_cli_db_session.flush()
+
+    result = await muse_cli_db_session.execute(select(MuseCliCommit))
+    commits = result.scalars().all()
+    assert len(commits) == 0, "write-tree must not create commit rows"
+
+
+@pytest.mark.anyio
+async def test_write_tree_does_not_modify_branch_ref(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """The branch HEAD ref file must be unchanged after write-tree."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path)
+
+    ref_path = tmp_path / ".muse" / "refs" / "heads" / "main"
+    before = ref_path.read_text()
+
+    await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+
+    after = ref_path.read_text()
+    assert before == after, "write-tree must not update the branch HEAD pointer"
+
+
+# ---------------------------------------------------------------------------
+# --prefix filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_write_tree_prefix_includes_matching_files_only(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--prefix restricts the snapshot to files under the given subdirectory."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, subdir="drums", files={"kick.mid": b"KICK"})
+    _populate_workdir(tmp_path, subdir="bass", files={"bassline.mid": b"BASS"})
+
+    snapshot_id = await _write_tree_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        prefix="drums",
+    )
+    await muse_cli_db_session.flush()
+
+    snap = await muse_cli_db_session.get(MuseCliSnapshot, snapshot_id)
+    assert snap is not None
+    assert any("kick.mid" in k for k in snap.manifest.keys())
+    assert not any("bassline.mid" in k for k in snap.manifest.keys())
+
+
+@pytest.mark.anyio
+async def test_write_tree_prefix_with_trailing_slash(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--prefix 'drums/' and --prefix 'drums' produce the same snapshot_id."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, subdir="drums", files={"hi_hat.mid": b"HH"})
+    _populate_workdir(tmp_path, subdir="bass", files={"bassline.mid": b"BASS"})
+
+    id_without_slash = await _write_tree_async(
+        root=tmp_path, session=muse_cli_db_session, prefix="drums"
+    )
+    id_with_slash = await _write_tree_async(
+        root=tmp_path, session=muse_cli_db_session, prefix="drums/"
+    )
+
+    assert id_without_slash == id_with_slash
+
+
+@pytest.mark.anyio
+async def test_write_tree_prefix_no_match_exits_1_by_default(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--prefix that matches no files exits USER_ERROR when --missing-ok is absent."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, subdir="drums", files={"kick.mid": b"KICK"})
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _write_tree_async(
+            root=tmp_path,
+            session=muse_cli_db_session,
+            prefix="nonexistent-subdir",
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_write_tree_prefix_no_match_missing_ok_succeeds(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--prefix that matches no files + --missing-ok returns an empty snapshot_id."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, subdir="drums", files={"kick.mid": b"KICK"})
+
+    snapshot_id = await _write_tree_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        prefix="nonexistent-subdir",
+        missing_ok=True,
+    )
+
+    # Empty manifest → deterministic empty snapshot_id
+    expected = compute_snapshot_id({})
+    assert snapshot_id == expected
+
+
+# ---------------------------------------------------------------------------
+# --missing-ok flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_write_tree_missing_workdir_exits_1_by_default(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Missing muse-work/ exits USER_ERROR (1) without --missing-ok."""
+    _init_muse_repo(tmp_path)
+    # Deliberately do NOT create muse-work/
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_write_tree_empty_workdir_exits_1_by_default(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Empty muse-work/ exits USER_ERROR (1) without --missing-ok."""
+    _init_muse_repo(tmp_path)
+    (tmp_path / "muse-work").mkdir()
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _write_tree_async(root=tmp_path, session=muse_cli_db_session)
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_write_tree_missing_workdir_missing_ok_returns_empty_snapshot(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """With --missing-ok, absent muse-work/ returns the empty snapshot_id."""
+    _init_muse_repo(tmp_path)
+    # No muse-work/ directory
+
+    snapshot_id = await _write_tree_async(
+        root=tmp_path, session=muse_cli_db_session, missing_ok=True
+    )
+
+    expected = compute_snapshot_id({})
+    assert snapshot_id == expected
+
+
+@pytest.mark.anyio
+async def test_write_tree_empty_workdir_missing_ok_returns_empty_snapshot(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """With --missing-ok, an empty muse-work/ returns the empty snapshot_id."""
+    _init_muse_repo(tmp_path)
+    (tmp_path / "muse-work").mkdir()
+
+    snapshot_id = await _write_tree_async(
+        root=tmp_path, session=muse_cli_db_session, missing_ok=True
+    )
+
+    expected = compute_snapshot_id({})
+    assert snapshot_id == expected
+
+
+# ---------------------------------------------------------------------------
+# CLI surface (repo detection, output format)
+# ---------------------------------------------------------------------------
+
+
+def test_write_tree_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """muse write-tree exits REPO_NOT_FOUND (2) when not inside a Muse repo."""
+    import os
+
+    from typer.testing import CliRunner
+
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    # Invoke without setting MUSE_REPO_ROOT so it falls back to cwd discovery.
+    env = {**os.environ, "MUSE_REPO_ROOT": str(tmp_path)}
+    result = runner.invoke(cli, ["write-tree"], env=env, catch_exceptions=False)
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND


### PR DESCRIPTION
## Summary
Closes #89 — Implements the `muse write-tree` plumbing command.

## Root Cause / Motivation
No write-tree plumbing command existed. Porcelain commands like `muse commit` bundle snapshot creation with commit creation and branch-pointer updates. Agents and tooling needed the snapshot primitive alone — to compare working tree state against a reference snapshot without recording history, or to pre-hash the tree before deciding whether to commit.

## Solution
Added `maestro/muse_cli/commands/write_tree.py` implementing `_write_tree_async` (testable async core) and the Typer `write_tree` command. Registered as `muse write-tree` in `app.py`.

Key design decisions:
- **Reuses existing DB helpers** (`upsert_object`, `upsert_snapshot`) — no new schema
- **Idempotent by construction** — same files always produce the same `snapshot_id`; second run makes zero new DB writes
- **No commit, no branch update** — writes only to `muse_cli_objects` and `muse_cli_snapshots`
- **Prefix filter** normalises trailing slashes so `--prefix drums` and `--prefix drums/` are identical
- **`--missing-ok`** allows empty-tree snapshots (valid use case for agents bootstrapping)

## Layers Affected
- [x] Muse VCS

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (482 files)
- [x] `docker compose exec storpheus mypy .` — clean
- [x] 18 targeted tests pass (`tests/muse_cli/test_write_tree.py`)
- [x] Docs updated (`docs/architecture/muse_vcs.md`)

## Tests Added
- `test_write_tree_returns_snapshot_id` — output is a 64-char sha256 hex string
- `test_write_tree_idempotent_same_content_same_id` — same files → same ID
- `test_write_tree_different_content_different_id` — changed file → different ID
- `test_write_tree_snapshot_id_matches_snapshot_module` — agrees with `compute_snapshot_id`
- `test_write_tree_persists_snapshot_row` — MuseCliSnapshot row in DB
- `test_write_tree_persists_object_rows` — MuseCliObject rows for each file
- `test_write_tree_objects_are_deduplicated` — no duplicate object rows on re-run
- `test_write_tree_does_not_create_commit` — no MuseCliCommit row written
- `test_write_tree_does_not_modify_branch_ref` — HEAD ref unchanged
- `test_write_tree_prefix_includes_matching_files_only` — prefix filter works
- `test_write_tree_prefix_with_trailing_slash` — slash normalisation
- `test_write_tree_prefix_no_match_exits_1_by_default` — error on no match
- `test_write_tree_prefix_no_match_missing_ok_succeeds` — --missing-ok allows no-match
- `test_write_tree_missing_workdir_exits_1_by_default` — missing dir → error
- `test_write_tree_empty_workdir_exits_1_by_default` — empty dir → error
- `test_write_tree_missing_workdir_missing_ok_returns_empty_snapshot` — --missing-ok allows missing dir
- `test_write_tree_empty_workdir_missing_ok_returns_empty_snapshot` — --missing-ok allows empty dir
- `test_write_tree_outside_repo_exits_2` — repo detection via CLI runner

## Handoff
N/A — no protocol change. CLI-only addition; no SSE events, no MCP tool schemas, no API endpoints affected.