### PR TITLE
feat: muse groove-check — analyze rhythmic drift across commits

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -2544,6 +2544,7 @@ branch for chord voicings while preserving the guitar branch's groove patterns.
 | `muse dynamics` | `commands/dynamics.py` | ✅ stub (PR #130) | #120 |
 | `muse export` | `commands/export.py` | ✅ implemented (PR #137) | #112 |
 | `muse grep` | `commands/grep_cmd.py` | ✅ stub (PR #128) | #124 |
+| `muse groove-check` | `commands/groove_check.py` | ✅ stub (PR #143) | #95 |
 | `muse import` | `commands/import_cmd.py` | ✅ implemented (PR #142) | #118 |
 | `muse meter` | `commands/meter.py` | ✅ implemented (PR #141) | #117 |
 | `muse recall` | `commands/recall.py` | ✅ stub (PR #135) | #122 |
@@ -2553,3 +2554,80 @@ branch for chord voicings while preserving the guitar branch's groove patterns.
 
 All stub commands have stable CLI contracts. Full musical analysis (MIDI content
 parsing, vector embeddings, LLM synthesis) is tracked as follow-up issues.
+
+---
+
+## `muse groove-check` — Rhythmic Drift Analysis
+
+**Purpose:** Detect which commit in a range introduced rhythmic inconsistency
+by measuring how much the average note-onset deviation from the quantization grid
+changed between adjacent commits.  The music-native equivalent of a style/lint gate.
+
+**Implementation:** `maestro/muse_cli/commands/groove_check.py` (CLI),
+`maestro/services/muse_groove_check.py` (pure service layer).
+**Status:** ✅ stub (issue #95)
+
+### Usage
+
+```bash
+muse groove-check [RANGE] [OPTIONS]
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `RANGE` | positional | last 10 commits | Commit range to analyze (e.g. `HEAD~5..HEAD`) |
+| `--track TEXT` | string | all | Scope analysis to a specific instrument track (e.g. `drums`) |
+| `--section TEXT` | string | all | Scope analysis to a specific musical section (e.g. `verse`) |
+| `--threshold FLOAT` | float | 0.1 | Drift threshold in beats; commits exceeding it are flagged WARN; >2× = FAIL |
+| `--json` | flag | off | Emit structured JSON for agent consumption |
+
+### Output example
+
+```
+Groove-check — range HEAD~6..HEAD  threshold 0.1 beats
+
+Commit    Groove Score  Drift Δ  Status
+--------  ------------  -------  ------
+a1b2c3d4        0.0400   0.0000  OK
+e5f6a7b8        0.0500   0.0100  OK
+c9d0e1f2        0.0600   0.0100  OK
+a3b4c5d6        0.0900   0.0300  OK
+e7f8a9b0        0.1500   0.0600  WARN
+c1d2e3f4        0.1300   0.0200  OK
+
+Flagged: 1 / 6 commits  (worst: e7f8a9b0)
+```
+
+### Result types
+
+`GrooveStatus` (Enum: OK/WARN/FAIL), `CommitGrooveMetrics` (frozen dataclass),
+`GrooveCheckResult` (frozen dataclass).
+See `docs/reference/type_contracts.md § GrooveCheckResult`.
+
+### Status classification
+
+| Status | Condition |
+|--------|-----------|
+| OK | `drift_delta ≤ threshold` |
+| WARN | `threshold < drift_delta ≤ 2 × threshold` |
+| FAIL | `drift_delta > 2 × threshold` |
+
+### Agent use case
+
+An AI agent runs `muse groove-check HEAD~20..HEAD --json` after a session to
+identify which commit degraded rhythmic tightness.  The `worst_commit` field
+pinpoints the exact SHA to inspect.  Feeding that into `muse describe` gives
+a natural-language explanation of what changed.  If `--threshold 0.05` returns
+multiple FAIL commits, the session's quantization workflow needs review before
+new layers are added.
+
+### Implementation stub note
+
+`groove_score` and `drift_delta` are computed from deterministic placeholder data.
+Full implementation will walk the `MuseCliCommit` chain, load MIDI snapshots via
+`MidiParser`, compute per-note onset deviation from the nearest quantization grid
+position (resolved from the commit's time-signature + tempo metadata), and
+aggregate by track / section.  Storpheus will expose a `/groove` route once
+the rhythmic-analysis pipeline is productionized.

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -25,6 +25,9 @@ This document is the single source of truth for every named entity (TypedDict, d
    - [ExpressivenessResult](#expressivenessresult)
    - [MuseTempoResult](#musetemporesult)
    - [MuseTempoHistoryEntry](#musetemopohistoryentry)
+   - [GrooveStatus](#groovestatuss)
+   - [CommitGrooveMetrics](#commitgroovemetrics)
+   - [GrooveCheckResult](#groovecheckresult)
 5. [Variation Layer (`app/variation/`)](#variation-layer)
    - [Event Envelope payloads](#event-envelope-payloads)
    - [PhraseRecord](#phraserecord)
@@ -1103,6 +1106,60 @@ On failure: `success=False` plus `error` (and optionally `message`).
 | `message` | `str` | Commit message |
 | `effective_bpm` | `float \| None` | Annotated BPM for this commit, or `None` |
 | `delta_bpm` | `float \| None` | Signed BPM change vs. the previous (older) commit; `None` for the oldest commit |
+
+---
+
+### `GrooveStatus`
+
+**Path:** `maestro/services/muse_groove_check.py`
+
+`str Enum` — Per-commit groove assessment relative to the configured drift threshold.
+
+| Member | Value | Condition |
+|--------|-------|-----------|
+| `OK` | `"OK"` | `drift_delta ≤ threshold` |
+| `WARN` | `"WARN"` | `threshold < drift_delta ≤ 2 × threshold` |
+| `FAIL` | `"FAIL"` | `drift_delta > 2 × threshold` |
+
+---
+
+### `CommitGrooveMetrics`
+
+**Path:** `maestro/services/muse_groove_check.py`
+
+`dataclass(frozen=True)` — Rhythmic groove metrics for a single commit in a
+`muse groove-check` range.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit` | `str` | Short commit ref (8 hex chars or resolved ID) |
+| `groove_score` | `float` | Average note-onset deviation from the quantization grid in beats; lower = tighter |
+| `drift_delta` | `float` | Absolute change in `groove_score` vs. the prior commit; 0.0 for the oldest commit |
+| `status` | `GrooveStatus` | OK / WARN / FAIL classification against the threshold |
+| `track` | `str` | Track scope used for analysis, or `"all"` |
+| `section` | `str` | Section scope used for analysis, or `"all"` |
+| `midi_files` | `int` | Number of MIDI snapshots analysed for this commit |
+
+---
+
+### `GrooveCheckResult`
+
+**Path:** `maestro/services/muse_groove_check.py`
+
+`dataclass(frozen=True)` — Aggregate result for a `muse groove-check` run.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_range` | `str` | The range string that was analysed (e.g. `"HEAD~5..HEAD"`) |
+| `threshold` | `float` | Drift threshold used for WARN/FAIL classification, in beats |
+| `total_commits` | `int` | Total commits in the analysis window |
+| `flagged_commits` | `int` | Number of commits with status WARN or FAIL |
+| `worst_commit` | `str` | Commit ref with the highest `drift_delta`, or empty string if no drift |
+| `entries` | `tuple[CommitGrooveMetrics, ...]` | Per-commit metrics, oldest-first |
+
+**Agent use case:** An AI agent reads `worst_commit` to identify the exact commit
+that degraded rhythmic consistency, then passes it to `muse describe` for a
+natural-language explanation of the change.
 
 ---
 

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -2,9 +2,9 @@
 
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (arrange, ask, checkout, commit, context, describe, divergence,
-dynamics, export, find, grep, import, init, log, merge, meter, open, play,
-pull, push, recall, remote, session, status, swing, tag, tempo) as Typer
-sub-applications.
+dynamics, export, find, grep, groove-check, import, init, log, merge, meter,
+open, play, pull, push, recall, remote, session, status, swing, tag, tempo)
+as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -22,6 +22,7 @@ from maestro.muse_cli.commands import (
     export,
     find,
     grep_cmd,
+    groove_check,
     import_cmd,
     init,
     log,
@@ -73,6 +74,7 @@ cli.add_typer(tempo.app, name="tempo", help="Read or set the tempo (BPM) of a co
 cli.add_typer(recall.app, name="recall", help="Search commit history by natural-language description.")
 cli.add_typer(context.app, name="context", help="Output structured musical context for AI agent consumption.")
 cli.add_typer(divergence.app, name="divergence", help="Show how two branches have diverged musically.")
+cli.add_typer(groove_check.app, name="groove-check", help="Analyze rhythmic drift across commits to find groove regressions.")
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/commands/groove_check.py
+++ b/maestro/muse_cli/commands/groove_check.py
@@ -1,0 +1,292 @@
+"""muse groove-check — analyze rhythmic drift across commits.
+
+Detects which commit in a range "killed the groove" by measuring how much
+the average note-onset deviation from the quantization grid shifted between
+adjacent commits.  A large drift_delta signals a quantize operation that was
+too aggressive, a tempo map change that made the pocket feel stiff, or any
+edit that disrupted rhythmic consistency.
+
+Output (default tabular)::
+
+    Groove-check — range HEAD~6..HEAD  threshold 0.1 beats
+
+    Commit    Groove Score  Drift Δ  Status
+    --------  ------------  -------  ------
+    a1b2c3d4        0.0400   0.0000  OK
+    e5f6a7b8        0.0500   0.0100  OK
+    c9d0e1f2        0.0600   0.0100  OK
+    a3b4c5d6        0.0900   0.0300  OK
+    e7f8a9b0        0.1500   0.0600  WARN
+    c1d2e3f4        0.1300   0.0200  OK
+
+    Flagged: 1 / 6 commits  (worst: e7f8a9b0)
+
+Flags
+-----
+[range]            Commit range to analyze (e.g. HEAD~5..HEAD). Default: last 10.
+--track TEXT       Scope analysis to a specific instrument track.
+--section TEXT     Scope analysis to a specific musical section.
+--threshold FLOAT  Drift threshold in beats (default 0.1). Commits that exceed
+                   this value are flagged WARN; >2× threshold = FAIL.
+--json             Emit machine-readable JSON output.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing_extensions import Annotated
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.services.muse_groove_check import (
+    DEFAULT_THRESHOLD,
+    GrooveCheckResult,
+    GrooveStatus,
+    compute_groove_check,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+# ---------------------------------------------------------------------------
+# Column widths
+# ---------------------------------------------------------------------------
+
+_COL_COMMIT = 8
+_COL_SCORE = 12
+_COL_DELTA = 7
+_COL_STATUS = 6
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_table(result: GrooveCheckResult) -> None:
+    """Emit an ASCII table of groove-check results to stdout.
+
+    Includes a summary line with the total flagged count and worst commit.
+
+    Args:
+        result: Completed :class:`GrooveCheckResult` from the analysis.
+    """
+    typer.echo(
+        f"Groove-check — range {result.commit_range}"
+        f"  threshold {result.threshold} beats"
+    )
+    typer.echo("")
+
+    header = (
+        f"{'Commit':<{_COL_COMMIT}}  "
+        f"{'Groove Score':>{_COL_SCORE}}  "
+        f"{'Drift Δ':>{_COL_DELTA}}  "
+        f"{'Status':<{_COL_STATUS}}"
+    )
+    sep = (
+        f"{'-' * _COL_COMMIT}  "
+        f"{'-' * _COL_SCORE}  "
+        f"{'-' * _COL_DELTA}  "
+        f"{'-' * _COL_STATUS}"
+    )
+    typer.echo(header)
+    typer.echo(sep)
+
+    for entry in result.entries:
+        typer.echo(
+            f"{entry.commit:<{_COL_COMMIT}}  "
+            f"{entry.groove_score:>{_COL_SCORE}.4f}  "
+            f"{entry.drift_delta:>{_COL_DELTA}.4f}  "
+            f"{entry.status.value:<{_COL_STATUS}}"
+        )
+
+    typer.echo("")
+    worst_label = (
+        f"  (worst: {result.worst_commit})" if result.worst_commit else ""
+    )
+    typer.echo(
+        f"Flagged: {result.flagged_commits} / {result.total_commits} commits"
+        f"{worst_label}"
+    )
+
+
+def _render_json(result: GrooveCheckResult) -> None:
+    """Emit groove-check results as structured JSON for agent consumption.
+
+    Args:
+        result: Completed :class:`GrooveCheckResult` from the analysis.
+    """
+    payload = {
+        "commit_range": result.commit_range,
+        "threshold": result.threshold,
+        "total_commits": result.total_commits,
+        "flagged_commits": result.flagged_commits,
+        "worst_commit": result.worst_commit,
+        "entries": [
+            {
+                "commit": e.commit,
+                "groove_score": e.groove_score,
+                "drift_delta": e.drift_delta,
+                "status": e.status.value,
+                "track": e.track,
+                "section": e.section,
+                "midi_files": e.midi_files,
+            }
+            for e in result.entries
+        ],
+    }
+    typer.echo(json.dumps(payload, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Async core (injectable for tests)
+# ---------------------------------------------------------------------------
+
+
+async def _groove_check_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    commit_range: Optional[str],
+    track: Optional[str],
+    section: Optional[str],
+    threshold: float,
+    as_json: bool,
+) -> GrooveCheckResult:
+    """Core groove-check logic — fully injectable for unit tests.
+
+    Resolves the effective commit range from the ``.muse/`` layout, calls
+    :func:`compute_groove_check` (pure, stub-backed), and renders output.
+
+    Args:
+        root:         Repository root (directory containing ``.muse/``).
+        session:      Open async DB session (reserved for full implementation).
+        commit_range: Explicit range string or None to use the last 10 commits.
+        track:        Restrict analysis to a named instrument track.
+        section:      Restrict analysis to a named musical section.
+        threshold:    Drift threshold in beats for WARN/FAIL classification.
+        as_json:      Emit JSON instead of the ASCII table.
+
+    Returns:
+        The :class:`GrooveCheckResult` produced by the analysis.
+    """
+    if threshold <= 0:
+        typer.echo("❌ --threshold must be a positive number.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    muse_dir = root / ".muse"
+    head_path = muse_dir / "HEAD"
+    head_ref = head_path.read_text().strip()
+    branch = head_ref.rsplit("/", 1)[-1] if "/" in head_ref else head_ref
+    ref_path = muse_dir / pathlib.Path(head_ref)
+    head_sha = ref_path.read_text().strip() if ref_path.exists() else ""
+
+    if not head_sha and not commit_range:
+        typer.echo(f"No commits yet on branch {branch} — nothing to analyse.")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    effective_range = commit_range or f"HEAD~{10}..HEAD"
+
+    result = compute_groove_check(
+        commit_range=effective_range,
+        threshold=threshold,
+        track=track,
+        section=section,
+    )
+
+    if as_json:
+        _render_json(result)
+    else:
+        _render_table(result)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def groove_check(
+    ctx: typer.Context,
+    commit_range: Annotated[
+        Optional[str],
+        typer.Argument(
+            help=(
+                "Commit range to analyze (e.g. HEAD~5..HEAD). "
+                "Defaults to the last 10 commits."
+            ),
+            show_default=False,
+            metavar="RANGE",
+        ),
+    ] = None,
+    track: Annotated[
+        Optional[str],
+        typer.Option(
+            "--track",
+            help="Scope analysis to a specific instrument track (e.g. 'drums').",
+            show_default=False,
+            metavar="TEXT",
+        ),
+    ] = None,
+    section: Annotated[
+        Optional[str],
+        typer.Option(
+            "--section",
+            help="Scope analysis to a specific musical section (e.g. 'verse').",
+            show_default=False,
+            metavar="TEXT",
+        ),
+    ] = None,
+    threshold: Annotated[
+        float,
+        typer.Option(
+            "--threshold",
+            help=(
+                "Drift threshold in beats (default 0.1). Commits whose "
+                "drift_delta exceeds this are flagged WARN; >2× = FAIL."
+            ),
+        ),
+    ] = DEFAULT_THRESHOLD,
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable JSON output."),
+    ] = False,
+) -> None:
+    """Analyze rhythmic drift across commits to find groove regressions.
+
+    Computes note-onset deviation from the quantization grid for each commit
+    in the range, then flags commits where the deviation shifted significantly
+    relative to their neighbors.  Use this after a session to spot which
+    commit made the pocket feel stiff.
+    """
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _groove_check_async(
+                root=root,
+                session=session,
+                commit_range=commit_range,
+                track=track,
+                section=section,
+                threshold=threshold,
+                as_json=as_json,
+            )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse groove-check failed: {exc}")
+        logger.error("❌ muse groove-check error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/services/muse_groove_check.py
+++ b/maestro/services/muse_groove_check.py
@@ -1,0 +1,230 @@
+"""Muse Groove-Check Service — rhythmic drift analysis across commits.
+
+Computes per-commit groove scores by measuring note-onset deviation
+from the quantization grid, then detects which commits introduced
+rhythmic inconsistency relative to their neighbors.
+
+"Groove drift" is the absolute change in average onset deviation between
+adjacent commits.  A commit with a large drift delta is the one that
+"killed the groove."
+
+This is a stub implementation that demonstrates the correct CLI contract
+and result schema.  Full MIDI content analysis will be wired in once
+Storpheus exposes a rhythmic quantization introspection route.
+
+Boundary rules:
+  - Pure data — no side effects, no external I/O.
+  - Must NOT import StateStore, EntityRegistry, or executor modules.
+  - Must NOT import LLM handlers or maestro_* pipeline modules.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_THRESHOLD = 0.1  # beats — flag commits whose drift_delta exceeds this
+DEFAULT_COMMIT_LIMIT = 10  # fallback window when no explicit range is given
+
+
+# ---------------------------------------------------------------------------
+# Result types (stable CLI contract)
+# ---------------------------------------------------------------------------
+
+
+class GrooveStatus(str, Enum):
+    """Per-commit groove assessment relative to the configured threshold.
+
+    OK   — drift_delta ≤ threshold; rhythm is consistent with neighbors.
+    WARN — drift_delta is between threshold and 2× threshold; mild drift.
+    FAIL — drift_delta > 2× threshold; likely culprit for groove regression.
+    """
+
+    OK = "OK"
+    WARN = "WARN"
+    FAIL = "FAIL"
+
+
+@dataclass(frozen=True)
+class CommitGrooveMetrics:
+    """Rhythmic groove metrics for a single commit.
+
+    groove_score  — average note-onset deviation from the quantization grid,
+                    in beats.  Lower is tighter (closer to the grid).
+    drift_delta   — absolute change in groove_score relative to the prior
+                    commit in the range.  The first commit always has delta 0.0.
+    status        — OK / WARN / FAIL classification against the threshold.
+    commit        — short commit ref (8 hex chars or resolved ID).
+    track         — track scope used for analysis, or "all".
+    section       — section scope used for analysis, or "all".
+    midi_files    — number of MIDI snapshots analysed for this commit.
+    """
+
+    commit: str
+    groove_score: float
+    drift_delta: float
+    status: GrooveStatus
+    track: str = "all"
+    section: str = "all"
+    midi_files: int = 0
+
+
+@dataclass(frozen=True)
+class GrooveCheckResult:
+    """Aggregate result for a `muse groove-check` run.
+
+    commit_range    — the range string that was analysed (e.g. "HEAD~5..HEAD").
+    threshold       — drift threshold used for WARN/FAIL classification.
+    total_commits   — total commits in the analysis window.
+    flagged_commits — number of commits with status WARN or FAIL.
+    worst_commit    — commit ref with the highest drift_delta, or empty string.
+    entries         — per-commit metrics, oldest-first.
+    """
+
+    commit_range: str
+    threshold: float
+    total_commits: int
+    flagged_commits: int
+    worst_commit: str
+    entries: tuple[CommitGrooveMetrics, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Status classification
+# ---------------------------------------------------------------------------
+
+
+def classify_status(drift_delta: float, threshold: float) -> GrooveStatus:
+    """Classify a drift delta against the threshold.
+
+    Args:
+        drift_delta: Absolute change in groove_score vs. prior commit.
+        threshold:   User-configurable WARN boundary in beats.
+
+    Returns:
+        :class:`GrooveStatus` OK, WARN, or FAIL.
+    """
+    if drift_delta <= threshold:
+        return GrooveStatus.OK
+    if drift_delta <= threshold * 2:
+        return GrooveStatus.WARN
+    return GrooveStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# Stub data factories
+# ---------------------------------------------------------------------------
+
+_STUB_COMMITS: tuple[tuple[str, float, int], ...] = (
+    ("a1b2c3d4", 0.04, 3),
+    ("e5f6a7b8", 0.05, 3),
+    ("c9d0e1f2", 0.06, 3),
+    ("a3b4c5d6", 0.09, 3),
+    ("e7f8a9b0", 0.15, 3),  # groove degraded here
+    ("c1d2e3f4", 0.13, 3),
+    ("a5b6c7d8", 0.08, 3),  # recovered
+)
+
+
+def build_stub_entries(
+    *,
+    threshold: float,
+    track: Optional[str],
+    section: Optional[str],
+    limit: int,
+) -> list[CommitGrooveMetrics]:
+    """Produce stub CommitGrooveMetrics for a commit window.
+
+    Returns the last ``limit`` entries from the stub table with
+    drift_delta and status computed against ``threshold``.
+
+    Args:
+        threshold: WARN/FAIL boundary in beats.
+        track:     Track filter (stored in metadata; no content effect in stub).
+        section:   Section filter (stored in metadata; no content effect in stub).
+        limit:     Maximum number of commits to return.
+
+    Returns:
+        List of :class:`CommitGrooveMetrics`, oldest-first.
+    """
+    sample = list(_STUB_COMMITS[-limit:])
+    entries: list[CommitGrooveMetrics] = []
+    prev_score: Optional[float] = None
+    for commit, score, midi_files in sample:
+        delta = abs(score - prev_score) if prev_score is not None else 0.0
+        status = classify_status(delta, threshold)
+        entries.append(
+            CommitGrooveMetrics(
+                commit=commit,
+                groove_score=round(score, 4),
+                drift_delta=round(delta, 4),
+                status=status,
+                track=track or "all",
+                section=section or "all",
+                midi_files=midi_files,
+            )
+        )
+        prev_score = score
+    return entries
+
+
+def compute_groove_check(
+    *,
+    commit_range: str,
+    threshold: float = DEFAULT_THRESHOLD,
+    track: Optional[str] = None,
+    section: Optional[str] = None,
+    limit: int = DEFAULT_COMMIT_LIMIT,
+) -> GrooveCheckResult:
+    """Compute groove-check metrics for a commit range.
+
+    Pure function — safe to call from tests without any repository context.
+    The stub implementation produces deterministic, musically-realistic results
+    using hardcoded representative data.
+
+    Args:
+        commit_range: Commit range string used for display (e.g. "HEAD~5..HEAD").
+        threshold:    Drift threshold in beats (default 0.1).
+        track:        Restrict analysis to a named instrument track.
+        section:      Restrict analysis to a named musical section.
+        limit:        Maximum number of commits to include (default 10).
+
+    Returns:
+        A :class:`GrooveCheckResult` with per-commit metrics and summary fields.
+    """
+    entries = build_stub_entries(
+        threshold=threshold,
+        track=track,
+        section=section,
+        limit=limit,
+    )
+    flagged = [e for e in entries if e.status != GrooveStatus.OK]
+    worst = max(entries, key=lambda e: e.drift_delta, default=None)
+    worst_commit = worst.commit if worst and worst.drift_delta > 0 else ""
+
+    result = GrooveCheckResult(
+        commit_range=commit_range,
+        threshold=threshold,
+        total_commits=len(entries),
+        flagged_commits=len(flagged),
+        worst_commit=worst_commit,
+        entries=tuple(entries),
+    )
+
+    logger.info(
+        "✅ Groove-check: range=%s threshold=%.3f flagged=%d/%d worst=%s",
+        commit_range,
+        threshold,
+        result.flagged_commits,
+        result.total_commits,
+        result.worst_commit or "none",
+    )
+    return result

--- a/tests/test_muse_groove_check.py
+++ b/tests/test_muse_groove_check.py
@@ -1,0 +1,559 @@
+"""Tests for ``muse groove-check`` — CLI interface, flag parsing, and stub output format.
+
+All CLI-level tests use ``typer.testing.CliRunner`` against the full ``muse``
+app so that argument parsing, flag handling, and exit codes are exercised end-to-end.
+
+Async core tests call ``_groove_check_async`` directly with an in-memory SQLite
+session (the stub does not query the DB; the session satisfies the signature
+contract only).
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+from typer.testing import CliRunner
+
+from maestro.db.database import Base
+import maestro.muse_cli.models  # noqa: F401  — registers MuseCli* with Base.metadata
+from maestro.muse_cli.app import cli
+from maestro.muse_cli.commands.groove_check import (
+    _groove_check_async,
+    _render_json,
+    _render_table,
+)
+from maestro.muse_cli.errors import ExitCode
+from maestro.services.muse_groove_check import (
+    DEFAULT_THRESHOLD,
+    CommitGrooveMetrics,
+    GrooveCheckResult,
+    GrooveStatus,
+    build_stub_entries,
+    classify_status,
+    compute_groove_check,
+)
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, branch: str = "main") -> str:
+    """Create a minimal .muse/ layout with one empty commit ref."""
+    rid = str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(json.dumps({"repo_id": rid, "schema_version": "1"}))
+    (muse / "HEAD").write_text(f"refs/heads/{branch}")
+    (muse / "refs" / "heads" / branch).write_text("")
+    return rid
+
+
+def _commit_ref(root: pathlib.Path, branch: str = "main") -> None:
+    """Write a fake commit ID into the branch ref so HEAD is non-empty."""
+    muse = root / ".muse"
+    (muse / "refs" / "heads" / branch).write_text("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    """In-memory SQLite session (stub groove-check does not actually query it)."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(bind=engine, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Unit — classify_status
+# ---------------------------------------------------------------------------
+
+
+def test_classify_status_ok_below_threshold() -> None:
+    """delta ≤ threshold → OK."""
+    assert classify_status(0.05, 0.1) == GrooveStatus.OK
+
+
+def test_classify_status_ok_at_threshold() -> None:
+    """delta exactly at threshold → OK (inclusive boundary)."""
+    assert classify_status(0.1, 0.1) == GrooveStatus.OK
+
+
+def test_classify_status_warn_between_threshold_and_double() -> None:
+    """threshold < delta ≤ 2× threshold → WARN."""
+    assert classify_status(0.15, 0.1) == GrooveStatus.WARN
+
+
+def test_classify_status_fail_above_double_threshold() -> None:
+    """delta > 2× threshold → FAIL."""
+    assert classify_status(0.25, 0.1) == GrooveStatus.FAIL
+
+
+def test_classify_status_zero_delta_ok() -> None:
+    """First commit always has delta 0.0 → OK regardless of threshold."""
+    assert classify_status(0.0, 0.1) == GrooveStatus.OK
+
+
+# ---------------------------------------------------------------------------
+# Unit — build_stub_entries
+# ---------------------------------------------------------------------------
+
+
+def test_build_stub_entries_returns_correct_limit() -> None:
+    """build_stub_entries respects the limit argument."""
+    entries = build_stub_entries(threshold=0.1, track=None, section=None, limit=3)
+    assert len(entries) == 3
+
+
+def test_build_stub_entries_first_entry_has_zero_delta() -> None:
+    """The oldest commit in the window always has drift_delta == 0.0."""
+    entries = build_stub_entries(threshold=0.1, track=None, section=None, limit=5)
+    assert entries[0].drift_delta == 0.0
+
+
+def test_build_stub_entries_track_stored_in_metadata() -> None:
+    """Track filter is stored in each entry's track field."""
+    entries = build_stub_entries(threshold=0.1, track="drums", section=None, limit=3)
+    for e in entries:
+        assert e.track == "drums"
+
+
+def test_build_stub_entries_section_stored_in_metadata() -> None:
+    """Section filter is stored in each entry's section field."""
+    entries = build_stub_entries(threshold=0.1, track=None, section="verse", limit=3)
+    for e in entries:
+        assert e.section == "verse"
+
+
+def test_build_stub_entries_status_matches_classification() -> None:
+    """Each entry's status is consistent with classify_status(drift_delta, threshold)."""
+    threshold = 0.05
+    entries = build_stub_entries(threshold=threshold, track=None, section=None, limit=7)
+    for e in entries:
+        expected = classify_status(e.drift_delta, threshold)
+        assert e.status == expected, f"{e.commit}: status mismatch"
+
+
+def test_build_stub_entries_groove_scores_positive() -> None:
+    """All groove_score values are non-negative."""
+    entries = build_stub_entries(threshold=0.1, track=None, section=None, limit=7)
+    for e in entries:
+        assert e.groove_score >= 0.0, f"{e.commit}: negative groove_score"
+
+
+# ---------------------------------------------------------------------------
+# Unit — compute_groove_check
+# ---------------------------------------------------------------------------
+
+
+def test_compute_groove_check_returns_result() -> None:
+    """compute_groove_check returns a GrooveCheckResult with entries."""
+    result = compute_groove_check(commit_range="HEAD~5..HEAD")
+    assert isinstance(result, GrooveCheckResult)
+    assert len(result.entries) > 0
+
+
+def test_compute_groove_check_stores_range() -> None:
+    """commit_range is echoed in the result."""
+    result = compute_groove_check(commit_range="abc123..def456")
+    assert result.commit_range == "abc123..def456"
+
+
+def test_compute_groove_check_stores_threshold() -> None:
+    """threshold is echoed in the result."""
+    result = compute_groove_check(commit_range="HEAD~5..HEAD", threshold=0.05)
+    assert result.threshold == 0.05
+
+
+def test_compute_groove_check_flagged_count_consistent() -> None:
+    """flagged_commits == number of entries whose status != OK."""
+    result = compute_groove_check(commit_range="HEAD~10..HEAD", threshold=0.01)
+    manual_count = sum(1 for e in result.entries if e.status != GrooveStatus.OK)
+    assert result.flagged_commits == manual_count
+
+
+def test_compute_groove_check_worst_commit_has_max_delta() -> None:
+    """worst_commit refers to the entry with the largest drift_delta."""
+    result = compute_groove_check(commit_range="HEAD~10..HEAD")
+    if result.worst_commit:
+        max_entry = max(result.entries, key=lambda e: e.drift_delta)
+        assert result.worst_commit == max_entry.commit
+
+
+def test_compute_groove_check_tight_threshold_flags_more() -> None:
+    """A tighter threshold flags more commits than a loose one."""
+    loose = compute_groove_check(commit_range="HEAD~10..HEAD", threshold=0.5)
+    tight = compute_groove_check(commit_range="HEAD~10..HEAD", threshold=0.01)
+    assert tight.flagged_commits >= loose.flagged_commits
+
+
+# ---------------------------------------------------------------------------
+# Unit — renderers
+# ---------------------------------------------------------------------------
+
+
+def test_render_table_outputs_header(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_table includes the range, threshold, and column headers."""
+    result = compute_groove_check(commit_range="HEAD~5..HEAD", threshold=0.1)
+    _render_table(result)
+    out = capsys.readouterr().out
+    assert "Groove-check" in out
+    assert "HEAD~5..HEAD" in out
+    assert "0.1 beats" in out
+    assert "Commit" in out
+    assert "Groove Score" in out
+    assert "Drift" in out
+    assert "Status" in out
+
+
+def test_render_table_shows_all_commits(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_table emits one row per entry."""
+    result = compute_groove_check(commit_range="HEAD~5..HEAD")
+    _render_table(result)
+    out = capsys.readouterr().out
+    for entry in result.entries:
+        assert entry.commit in out
+
+
+def test_render_table_shows_flagged_summary(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_table includes 'Flagged:' summary line."""
+    result = compute_groove_check(commit_range="HEAD~5..HEAD")
+    _render_table(result)
+    out = capsys.readouterr().out
+    assert "Flagged:" in out
+
+
+def test_render_json_is_valid(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_json emits parseable JSON with the expected top-level keys."""
+    result = compute_groove_check(commit_range="HEAD~5..HEAD", threshold=0.1)
+    _render_json(result)
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    assert payload["commit_range"] == "HEAD~5..HEAD"
+    assert payload["threshold"] == 0.1
+    assert "total_commits" in payload
+    assert "flagged_commits" in payload
+    assert "worst_commit" in payload
+    assert isinstance(payload["entries"], list)
+
+
+def test_render_json_entries_have_required_fields(capsys: pytest.CaptureFixture[str]) -> None:
+    """Each JSON entry contains all required per-commit fields."""
+    result = compute_groove_check(commit_range="HEAD~5..HEAD")
+    _render_json(result)
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    required = {"commit", "groove_score", "drift_delta", "status", "track", "section", "midi_files"}
+    for entry in payload["entries"]:
+        assert required.issubset(entry.keys()), f"Missing fields in entry: {entry}"
+
+
+def test_render_json_status_values_valid(capsys: pytest.CaptureFixture[str]) -> None:
+    """All JSON status values are valid GrooveStatus members."""
+    valid = {s.value for s in GrooveStatus}
+    result = compute_groove_check(commit_range="HEAD~5..HEAD", threshold=0.01)
+    _render_json(result)
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    for entry in payload["entries"]:
+        assert entry["status"] in valid, f"Unknown status: {entry['status']}"
+
+
+# ---------------------------------------------------------------------------
+# Async core — _groove_check_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_groove_check_async_default_output(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_groove_check_async with no filters shows a table with commit rows."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _groove_check_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range=None,
+        track=None,
+        section=None,
+        threshold=DEFAULT_THRESHOLD,
+        as_json=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "Groove-check" in out
+    assert "Flagged:" in out
+
+
+@pytest.mark.anyio
+async def test_groove_check_async_json_mode(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_groove_check_async --json emits valid JSON with entries list."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _groove_check_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range=None,
+        track=None,
+        section=None,
+        threshold=DEFAULT_THRESHOLD,
+        as_json=True,
+    )
+
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    assert "entries" in payload
+    assert len(payload["entries"]) > 0
+
+
+@pytest.mark.anyio
+async def test_groove_check_async_explicit_range(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An explicit commit range appears in the table header."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _groove_check_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range="HEAD~3..HEAD",
+        track=None,
+        section=None,
+        threshold=DEFAULT_THRESHOLD,
+        as_json=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "HEAD~3..HEAD" in out
+
+
+@pytest.mark.anyio
+async def test_groove_check_async_track_filter_stored(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--track is propagated to the result entries."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _groove_check_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range=None,
+        track="drums",
+        section=None,
+        threshold=DEFAULT_THRESHOLD,
+        as_json=True,
+    )
+
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    for entry in payload["entries"]:
+        assert entry["track"] == "drums"
+
+
+@pytest.mark.anyio
+async def test_groove_check_async_section_filter_stored(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--section is propagated to the result entries."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _groove_check_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range=None,
+        track=None,
+        section="verse",
+        threshold=DEFAULT_THRESHOLD,
+        as_json=True,
+    )
+
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    for entry in payload["entries"]:
+        assert entry["section"] == "verse"
+
+
+@pytest.mark.anyio
+async def test_groove_check_async_custom_threshold(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Custom threshold is reflected in the JSON output."""
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _groove_check_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range=None,
+        track=None,
+        section=None,
+        threshold=0.05,
+        as_json=True,
+    )
+
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    assert payload["threshold"] == 0.05
+
+
+@pytest.mark.anyio
+async def test_groove_check_async_invalid_threshold_exits(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """threshold ≤ 0 exits with USER_ERROR."""
+    import typer
+
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _groove_check_async(
+            root=tmp_path,
+            session=db_session,
+            commit_range=None,
+            track=None,
+            section=None,
+            threshold=0.0,
+            as_json=False,
+        )
+    assert exc_info.value.exit_code == int(ExitCode.USER_ERROR)
+
+
+@pytest.mark.anyio
+async def test_groove_check_async_no_commits_exits_success(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """With no commits and no explicit range, exits 0 with informative message."""
+    import typer
+
+    _init_muse_repo(tmp_path)
+    # No _commit_ref call — branch ref is empty.
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _groove_check_async(
+            root=tmp_path,
+            session=db_session,
+            commit_range=None,
+            track=None,
+            section=None,
+            threshold=DEFAULT_THRESHOLD,
+            as_json=False,
+        )
+    assert exc_info.value.exit_code == int(ExitCode.SUCCESS)
+    out = capsys.readouterr().out
+    assert "No commits yet" in out
+
+
+# ---------------------------------------------------------------------------
+# Regression — test_groove_check_outputs_table_with_drift_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_groove_check_outputs_table_with_drift_status(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Regression: groove-check always outputs a table with commit/drift/status columns.
+
+    This is the primary acceptance-criteria test from issue #95:
+    the table must include commit refs, groove_score, drift_delta, and a status
+    column with OK/WARN/FAIL values.
+    """
+    _init_muse_repo(tmp_path)
+    _commit_ref(tmp_path)
+
+    await _groove_check_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range="HEAD~6..HEAD",
+        track=None,
+        section=None,
+        threshold=DEFAULT_THRESHOLD,
+        as_json=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "Groove-check" in out
+    assert "Commit" in out
+    assert "Groove Score" in out
+    assert "Drift" in out
+    assert "Status" in out
+    # At least one valid status label must appear
+    assert any(status in out for status in ("OK", "WARN", "FAIL"))
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — CliRunner
+# ---------------------------------------------------------------------------
+
+
+def test_cli_groove_check_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse groove-check`` exits 2 when invoked outside a Muse repository."""
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["groove-check"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == int(ExitCode.REPO_NOT_FOUND)
+    assert "not a muse repository" in result.output.lower()
+
+
+def test_cli_groove_check_help_lists_flags(tmp_path: pathlib.Path) -> None:
+    """``muse groove-check --help`` shows all documented flags."""
+    result = runner.invoke(cli, ["groove-check", "--help"])
+    assert result.exit_code == 0
+    for flag in ("--track", "--section", "--threshold", "--json"):
+        assert flag in result.output, f"Flag '{flag}' not found in help output"
+
+
+def test_cli_groove_check_appears_in_muse_help() -> None:
+    """``muse --help`` lists the groove-check subcommand."""
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "groove-check" in result.output


### PR DESCRIPTION
## Summary
Closes #95 — implements `muse groove-check`, the music-native equivalent of a style/lint gate that detects which commit in a range degraded rhythmic consistency.

## Root Cause / Motivation
No groove-check command existed. Producers using Muse had no way to identify which commit "killed the groove" — whether an overly aggressive quantize, a tempo map change, or any edit that disrupted note-onset alignment with the quantization grid.

## Solution
Added two new modules following the established swing/dynamics stub pattern:

- **`maestro/services/muse_groove_check.py`** — pure service layer with typed result entities (`GrooveStatus` enum, `CommitGrooveMetrics` frozen dataclass, `GrooveCheckResult` frozen dataclass), `classify_status()`, `build_stub_entries()`, and `compute_groove_check()`. No side effects, no DB access — safe to call from tests.
- **`maestro/muse_cli/commands/groove_check.py`** — Typer CLI command with the full flag set (`[RANGE] --track --section --threshold --json`), ASCII table + JSON renderers, and an injectable async core (`_groove_check_async`) for test isolation.
- **`maestro/muse_cli/app.py`** — registered `groove-check` subcommand.

Docs updated in the same commit:
- `docs/architecture/muse_vcs.md` — groove-check command reference (purpose, flags table, output example, result types, status classification, agent use case, stub boundary note)
- `docs/reference/type_contracts.md` — `GrooveStatus`, `CommitGrooveMetrics`, `GrooveCheckResult` entries

## Layers Affected
- [x] Muse VCS

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (491 files)
- [x] `docker compose exec storpheus mypy .` — not affected
- [x] 35 tests pass
- [x] Docs updated

## Tests Added
- `test_classify_status_*` (5) — boundary conditions for OK/WARN/FAIL classification
- `test_build_stub_entries_*` (6) — limit, delta, track/section metadata, status consistency, score positivity
- `test_compute_groove_check_*` (6) — result structure, range/threshold storage, flagged count consistency, worst commit, threshold sensitivity
- `test_render_table_*` (3) — header, commit rows, flagged summary
- `test_render_json_*` (3) — valid JSON, required fields, valid status values
- `test_groove_check_async_*` (8) — default output, JSON mode, explicit range, track filter, section filter, custom threshold, invalid threshold exits, no-commits exits
- `test_groove_check_outputs_table_with_drift_status` — **primary regression test** from issue #95 acceptance criteria
- `test_cli_groove_check_*` (3) — outside repo exit 2, help flags, appears in muse --help

## Handoff
N/A — no protocol change. Pure Muse CLI addition.