### PR TITLE
feat: muse motif — identify, track, and compare recurring melodic motifs across commits

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -2533,6 +2533,164 @@ branch for chord voicings while preserving the guitar branch's groove patterns.
 
 ---
 
+## `muse motif` — Recurring Melodic Motif Analysis
+
+### `muse motif find`
+
+**Purpose:** Detect recurring melodic and rhythmic patterns in a single commit.
+An AI agent uses this before generating a new variation to identify the established
+motific language of the composition, ensuring new material is thematically coherent.
+
+**Usage:**
+```bash
+muse motif find [<commit>] [OPTIONS]
+```
+
+**Flags:**
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--min-length N` | int | 3 | Minimum motif length in notes |
+| `--track TEXT` | str | — | Restrict to a named MIDI track |
+| `--section TEXT` | str | — | Restrict to a named section/region |
+| `--json` | flag | off | Emit structured JSON for agent consumption |
+
+**Output example:**
+```
+Recurring motifs — commit a1b2c3d4  (HEAD -> main)
+── stub mode: full MIDI analysis pending ──
+
+#  Fingerprint            Contour             Count
+-  ----------------------  ------------------  -----
+1  [+2, +2, -1, +2]       ascending-step          3
+2  [-2, -2, +1, -2]       descending-step         2
+3  [+4, -2, +3]           arch                    2
+
+3 motif(s) found (min-length 3)
+```
+
+**Result type:** `MotifFindResult` — fields: `commit_id`, `branch`, `min_length`, `motifs` (list of `MotifGroup`), `total_found`, `source`.
+
+**Agent use case:** Call `muse motif find --json HEAD` before composing a new section.
+Parse `motifs[0].fingerprint` to retrieve the primary interval sequence, then instruct
+the generation model to build on that pattern rather than introducing unrelated material.
+
+**Implementation note:** Stub — returns realistic placeholder motifs. Full
+implementation requires MIDI note data queryable from the commit snapshot store.
+
+---
+
+### `muse motif track`
+
+**Purpose:** Search all commits in branch history for appearances of a specific motif.
+Detects not only exact transpositions but also melodic inversion, retrograde, and
+retrograde-inversion — the four canonical classical transformations.
+
+**Usage:**
+```bash
+muse motif track "<pattern>" [OPTIONS]
+```
+
+**Arguments:**
+| Argument | Description |
+|----------|-------------|
+| `pattern` | Space-separated note names (`"C D E G"`) or MIDI numbers (`"60 62 64 67"`) |
+
+**Flags:**
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | flag | off | Emit structured JSON |
+
+**Output example:**
+```
+Tracking motif: 'C D E G'
+Fingerprint: [+2, +2, +3]
+Commits scanned: 12
+
+Commit      Track         Transform       Position
+----------  ------------  --------------  --------
+a1b2c3d4    melody        exact                  0
+f4e3d2c1    melody        inversion              4
+b2c3d4e5    bass          retrograde             2
+
+3 occurrence(s) found.
+```
+
+**Result type:** `MotifTrackResult` — fields: `pattern`, `fingerprint`, `occurrences` (list of `MotifOccurrence`), `total_commits_scanned`, `source`.
+
+**Agent use case:** When the agent needs to understand how a theme has evolved,
+call `muse motif track "C D E G" --json` and inspect the `transformation` field
+on each occurrence to chart the motif's journey through the composition's history.
+
+---
+
+### `muse motif diff`
+
+**Purpose:** Show how the dominant motif transformed between two commits.
+Classifies the change as one of: exact (transposition), inversion, retrograde,
+retrograde-inversion, augmentation, diminution, or approximate.
+
+**Usage:**
+```bash
+muse motif diff <commit-a> <commit-b> [OPTIONS]
+```
+
+**Flags:**
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | flag | off | Emit structured JSON |
+
+**Output example:**
+```
+Motif diff: a1b2c3d4 → f4e3d2c1
+
+  A (a1b2c3d4): [+2, +2, -1, +2]  [ascending-step]
+  B (f4e3d2c1): [-2, -2, +1, -2]  [descending-step]
+
+Transformation: INVERSION
+The motif was inverted — ascending intervals became descending.
+```
+
+**Result type:** `MotifDiffResult` — fields: `commit_a` (`MotifDiffEntry`), `commit_b` (`MotifDiffEntry`), `transformation` (`MotifTransformation`), `description`, `source`.
+
+**Agent use case:** Use after detecting a structural change to understand whether
+the composer inverted or retrogressed the theme — crucial context for deciding
+how to develop material in the next variation.
+
+---
+
+### `muse motif list`
+
+**Purpose:** List all named motifs saved in `.muse/motifs/`. Named motifs are
+user-annotated melodic ideas that the composer has labelled for future recall.
+
+**Usage:**
+```bash
+muse motif list [OPTIONS]
+```
+
+**Flags:**
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | flag | off | Emit structured JSON |
+
+**Output example:**
+```
+Named motifs:
+
+Name                  Fingerprint             Created                   Description
+--------------------  ----------------------  ------------------------  ------------------------------
+main-theme            [+2, +2, -1, +2]        2026-01-15T10:30:00Z      The central ascending motif…
+bass-riff             [-2, -3, +2]            2026-01-20T14:15:00Z      Chromatic bass figure…
+```
+
+**Result type:** `MotifListResult` — fields: `motifs` (list of `SavedMotif`), `source`.
+
+**Agent use case:** Load the named motif library at session start. Cross-reference
+`fingerprint` values against `muse motif find` output to check whether detected
+patterns match known named motifs before introducing new thematic material.
+
+---
+
 ## Command Registration Summary
 
 | Command | File | Status | Issue |
@@ -2549,6 +2707,7 @@ branch for chord voicings while preserving the guitar branch's groove patterns.
 | `muse recall` | `commands/recall.py` | ✅ stub (PR #135) | #122 |
 | `muse session` | `commands/session.py` | ✅ implemented (PR #129) | #127 |
 | `muse swing` | `commands/swing.py` | ✅ stub (PR #131) | #121 |
+| `muse motif` | `commands/motif.py` | ✅ stub (PR —) | #101 |
 | `muse tag` | `commands/tag.py` | ✅ implemented (PR #133) | #123 |
 
 All stub commands have stable CLI contracts. Full musical analysis (MIDI content

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -25,6 +25,7 @@ This document is the single source of truth for every named entity (TypedDict, d
    - [ExpressivenessResult](#expressivenessresult)
    - [MuseTempoResult](#musetemporesult)
    - [MuseTempoHistoryEntry](#musetemopohistoryentry)
+   - [Muse Motif Types](#muse-motif-types-maestroservicesmuse_motifpy)
 5. [Variation Layer (`app/variation/`)](#variation-layer)
    - [Event Envelope payloads](#event-envelope-payloads)
    - [PhraseRecord](#phraserecord)
@@ -2429,6 +2430,128 @@ Swing comparison between HEAD and a reference commit.
 
 **Producer:** `_swing_compare_async()`
 **Consumer:** `_format_compare()`
+
+### Muse Motif Types (`maestro/services/muse_motif.py`)
+
+All motif types are frozen `dataclass` instances (not TypedDicts) so they carry
+semantic labels and are safe to store in tuples.
+
+#### `MotifOccurrence`
+
+A single occurrence of a motif within a commit or pattern search.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | Short (8-char) commit SHA where the motif was found |
+| `track` | `str` | Track name (e.g. `"melody"`, `"bass"`) |
+| `section` | `str \| None` | Named section the occurrence falls in, or `None` |
+| `start_position` | `int` | Index of the first note of the motif |
+| `transformation` | `MotifTransformation` | Relationship to the query motif |
+| `pitch_sequence` | `tuple[int, ...]` | Literal MIDI pitch values at this occurrence |
+| `interval_fingerprint` | `IntervalSequence` | Normalised interval sequence used for matching |
+
+#### `MotifGroup`
+
+A single recurring motif and all its occurrences in a scanned commit.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fingerprint` | `IntervalSequence` | Normalised interval sequence (the motif's identity) |
+| `count` | `int` | Number of times the motif appears |
+| `occurrences` | `tuple[MotifOccurrence, ...]` | All detected occurrences |
+| `label` | `str` | Contour label: `ascending-step`, `ascending-leap`, `descending-step`, `descending-leap`, `arch`, `valley`, `oscillating`, `static` |
+
+#### `MotifFindResult`
+
+Results from `muse motif find` — recurring patterns in a single commit.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | Short commit SHA analysed |
+| `branch` | `str` | Branch name |
+| `min_length` | `int` | Minimum motif length requested |
+| `motifs` | `tuple[MotifGroup, ...]` | Detected motif groups, sorted by count desc |
+| `total_found` | `int` | Total number of distinct recurring motifs |
+| `source` | `str` | `"stub"` or `"live"` |
+
+**Producer:** `find_motifs()`
+**Consumer:** `_format_find()` in `motif.py`
+
+#### `MotifTrackResult`
+
+Results from `muse motif track` — appearances of a pattern across history.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pattern` | `str` | The original query pattern string |
+| `fingerprint` | `IntervalSequence` | Derived transposition-invariant fingerprint |
+| `occurrences` | `tuple[MotifOccurrence, ...]` | All occurrences found across commits |
+| `total_commits_scanned` | `int` | Number of commits searched |
+| `source` | `str` | `"stub"` or `"live"` |
+
+**Producer:** `track_motif()`
+**Consumer:** `_format_track()` in `motif.py`
+
+#### `MotifDiffEntry`
+
+One side of a `muse motif diff` comparison.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | Short commit SHA |
+| `fingerprint` | `IntervalSequence` | Interval sequence at this commit |
+| `label` | `str` | Contour label |
+| `pitch_sequence` | `tuple[int, ...]` | Literal pitches (if available) |
+
+#### `MotifDiffResult`
+
+Results from `muse motif diff` — how a motif transformed between two commits.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_a` | `MotifDiffEntry` | Analysis of the motif at the first commit |
+| `commit_b` | `MotifDiffEntry` | Analysis of the motif at the second commit |
+| `transformation` | `MotifTransformation` | Detected transformation relationship |
+| `description` | `str` | Human-readable description |
+| `source` | `str` | `"stub"` or `"live"` |
+
+**Producer:** `diff_motifs()`
+**Consumer:** `_format_diff()` in `motif.py`
+
+#### `SavedMotif`
+
+A named motif stored in `.muse/motifs/`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `str` | User-assigned motif name (e.g. `"main-theme"`) |
+| `fingerprint` | `IntervalSequence` | Stored interval fingerprint |
+| `created_at` | `str` | ISO-8601 UTC timestamp |
+| `description` | `str \| None` | Optional free-text annotation |
+
+#### `MotifListResult`
+
+Results from `muse motif list` — all named motifs in the repository.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `motifs` | `tuple[SavedMotif, ...]` | All saved named motifs |
+| `source` | `str` | `"stub"` or `"live"` |
+
+**Producer:** `list_motifs()`
+**Consumer:** `_format_list()` in `motif.py`
+
+#### `MotifTransformation` (Enum)
+
+| Value | Meaning |
+|-------|---------|
+| `EXACT` | Identical interval sequence (possibly transposed) |
+| `INVERSION` | Each interval negated (melodic mirror) |
+| `RETROGRADE` | Interval sequence reversed |
+| `RETRO_INV` | Retrograde + inversion combined |
+| `AUGMENTED` | Same intervals; note durations scaled up |
+| `DIMINISHED` | Same intervals; note durations compressed |
+| `APPROXIMATE` | Similar contour but no exact variant match |
 
 ### `AnswerResult`
 

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -2,9 +2,9 @@
 
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (arrange, ask, checkout, commit, context, describe, divergence,
-dynamics, export, find, grep, import, init, log, merge, meter, open, play,
-pull, push, recall, remote, session, status, swing, tag, tempo) as Typer
-sub-applications.
+dynamics, export, find, grep, import, init, log, merge, meter, motif, open,
+play, pull, push, recall, remote, session, status, swing, tag, tempo) as
+Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -27,6 +27,7 @@ from maestro.muse_cli.commands import (
     log,
     merge,
     meter,
+    motif,
     open_cmd,
     play,
     pull,
@@ -73,6 +74,7 @@ cli.add_typer(tempo.app, name="tempo", help="Read or set the tempo (BPM) of a co
 cli.add_typer(recall.app, name="recall", help="Search commit history by natural-language description.")
 cli.add_typer(context.app, name="context", help="Output structured musical context for AI agent consumption.")
 cli.add_typer(divergence.app, name="divergence", help="Show how two branches have diverged musically.")
+cli.add_typer(motif.app, name="motif", help="Identify, track, and compare recurring melodic motifs.")
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/commands/motif.py
+++ b/maestro/muse_cli/commands/motif.py
@@ -1,0 +1,453 @@
+"""muse motif — identify, track, and compare recurring melodic motifs.
+
+A motif is a short melodic or rhythmic idea that reappears and transforms
+throughout a composition.  This command group surfaces motif-level analysis
+over the Muse VCS commit history.
+
+Subcommands
+-----------
+
+``muse motif find [<commit>]``
+    Detect recurring melodic/rhythmic patterns in a commit (default: HEAD).
+
+``muse motif track <pattern>``
+    Search all commits for appearances of a specific motif.  The pattern
+    is expressed as space-separated note names (``"C D E G"``) or MIDI
+    numbers (``"60 62 64 67"``).  Transpositions and standard transformations
+    (inversion, retrograde, retrograde-inversion) are detected automatically.
+
+``muse motif diff <commit-a> <commit-b>``
+    Show how the dominant motif transformed between two commits.
+
+``muse motif list``
+    List all named motifs stored in ``.muse/motifs/``.
+
+Flags on ``find``
+-----------------
+--min-length N     Minimum motif length in notes (default: 3).
+--section TEXT     Scope to a named section/region.
+--track TEXT       Scope to a named MIDI track.
+--json             Machine-readable JSON output.
+
+All subcommands support ``--json`` for agent consumption.
+
+Output example (find, default)::
+
+    Recurring motifs — commit a1b2c3d4  (HEAD -> main)
+    ── stub mode: full MIDI analysis pending ──
+
+    #  Fingerprint          Contour           Count
+    -  -------------------  ----------------  -----
+    1  [+2, +2, -1, +2]     ascending-step    3
+    2  [-2, -2, +1, -2]     descending-step   2
+    3  [+4, -2, +3]         arch              2
+
+    3 motifs found (min-length 3)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+from typing_extensions import Annotated
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.services.muse_motif import (
+    MotifDiffResult,
+    MotifFindResult,
+    MotifListResult,
+    MotifOccurrence,
+    MotifTrackResult,
+    diff_motifs,
+    find_motifs,
+    list_motifs,
+    track_motif,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(no_args_is_help=True)
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+
+def _format_find(result: MotifFindResult, *, as_json: bool) -> str:
+    """Render a find result as a human-readable table or JSON."""
+    if as_json:
+        payload = {
+            "commit": result.commit_id,
+            "branch": result.branch,
+            "min_length": result.min_length,
+            "total_found": result.total_found,
+            "source": result.source,
+            "motifs": [
+                {
+                    "fingerprint": list(g.fingerprint),
+                    "label": g.label,
+                    "count": g.count,
+                    "occurrences": [
+                        {
+                            "commit": o.commit_id,
+                            "track": o.track,
+                            "section": o.section,
+                            "start_position": o.start_position,
+                            "transformation": o.transformation.value,
+                            "pitches": list(o.pitch_sequence),
+                        }
+                        for o in g.occurrences
+                    ],
+                }
+                for g in result.motifs
+            ],
+        }
+        return json.dumps(payload, indent=2)
+
+    lines: list[str] = [
+        f"Recurring motifs — commit {result.commit_id}  (HEAD -> {result.branch})",
+    ]
+    if result.source == "stub":
+        lines.append("── stub mode: full MIDI analysis pending ──")
+    lines.append("")
+    lines.append(f"{'#':<3}  {'Fingerprint':<22}  {'Contour':<18}  {'Count':>5}")
+    lines.append(f"{'-':<3}  {'-'*22}  {'-'*18}  {'-'*5}")
+    for idx, group in enumerate(result.motifs, start=1):
+        fp_str = "[" + ", ".join(f"{'+' if i >= 0 else ''}{i}" for i in group.fingerprint) + "]"
+        lines.append(
+            f"{idx:<3}  {fp_str:<22}  {group.label:<18}  {group.count:>5}"
+        )
+    lines.append("")
+    lines.append(f"{result.total_found} motif(s) found (min-length {result.min_length})")
+    return "\n".join(lines)
+
+
+def _format_track(result: MotifTrackResult, *, as_json: bool) -> str:
+    """Render a track result as a human-readable table or JSON."""
+    if as_json:
+        payload = {
+            "pattern": result.pattern,
+            "fingerprint": list(result.fingerprint),
+            "total_commits_scanned": result.total_commits_scanned,
+            "source": result.source,
+            "occurrences": [
+                {
+                    "commit": o.commit_id,
+                    "track": o.track,
+                    "section": o.section,
+                    "start_position": o.start_position,
+                    "transformation": o.transformation.value,
+                    "pitches": list(o.pitch_sequence),
+                }
+                for o in result.occurrences
+            ],
+        }
+        return json.dumps(payload, indent=2)
+
+    fp_str = "[" + ", ".join(f"{'+' if i >= 0 else ''}{i}" for i in result.fingerprint) + "]"
+    lines: list[str] = [
+        f"Tracking motif: {result.pattern!r}",
+        f"Fingerprint: {fp_str}",
+        f"Commits scanned: {result.total_commits_scanned}",
+        "",
+    ]
+    if result.source == "stub":
+        lines.append("── stub mode: full history scan pending ──")
+        lines.append("")
+    if not result.occurrences:
+        lines.append("No occurrences found.")
+        return "\n".join(lines)
+
+    lines.append(f"{'Commit':<10}  {'Track':<12}  {'Transform':<14}  {'Position':>8}")
+    lines.append(f"{'-'*10}  {'-'*12}  {'-'*14}  {'-'*8}")
+    for occ in result.occurrences:
+        lines.append(
+            f"{occ.commit_id:<10}  {occ.track:<12}  "
+            f"{occ.transformation.value:<14}  {occ.start_position:>8}"
+        )
+    lines.append("")
+    lines.append(f"{len(result.occurrences)} occurrence(s) found.")
+    return "\n".join(lines)
+
+
+def _format_diff(result: MotifDiffResult, *, as_json: bool) -> str:
+    """Render a diff result as human-readable text or JSON."""
+    if as_json:
+        payload = {
+            "transformation": result.transformation.value,
+            "description": result.description,
+            "source": result.source,
+            "commit_a": {
+                "commit": result.commit_a.commit_id,
+                "fingerprint": list(result.commit_a.fingerprint),
+                "label": result.commit_a.label,
+                "pitches": list(result.commit_a.pitch_sequence),
+            },
+            "commit_b": {
+                "commit": result.commit_b.commit_id,
+                "fingerprint": list(result.commit_b.fingerprint),
+                "label": result.commit_b.label,
+                "pitches": list(result.commit_b.pitch_sequence),
+            },
+        }
+        return json.dumps(payload, indent=2)
+
+    def _fp(intervals: tuple[int, ...]) -> str:
+        return "[" + ", ".join(f"{'+' if i >= 0 else ''}{i}" for i in intervals) + "]"
+
+    lines: list[str] = [
+        f"Motif diff: {result.commit_a.commit_id} → {result.commit_b.commit_id}",
+        "",
+        f"  A ({result.commit_a.commit_id}): {_fp(result.commit_a.fingerprint)}  [{result.commit_a.label}]",
+        f"  B ({result.commit_b.commit_id}): {_fp(result.commit_b.fingerprint)}  [{result.commit_b.label}]",
+        "",
+        f"Transformation: {result.transformation.value.upper()}",
+        f"{result.description}",
+    ]
+    if result.source == "stub":
+        lines.append("")
+        lines.append("── stub mode: full MIDI analysis pending ──")
+    return "\n".join(lines)
+
+
+def _format_list(result: MotifListResult, *, as_json: bool) -> str:
+    """Render a list result as a human-readable table or JSON."""
+    if as_json:
+        payload = {
+            "source": result.source,
+            "motifs": [
+                {
+                    "name": m.name,
+                    "fingerprint": list(m.fingerprint),
+                    "created_at": m.created_at,
+                    "description": m.description,
+                }
+                for m in result.motifs
+            ],
+        }
+        return json.dumps(payload, indent=2)
+
+    if not result.motifs:
+        return "No named motifs saved. Use `muse motif find` to discover them."
+
+    lines: list[str] = ["Named motifs:", ""]
+    lines.append(f"{'Name':<20}  {'Fingerprint':<22}  {'Created':<24}  Description")
+    lines.append(f"{'-'*20}  {'-'*22}  {'-'*24}  {'-'*30}")
+    for m in result.motifs:
+        fp_str = "[" + ", ".join(f"{'+' if i >= 0 else ''}{i}" for i in m.fingerprint) + "]"
+        desc = (m.description or "")[:30]
+        lines.append(f"{m.name:<20}  {fp_str:<22}  {m.created_at:<24}  {desc}")
+    return "\n".join(lines)
+
+
+def _resolve_head(root: pathlib.Path) -> tuple[str, str]:
+    """Return (short_commit_id, branch) for the current HEAD.
+
+    Args:
+        root: Repository root (directory containing ``.muse/``).
+
+    Returns:
+        A ``(commit_id, branch)`` pair.  ``commit_id`` is at most 8 chars;
+        ``branch`` is the branch name extracted from the HEAD ref.
+    """
+    muse_dir = root / ".muse"
+    head_ref = (muse_dir / "HEAD").read_text().strip()
+    branch = head_ref.rsplit("/", 1)[-1] if "/" in head_ref else head_ref
+    ref_path = muse_dir / pathlib.Path(head_ref)
+    head_sha = ref_path.read_text().strip() if ref_path.exists() else "0000000"
+    return head_sha[:8], branch
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: find
+# ---------------------------------------------------------------------------
+
+
+@app.command(name="find")
+def motif_find(
+    commit: Annotated[
+        Optional[str],
+        typer.Argument(
+            help="Commit SHA to analyse. Defaults to HEAD.",
+            show_default=False,
+        ),
+    ] = None,
+    min_length: Annotated[
+        int,
+        typer.Option(
+            "--min-length",
+            help="Minimum motif length in notes (default: 3).",
+            min=2,
+        ),
+    ] = 3,
+    track: Annotated[
+        Optional[str],
+        typer.Option(
+            "--track",
+            help="Restrict analysis to a named MIDI track.",
+            show_default=False,
+        ),
+    ] = None,
+    section: Annotated[
+        Optional[str],
+        typer.Option(
+            "--section",
+            help="Restrict analysis to a named section/region.",
+            show_default=False,
+        ),
+    ] = None,
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable JSON output."),
+    ] = False,
+) -> None:
+    """Detect recurring melodic/rhythmic patterns in a commit (default: HEAD)."""
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:  # noqa: F841 — reserved for DB queries
+            commit_id, branch = _resolve_head(root)
+            resolved = commit or commit_id
+            result = await find_motifs(
+                commit_id=resolved,
+                branch=branch,
+                min_length=min_length,
+                track=track,
+                section=section,
+                as_json=as_json,
+            )
+            typer.echo(_format_find(result, as_json=as_json))
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse motif find failed: {exc}")
+        logger.error("❌ muse motif find error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: track
+# ---------------------------------------------------------------------------
+
+
+@app.command(name="track")
+def motif_track(
+    pattern: Annotated[
+        str,
+        typer.Argument(
+            help=(
+                "Motif to track — space-separated note names (e.g. 'C D E G') "
+                "or MIDI numbers (e.g. '60 62 64 67')."
+            ),
+        ),
+    ],
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable JSON output."),
+    ] = False,
+) -> None:
+    """Search all commits for appearances of a specific motif.
+
+    Detects the motif and its common transformations: transposition,
+    inversion, retrograde, and retrograde-inversion.
+    """
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:  # noqa: F841 — reserved for DB queries
+            muse_dir = root / ".muse"
+            commit_ids: list[str] = []
+            head_ref = (muse_dir / "HEAD").read_text().strip()
+            ref_path = muse_dir / pathlib.Path(head_ref)
+            if ref_path.exists():
+                commit_ids = [ref_path.read_text().strip()]
+
+            result = await track_motif(pattern=pattern, commit_ids=commit_ids)
+            typer.echo(_format_track(result, as_json=as_json))
+
+    try:
+        asyncio.run(_run())
+    except ValueError as exc:
+        typer.echo(f"❌ {exc}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse motif track failed: {exc}")
+        logger.error("❌ muse motif track error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: diff
+# ---------------------------------------------------------------------------
+
+
+@app.command(name="diff")
+def motif_diff(
+    commit_a: Annotated[
+        str,
+        typer.Argument(help="First (earlier) commit SHA.", metavar="COMMIT-A"),
+    ],
+    commit_b: Annotated[
+        str,
+        typer.Argument(help="Second (later) commit SHA.", metavar="COMMIT-B"),
+    ],
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable JSON output."),
+    ] = False,
+) -> None:
+    """Show how the dominant motif transformed between two commits."""
+    require_repo()
+
+    async def _run() -> None:
+        result = await diff_motifs(commit_a_id=commit_a, commit_b_id=commit_b)
+        typer.echo(_format_diff(result, as_json=as_json))
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse motif diff failed: {exc}")
+        logger.error("❌ muse motif diff error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: list
+# ---------------------------------------------------------------------------
+
+
+@app.command(name="list")
+def motif_list(
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable JSON output."),
+    ] = False,
+) -> None:
+    """List all named motifs stored in ``.muse/motifs/``."""
+    root = require_repo()
+
+    async def _run() -> None:
+        result = await list_motifs(muse_dir_path=str(root / ".muse"))
+        typer.echo(_format_list(result, as_json=as_json))
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse motif list failed: {exc}")
+        logger.error("❌ muse motif list error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/services/muse_motif.py
+++ b/maestro/services/muse_motif.py
@@ -1,0 +1,655 @@
+"""Muse Motif Engine — identify, track, and compare recurring melodic motifs.
+
+A *motif* is a short melodic or rhythmic idea — a sequence of pitches and/or
+durations — that reappears and transforms throughout a composition. This
+module implements the core analysis engine used by ``muse motif find``,
+``muse motif track``, and ``muse motif diff``.
+
+Design
+------
+- Melodic identity is encoded as **interval sequences** (signed semitone
+  differences between consecutive pitches) so that transpositions of the same
+  motif hash to the same fingerprint.
+- Rhythmic identity is encoded as **relative duration ratios** normalised
+  against the shortest note in the sequence so that augmented / diminished
+  versions are detectable.
+- A motif fingerprint is the concatenation of its interval sequence, allowing
+  fast set-based matching across commits.
+- Transformation detection (inversion, retrograde, augmentation, diminution)
+  compares the found fingerprint against the query fingerprint's variants.
+
+Boundary rules
+--------------
+- Must NOT import StateStore, executor, MCP tools, or route handlers.
+- May import ``muse_cli.{db, models}``.
+- Pure helpers (fingerprint computation, transformation detection) are
+  synchronous and fully testable without a DB.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Primitive types
+# ---------------------------------------------------------------------------
+
+#: A melodic motif expressed as a sequence of semitone intervals.
+#: e.g. [2, 2, -1, 2] for a 4-note motif with those ascending/descending steps.
+IntervalSequence = tuple[int, ...]
+
+#: A rhythmic motif expressed as relative duration ratios (float).
+#: e.g. (1.0, 2.0, 1.0) means short–long–short relative durations.
+RhythmSequence = tuple[float, ...]
+
+
+# ---------------------------------------------------------------------------
+# Transformation vocabulary
+# ---------------------------------------------------------------------------
+
+
+class MotifTransformation(str, Enum):
+    """Detected relationship between a found motif and the query motif.
+
+    - ``EXACT``       — identical interval sequence (possibly transposed).
+    - ``INVERSION``   — each interval negated (melodic mirror).
+    - ``RETROGRADE``  — interval sequence reversed.
+    - ``RETRO_INV``   — retrograde + inversion combined.
+    - ``AUGMENTED``   — same intervals; note durations scaled up.
+    - ``DIMINISHED``  — same intervals; note durations scaled down.
+    - ``APPROXIMATE`` — similar contour but not an exact variant.
+    """
+
+    EXACT = "exact"
+    INVERSION = "inversion"
+    RETROGRADE = "retrograde"
+    RETRO_INV = "retro_inv"
+    AUGMENTED = "augmented"
+    DIMINISHED = "diminished"
+    APPROXIMATE = "approximate"
+
+
+# ---------------------------------------------------------------------------
+# Named result types (public API contract)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MotifOccurrence:
+    """A single occurrence of a motif within a commit or pattern search.
+
+    Attributes:
+        commit_id:       Short commit SHA where the motif was found.
+        track:           Track name (e.g. ``"melody"``, ``"bass"``).
+        section:         Named section the occurrence falls in (optional).
+        start_position:  Position index of the first note of the motif.
+        transformation:  Relationship to the query motif.
+        pitch_sequence:  Literal pitch values at this occurrence (MIDI note numbers).
+        interval_fingerprint: Normalised interval sequence used for matching.
+    """
+
+    commit_id: str
+    track: str
+    section: Optional[str]
+    start_position: int
+    transformation: MotifTransformation
+    pitch_sequence: tuple[int, ...]
+    interval_fingerprint: IntervalSequence
+
+
+@dataclass(frozen=True)
+class MotifFindResult:
+    """Results from ``muse motif find`` — recurring patterns in a single commit.
+
+    Attributes:
+        commit_id:    Short commit SHA analysed.
+        branch:       Branch name.
+        min_length:   Minimum motif length requested.
+        motifs:       Detected recurring motif groups, sorted by occurrence count desc.
+        total_found:  Total number of distinct recurring motifs identified.
+        source:       ``"stub"`` until full MIDI analysis is wired; ``"live"`` thereafter.
+    """
+
+    commit_id: str
+    branch: str
+    min_length: int
+    motifs: tuple[MotifGroup, ...]
+    total_found: int
+    source: str
+
+
+@dataclass(frozen=True)
+class MotifGroup:
+    """A single recurring motif and all its occurrences in the scanned commit.
+
+    Attributes:
+        fingerprint:   Normalised interval sequence (the motif's identity).
+        count:         Number of times the motif appears.
+        occurrences:   All detected occurrences.
+        label:         Human-readable contour label (e.g. ``"ascending-step"``,
+                       ``"arch"``, ``"descending-leap"``).
+    """
+
+    fingerprint: IntervalSequence
+    count: int
+    occurrences: tuple[MotifOccurrence, ...]
+    label: str
+
+
+@dataclass(frozen=True)
+class MotifTrackResult:
+    """Results from ``muse motif track`` — appearances of a pattern across history.
+
+    Attributes:
+        pattern:      The query pattern (as a space-separated pitch string or
+                      interval fingerprint).
+        fingerprint:  Normalised interval sequence derived from the pattern.
+        occurrences:  All commits where the motif (or a transformation) was found.
+        total_commits_scanned: How many commits were searched.
+        source:       ``"stub"`` or ``"live"``.
+    """
+
+    pattern: str
+    fingerprint: IntervalSequence
+    occurrences: tuple[MotifOccurrence, ...]
+    total_commits_scanned: int
+    source: str
+
+
+@dataclass(frozen=True)
+class MotifDiffEntry:
+    """One side of a motif diff comparison.
+
+    Attributes:
+        commit_id:    Short commit SHA.
+        fingerprint:  Interval sequence at this commit.
+        label:        Contour label.
+        pitch_sequence: Literal pitches (if available).
+    """
+
+    commit_id: str
+    fingerprint: IntervalSequence
+    label: str
+    pitch_sequence: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class MotifDiffResult:
+    """Results from ``muse motif diff`` — how a motif transformed between commits.
+
+    Attributes:
+        commit_a:       Analysis of the motif at the first commit.
+        commit_b:       Analysis of the motif at the second commit.
+        transformation: How the motif changed from commit A to commit B.
+        description:    Human-readable description of the transformation.
+        source:         ``"stub"`` or ``"live"``.
+    """
+
+    commit_a: MotifDiffEntry
+    commit_b: MotifDiffEntry
+    transformation: MotifTransformation
+    description: str
+    source: str
+
+
+@dataclass(frozen=True)
+class SavedMotif:
+    """A named motif stored in ``.muse/motifs/``.
+
+    Attributes:
+        name:        User-assigned motif name (e.g. ``"main-theme"``).
+        fingerprint: Stored interval fingerprint.
+        created_at:  ISO-8601 timestamp when the motif was named.
+        description: Optional free-text annotation.
+    """
+
+    name: str
+    fingerprint: IntervalSequence
+    created_at: str
+    description: Optional[str]
+
+
+@dataclass(frozen=True)
+class MotifListResult:
+    """Results from ``muse motif list`` — all named motifs in the repository.
+
+    Attributes:
+        motifs: All saved named motifs.
+        source: ``"stub"`` or ``"live"``.
+    """
+
+    motifs: tuple[SavedMotif, ...]
+    source: str
+
+
+# ---------------------------------------------------------------------------
+# Pure fingerprint helpers
+# ---------------------------------------------------------------------------
+
+
+def pitches_to_intervals(pitches: tuple[int, ...]) -> IntervalSequence:
+    """Convert a sequence of MIDI pitch numbers to a signed semitone interval sequence.
+
+    The interval representation is transposition-invariant — the same motif
+    at different pitch levels produces identical fingerprints.
+
+    Args:
+        pitches: Sequence of MIDI note numbers (0–127), length ≥ 2.
+
+    Returns:
+        Tuple of signed semitone differences, length = ``len(pitches) - 1``.
+        Returns an empty tuple for inputs shorter than 2 notes.
+    """
+    if len(pitches) < 2:
+        return ()
+    return tuple(pitches[i + 1] - pitches[i] for i in range(len(pitches) - 1))
+
+
+def invert_intervals(intervals: IntervalSequence) -> IntervalSequence:
+    """Return the melodic inversion of an interval sequence (negate each step).
+
+    Inversion mirrors the motif around its starting pitch so that what went
+    up now goes down by the same interval.
+
+    Args:
+        intervals: Normalised interval sequence from :func:`pitches_to_intervals`.
+
+    Returns:
+        Interval sequence with each element negated.
+    """
+    return tuple(-i for i in intervals)
+
+
+def retrograde_intervals(intervals: IntervalSequence) -> IntervalSequence:
+    """Return the retrograde (reverse) of an interval sequence.
+
+    Note: reversing the intervals gives the same pitches played backward,
+    which is not the same as reversing the pitch list directly.
+
+    Args:
+        intervals: Normalised interval sequence.
+
+    Returns:
+        Reversed interval sequence, with each element negated (retrograde
+        of pitches is the negation of reversed intervals).
+    """
+    return tuple(-i for i in reversed(intervals))
+
+
+def detect_transformation(
+    query: IntervalSequence,
+    candidate: IntervalSequence,
+) -> Optional[MotifTransformation]:
+    """Determine the transformation relationship between a query and candidate motif.
+
+    Checks for exact match (transposition), inversion, retrograde, and the
+    combined retrograde-inversion.
+
+    Args:
+        query:     The reference interval sequence.
+        candidate: The interval sequence to test.
+
+    Returns:
+        The :class:`MotifTransformation` if a relationship is detected, or
+        ``None`` if no recognised transformation applies.
+    """
+    if candidate == query:
+        return MotifTransformation.EXACT
+    if candidate == invert_intervals(query):
+        return MotifTransformation.INVERSION
+    if candidate == retrograde_intervals(query):
+        return MotifTransformation.RETROGRADE
+    if candidate == invert_intervals(retrograde_intervals(query)):
+        return MotifTransformation.RETRO_INV
+    return None
+
+
+def contour_label(intervals: IntervalSequence) -> str:
+    """Assign a human-readable contour label to an interval sequence.
+
+    Labels encode the overall melodic direction and whether movement is
+    predominantly stepwise (≤2 semitones) or leap-based (>2 semitones).
+
+    Args:
+        intervals: Normalised interval sequence. Empty sequences return ``"static"``.
+
+    Returns:
+        One of: ``"ascending-step"``, ``"ascending-leap"``,
+        ``"descending-step"``, ``"descending-leap"``, ``"arch"``,
+        ``"valley"``, ``"oscillating"``, or ``"static"``.
+    """
+    if not intervals:
+        return "static"
+    net = sum(intervals)
+    max_step = max(abs(i) for i in intervals)
+    direction_changes = sum(
+        1
+        for j in range(len(intervals) - 1)
+        if (intervals[j] > 0) != (intervals[j + 1] > 0)
+    )
+    if direction_changes >= len(intervals) // 2:
+        return "oscillating"
+    ups = sum(1 for i in intervals if i > 0)
+    downs = sum(1 for i in intervals if i < 0)
+    if ups > 0 and downs > 0:
+        if ups > downs:
+            return "arch"
+        if downs > ups:
+            return "valley"
+        # Equal ups and downs: arch if motion starts upward, valley if downward.
+        return "arch" if intervals[0] > 0 else "valley"
+    stepwise = max_step <= 2
+    if net > 0:
+        return "ascending-step" if stepwise else "ascending-leap"
+    if net < 0:
+        return "descending-step" if stepwise else "descending-leap"
+    return "static"
+
+
+def parse_pitch_string(pattern: str) -> tuple[int, ...]:
+    """Parse a space-separated pitch-name or MIDI-number string into pitch values.
+
+    Supports:
+    - MIDI integers:  ``"60 62 64 67"``
+    - Note names:     ``"C D E G"`` (middle octave assumed, sharps as ``C#``/``Cs``)
+
+    Args:
+        pattern: Space-separated pitch tokens.
+
+    Returns:
+        Tuple of MIDI note numbers (0–127).
+
+    Raises:
+        ValueError: If any token cannot be parsed as a MIDI number or note name.
+    """
+    _NOTE_MAP: dict[str, int] = {
+        "C": 60, "C#": 61, "CS": 61, "DB": 61,
+        "D": 62, "D#": 63, "DS": 63, "EB": 63,
+        "E": 64, "F": 65, "F#": 66, "FS": 66, "GB": 66,
+        "G": 67, "G#": 68, "GS": 68, "AB": 68,
+        "A": 69, "A#": 70, "AS": 70, "BB": 70,
+        "B": 71,
+    }
+    result: list[int] = []
+    for token in pattern.strip().split():
+        upper = token.upper().replace("-", "")
+        if upper in _NOTE_MAP:
+            result.append(_NOTE_MAP[upper])
+        else:
+            try:
+                midi = int(token)
+                if not 0 <= midi <= 127:
+                    raise ValueError(f"MIDI pitch {midi} out of range [0, 127]")
+                result.append(midi)
+            except ValueError as exc:
+                raise ValueError(f"Cannot parse pitch token {token!r}") from exc
+    return tuple(result)
+
+
+# ---------------------------------------------------------------------------
+# Stub data helpers
+# ---------------------------------------------------------------------------
+
+_STUB_MOTIFS: list[tuple[IntervalSequence, str, int]] = [
+    ((2, 2, -1, 2), "ascending-step", 3),
+    ((-2, -2, 1, -2), "descending-step", 2),
+    ((4, -2, 3), "arch", 2),
+]
+
+
+def _stub_motif_groups(
+    commit_id: str,
+    track: Optional[str],
+    min_length: int,
+) -> tuple[MotifGroup, ...]:
+    """Return placeholder MotifGroup entries for stub mode.
+
+    Args:
+        commit_id:  Short commit SHA to embed in occurrences.
+        track:      Track filter (if provided, used as the occurrence track name).
+        min_length: Minimum motif length filter (intervals of length ≥ min_length - 1).
+
+    Returns:
+        Tuple of :class:`MotifGroup` objects filtered to min_length.
+    """
+    groups: list[MotifGroup] = []
+    for fp, label, count in _STUB_MOTIFS:
+        if len(fp) + 1 < min_length:
+            continue
+        track_name = track or "melody"
+        pitches = _intervals_to_pitches(fp, start=60)
+        occurrence = MotifOccurrence(
+            commit_id=commit_id,
+            track=track_name,
+            section=None,
+            start_position=0,
+            transformation=MotifTransformation.EXACT,
+            pitch_sequence=pitches,
+            interval_fingerprint=fp,
+        )
+        groups.append(
+            MotifGroup(
+                fingerprint=fp,
+                count=count,
+                occurrences=(occurrence,) * count,
+                label=label,
+            )
+        )
+    return tuple(sorted(groups, key=lambda g: g.count, reverse=True))
+
+
+def _intervals_to_pitches(
+    intervals: IntervalSequence,
+    start: int = 60,
+) -> tuple[int, ...]:
+    """Reconstruct a pitch sequence from an interval sequence starting at *start*.
+
+    Args:
+        intervals: Signed semitone intervals.
+        start:     MIDI pitch of the first note (default: 60 = middle C).
+
+    Returns:
+        Tuple of MIDI pitch values.
+    """
+    pitches: list[int] = [start]
+    for step in intervals:
+        pitches.append(pitches[-1] + step)
+    return tuple(pitches)
+
+
+# ---------------------------------------------------------------------------
+# Public async API (stub implementations — contract-correct)
+# ---------------------------------------------------------------------------
+
+
+async def find_motifs(
+    *,
+    commit_id: str,
+    branch: str,
+    min_length: int = 3,
+    track: Optional[str] = None,
+    section: Optional[str] = None,
+    as_json: bool = False,
+) -> MotifFindResult:
+    """Detect recurring melodic/rhythmic patterns in a single commit.
+
+    Scans the MIDI data at *commit_id* for note sequences that appear more
+    than once within the commit, groups them by their transposition-invariant
+    fingerprint, and returns them sorted by occurrence count.
+
+    Args:
+        commit_id:  Short or full commit SHA to analyse.
+        branch:     Branch name (for context in the result).
+        min_length: Minimum motif length in notes (default: 3). Shorter
+                    motifs tend to be musically trivial.
+        track:      Restrict analysis to a single named track, or ``None`` for all.
+        section:    Restrict to a named section/region, or ``None`` for all.
+        as_json:    Unused here — rendered by the CLI layer.
+
+    Returns:
+        A :class:`MotifFindResult` with all detected recurring motifs.
+    """
+    logger.info("✅ muse motif find: commit=%s min_length=%d", commit_id[:8], min_length)
+    groups = _stub_motif_groups(commit_id[:8], track=track, min_length=min_length)
+    return MotifFindResult(
+        commit_id=commit_id[:8],
+        branch=branch,
+        min_length=min_length,
+        motifs=groups,
+        total_found=len(groups),
+        source="stub",
+    )
+
+
+async def track_motif(
+    *,
+    pattern: str,
+    commit_ids: list[str],
+) -> MotifTrackResult:
+    """Search all commits for appearances of a specific motif pattern.
+
+    Parses *pattern* as a sequence of pitch names or MIDI numbers, derives the
+    transposition-invariant interval fingerprint, and scans each commit in
+    *commit_ids* for exact matches or recognised transformations (inversion,
+    retrograde, retrograde-inversion).
+
+    Args:
+        pattern:     Space-separated pitch names (e.g. ``"C D E G"``) or MIDI
+                     numbers (e.g. ``"60 62 64 67"``).
+        commit_ids:  Ordered list of commit SHAs to scan (newest first).
+
+    Returns:
+        A :class:`MotifTrackResult` with all occurrences found.
+
+    Raises:
+        ValueError: If *pattern* cannot be parsed into a valid pitch sequence.
+    """
+    pitches = parse_pitch_string(pattern)
+    fingerprint = pitches_to_intervals(pitches)
+    logger.info(
+        "✅ muse motif track: pattern=%r fingerprint=%r commits=%d",
+        pattern,
+        fingerprint,
+        len(commit_ids),
+    )
+
+    occurrences: list[MotifOccurrence] = []
+    for cid in commit_ids:
+        short = cid[:8]
+        occ = MotifOccurrence(
+            commit_id=short,
+            track="melody",
+            section=None,
+            start_position=0,
+            transformation=MotifTransformation.EXACT,
+            pitch_sequence=pitches,
+            interval_fingerprint=fingerprint,
+        )
+        occurrences.append(occ)
+
+    return MotifTrackResult(
+        pattern=pattern,
+        fingerprint=fingerprint,
+        occurrences=tuple(occurrences),
+        total_commits_scanned=len(commit_ids),
+        source="stub",
+    )
+
+
+async def diff_motifs(
+    *,
+    commit_a_id: str,
+    commit_b_id: str,
+) -> MotifDiffResult:
+    """Show how the dominant motif transformed between two commits.
+
+    Extracts the most prominent motif from each commit and computes the
+    transformation relationship between them (exact, inversion, retrograde, etc.).
+
+    Args:
+        commit_a_id: Short or full SHA of the first (earlier) commit.
+        commit_b_id: Short or full SHA of the second (later) commit.
+
+    Returns:
+        A :class:`MotifDiffResult` describing the transformation.
+    """
+    fp_a: IntervalSequence = (2, 2, -1, 2)
+    fp_b: IntervalSequence = (-2, -2, 1, -2)
+
+    transformation = detect_transformation(fp_a, fp_b) or MotifTransformation.APPROXIMATE
+
+    descriptions: dict[MotifTransformation, str] = {
+        MotifTransformation.EXACT: "The motif is transposition-equivalent — same shape, different pitch level.",
+        MotifTransformation.INVERSION: "The motif was inverted — ascending intervals became descending.",
+        MotifTransformation.RETROGRADE: "The motif was played in retrograde — same pitches reversed.",
+        MotifTransformation.RETRO_INV: "The motif was retrograde-inverted — reversed and mirrored.",
+        MotifTransformation.AUGMENTED: "The motif was augmented — note durations scaled up.",
+        MotifTransformation.DIMINISHED: "The motif was diminished — note durations compressed.",
+        MotifTransformation.APPROXIMATE: "The motif contour changed significantly between commits.",
+    }
+
+    entry_a = MotifDiffEntry(
+        commit_id=commit_a_id[:8],
+        fingerprint=fp_a,
+        label=contour_label(fp_a),
+        pitch_sequence=_intervals_to_pitches(fp_a),
+    )
+    entry_b = MotifDiffEntry(
+        commit_id=commit_b_id[:8],
+        fingerprint=fp_b,
+        label=contour_label(fp_b),
+        pitch_sequence=_intervals_to_pitches(fp_b),
+    )
+
+    logger.info(
+        "✅ muse motif diff: %s → %s, transformation=%s",
+        commit_a_id[:8],
+        commit_b_id[:8],
+        transformation.value,
+    )
+
+    return MotifDiffResult(
+        commit_a=entry_a,
+        commit_b=entry_b,
+        transformation=transformation,
+        description=descriptions[transformation],
+        source="stub",
+    )
+
+
+async def list_motifs(
+    *,
+    muse_dir_path: str,
+) -> MotifListResult:
+    """List all named motifs stored in ``.muse/motifs/``.
+
+    Named motifs are user-annotated melodic ideas saved for future recall.
+    This command surfaces them in a structured format suitable for both
+    human review and agent consumption.
+
+    Args:
+        muse_dir_path: Absolute path to the ``.muse/`` directory.
+
+    Returns:
+        A :class:`MotifListResult` with all saved named motifs.
+    """
+    logger.info("✅ muse motif list: scanning %s", muse_dir_path)
+    stub_motifs: tuple[SavedMotif, ...] = (
+        SavedMotif(
+            name="main-theme",
+            fingerprint=(2, 2, -1, 2),
+            created_at="2026-01-15T10:30:00Z",
+            description="The central ascending motif introduced in the opening.",
+        ),
+        SavedMotif(
+            name="bass-riff",
+            fingerprint=(-2, -3, 2),
+            created_at="2026-01-20T14:15:00Z",
+            description="Chromatic bass figure used throughout the bridge.",
+        ),
+    )
+    return MotifListResult(motifs=stub_motifs, source="stub")

--- a/tests/test_muse_motif.py
+++ b/tests/test_muse_motif.py
@@ -1,0 +1,395 @@
+"""Tests for the Muse Motif Engine (muse_motif.py) and CLI commands (motif.py).
+
+Covers:
+- Pure fingerprint helpers: pitches_to_intervals, invert_intervals,
+  retrograde_intervals, detect_transformation, contour_label, parse_pitch_string.
+- Async service functions: find_motifs, track_motif, diff_motifs, list_motifs.
+- CLI command rendering helpers: _format_find, _format_track, _format_diff,
+  _format_list.
+
+All async tests use @pytest.mark.anyio.  No live DB or external API calls.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from maestro.muse_cli.commands.motif import (
+    _format_diff,
+    _format_find,
+    _format_list,
+    _format_track,
+)
+from maestro.services.muse_motif import (
+    IntervalSequence,
+    MotifTransformation,
+    contour_label,
+    detect_transformation,
+    diff_motifs,
+    find_motifs,
+    invert_intervals,
+    list_motifs,
+    parse_pitch_string,
+    pitches_to_intervals,
+    retrograde_intervals,
+    track_motif,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestPitchesToIntervals:
+    def test_basic_ascending(self) -> None:
+        pitches = (60, 62, 64, 67)
+        intervals = pitches_to_intervals(pitches)
+        assert intervals == (2, 2, 3)
+
+    def test_basic_descending(self) -> None:
+        pitches = (67, 65, 62, 60)
+        intervals = pitches_to_intervals(pitches)
+        assert intervals == (-2, -3, -2)
+
+    def test_single_note_returns_empty(self) -> None:
+        assert pitches_to_intervals((60,)) == ()
+
+    def test_empty_returns_empty(self) -> None:
+        assert pitches_to_intervals(()) == ()
+
+    def test_two_notes_returns_one_interval(self) -> None:
+        assert pitches_to_intervals((60, 62)) == (2,)
+
+    def test_transposition_invariant(self) -> None:
+        """Motif at C and motif at G should produce identical fingerprints."""
+        c_major = (60, 62, 64)
+        g_major = (67, 69, 71)
+        assert pitches_to_intervals(c_major) == pitches_to_intervals(g_major)
+
+
+class TestInvertIntervals:
+    def test_inversion_negates_all(self) -> None:
+        intervals: IntervalSequence = (2, 2, -1, 2)
+        assert invert_intervals(intervals) == (-2, -2, 1, -2)
+
+    def test_inversion_of_empty(self) -> None:
+        assert invert_intervals(()) == ()
+
+    def test_double_inversion_identity(self) -> None:
+        intervals: IntervalSequence = (3, -2, 1)
+        assert invert_intervals(invert_intervals(intervals)) == intervals
+
+
+class TestRetrogradeIntervals:
+    def test_retrograde_reverses_and_negates(self) -> None:
+        """Retrograde of interval sequence = negation of reversed sequence."""
+        intervals: IntervalSequence = (2, 2, -1)
+        assert retrograde_intervals(intervals) == (1, -2, -2)
+
+    def test_retrograde_of_symmetric(self) -> None:
+        """A palindromic interval sequence reversed is its own negation."""
+        intervals: IntervalSequence = (1, -1)
+        retro = retrograde_intervals(intervals)
+        assert retro == (1, -1)
+
+    def test_double_retrograde_identity(self) -> None:
+        intervals: IntervalSequence = (2, -3, 1)
+        assert retrograde_intervals(retrograde_intervals(intervals)) == intervals
+
+
+class TestDetectTransformation:
+    def test_exact_match(self) -> None:
+        iv: IntervalSequence = (2, 2, -1, 2)
+        assert detect_transformation(iv, iv) == MotifTransformation.EXACT
+
+    def test_inversion_detected(self) -> None:
+        query: IntervalSequence = (2, 2, -1, 2)
+        candidate = invert_intervals(query)
+        assert detect_transformation(query, candidate) == MotifTransformation.INVERSION
+
+    def test_retrograde_detected(self) -> None:
+        query: IntervalSequence = (2, 2, -1, 2)
+        candidate = retrograde_intervals(query)
+        assert detect_transformation(query, candidate) == MotifTransformation.RETROGRADE
+
+    def test_retro_inv_detected(self) -> None:
+        query: IntervalSequence = (2, 2, -1, 2)
+        candidate = invert_intervals(retrograde_intervals(query))
+        assert detect_transformation(query, candidate) == MotifTransformation.RETRO_INV
+
+    def test_unrelated_returns_none(self) -> None:
+        query: IntervalSequence = (2, 2, -1, 2)
+        candidate: IntervalSequence = (5, -3, 7)
+        assert detect_transformation(query, candidate) is None
+
+
+class TestContourLabel:
+    def test_ascending_step(self) -> None:
+        assert contour_label((1, 2, 1)) == "ascending-step"
+
+    def test_descending_step(self) -> None:
+        assert contour_label((-1, -2, -1)) == "descending-step"
+
+    def test_ascending_leap(self) -> None:
+        assert contour_label((4, 5, 3)) == "ascending-leap"
+
+    def test_descending_leap(self) -> None:
+        assert contour_label((-4, -5, -3)) == "descending-leap"
+
+    def test_arch_shape(self) -> None:
+        assert contour_label((3, 2, -2, -3)) == "arch"
+
+    def test_valley_shape(self) -> None:
+        assert contour_label((-3, -2, 2, 3)) == "valley"
+
+    def test_static_zero_intervals(self) -> None:
+        assert contour_label((0, 0, 0)) == "static"
+
+    def test_empty_is_static(self) -> None:
+        assert contour_label(()) == "static"
+
+    def test_oscillating(self) -> None:
+        assert contour_label((2, -2, 2, -2)) == "oscillating"
+
+
+class TestParsePitchString:
+    def test_midi_numbers(self) -> None:
+        assert parse_pitch_string("60 62 64 67") == (60, 62, 64, 67)
+
+    def test_note_names_c_major(self) -> None:
+        result = parse_pitch_string("C D E G")
+        assert result == (60, 62, 64, 67)
+
+    def test_note_names_with_sharp(self) -> None:
+        result = parse_pitch_string("C C# D")
+        assert result == (60, 61, 62)
+
+    def test_mixed_case_note_names(self) -> None:
+        result = parse_pitch_string("c d e g")
+        assert result == (60, 62, 64, 67)
+
+    def test_invalid_token_raises(self) -> None:
+        with pytest.raises(ValueError, match="Cannot parse pitch token"):
+            parse_pitch_string("C D XQ")
+
+    def test_out_of_range_midi_raises(self) -> None:
+        with pytest.raises(ValueError):
+            parse_pitch_string("200")
+
+    def test_single_note(self) -> None:
+        assert parse_pitch_string("60") == (60,)
+
+
+# ---------------------------------------------------------------------------
+# Async service tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_motif_find_detects_recurring_pattern() -> None:
+    """find_motifs returns a result with at least one motif group above min-length."""
+    result = await find_motifs(
+        commit_id="abc12345",
+        branch="main",
+        min_length=3,
+    )
+    assert result.commit_id == "abc12345"
+    assert result.branch == "main"
+    assert result.min_length == 3
+    assert result.total_found > 0
+    assert len(result.motifs) == result.total_found
+
+
+@pytest.mark.anyio
+async def test_motif_find_min_length_filter() -> None:
+    """Increasing min-length reduces (or equals) the number of detected motifs."""
+    result_short = await find_motifs(
+        commit_id="deadbeef",
+        branch="main",
+        min_length=2,
+    )
+    result_long = await find_motifs(
+        commit_id="deadbeef",
+        branch="main",
+        min_length=8,
+    )
+    assert result_long.total_found <= result_short.total_found
+
+
+@pytest.mark.anyio
+async def test_motif_find_track_filter_respected() -> None:
+    """find_motifs with a track filter propagates the track name to occurrences."""
+    result = await find_motifs(
+        commit_id="abc12345",
+        branch="main",
+        min_length=3,
+        track="bass",
+    )
+    for group in result.motifs:
+        for occ in group.occurrences:
+            assert occ.track == "bass"
+
+
+@pytest.mark.anyio
+async def test_motif_find_source_is_stub() -> None:
+    """Stub implementation always returns source='stub'."""
+    result = await find_motifs(commit_id="abc12345", branch="main", min_length=3)
+    assert result.source == "stub"
+
+
+@pytest.mark.anyio
+async def test_motif_find_motifs_sorted_by_count_descending() -> None:
+    """Motif groups are sorted by occurrence count, highest first."""
+    result = await find_motifs(commit_id="abc12345", branch="main", min_length=3)
+    counts = [g.count for g in result.motifs]
+    assert counts == sorted(counts, reverse=True)
+
+
+@pytest.mark.anyio
+async def test_motif_track_finds_transpositions() -> None:
+    """track_motif parses the pattern and returns a MotifTrackResult."""
+    result = await track_motif(pattern="C D E G", commit_ids=["abc12345"])
+    assert result.pattern == "C D E G"
+    assert result.fingerprint == (2, 2, 3)
+    assert result.total_commits_scanned == 1
+    assert len(result.occurrences) == 1
+
+
+@pytest.mark.anyio
+async def test_motif_track_empty_commit_list() -> None:
+    """track_motif with no commits returns an empty occurrence list."""
+    result = await track_motif(pattern="60 62 64", commit_ids=[])
+    assert result.total_commits_scanned == 0
+    assert len(result.occurrences) == 0
+
+
+@pytest.mark.anyio
+async def test_motif_track_multiple_commits() -> None:
+    """track_motif scans all provided commit IDs."""
+    commit_ids = ["aaa11111", "bbb22222", "ccc33333"]
+    result = await track_motif(pattern="C D E", commit_ids=commit_ids)
+    assert result.total_commits_scanned == 3
+    assert len(result.occurrences) == 3
+    found_ids = {occ.commit_id for occ in result.occurrences}
+    assert found_ids == {"aaa11111"[:8], "bbb22222"[:8], "ccc33333"[:8]}
+
+
+@pytest.mark.anyio
+async def test_motif_track_invalid_pattern_raises() -> None:
+    """track_motif raises ValueError for an unparseable pattern."""
+    with pytest.raises(ValueError):
+        await track_motif(pattern="C D XYZ", commit_ids=["abc"])
+
+
+@pytest.mark.anyio
+async def test_motif_diff_identifies_inversion() -> None:
+    """diff_motifs returns a MotifDiffResult with a valid transformation."""
+    result = await diff_motifs(commit_a_id="aaa11111", commit_b_id="bbb22222")
+    assert result.commit_a.commit_id == "aaa11111"[:8]
+    assert result.commit_b.commit_id == "bbb22222"[:8]
+    assert result.transformation in MotifTransformation.__members__.values()
+    assert result.description
+
+
+@pytest.mark.anyio
+async def test_motif_diff_source_is_stub() -> None:
+    result = await diff_motifs(commit_a_id="aaa", commit_b_id="bbb")
+    assert result.source == "stub"
+
+
+@pytest.mark.anyio
+async def test_motif_list_returns_named_motifs() -> None:
+    """list_motifs returns a MotifListResult with named motif entries."""
+    result = await list_motifs(muse_dir_path="/tmp/fake-muse")
+    assert len(result.motifs) > 0
+    names = {m.name for m in result.motifs}
+    assert "main-theme" in names
+
+
+@pytest.mark.anyio
+async def test_motif_list_source_is_stub() -> None:
+    result = await list_motifs(muse_dir_path="/tmp/fake-muse")
+    assert result.source == "stub"
+
+
+@pytest.mark.anyio
+async def test_motif_list_fingerprints_are_non_empty() -> None:
+    result = await list_motifs(muse_dir_path="/tmp/fake-muse")
+    for motif in result.motifs:
+        assert len(motif.fingerprint) > 0
+
+
+# ---------------------------------------------------------------------------
+# Formatter / rendering tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_format_find_text_output() -> None:
+    """_format_find produces non-empty tabular text."""
+    result = await find_motifs(commit_id="abc12345", branch="main", min_length=3)
+    text = _format_find(result, as_json=False)
+    assert "Recurring motifs" in text
+    assert "ascending" in text or "descending" in text or "arch" in text
+
+
+@pytest.mark.anyio
+async def test_format_find_json_output_valid() -> None:
+    """_format_find with as_json=True produces parseable JSON."""
+    result = await find_motifs(commit_id="abc12345", branch="main", min_length=3)
+    raw = _format_find(result, as_json=True)
+    parsed = json.loads(raw)
+    assert "motifs" in parsed
+    assert parsed["total_found"] == result.total_found
+
+
+@pytest.mark.anyio
+async def test_format_track_text_output() -> None:
+    result = await track_motif(pattern="C D E G", commit_ids=["abc12345"])
+    text = _format_track(result, as_json=False)
+    assert "Tracking motif" in text
+
+
+@pytest.mark.anyio
+async def test_format_track_json_output_valid() -> None:
+    result = await track_motif(pattern="C D E G", commit_ids=["abc12345"])
+    raw = _format_track(result, as_json=True)
+    parsed = json.loads(raw)
+    assert "fingerprint" in parsed
+    assert "occurrences" in parsed
+
+
+@pytest.mark.anyio
+async def test_format_diff_text_output() -> None:
+    result = await diff_motifs(commit_a_id="aaa11111", commit_b_id="bbb22222")
+    text = _format_diff(result, as_json=False)
+    assert "Motif diff" in text
+    assert "Transformation" in text
+
+
+@pytest.mark.anyio
+async def test_format_diff_json_output_valid() -> None:
+    result = await diff_motifs(commit_a_id="aaa11111", commit_b_id="bbb22222")
+    raw = _format_diff(result, as_json=True)
+    parsed = json.loads(raw)
+    assert "transformation" in parsed
+    assert "commit_a" in parsed
+    assert "commit_b" in parsed
+
+
+@pytest.mark.anyio
+async def test_format_list_text_output() -> None:
+    result = await list_motifs(muse_dir_path="/tmp/fake-muse")
+    text = _format_list(result, as_json=False)
+    assert "main-theme" in text
+
+
+@pytest.mark.anyio
+async def test_format_list_json_output_valid() -> None:
+    result = await list_motifs(muse_dir_path="/tmp/fake-muse")
+    raw = _format_list(result, as_json=True)
+    parsed = json.loads(raw)
+    assert "motifs" in parsed
+    assert len(parsed["motifs"]) > 0


### PR DESCRIPTION
## Summary
Closes #101 — Implement `muse motif` command group to identify, track, and compare recurring melodic motifs across Muse VCS commits.

## Root Cause / Motivation
No motif analysis existed in the Muse VCS CLI. Agents had no way to discover recurring musical patterns across a composition's history — one of the most uniquely musical capabilities missing from the toolset.

## Solution
Implements four subcommands:

- **`muse motif find [<commit>]`** — detect recurring melodic/rhythmic patterns in a commit using transposition-invariant interval fingerprinting
- **`muse motif track <pattern>`** — search all commits for appearances of a specific motif, including inversion, retrograde, and retrograde-inversion transformations
- **`muse motif diff <commit-a> <commit-b>`** — show how the dominant motif transformed between two commits
- **`muse motif list`** — list all named motifs stored in `.muse/motifs/`

### Key Design Decisions
- **Transposition-invariant fingerprinting**: Motifs are represented as interval sequences (semitone differences), so the same motif at any pitch level hashes to the same fingerprint
- **Transformation detection**: Detects all four canonical classical transformations (exact/transposed, inversion, retrograde, retrograde-inversion)
- **Contour labeling**: 8-label vocabulary (ascending-step, ascending-leap, descending-step, descending-leap, arch, valley, oscillating, static)
- **Stub implementation with stable contract**: Full MIDI analysis deferred; placeholders are realistic and all result types are fully typed

## Layers Affected
- [x] Muse VCS (new service + CLI command group)

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (483 → 485 files, 0 errors)
- [x] `docker compose exec storpheus mypy .` — not affected
- [x] 55 tests pass (`tests/test_muse_motif.py`)
- [x] Docs updated (`docs/architecture/muse_vcs.md`, `docs/reference/type_contracts.md`)

## Tests Added
- `TestPitchesToIntervals` (6 tests) — transposition invariance, edge cases
- `TestInvertIntervals` (3 tests) — negation, identity
- `TestRetrogradeIntervals` (3 tests) — reversal + negation, identity
- `TestDetectTransformation` (5 tests) — all four transformations + unrelated
- `TestContourLabel` (9 tests) — all 8 contour labels
- `TestParsePitchString` (7 tests) — MIDI numbers, note names, sharps, errors
- Async service tests (14 tests) — find_motifs, track_motif, diff_motifs, list_motifs
- Formatter tests (8 tests) — text and JSON rendering for all four subcommands

## Handoff
N/A — no protocol change. Pure CLI addition; no SSE events or MCP tool schemas modified.