### PR TITLE
feat: muse rev-parse <revision> — resolve a revision expression to a commit ID

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -2533,6 +2533,68 @@ branch for chord voicings while preserving the guitar branch's groove patterns.
 
 ---
 
+## `muse rev-parse` — Resolve a Revision Expression to a Commit ID
+
+**Purpose:** Translate a symbolic revision expression into a concrete 64-character
+commit ID.  Mirrors `git rev-parse` semantics and is the plumbing primitive used
+internally by other Muse commands that accept revision arguments.
+
+```
+muse rev-parse <revision> [OPTIONS]
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `REVISION` | positional | required | Revision expression to resolve |
+| `--short` | flag | off | Print only the first 8 characters of the commit ID |
+| `--verify` | flag | off | Exit 1 if the expression does not resolve (default: print nothing) |
+| `--abbrev-ref` | flag | off | Print the branch name instead of the commit ID |
+
+### Supported Revision Expressions
+
+| Expression | Resolves to |
+|------------|-------------|
+| `HEAD` | Tip of the current branch |
+| `<branch>` | Tip of the named branch |
+| `<commit_id>` | Exact or prefix-matched commit |
+| `HEAD~N` | N parents back from HEAD |
+| `<branch>~N` | N parents back from the branch tip |
+
+### Output Example
+
+```
+$ muse rev-parse HEAD
+a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+
+$ muse rev-parse --short HEAD
+a1b2c3d4
+
+$ muse rev-parse --abbrev-ref HEAD
+main
+
+$ muse rev-parse HEAD~2
+f9e8d7c6b5a4f9e8d7c6b5a4f9e8d7c6b5a4f9e8d7c6b5a4f9e8d7c6b5a4f9e8
+
+$ muse rev-parse --verify nonexistent
+fatal: Not a valid revision: 'nonexistent'
+# exit code 1
+```
+
+### Result Type
+
+`RevParseResult` — see `docs/reference/type_contracts.md § Muse rev-parse Types`.
+
+### Agent Use Case
+
+An AI agent resolves `HEAD~1` before generating a new variation to obtain the
+parent commit ID, which it passes as a `base_commit` argument to downstream
+commands.  Use `--verify` in automation scripts to fail fast rather than
+silently producing empty output.
+
+---
+
 ## Command Registration Summary
 
 | Command | File | Status | Issue |
@@ -2547,6 +2609,7 @@ branch for chord voicings while preserving the guitar branch's groove patterns.
 | `muse import` | `commands/import_cmd.py` | ✅ implemented (PR #142) | #118 |
 | `muse meter` | `commands/meter.py` | ✅ implemented (PR #141) | #117 |
 | `muse recall` | `commands/recall.py` | ✅ stub (PR #135) | #122 |
+| `muse rev-parse` | `commands/rev_parse.py` | ✅ implemented (PR #143) | #92 |
 | `muse session` | `commands/session.py` | ✅ implemented (PR #129) | #127 |
 | `muse swing` | `commands/swing.py` | ✅ stub (PR #131) | #121 |
 | `muse tag` | `commands/tag.py` | ✅ implemented (PR #133) | #123 |

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -4119,6 +4119,34 @@ classDiagram
 
 ---
 
+## Muse rev-parse Types (`maestro/muse_cli/commands/rev_parse.py`)
+
+### `RevParseResult`
+
+Immutable value object returned by `resolve_revision()` when a revision expression
+resolves successfully.  Consumers should always check for `None` before accessing
+fields — `resolve_revision` returns `None` on any resolution failure.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | Full 64-character hex commit ID of the resolved commit. |
+| `branch` | `str` | Branch that the resolved commit lives on. |
+| `revision_expr` | `str` | The original expression that was resolved (useful for error messages). |
+
+```python
+class RevParseResult:
+    commit_id: str
+    branch: str
+    revision_expr: str
+```
+
+**When to call `resolve_revision`:** any command that accepts a user-supplied
+revision argument (e.g. `muse describe <rev>`, `muse export --from <rev>`)
+should delegate resolution to this function rather than reimplementing tilde
+parsing and branch lookup.
+
+---
+
 ## Muse CLI — Export Types (`maestro/muse_cli/export_engine.py`)
 
 ### `ExportFormat`

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -3,8 +3,8 @@
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (arrange, ask, checkout, commit, context, describe, divergence,
 dynamics, export, find, grep, import, init, log, merge, meter, open, play,
-pull, push, recall, remote, session, status, swing, tag, tempo) as Typer
-sub-applications.
+pull, push, recall, remote, rev_parse, session, status, swing, tag, tempo)
+as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -33,6 +33,7 @@ from maestro.muse_cli.commands import (
     push,
     recall,
     remote,
+    rev_parse,
     session,
     status,
     swing,
@@ -73,6 +74,7 @@ cli.add_typer(tempo.app, name="tempo", help="Read or set the tempo (BPM) of a co
 cli.add_typer(recall.app, name="recall", help="Search commit history by natural-language description.")
 cli.add_typer(context.app, name="context", help="Output structured musical context for AI agent consumption.")
 cli.add_typer(divergence.app, name="divergence", help="Show how two branches have diverged musically.")
+cli.add_typer(rev_parse.app, name="rev-parse", help="Resolve a revision expression to a commit ID.")
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/commands/rev_parse.py
+++ b/maestro/muse_cli/commands/rev_parse.py
@@ -1,0 +1,324 @@
+"""muse rev-parse — resolve a revision expression to a commit ID.
+
+Translates a symbolic revision expression into a concrete commit ID, mirroring
+``git rev-parse`` semantics for the Muse VCS.  Designed to be used both
+interactively and as a plumbing primitive that other commands can call
+internally to resolve user-supplied refs.
+
+Supported revision expressions
+--------------------------------
+- ``HEAD``          — current branch tip
+- ``<branch>``      — tip of a named branch
+- ``<commit_id>``   — full or abbreviated (prefix) commit ID
+- ``HEAD~N``        — N parents back from HEAD
+- ``<branch>~N``    — N parents back from branch tip
+
+Flags
+------
+- ``--short``       — print only the first 8 characters of the resolved ID
+- ``--verify``      — exit 1 when the expression does not resolve (default:
+                      print nothing and exit 0)
+- ``--abbrev-ref``  — print the branch name rather than the commit ID
+                      (meaningful for HEAD and branch refs; for a raw commit ID
+                      the branch of that commit is printed)
+
+Result type: ``RevParseResult`` — see ``docs/reference/type_contracts.md``.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+import re
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+# Regex: "HEAD~3", "main~1", "a1b2c3~2" etc.
+_TILDE_RE = re.compile(r"^(.+?)~(\d+)$")
+
+
+# ---------------------------------------------------------------------------
+# Named result type (registered in docs/reference/type_contracts.md)
+# ---------------------------------------------------------------------------
+
+
+class RevParseResult:
+    """Resolved output of a revision expression.
+
+    Returned by ``_resolve_revision`` so that callers have access to both the
+    full commit ID and its branch without re-querying the database.  Treat as
+    an immutable value object — all fields are set in ``__init__`` and never
+    mutated.
+
+    Fields
+    ------
+    commit_id : str
+        Full 64-character hex commit ID.
+    branch : str
+        Branch that the commit lives on (may differ from the expression when a
+        raw commit ID spanning multiple branches is resolved).
+    revision_expr : str
+        The original expression that was resolved (useful for error messages).
+    """
+
+    __slots__ = ("commit_id", "branch", "revision_expr")
+
+    def __init__(self, commit_id: str, branch: str, revision_expr: str) -> None:
+        self.commit_id = commit_id
+        self.branch = branch
+        self.revision_expr = revision_expr
+
+    def __repr__(self) -> str:
+        return (
+            f"RevParseResult(commit_id={self.commit_id[:8]!r},"
+            f" branch={self.branch!r},"
+            f" revision_expr={self.revision_expr!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _get_branch_tip(
+    session: AsyncSession,
+    repo_id: str,
+    branch: str,
+) -> MuseCliCommit | None:
+    """Return the most-recent commit on *branch*, or ``None`` if none exist."""
+    result = await session.execute(
+        select(MuseCliCommit)
+        .where(MuseCliCommit.repo_id == repo_id, MuseCliCommit.branch == branch)
+        .order_by(MuseCliCommit.committed_at.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _resolve_commit_by_id(
+    session: AsyncSession,
+    repo_id: str,
+    ref: str,
+) -> MuseCliCommit | None:
+    """Resolve *ref* as an exact or prefix-matched commit ID.
+
+    Tries an exact primary-key lookup first; falls back to a prefix scan
+    (acceptable for CLI latency — commit tables are shallow in typical usage).
+    """
+    commit = await session.get(MuseCliCommit, ref)
+    if commit is not None:
+        return commit
+    # Abbreviated prefix match
+    result = await session.execute(
+        select(MuseCliCommit).where(
+            MuseCliCommit.repo_id == repo_id,
+            MuseCliCommit.commit_id.startswith(ref),
+        )
+    )
+    return result.scalars().first()
+
+
+async def _walk_parents(
+    session: AsyncSession,
+    start: MuseCliCommit,
+    steps: int,
+) -> MuseCliCommit | None:
+    """Walk *steps* parent hops from *start*, returning the ancestor or None.
+
+    ``steps=0`` returns *start* unchanged.  Each step follows
+    ``parent_commit_id``; if a parent is missing from the DB the walk stops
+    and ``None`` is returned.
+    """
+    current: MuseCliCommit = start
+    for _ in range(steps):
+        if current.parent_commit_id is None:
+            logger.debug("⚠️ Parent chain exhausted after %d step(s)", steps)
+            return None
+        parent = await session.get(MuseCliCommit, current.parent_commit_id)
+        if parent is None:
+            logger.warning(
+                "⚠️ Parent commit %s not found in DB — chain broken",
+                current.parent_commit_id[:8],
+            )
+            return None
+        current = parent
+    return current
+
+
+async def _branch_exists_on_disk(muse_dir: pathlib.Path, name: str) -> bool:
+    """Return True when a ref file exists for *name* under ``.muse/refs/heads/``."""
+    return (muse_dir / "refs" / "heads" / name).exists()
+
+
+async def resolve_revision(
+    session: AsyncSession,
+    repo_id: str,
+    current_branch: str,
+    muse_dir: pathlib.Path,
+    revision_expr: str,
+) -> RevParseResult | None:
+    """Resolve *revision_expr* to a ``RevParseResult``, or return ``None``.
+
+    This is the public plumbing primitive used by ``muse rev-parse`` and
+    intended for reuse by other commands that accept revision arguments.
+
+    Resolution order
+    ----------------
+    1. Strip a ``~N`` suffix and record *steps*.
+    2. Resolve the base token:
+       a. ``HEAD``              → tip of *current_branch*
+       b. Named branch (ref file exists)  → tip of that branch
+       c. Commit ID / prefix   → exact or prefix match
+    3. Walk *steps* parent hops from the resolved base.
+    4. Return ``RevParseResult`` or ``None`` when unresolvable.
+    """
+    # Step 1 — parse tilde suffix
+    steps = 0
+    base = revision_expr
+    m = _TILDE_RE.match(revision_expr)
+    if m:
+        base = m.group(1)
+        steps = int(m.group(2))
+
+    # Step 2 — resolve base token to a commit
+    commit: MuseCliCommit | None = None
+
+    if base.upper() == "HEAD":
+        commit = await _get_branch_tip(session, repo_id, current_branch)
+        resolved_branch = current_branch
+    elif await _branch_exists_on_disk(muse_dir, base):
+        commit = await _get_branch_tip(session, repo_id, base)
+        resolved_branch = base
+    else:
+        commit = await _resolve_commit_by_id(session, repo_id, base)
+        resolved_branch = commit.branch if commit is not None else ""
+
+    if commit is None:
+        return None
+
+    # Step 3 — walk parent chain
+    ancestor = await _walk_parents(session, commit, steps)
+    if ancestor is None:
+        return None
+
+    return RevParseResult(
+        commit_id=ancestor.commit_id,
+        branch=ancestor.branch,
+        revision_expr=revision_expr,
+    )
+
+
+async def _rev_parse_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    revision: str,
+    short: bool,
+    verify: bool,
+    abbrev_ref: bool,
+) -> None:
+    """Core rev-parse logic — fully injectable for tests.
+
+    Reads repo state from ``.muse/``, resolves *revision*, and writes output
+    via ``typer.echo``.  Raises ``typer.Exit`` on resolution failure when
+    ``--verify`` is set.
+    """
+    muse_dir = root / ".muse"
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]
+
+    head_ref = (muse_dir / "HEAD").read_text().strip()   # "refs/heads/main"
+    current_branch = head_ref.rsplit("/", 1)[-1]         # "main"
+
+    result = await resolve_revision(
+        session=session,
+        repo_id=repo_id,
+        current_branch=current_branch,
+        muse_dir=muse_dir,
+        revision_expr=revision,
+    )
+
+    if result is None:
+        if verify:
+            typer.echo(f"fatal: Not a valid revision: {revision!r}", err=True)
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+        # --verify not set: print nothing, exit 0
+        return
+
+    if abbrev_ref:
+        typer.echo(result.branch)
+    elif short:
+        typer.echo(result.commit_id[:8])
+    else:
+        typer.echo(result.commit_id)
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def rev_parse(
+    ctx: typer.Context,
+    revision: str = typer.Argument(..., help="Revision expression to resolve."),
+    short: bool = typer.Option(
+        False,
+        "--short",
+        help="Print only the first 8 characters of the commit ID.",
+    ),
+    verify: bool = typer.Option(
+        False,
+        "--verify",
+        help="Exit 1 if the revision does not resolve (default: print nothing).",
+    ),
+    abbrev_ref: bool = typer.Option(
+        False,
+        "--abbrev-ref",
+        help="Print the branch name instead of the commit ID.",
+    ),
+) -> None:
+    """Resolve a revision expression to a commit ID.
+
+    Examples::
+
+        muse rev-parse HEAD
+        muse rev-parse HEAD~2
+        muse rev-parse --short HEAD
+        muse rev-parse --abbrev-ref HEAD
+        muse rev-parse --verify nonexistent
+    """
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _rev_parse_async(
+                root=root,
+                session=session,
+                revision=revision,
+                short=short,
+                verify=verify,
+                abbrev_ref=abbrev_ref,
+            )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse rev-parse failed: {exc}")
+        logger.error("❌ muse rev-parse error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/tests/muse_cli/test_rev_parse.py
+++ b/tests/muse_cli/test_rev_parse.py
@@ -1,0 +1,505 @@
+"""Tests for ``muse rev-parse``.
+
+All async tests call ``_rev_parse_async`` directly with an in-memory SQLite
+session and a ``tmp_path`` repo root — no real Postgres or running process
+required.  Commits are seeded via ``_commit_async`` for realistic parent
+chain data.
+
+Covers all revision expression types:
+- HEAD
+- <branch>
+- <commit_id> (full and prefix)
+- HEAD~N
+- <branch>~N
+
+And all flags:
+- --short
+- --verify
+- --abbrev-ref
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import uuid
+
+import pytest
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.commands.rev_parse import (
+    RevParseResult,
+    _rev_parse_async,
+    resolve_revision,
+)
+from maestro.muse_cli.errors import ExitCode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    """Initialise a minimal .muse/ directory and return the repo_id."""
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _write_workdir(root: pathlib.Path, files: dict[str, bytes]) -> None:
+    workdir = root / "muse-work"
+    workdir.mkdir(exist_ok=True)
+    for name, content in files.items():
+        (workdir / name).write_bytes(content)
+
+
+async def _make_commits(
+    root: pathlib.Path,
+    session: AsyncSession,
+    messages: list[str],
+    file_seed: int = 0,
+) -> list[str]:
+    """Seed N commits on main, returning their commit_ids oldest-first."""
+    commit_ids: list[str] = []
+    for i, msg in enumerate(messages):
+        _write_workdir(root, {f"track_{file_seed + i}.mid": f"MIDI-{file_seed + i}".encode()})
+        cid = await _commit_async(message=msg, root=root, session=session)
+        commit_ids.append(cid)
+    return commit_ids
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_HEAD_returns_head_commit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_HEAD_returns_head_commit(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``muse rev-parse HEAD`` prints the most recent commit ID."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["take 1", "take 2"])
+
+    capsys.readouterr()
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision="HEAD",
+        short=False,
+        verify=False,
+        abbrev_ref=False,
+    )
+    out = capsys.readouterr().out.strip()
+    assert out == cids[-1]  # newest commit
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_branch_name_returns_tip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_branch_name_returns_tip(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``muse rev-parse main`` resolves the tip of the named branch."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["alpha", "beta"])
+
+    capsys.readouterr()
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision="main",
+        short=False,
+        verify=False,
+        abbrev_ref=False,
+    )
+    out = capsys.readouterr().out.strip()
+    assert out == cids[-1]
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_full_commit_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_full_commit_id(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``muse rev-parse <full_id>`` echoes the same commit ID back."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["v1", "v2", "v3"])
+    target = cids[1]  # middle commit
+
+    capsys.readouterr()
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision=target,
+        short=False,
+        verify=False,
+        abbrev_ref=False,
+    )
+    out = capsys.readouterr().out.strip()
+    assert out == target
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_prefix_commit_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_prefix_commit_id(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An 8-char prefix is resolved to the full commit ID."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["groove"])
+    prefix = cids[0][:8]
+
+    capsys.readouterr()
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision=prefix,
+        short=False,
+        verify=False,
+        abbrev_ref=False,
+    )
+    out = capsys.readouterr().out.strip()
+    assert out == cids[0]
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_HEAD_tilde_1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_HEAD_tilde_1(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``HEAD~1`` resolves to the parent of the current HEAD."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["a", "b", "c"])
+
+    capsys.readouterr()
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision="HEAD~1",
+        short=False,
+        verify=False,
+        abbrev_ref=False,
+    )
+    out = capsys.readouterr().out.strip()
+    assert out == cids[1]  # one step back from cids[2]
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_HEAD_tilde_2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_HEAD_tilde_2(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``HEAD~2`` walks two parents back from HEAD."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["x", "y", "z"])
+
+    capsys.readouterr()
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision="HEAD~2",
+        short=False,
+        verify=False,
+        abbrev_ref=False,
+    )
+    out = capsys.readouterr().out.strip()
+    assert out == cids[0]  # two steps back from cids[2]
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_branch_tilde
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_branch_tilde(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``main~1`` walks one parent back from the main branch tip."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["first", "second"])
+
+    capsys.readouterr()
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision="main~1",
+        short=False,
+        verify=False,
+        abbrev_ref=False,
+    )
+    out = capsys.readouterr().out.strip()
+    assert out == cids[0]
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_short_flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_short_flag(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--short`` outputs only the first 8 characters of the commit ID."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["take"])
+
+    capsys.readouterr()
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision="HEAD",
+        short=True,
+        verify=False,
+        abbrev_ref=False,
+    )
+    out = capsys.readouterr().out.strip()
+    assert out == cids[0][:8]
+    assert len(out) == 8
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_abbrev_ref_HEAD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_abbrev_ref_HEAD(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--abbrev-ref HEAD`` prints the current branch name, not the commit ID."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(tmp_path, muse_cli_db_session, ["beat"])
+
+    capsys.readouterr()
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision="HEAD",
+        short=False,
+        verify=False,
+        abbrev_ref=True,
+    )
+    out = capsys.readouterr().out.strip()
+    assert out == "main"
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_verify_fails_on_unknown_ref
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_verify_fails_on_unknown_ref(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--verify`` exits USER_ERROR when the revision does not resolve."""
+    _init_muse_repo(tmp_path)
+    # No commits — nothing to resolve
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _rev_parse_async(
+            root=tmp_path,
+            session=muse_cli_db_session,
+            revision="nonexistent",
+            short=False,
+            verify=True,
+            abbrev_ref=False,
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_no_verify_prints_nothing_on_miss
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_no_verify_prints_nothing_on_miss(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Without ``--verify``, an unresolvable ref prints nothing and exits 0."""
+    _init_muse_repo(tmp_path)
+
+    # Should not raise
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision="deadbeef",
+        short=False,
+        verify=False,
+        abbrev_ref=False,
+    )
+    out = capsys.readouterr().out.strip()
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_tilde_beyond_root_returns_nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_tilde_beyond_root_returns_nothing(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``HEAD~10`` on a 2-commit chain prints nothing (no --verify)."""
+    _init_muse_repo(tmp_path)
+    await _make_commits(tmp_path, muse_cli_db_session, ["one", "two"])
+
+    capsys.readouterr()  # discard commit output from _make_commits
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision="HEAD~10",
+        short=False,
+        verify=False,
+        abbrev_ref=False,
+    )
+    out = capsys.readouterr().out.strip()
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_head_tilde_zero_equals_HEAD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_rev_parse_head_tilde_zero_equals_HEAD(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``HEAD~0`` resolves to the same commit as ``HEAD``."""
+    _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["r1", "r2"])
+
+    capsys.readouterr()
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision="HEAD~0",
+        short=False,
+        verify=False,
+        abbrev_ref=False,
+    )
+    out_tilde = capsys.readouterr().out.strip()
+
+    capsys.readouterr()
+    await _rev_parse_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        revision="HEAD",
+        short=False,
+        verify=False,
+        abbrev_ref=False,
+    )
+    out_head = capsys.readouterr().out.strip()
+
+    assert out_tilde == out_head == cids[-1]
+
+
+# ---------------------------------------------------------------------------
+# test_resolve_revision_returns_RevParseResult_type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_resolve_revision_returns_RevParseResult_type(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """``resolve_revision`` returns a ``RevParseResult`` with correct fields."""
+    repo_id = _init_muse_repo(tmp_path)
+    cids = await _make_commits(tmp_path, muse_cli_db_session, ["init"])
+
+    result = await resolve_revision(
+        session=muse_cli_db_session,
+        repo_id=repo_id,
+        current_branch="main",
+        muse_dir=tmp_path / ".muse",
+        revision_expr="HEAD",
+    )
+
+    assert result is not None
+    assert isinstance(result, RevParseResult)
+    assert result.commit_id == cids[0]
+    assert result.branch == "main"
+    assert result.revision_expr == "HEAD"
+
+
+# ---------------------------------------------------------------------------
+# test_rev_parse_outside_repo_exits_2
+# ---------------------------------------------------------------------------
+
+
+def test_rev_parse_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse rev-parse`` outside a .muse/ directory exits with code 2."""
+    from typer.testing import CliRunner
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["rev-parse", "HEAD"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND


### PR DESCRIPTION
## Summary
Closes #92 — implements `muse rev-parse` as a plumbing command for the Muse VCS.

## Root Cause / Motivation
No rev-parse command existed. Without it, scripts and other commands have no standard way to resolve symbolic revision expressions (HEAD, branch names, tilde ancestors) to concrete commit IDs.

## Solution
- New `maestro/muse_cli/commands/rev_parse.py` implementing full revision resolution:
  - Supports: `HEAD`, `<branch>`, `<commit_id>` (full or prefix), `HEAD~N`, `<branch>~N`
  - Flags: `--short` (8-char prefix), `--verify` (exit 1 on miss), `--abbrev-ref` (branch name)
  - Exposes `resolve_revision()` as a typed plumbing primitive for other commands
  - Named result type `RevParseResult` (commit_id, branch, revision_expr)
- Registered in `app.py` as `muse rev-parse`
- 15 unit tests covering all expression types and all flags
- Docs: new section in `docs/architecture/muse_vcs.md`, `RevParseResult` registered in `docs/reference/type_contracts.md`

## Verification
- [x] mypy clean (490 source files)
- [x] 15/15 tests pass
- [x] Docs updated