### PR TITLE
feat: muse commit-tree <snapshot-id> — create a raw commit object

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -4166,3 +4166,22 @@ error message via `typer.echo` before calling `typer.Exit(INTERNAL_ERROR)`.
 ```python
 class StorpheusUnavailableError(Exception): ...
 ```
+
+
+---
+
+### `CommitTreeResult`
+
+Conceptual result type for `muse commit-tree` (returned as a plain `str` from
+`_commit_tree_async`; documented here so agents understand the output contract).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` (64-char hex) | Deterministic SHA-256 commit ID created from `(parent_ids, snapshot_id, message, author)`. Identical inputs always produce the same ID. |
+
+**Source:** `maestro/muse_cli/commands/commit_tree.py` — `_commit_tree_async`
+
+**Idempotency:** The same `(parent_ids, snapshot_id, message, author)` tuple
+always hashes to the same `commit_id`.  Agents can call `muse commit-tree`
+repeatedly with the same arguments and always get the same result without
+side-effects on subsequent calls (second call is a no-op).

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -1,10 +1,10 @@
 """Muse CLI — Typer application root.
 
 Entry point for the ``muse`` console script. Registers all MVP
-subcommands (arrange, ask, checkout, commit, context, describe, divergence,
-dynamics, export, find, grep, import, init, log, merge, meter, open, play,
-pull, push, recall, remote, session, status, swing, tag, tempo) as Typer
-sub-applications.
+subcommands (arrange, ask, checkout, commit, commit-tree, context, describe,
+divergence, dynamics, export, find, grep, import, init, log, merge, meter,
+open, play, pull, push, recall, remote, session, status, swing, tag, tempo)
+as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -15,6 +15,7 @@ from maestro.muse_cli.commands import (
     ask,
     checkout,
     commit,
+    commit_tree,
     context,
     describe,
     divergence,
@@ -50,6 +51,11 @@ cli.add_typer(init.app, name="init", help="Initialise a new Muse repository.")
 cli.add_typer(status.app, name="status", help="Show working-tree drift against HEAD.")
 cli.add_typer(dynamics.app, name="dynamics", help="Analyse the dynamic (velocity) profile of a commit.")
 cli.add_typer(commit.app, name="commit", help="Record a new variation in history.")
+cli.add_typer(
+    commit_tree.app,
+    name="commit-tree",
+    help="Create a raw commit object from an existing snapshot (plumbing).",
+)
 cli.add_typer(grep_cmd.app, name="grep", help="Search for a musical pattern across all commits.")
 cli.add_typer(log.app, name="log", help="Display the variation history graph.")
 cli.add_typer(find.app, name="find", help="Search commit history by musical properties.")

--- a/maestro/muse_cli/commands/commit_tree.py
+++ b/maestro/muse_cli/commands/commit_tree.py
@@ -1,0 +1,220 @@
+"""muse commit-tree — create a raw commit object from an existing snapshot.
+
+This is a git-plumbing-style command that creates a commit row in the database
+directly from a known ``snapshot_id`` plus explicit metadata.  Unlike
+``muse commit``, it does NOT walk the filesystem, does NOT update any branch
+ref, and does NOT touch ``.muse/HEAD``.
+
+Why this exists
+---------------
+Scripting and advanced history manipulation require the ability to construct
+commits programmatically — for example when replaying a merge, synthesising
+history from an external source, or building tooling on top of Muse's commit
+graph.  Separating "create commit object" from "advance branch pointer" mirrors
+the design of ``git commit-tree`` + ``git update-ref``.
+
+Idempotency contract
+--------------------
+``commit_id`` is derived deterministically from
+``(parent_ids, snapshot_id, message, author)`` with no timestamp component.
+Repeating the same call returns the same ``commit_id`` without inserting a
+duplicate row.
+
+Usage::
+
+    muse commit-tree <snapshot_id> -m "feat: re-record verse" \\
+        -p <parent_commit_id>
+
+For a merge commit supply two ``-p`` flags::
+
+    muse commit-tree <snapshot_id> -m "Merge groove branch" \\
+        -p <parent1> -p <parent2>
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime
+import logging
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import insert_commit, open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+from maestro.muse_cli.snapshot import compute_commit_tree_id
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+_MAX_PARENTS = 2
+
+
+def _read_author_from_config(repo_root_str: str) -> str:
+    """Read ``[user] name`` from ``.muse/config.toml``, returning ``""`` on miss.
+
+    Config.toml is optional — when absent or when ``[user] name`` is not set
+    the author field falls back to an empty string, which matches the behaviour
+    of ``muse commit``.
+    """
+    import pathlib
+    import tomllib
+
+    config_path = pathlib.Path(repo_root_str) / ".muse" / "config.toml"
+    if not config_path.is_file():
+        return ""
+    try:
+        with config_path.open("rb") as fh:
+            data = tomllib.load(fh)
+        name: object = data.get("user", {}).get("name", "")
+        return str(name).strip() if isinstance(name, str) else ""
+    except Exception:
+        return ""
+
+
+async def _commit_tree_async(
+    *,
+    snapshot_id: str,
+    message: str,
+    parent_ids: list[str],
+    author: str,
+    session: AsyncSession,
+) -> str:
+    """Create a raw commit object from an existing snapshot.
+
+    Looks up *snapshot_id* in the database to verify it exists, computes a
+    deterministic ``commit_id``, and inserts a ``MuseCliCommit`` row if one
+    does not already exist.
+
+    Args:
+        snapshot_id: Must reference an existing ``muse_cli_snapshots`` row.
+        message: Human-readable commit message (required, non-empty).
+        parent_ids: Zero, one, or two parent commit IDs.  Order is irrelevant
+            for hashing (sorted internally) but at most two are stored in
+            ``parent_commit_id`` / ``parent2_commit_id``.
+        author: Author name string.  Empty string is valid.
+        session: An open async DB session (committed by the caller).
+
+    Returns:
+        The deterministic ``commit_id`` (64-char hex SHA-256).
+
+    Raises:
+        ``typer.Exit(USER_ERROR)`` when *snapshot_id* is not found or inputs
+        are invalid.
+        ``typer.Exit(INTERNAL_ERROR)`` on unexpected DB failures.
+    """
+    if len(parent_ids) > _MAX_PARENTS:
+        typer.echo(
+            f"❌ At most {_MAX_PARENTS} parent IDs are supported "
+            f"(got {len(parent_ids)})."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # Verify snapshot exists
+    snapshot = await session.get(MuseCliSnapshot, snapshot_id)
+    if snapshot is None:
+        typer.echo(
+            f"❌ Snapshot {snapshot_id[:12]!r} not found in the database.\n"
+            "   Run 'muse commit' first to create a snapshot, or check the ID."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # Derive deterministic commit_id (no timestamp → truly idempotent)
+    commit_id = compute_commit_tree_id(
+        parent_ids=parent_ids,
+        snapshot_id=snapshot_id,
+        message=message,
+        author=author,
+    )
+
+    # Idempotency: if the commit already exists, return its ID without re-inserting
+    existing = await session.get(MuseCliCommit, commit_id)
+    if existing is not None:
+        logger.debug("⚠️ commit-tree: commit %s already exists — skipping insert", commit_id[:8])
+        typer.echo(commit_id)
+        return commit_id
+
+    # Derive parent columns
+    parent1: str | None = parent_ids[0] if len(parent_ids) >= 1 else None
+    parent2: str | None = parent_ids[1] if len(parent_ids) >= 2 else None
+
+    # Branch is empty: commit-tree does not associate with any branch.
+    # Association is deferred to `muse update-ref` (a separate plumbing command).
+    new_commit = MuseCliCommit(
+        commit_id=commit_id,
+        repo_id="",  # plumbing commits carry no repo_id until linked via update-ref
+        branch="",  # not associated with any branch ref
+        parent_commit_id=parent1,
+        parent2_commit_id=parent2,
+        snapshot_id=snapshot_id,
+        message=message,
+        author=author,
+        committed_at=datetime.datetime.now(datetime.timezone.utc),
+    )
+    await insert_commit(session, new_commit)
+
+    logger.info("✅ muse commit-tree created %s", commit_id[:8])
+    typer.echo(commit_id)
+    return commit_id
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def commit_tree(
+    ctx: typer.Context,
+    snapshot_id: str = typer.Argument(
+        ..., help="The snapshot_id to wrap in a new commit object."
+    ),
+    message: str = typer.Option(
+        ..., "-m", "--message", help="Commit message (required)."
+    ),
+    parents: Optional[list[str]] = typer.Option(
+        None,
+        "-p",
+        "--parent",
+        help=(
+            "Parent commit ID.  Specify once for a regular commit, "
+            "twice for a merge commit."
+        ),
+    ),
+    author: Optional[str] = typer.Option(
+        None,
+        "--author",
+        help="Author name.  Defaults to [user] name from .muse/config.toml.",
+    ),
+) -> None:
+    """Create a raw commit object from an existing snapshot_id.
+
+    Prints the new (or pre-existing) commit_id to stdout.  Does NOT
+    update .muse/HEAD or any branch ref.
+    """
+    root = require_repo()
+
+    resolved_author = author if author is not None else _read_author_from_config(str(root))
+    resolved_parents: list[str] = list(parents) if parents else []
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _commit_tree_async(
+                snapshot_id=snapshot_id,
+                message=message,
+                parent_ids=resolved_parents,
+                author=resolved_author,
+                session=session,
+            )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse commit-tree failed: {exc}")
+        logger.error("❌ muse commit-tree error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/muse_cli/snapshot.py
+++ b/maestro/muse_cli/snapshot.py
@@ -125,3 +125,36 @@ def compute_commit_id(
     ]
     payload = "|".join(parts).encode()
     return hashlib.sha256(payload).hexdigest()
+
+
+def compute_commit_tree_id(
+    parent_ids: list[str],
+    snapshot_id: str,
+    message: str,
+    author: str,
+) -> str:
+    """Return a deterministic commit ID for a raw plumbing commit (no timestamp).
+
+    Unlike ``compute_commit_id``, this function omits ``committed_at`` so that
+    the same (parent_ids, snapshot_id, message, author) tuple always produces
+    the same commit_id.  This guarantees idempotency for ``muse commit-tree``:
+    re-running with identical inputs returns the same ID without inserting a
+    duplicate row.
+
+    Args:
+        parent_ids: Zero or more parent commit IDs.  Sorted before hashing.
+        snapshot_id: The sha256 ID of the snapshot this commit points to.
+        message: The commit message.
+        author: The author name string.
+
+    Returns:
+        A 64-character lowercase hex SHA-256 digest.
+    """
+    parts = [
+        "|".join(sorted(parent_ids)),
+        snapshot_id,
+        message,
+        author,
+    ]
+    payload = "|".join(parts).encode()
+    return hashlib.sha256(payload).hexdigest()

--- a/tests/muse_cli/test_commit_tree.py
+++ b/tests/muse_cli/test_commit_tree.py
@@ -1,0 +1,333 @@
+"""Tests for ``muse commit-tree``.
+
+Tests exercise ``_commit_tree_async`` directly with an in-memory SQLite session
+so no real Postgres instance is required.  The ``muse_cli_db_session`` fixture
+(from tests/muse_cli/conftest.py) provides the isolated SQLite session.
+
+All async tests use ``@pytest.mark.anyio``.
+"""
+from __future__ import annotations
+
+import pathlib
+import uuid
+
+import pytest
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from maestro.muse_cli.commands.commit_tree import _commit_tree_async
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+from maestro.muse_cli.snapshot import compute_commit_tree_id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_snapshot(session: AsyncSession, files: int = 2) -> str:
+    """Insert a minimal MuseCliSnapshot row and return its snapshot_id."""
+    snapshot_id = "a" * 64  # fixed deterministic value for test simplicity
+    manifest: dict[str, str] = {f"track{i}.mid": "b" * 64 for i in range(files)}
+    snap = MuseCliSnapshot(snapshot_id=snapshot_id, manifest=manifest)
+    session.add(snap)
+    await session.flush()
+    return snapshot_id
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_commit_tree_creates_commit_row(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """commit-tree inserts a MuseCliCommit row with correct fields."""
+    snapshot_id = await _seed_snapshot(muse_cli_db_session)
+
+    commit_id = await _commit_tree_async(
+        snapshot_id=snapshot_id,
+        message="raw commit",
+        parent_ids=[],
+        author="Alice",
+        session=muse_cli_db_session,
+    )
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == commit_id)
+    )
+    row = result.scalar_one_or_none()
+    assert row is not None, "commit row must exist after _commit_tree_async"
+    assert row.message == "raw commit"
+    assert row.author == "Alice"
+    assert row.snapshot_id == snapshot_id
+    assert row.parent_commit_id is None
+    assert row.parent2_commit_id is None
+
+
+@pytest.mark.anyio
+async def test_commit_tree_returns_64_char_hex(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """commit_id returned by commit-tree is a valid 64-char hex SHA-256."""
+    snapshot_id = await _seed_snapshot(muse_cli_db_session)
+
+    commit_id = await _commit_tree_async(
+        snapshot_id=snapshot_id,
+        message="hex check",
+        parent_ids=[],
+        author="",
+        session=muse_cli_db_session,
+    )
+
+    assert len(commit_id) == 64
+    assert all(c in "0123456789abcdef" for c in commit_id)
+
+
+@pytest.mark.anyio
+async def test_commit_tree_does_not_update_any_ref(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """commit-tree must NOT write to .muse/refs/ or .muse/HEAD."""
+    # Set up a minimal .muse layout so we can verify no ref is written
+    muse_dir = tmp_path / ".muse"
+    refs_dir = muse_dir / "refs" / "heads"
+    refs_dir.mkdir(parents=True)
+    (muse_dir / "HEAD").write_text("refs/heads/main")
+    (refs_dir / "main").write_text("deadbeef" * 8)  # fake HEAD SHA
+
+    snapshot_id = await _seed_snapshot(muse_cli_db_session)
+
+    await _commit_tree_async(
+        snapshot_id=snapshot_id,
+        message="should not move ref",
+        parent_ids=[],
+        author="",
+        session=muse_cli_db_session,
+    )
+
+    # Ref must be unchanged
+    head_ref = (refs_dir / "main").read_text()
+    assert head_ref == "deadbeef" * 8, "commit-tree must not update branch ref"
+    # HEAD must be unchanged
+    head_content = (muse_dir / "HEAD").read_text()
+    assert head_content == "refs/heads/main"
+
+
+@pytest.mark.anyio
+async def test_commit_tree_single_parent(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """With one -p flag, parent_commit_id is set and parent2 remains None."""
+    snapshot_id = await _seed_snapshot(muse_cli_db_session)
+    parent_id = "c" * 64
+
+    commit_id = await _commit_tree_async(
+        snapshot_id=snapshot_id,
+        message="has parent",
+        parent_ids=[parent_id],
+        author="",
+        session=muse_cli_db_session,
+    )
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == commit_id)
+    )
+    row = result.scalar_one()
+    assert row.parent_commit_id == parent_id
+    assert row.parent2_commit_id is None
+
+
+@pytest.mark.anyio
+async def test_commit_tree_merge_commit_two_parents(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """With two -p flags, both parent columns are populated (merge commit)."""
+    snapshot_id = await _seed_snapshot(muse_cli_db_session)
+    parent1 = "d" * 64
+    parent2 = "e" * 64
+
+    commit_id = await _commit_tree_async(
+        snapshot_id=snapshot_id,
+        message="merge commit",
+        parent_ids=[parent1, parent2],
+        author="",
+        session=muse_cli_db_session,
+    )
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == commit_id)
+    )
+    row = result.scalar_one()
+    assert row.parent_commit_id == parent1
+    assert row.parent2_commit_id == parent2
+
+
+@pytest.mark.anyio
+async def test_commit_tree_idempotent_same_inputs(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Calling commit-tree twice with identical inputs returns the same commit_id
+    without inserting a duplicate row."""
+    snapshot_id = await _seed_snapshot(muse_cli_db_session)
+
+    async def _call() -> str:
+        return await _commit_tree_async(
+            snapshot_id=snapshot_id,
+            message="idempotent",
+            parent_ids=[],
+            author="Bob",
+            session=muse_cli_db_session,
+        )
+
+    id1 = await _call()
+    id2 = await _call()
+
+    assert id1 == id2, "same inputs must produce the same commit_id"
+
+    # Only one row must exist
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == id1)
+    )
+    rows = result.scalars().all()
+    assert len(rows) == 1, "idempotent call must not insert a duplicate row"
+
+
+@pytest.mark.anyio
+async def test_commit_tree_deterministic_hash(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """compute_commit_tree_id is deterministic: same inputs → same digest."""
+    snapshot_id = "f" * 64
+    parent = "0" * 64
+
+    h1 = compute_commit_tree_id(
+        parent_ids=[parent],
+        snapshot_id=snapshot_id,
+        message="determinism",
+        author="Carol",
+    )
+    h2 = compute_commit_tree_id(
+        parent_ids=[parent],
+        snapshot_id=snapshot_id,
+        message="determinism",
+        author="Carol",
+    )
+    assert h1 == h2
+    assert len(h1) == 64
+
+
+@pytest.mark.anyio
+async def test_commit_tree_different_messages_different_ids(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Different messages produce different commit_ids for the same snapshot."""
+    snapshot_id = await _seed_snapshot(muse_cli_db_session)
+
+    # Use a second unique snapshot for the second call
+    snap2_id = "b" * 64
+    snap2 = MuseCliSnapshot(snapshot_id=snap2_id, manifest={"x.mid": "c" * 64})
+    muse_cli_db_session.add(snap2)
+    await muse_cli_db_session.flush()
+
+    id1 = await _commit_tree_async(
+        snapshot_id=snapshot_id,
+        message="message A",
+        parent_ids=[],
+        author="",
+        session=muse_cli_db_session,
+    )
+    id2 = await _commit_tree_async(
+        snapshot_id=snap2_id,
+        message="message B",
+        parent_ids=[],
+        author="",
+        session=muse_cli_db_session,
+    )
+
+    assert id1 != id2
+
+
+@pytest.mark.anyio
+async def test_commit_tree_branch_is_empty_string(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """commit-tree stores branch as empty string (not associated with any ref)."""
+    snapshot_id = await _seed_snapshot(muse_cli_db_session)
+
+    commit_id = await _commit_tree_async(
+        snapshot_id=snapshot_id,
+        message="branch check",
+        parent_ids=[],
+        author="",
+        session=muse_cli_db_session,
+    )
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == commit_id)
+    )
+    row = result.scalar_one()
+    assert row.branch == "", "commit-tree must not associate with any branch"
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_commit_tree_unknown_snapshot_exits_1(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """When snapshot_id is not in the DB, commit-tree exits USER_ERROR."""
+    nonexistent_snapshot = "9" * 64
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _commit_tree_async(
+            snapshot_id=nonexistent_snapshot,
+            message="ghost snapshot",
+            parent_ids=[],
+            author="",
+            session=muse_cli_db_session,
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_commit_tree_too_many_parents_exits_1(
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Supplying more than 2 parent IDs exits USER_ERROR (DB only stores 2)."""
+    snapshot_id = await _seed_snapshot(muse_cli_db_session)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _commit_tree_async(
+            snapshot_id=snapshot_id,
+            message="octopus merge",
+            parent_ids=["a" * 64, "b" * 64, "c" * 64],
+            author="",
+            session=muse_cli_db_session,
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+def test_commit_tree_no_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """Typer CLI runner: commit-tree outside a repo exits REPO_NOT_FOUND."""
+    from typer.testing import CliRunner
+
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["commit-tree", "a" * 64, "-m", "no repo"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND


### PR DESCRIPTION
## Summary
Closes #94 — implements `muse commit-tree` plumbing command that creates a raw commit object from an existing snapshot without touching any branch ref.

## Root Cause / Motivation
No plumbing-layer command existed for creating commit objects directly from snapshot IDs. This is required for scripted history manipulation (replaying merges, synthesising history from external sources, building commit graphs programmatically) and mirrors git's `git commit-tree` design.

## Solution
- **`maestro/muse_cli/commands/commit_tree.py`** — new Typer command with `_commit_tree_async` core. Verifies snapshot exists, derives a deterministic commit ID (no timestamp → truly idempotent), inserts `MuseCliCommit` row with empty `branch` field (not associated with any ref), and handles idempotent repeats by returning the existing ID without re-inserting.
- **`maestro/muse_cli/snapshot.py`** — added `compute_commit_tree_id(parent_ids, snapshot_id, message, author)` alongside the existing `compute_commit_id` (which keeps its timestamp for `muse commit`).
- **`maestro/muse_cli/app.py`** — registered `commit-tree` as a new Typer sub-application.
- **`docs/architecture/muse_vcs.md`** — new "Muse CLI — Plumbing Command Reference" section with full `muse commit-tree` documentation.
- **`docs/reference/type_contracts.md`** — registered `CommitTreeResult`.

## Layers Affected
- [x] Muse VCS

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (490 files)
- [x] `docker compose exec storpheus mypy .` — clean
- [x] 12 tests pass in `tests/muse_cli/test_commit_tree.py`
- [x] Docs updated

## Tests Added
- `test_commit_tree_creates_commit_row` — happy path, fields correct
- `test_commit_tree_returns_64_char_hex` — output is valid SHA-256
- `test_commit_tree_does_not_update_any_ref` — no ref files modified
- `test_commit_tree_single_parent` — parent_commit_id set, parent2 None
- `test_commit_tree_merge_commit_two_parents` — both parent columns populated
- `test_commit_tree_idempotent_same_inputs` — second call returns same ID, no duplicate row
- `test_commit_tree_deterministic_hash` — compute_commit_tree_id is pure
- `test_commit_tree_different_messages_different_ids` — different inputs → different IDs
- `test_commit_tree_branch_is_empty_string` — branch field is `""` (not associated with ref)
- `test_commit_tree_unknown_snapshot_exits_1` — missing snapshot → USER_ERROR
- `test_commit_tree_too_many_parents_exits_1` — >2 parents → USER_ERROR
- `test_commit_tree_no_repo_exits_2` — outside repo → REPO_NOT_FOUND

## Handoff
N/A — no protocol change. Plumbing command, no SSE or MCP tool schema impact.