### PR TITLE
feat: muse symbolic-ref <name> [<ref>] — read or write a symbolic ref

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -4166,3 +4166,29 @@ error message via `typer.echo` before calling `typer.Exit(INTERNAL_ERROR)`.
 ```python
 class StorpheusUnavailableError(Exception): ...
 ```
+
+---
+
+## Muse CLI — Symbolic Ref Types (`maestro/muse_cli/commands/symbolic_ref.py`)
+
+### `SymbolicRefResult`
+
+Slotted class returned by `read_symbolic_ref()` when the named ref file exists
+and its content starts with `refs/`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `str` | The symbolic ref name that was queried, e.g. `HEAD`. |
+| `ref` | `str` | Full target ref string stored in the file, e.g. `refs/heads/main`. |
+| `short` | `str` | Last path component of `ref` (e.g. `main`). Computed on construction. |
+
+**Agent contract:** Callers receive `None` when the ref is absent or not
+symbolic (detached HEAD, bare SHA). Agents must guard with `if result is None`
+before accessing fields.
+
+```python
+result = read_symbolic_ref(muse_dir, "HEAD")
+if result is not None:
+    branch = result.short   # "main"
+    full   = result.ref     # "refs/heads/main"
+```

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -3,8 +3,8 @@
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (arrange, ask, checkout, commit, context, describe, divergence,
 dynamics, export, find, grep, import, init, log, merge, meter, open, play,
-pull, push, recall, remote, session, status, swing, tag, tempo) as Typer
-sub-applications.
+pull, push, recall, remote, session, status, swing, symbolic-ref, tag, tempo)
+as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -36,6 +36,7 @@ from maestro.muse_cli.commands import (
     session,
     status,
     swing,
+    symbolic_ref,
     tag,
     tempo,
 )
@@ -73,6 +74,7 @@ cli.add_typer(tempo.app, name="tempo", help="Read or set the tempo (BPM) of a co
 cli.add_typer(recall.app, name="recall", help="Search commit history by natural-language description.")
 cli.add_typer(context.app, name="context", help="Output structured musical context for AI agent consumption.")
 cli.add_typer(divergence.app, name="divergence", help="Show how two branches have diverged musically.")
+cli.add_typer(symbolic_ref.app, name="symbolic-ref", help="Read or write a symbolic ref (e.g. HEAD).")
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/commands/symbolic_ref.py
+++ b/maestro/muse_cli/commands/symbolic_ref.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import logging
 import pathlib
-from typing import Optional
 
 import typer
 
@@ -176,7 +175,7 @@ def symbolic_ref(
         metavar="<name>",
         help="Symbolic ref name, e.g. HEAD or refs/heads/main.",
     ),
-    new_target: Optional[str] = typer.Argument(
+    new_target: str | None = typer.Argument(
         None,
         metavar="<ref>",
         help=(

--- a/maestro/muse_cli/commands/symbolic_ref.py
+++ b/maestro/muse_cli/commands/symbolic_ref.py
@@ -1,0 +1,249 @@
+"""muse symbolic-ref — read or write a symbolic ref in the Muse repository.
+
+A symbolic ref is a file whose contents point to another ref.  The canonical
+example is ``.muse/HEAD``, which contains ``refs/heads/main`` when on the main
+branch and a bare 40-char SHA when in detached HEAD state.
+
+Usage
+-----
+::
+
+    muse symbolic-ref HEAD                          # read: prints refs/heads/main
+    muse symbolic-ref --short HEAD                  # read short: prints main
+    muse symbolic-ref HEAD refs/heads/feature/x    # write new target
+    muse symbolic-ref --delete HEAD                 # delete (detached HEAD scenarios)
+    -q / --quiet suppresses error output when the ref is not symbolic.
+
+Design notes
+------------
+- Pure filesystem operations — no DB session needed.
+- The ``name`` argument is resolved relative to ``.muse/``, so callers pass
+  bare names like ``HEAD`` or ``refs/heads/main``.
+- ``--delete`` removes the file entirely. Callers that rely on HEAD being
+  absent after deletion must handle ``FileNotFoundError`` themselves.
+- Mirrors the contract of ``git symbolic-ref``.
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.errors import ExitCode
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+_SYMBOLIC_REF_PREFIX = "refs/"
+
+
+# ---------------------------------------------------------------------------
+# Pure logic — testable without Typer
+# ---------------------------------------------------------------------------
+
+
+class SymbolicRefResult:
+    """Structured result of a symbolic-ref read operation.
+
+    Attributes
+    ----------
+    ref:
+        The full target ref string stored in the file, e.g. ``refs/heads/main``.
+    short:
+        The short form — the last component of *ref* after the final ``/``.
+        For ``refs/heads/main`` this is ``main``.
+    name:
+        The symbolic ref name that was queried, e.g. ``HEAD``.
+    """
+
+    __slots__ = ("ref", "short", "name")
+
+    def __init__(self, *, name: str, ref: str) -> None:
+        self.name = name
+        self.ref = ref
+        self.short = ref.rsplit("/", 1)[-1] if "/" in ref else ref
+
+
+def read_symbolic_ref(
+    muse_dir: pathlib.Path,
+    name: str,
+    *,
+    quiet: bool = False,
+) -> SymbolicRefResult | None:
+    """Read a symbolic ref from ``muse_dir``.
+
+    Returns a :class:`SymbolicRefResult` when the file exists and its content
+    starts with ``refs/``.  Returns ``None`` when:
+    - The file does not exist.
+    - The content does not start with ``refs/`` (detached HEAD / bare SHA).
+
+    When *quiet* is ``False`` and the ref is not symbolic, a warning is written
+    via the module logger.  Callers may also echo to the user themselves.
+
+    Args:
+        muse_dir: Path to the ``.muse/`` directory.
+        name: Ref name, e.g. ``HEAD`` or ``refs/heads/main``.
+        quiet: Suppress warning log when the ref is not symbolic.
+
+    Returns:
+        :class:`SymbolicRefResult` or ``None``.
+    """
+    ref_path = muse_dir / name
+    if not ref_path.exists():
+        if not quiet:
+            logger.warning("⚠️ symbolic-ref: %s not found in %s", name, muse_dir)
+        return None
+
+    content = ref_path.read_text().strip()
+    if not content.startswith(_SYMBOLIC_REF_PREFIX):
+        if not quiet:
+            logger.warning(
+                "⚠️ symbolic-ref: %s is not a symbolic ref (content: %r)", name, content
+            )
+        return None
+
+    return SymbolicRefResult(name=name, ref=content)
+
+
+def write_symbolic_ref(
+    muse_dir: pathlib.Path,
+    name: str,
+    target: str,
+) -> None:
+    """Write *target* into the symbolic ref *name* inside *muse_dir*.
+
+    Creates any intermediate directories needed so that writing
+    ``refs/heads/feature/guitar`` works without a prior ``mkdir``.
+
+    Args:
+        muse_dir: Path to the ``.muse/`` directory.
+        name: Ref name, e.g. ``HEAD`` or ``refs/heads/new-branch``.
+        target: Full ref target, e.g. ``refs/heads/feature/guitar``.
+
+    Raises:
+        ValueError: If *target* does not start with ``refs/``.
+    """
+    if not target.startswith(_SYMBOLIC_REF_PREFIX):
+        raise ValueError(
+            f"Invalid symbolic-ref target {target!r}: must start with 'refs/'"
+        )
+    ref_path = muse_dir / name
+    ref_path.parent.mkdir(parents=True, exist_ok=True)
+    ref_path.write_text(target + "\n")
+    logger.info("✅ symbolic-ref: wrote %r → %r", name, target)
+
+
+def delete_symbolic_ref(
+    muse_dir: pathlib.Path,
+    name: str,
+    *,
+    quiet: bool = False,
+) -> bool:
+    """Delete the symbolic ref file *name* from *muse_dir*.
+
+    Args:
+        muse_dir: Path to the ``.muse/`` directory.
+        name: Ref name to delete, e.g. ``HEAD``.
+        quiet: When ``True``, suppress the warning log if the file is absent.
+
+    Returns:
+        ``True`` if the file was deleted, ``False`` if it was already absent.
+    """
+    ref_path = muse_dir / name
+    if not ref_path.exists():
+        if not quiet:
+            logger.warning("⚠️ symbolic-ref: cannot delete %s — file not found", name)
+        return False
+    ref_path.unlink()
+    logger.info("✅ symbolic-ref: deleted %r", name)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def symbolic_ref(
+    ctx: typer.Context,
+    name: str = typer.Argument(
+        ...,
+        metavar="<name>",
+        help="Symbolic ref name, e.g. HEAD or refs/heads/main.",
+    ),
+    new_target: Optional[str] = typer.Argument(
+        None,
+        metavar="<ref>",
+        help=(
+            "When supplied, write this target into the symbolic ref. "
+            "Must start with 'refs/'."
+        ),
+    ),
+    short: bool = typer.Option(
+        False,
+        "--short",
+        help="Print just the branch name instead of the full ref path.",
+    ),
+    delete: bool = typer.Option(
+        False,
+        "--delete",
+        "-d",
+        help="Delete the symbolic ref file entirely.",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Suppress error output when the ref is not symbolic.",
+    ),
+) -> None:
+    """Read or write a symbolic ref in the Muse repository.
+
+    Read: ``muse symbolic-ref HEAD`` prints ``refs/heads/main``.
+    Write: ``muse symbolic-ref HEAD refs/heads/feature/x`` updates .muse/HEAD.
+    Short: ``muse symbolic-ref --short HEAD`` prints ``main``.
+    Delete: ``muse symbolic-ref --delete HEAD`` removes the file.
+    """
+    root = require_repo()
+    muse_dir = root / ".muse"
+
+    if delete:
+        deleted = delete_symbolic_ref(muse_dir, name, quiet=quiet)
+        if not deleted:
+            if not quiet:
+                typer.echo(f"❌ {name}: not found — nothing to delete")
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+        typer.echo(f"✅ Deleted symbolic ref {name!r}")
+        return
+
+    if new_target is not None:
+        if not new_target.startswith(_SYMBOLIC_REF_PREFIX):
+            typer.echo(
+                f"❌ Invalid symbolic-ref target {new_target!r}: must start with 'refs/'"
+            )
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+        try:
+            write_symbolic_ref(muse_dir, name, new_target)
+        except ValueError as exc:
+            typer.echo(f"❌ {exc}")
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+        except Exception as exc:
+            typer.echo(f"❌ muse symbolic-ref write failed: {exc}")
+            logger.error("❌ muse symbolic-ref write error: %s", exc, exc_info=True)
+            raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+        typer.echo(f"✅ {name} → {new_target}")
+        return
+
+    # Read path
+    result = read_symbolic_ref(muse_dir, name, quiet=quiet)
+    if result is None:
+        if not quiet:
+            typer.echo(f"❌ {name} is not a symbolic ref or does not exist")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    typer.echo(result.short if short else result.ref)

--- a/tests/test_muse_symbolic_ref.py
+++ b/tests/test_muse_symbolic_ref.py
@@ -1,0 +1,230 @@
+"""Tests for ``muse symbolic-ref`` — read or write a symbolic ref.
+
+Verifies:
+- read_symbolic_ref: returns SymbolicRefResult for a valid symbolic ref.
+- read_symbolic_ref: returns None for a non-existent file.
+- read_symbolic_ref: returns None when content is a bare SHA (not symbolic).
+- read_symbolic_ref.short: last path component only.
+- write_symbolic_ref: creates the file with the given target.
+- write_symbolic_ref: raises ValueError for a non-refs/ target.
+- write_symbolic_ref: creates intermediate directories for nested refs.
+- delete_symbolic_ref: removes the file; returns True.
+- delete_symbolic_ref: returns False for a non-existent file.
+- CLI read path: ``muse symbolic-ref HEAD`` prints full ref.
+- CLI --short: prints just the branch name.
+- CLI write path: ``muse symbolic-ref HEAD refs/heads/x`` updates the file.
+- CLI write rejects non-refs/ target.
+- CLI --delete: removes the file; exits 0.
+- CLI --delete absent file: exits USER_ERROR.
+- CLI -q suppresses error output when ref is not symbolic.
+- Boundary seal (AST): ``from __future__ import annotations`` present.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+from typer.testing import CliRunner
+
+from maestro.muse_cli.app import cli
+from maestro.muse_cli.commands.symbolic_ref import (
+    SymbolicRefResult,
+    delete_symbolic_ref,
+    read_symbolic_ref,
+    write_symbolic_ref,
+)
+from maestro.muse_cli.errors import ExitCode
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def muse_dir(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a minimal .muse directory."""
+    d = tmp_path / ".muse"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def repo_root_with_head(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Full repo directory with .muse/HEAD pointing at refs/heads/main."""
+    muse = tmp_path / ".muse"
+    muse.mkdir()
+    (muse / "HEAD").write_text("refs/heads/main\n")
+    refs = muse / "refs" / "heads"
+    refs.mkdir(parents=True)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — pure logic
+# ---------------------------------------------------------------------------
+
+
+def test_read_symbolic_ref_returns_result(muse_dir: pathlib.Path) -> None:
+    (muse_dir / "HEAD").write_text("refs/heads/main\n")
+    result = read_symbolic_ref(muse_dir, "HEAD")
+    assert result is not None
+    assert result.ref == "refs/heads/main"
+    assert result.name == "HEAD"
+    assert result.short == "main"
+
+
+def test_read_symbolic_ref_missing_file_returns_none(muse_dir: pathlib.Path) -> None:
+    result = read_symbolic_ref(muse_dir, "HEAD", quiet=True)
+    assert result is None
+
+
+def test_read_symbolic_ref_bare_sha_returns_none(muse_dir: pathlib.Path) -> None:
+    """Detached HEAD contains a bare SHA — not a symbolic ref."""
+    (muse_dir / "HEAD").write_text("a" * 64 + "\n")
+    result = read_symbolic_ref(muse_dir, "HEAD", quiet=True)
+    assert result is None
+
+
+def test_symbolic_ref_result_short_no_slash() -> None:
+    """A ref without slashes uses the whole string as short form."""
+    result = SymbolicRefResult(name="HEAD", ref="main")
+    assert result.short == "main"
+
+
+def test_write_symbolic_ref_creates_file(muse_dir: pathlib.Path) -> None:
+    write_symbolic_ref(muse_dir, "HEAD", "refs/heads/feature/x")
+    content = (muse_dir / "HEAD").read_text().strip()
+    assert content == "refs/heads/feature/x"
+
+
+def test_write_symbolic_ref_raises_for_non_refs_target(muse_dir: pathlib.Path) -> None:
+    with pytest.raises(ValueError, match="must start with 'refs/'"):
+        write_symbolic_ref(muse_dir, "HEAD", "main")
+
+
+def test_write_symbolic_ref_creates_intermediate_dirs(muse_dir: pathlib.Path) -> None:
+    write_symbolic_ref(muse_dir, "refs/heads/feature/guitar", "refs/heads/main")
+    assert (muse_dir / "refs" / "heads" / "feature" / "guitar").exists()
+
+
+def test_delete_symbolic_ref_removes_file(muse_dir: pathlib.Path) -> None:
+    (muse_dir / "HEAD").write_text("refs/heads/main\n")
+    deleted = delete_symbolic_ref(muse_dir, "HEAD")
+    assert deleted is True
+    assert not (muse_dir / "HEAD").exists()
+
+
+def test_delete_symbolic_ref_absent_returns_false(muse_dir: pathlib.Path) -> None:
+    deleted = delete_symbolic_ref(muse_dir, "HEAD", quiet=True)
+    assert deleted is False
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_cli_read_prints_full_ref(repo_root_with_head: pathlib.Path) -> None:
+    result = runner.invoke(cli, ["symbolic-ref", "HEAD"], env={"MUSE_REPO_ROOT": str(repo_root_with_head)})
+    assert result.exit_code == ExitCode.SUCCESS
+    assert "refs/heads/main" in result.output
+
+
+def test_cli_read_short_prints_branch_name(repo_root_with_head: pathlib.Path) -> None:
+    result = runner.invoke(
+        cli,
+        ["symbolic-ref", "--short", "HEAD"],
+        env={"MUSE_REPO_ROOT": str(repo_root_with_head)},
+    )
+    assert result.exit_code == ExitCode.SUCCESS
+    assert result.output.strip() == "main"
+    assert "refs/heads/main" not in result.output
+
+
+def test_cli_write_updates_file(repo_root_with_head: pathlib.Path) -> None:
+    result = runner.invoke(
+        cli,
+        ["symbolic-ref", "HEAD", "refs/heads/feature/guitar"],
+        env={"MUSE_REPO_ROOT": str(repo_root_with_head)},
+    )
+    assert result.exit_code == ExitCode.SUCCESS
+    content = (repo_root_with_head / ".muse" / "HEAD").read_text().strip()
+    assert content == "refs/heads/feature/guitar"
+
+
+def test_cli_write_rejects_non_refs_target(repo_root_with_head: pathlib.Path) -> None:
+    result = runner.invoke(
+        cli,
+        ["symbolic-ref", "HEAD", "main"],
+        env={"MUSE_REPO_ROOT": str(repo_root_with_head)},
+    )
+    assert result.exit_code == ExitCode.USER_ERROR
+    assert "refs/" in result.output
+
+
+def test_cli_delete_removes_file(repo_root_with_head: pathlib.Path) -> None:
+    result = runner.invoke(
+        cli,
+        ["symbolic-ref", "--delete", "HEAD"],
+        env={"MUSE_REPO_ROOT": str(repo_root_with_head)},
+    )
+    assert result.exit_code == ExitCode.SUCCESS
+    assert not (repo_root_with_head / ".muse" / "HEAD").exists()
+
+
+def test_cli_delete_absent_file_exits_user_error(repo_root_with_head: pathlib.Path) -> None:
+    muse_dir = repo_root_with_head / ".muse"
+    (muse_dir / "HEAD").unlink()
+    result = runner.invoke(
+        cli,
+        ["symbolic-ref", "--delete", "HEAD"],
+        env={"MUSE_REPO_ROOT": str(repo_root_with_head)},
+    )
+    assert result.exit_code == ExitCode.USER_ERROR
+
+
+def test_cli_read_non_symbolic_exits_user_error(repo_root_with_head: pathlib.Path) -> None:
+    """Detached HEAD (bare SHA) should exit USER_ERROR on read."""
+    (repo_root_with_head / ".muse" / "HEAD").write_text("a" * 64 + "\n")
+    result = runner.invoke(
+        cli,
+        ["symbolic-ref", "HEAD"],
+        env={"MUSE_REPO_ROOT": str(repo_root_with_head)},
+    )
+    assert result.exit_code == ExitCode.USER_ERROR
+
+
+def test_cli_quiet_suppresses_error_output(repo_root_with_head: pathlib.Path) -> None:
+    """With -q, reading a non-symbolic ref should produce no user-facing text."""
+    (repo_root_with_head / ".muse" / "HEAD").write_text("a" * 64 + "\n")
+    result = runner.invoke(
+        cli,
+        ["symbolic-ref", "-q", "HEAD"],
+        env={"MUSE_REPO_ROOT": str(repo_root_with_head)},
+    )
+    assert result.exit_code == ExitCode.USER_ERROR
+    assert result.output.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Boundary seal
+# ---------------------------------------------------------------------------
+
+
+def test_boundary_seal_future_annotations() -> None:
+    """Verify ``from __future__ import annotations`` is the first import."""
+    import maestro.muse_cli.commands.symbolic_ref as mod
+
+    source = pathlib.Path(mod.__file__).read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "__future__" and any(
+                alias.name == "annotations" for alias in node.names
+            ):
+                return
+    pytest.fail("from __future__ import annotations not found in symbolic_ref.py")


### PR DESCRIPTION
## Summary
Closes #93 — implements `muse symbolic-ref`, the plumbing command for reading and writing symbolic refs (e.g. `.muse/HEAD`) in the Muse VCS.

## Root Cause / Motivation
No symbolic-ref command existed. HEAD and other symbolic pointers could not be read or updated programmatically, blocking agents that need to inspect or switch branches without a full `muse checkout` cycle.

## Solution
Added `maestro/muse_cli/commands/symbolic_ref.py` with three pure-filesystem operations:
- `read_symbolic_ref()` — reads a ref file, returns `SymbolicRefResult(name, ref, short)` or `None` for non-symbolic content (detached HEAD / bare SHA)
- `write_symbolic_ref()` — writes a `refs/...` target into a ref file, creating intermediate dirs
- `delete_symbolic_ref()` — removes the ref file (for detached HEAD scenarios)

CLI sub-commands wired into `muse symbolic-ref` via Typer:
- `muse symbolic-ref HEAD` → `refs/heads/main`
- `muse symbolic-ref --short HEAD` → `main`
- `muse symbolic-ref HEAD refs/heads/feature/x` → updates `.muse/HEAD`
- `muse symbolic-ref --delete HEAD` → removes the file
- `-q / --quiet` — suppresses error output when ref is not symbolic

Named result type `SymbolicRefResult` registered in `docs/reference/type_contracts.md`. No DB session needed — pure filesystem, sub-millisecond latency.

## Layers Affected
- [x] Muse VCS

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (490 files)
- [x] `docker compose exec storpheus mypy .` — not affected
- [x] 18 tests pass (`tests/test_muse_symbolic_ref.py`)
- [x] Docs updated: `docs/architecture/muse_vcs.md`, `docs/reference/type_contracts.md`

## Tests Added
- `test_read_symbolic_ref_returns_result` — happy path read
- `test_read_symbolic_ref_missing_file_returns_none` — absent file
- `test_read_symbolic_ref_bare_sha_returns_none` — detached HEAD
- `test_symbolic_ref_result_short_no_slash` — short form edge case
- `test_write_symbolic_ref_creates_file` — write path
- `test_write_symbolic_ref_raises_for_non_refs_target` — invalid target guard
- `test_write_symbolic_ref_creates_intermediate_dirs` — nested ref paths
- `test_delete_symbolic_ref_removes_file` — delete happy path
- `test_delete_symbolic_ref_absent_returns_false` — delete idempotency
- `test_cli_read_prints_full_ref` — CLI read integration
- `test_cli_read_short_prints_branch_name` — CLI --short
- `test_cli_write_updates_file` — CLI write integration
- `test_cli_write_rejects_non_refs_target` — CLI write guard
- `test_cli_delete_removes_file` — CLI delete integration
- `test_cli_delete_absent_file_exits_user_error` — CLI delete guard
- `test_cli_read_non_symbolic_exits_user_error` — detached HEAD CLI
- `test_cli_quiet_suppresses_error_output` — -q flag
- `test_boundary_seal_future_annotations` — AST boundary seal

## Handoff
N/A — no protocol change. Pure Muse CLI filesystem command.