### PR TITLE
feat: muse timeline — visualize musical evolution chronologically

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -2531,6 +2531,79 @@ An AI deciding which branch to merge calls `muse divergence feature/guitar featu
 before generation.  HIGH harmonic divergence + LOW rhythmic divergence means lean on the piano
 branch for chord voicings while preserving the guitar branch's groove patterns.
 
+### `muse timeline`
+
+**Purpose:** Render a commit-by-commit chronological view of a composition's
+creative arc — emotion transitions, section progress, and per-track activity.
+This is the "album liner notes" view that no Git command provides.  Agents
+use it to understand how a project's emotional and structural character
+evolved before making generation decisions.
+
+**Usage:**
+```bash
+muse timeline [RANGE] [OPTIONS]
+```
+
+**Flags:**
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `RANGE` | positional string | full history | Commit range (reserved — full history shown for now) |
+| `--emotion` | flag | off | Add emotion column (from `emotion:*` tags) |
+| `--sections` | flag | off | Group commits under section headers (from `section:*` tags) |
+| `--tracks` | flag | off | Show per-track activity column (from `track:*` tags) |
+| `--json` | flag | off | Emit structured JSON for UI rendering or agent consumption |
+| `--limit N` | int | 1000 | Maximum commits to walk |
+
+**Output example (text):**
+```
+Timeline — branch: main  (3 commit(s))
+
+  ── verse ──
+2026-02-01  abc1234  Initial drum arrangement    [drums]        [melancholic]  ████
+2026-02-02  def5678  Add bass line               [bass]         [melancholic]  ██████
+  ── chorus ──
+2026-02-03  ghi9012  Chorus melody               [keys,vocals]  [joyful]       █████████
+
+Emotion arc: melancholic → joyful
+Sections:    verse → chorus
+```
+
+**Output example (JSON):**
+```json
+{
+  "branch": "main",
+  "total_commits": 3,
+  "emotion_arc": ["melancholic", "joyful"],
+  "section_order": ["verse", "chorus"],
+  "entries": [
+    {
+      "commit_id": "abc1234...",
+      "short_id": "abc1234",
+      "committed_at": "2026-02-01T00:00:00+00:00",
+      "message": "Initial drum arrangement",
+      "emotion": "melancholic",
+      "sections": ["verse"],
+      "tracks": ["drums"],
+      "activity": 1
+    }
+  ]
+}
+```
+
+**Result types:** `MuseTimelineEntry`, `MuseTimelineResult` — see `docs/reference/type_contracts.md § Muse Timeline Types`.
+
+**Agent use case:** An AI agent calls `muse timeline --json` before composing a new
+section to understand the emotional arc to date (e.g. `melancholic → joyful → tense`).
+It uses `section_order` to determine what structural elements have been established
+and `emotion_arc` to decide whether to maintain or contrast the current emotional
+character.  `activity` per commit helps identify which sections were most actively
+developed.
+
+**Implementation note:** Emotion, section, and track data are derived entirely from
+tags attached via `muse tag add`.  Commits with no tags show `—` in filtered columns.
+The commit range argument (`RANGE`) is accepted but reserved for a future iteration
+that supports `HEAD~10..HEAD` syntax.
+
 ---
 
 ## Command Registration Summary
@@ -2550,6 +2623,7 @@ branch for chord voicings while preserving the guitar branch's groove patterns.
 | `muse session` | `commands/session.py` | ✅ implemented (PR #129) | #127 |
 | `muse swing` | `commands/swing.py` | ✅ stub (PR #131) | #121 |
 | `muse tag` | `commands/tag.py` | ✅ implemented (PR #133) | #123 |
+| `muse timeline` | `commands/timeline.py` | ✅ implemented (PR #TBD) | #97 |
 
 All stub commands have stable CLI contracts. Full musical analysis (MIDI content
 parsing, vector embeddings, LLM synthesis) is tracked as follow-up issues.

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -4166,3 +4166,45 @@ error message via `typer.echo` before calling `typer.Exit(INTERNAL_ERROR)`.
 ```python
 class StorpheusUnavailableError(Exception): ...
 ```
+
+
+---
+
+## Muse Timeline Types
+
+Defined in `maestro/services/muse_timeline.py`.
+
+### `MuseTimelineEntry`
+
+A single commit in the chronological musical timeline.
+Music-semantic fields are derived from tags attached via `muse tag add`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | Full 64-char commit hash. |
+| `short_id` | `str` | First 7 characters for display. |
+| `committed_at` | `datetime` | Commit timestamp (UTC). |
+| `message` | `str` | Human-authored commit message. |
+| `emotion` | `str \| None` | First `emotion:*` tag value (prefix stripped), or `None`. |
+| `sections` | `tuple[str, ...]` | All `section:*` tag values (prefix stripped). |
+| `tracks` | `tuple[str, ...]` | All `track:*` tag values (prefix stripped). |
+| `activity` | `int` | Number of tracks modified; 1 when no track tags present. |
+
+### `MuseTimelineResult`
+
+Full chronological timeline for a single repository branch.
+Returned by `build_timeline()` in `maestro/services/muse_timeline.py`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `entries` | `tuple[MuseTimelineEntry, ...]` | Timeline entries, oldest-first. |
+| `branch` | `str` | Branch name this timeline was built from. |
+| `emotion_arc` | `tuple[str, ...]` | Ordered unique emotion labels (oldest first). |
+| `section_order` | `tuple[str, ...]` | Ordered unique section names (oldest first). |
+| `total_commits` | `int` | Total number of commits in the timeline. |
+
+**Agent use case:** An AI agent calls `muse timeline --json` and inspects
+`emotion_arc` to understand how the composition's emotional character has
+evolved.  `section_order` maps the structural progression of the piece.
+`entries[*].activity` can be used to weight which commits had the most
+musical change — useful for selecting seed material for generation.

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -50,11 +50,8 @@ from maestro.muse_cli.commands import (
     tag,
     tempo,
     tempo_scale,
-<<<<<<< HEAD
     timeline,
-=======
     validate,
->>>>>>> origin/dev
 )
 
 cli = typer.Typer(
@@ -105,11 +102,8 @@ cli.add_typer(groove_check.app, name="groove-check", help="Analyze rhythmic drif
 cli.add_typer(form.app, name="form", help="Analyze or annotate the formal structure (sections) of a commit.")
 cli.add_typer(similarity.app, name="similarity", help="Compare two commits by musical similarity score.")
 cli.add_typer(tempo_scale.app, name="tempo-scale", help="Stretch or compress the timing of a commit.")
-<<<<<<< HEAD
 cli.add_typer(timeline.app, name="timeline", help="Visualize musical evolution chronologically.")
-=======
 cli.add_typer(validate.app, name="validate", help="Check musical integrity of the working tree.")
->>>>>>> origin/dev
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -3,8 +3,8 @@
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (arrange, ask, checkout, commit, context, describe, divergence,
 dynamics, export, find, grep, import, init, log, merge, meter, open, play,
-pull, push, recall, remote, session, status, swing, tag, tempo) as Typer
-sub-applications.
+pull, push, recall, remote, session, status, swing, tag, tempo, timeline)
+as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -38,6 +38,7 @@ from maestro.muse_cli.commands import (
     swing,
     tag,
     tempo,
+    timeline,
 )
 
 cli = typer.Typer(
@@ -73,6 +74,7 @@ cli.add_typer(tempo.app, name="tempo", help="Read or set the tempo (BPM) of a co
 cli.add_typer(recall.app, name="recall", help="Search commit history by natural-language description.")
 cli.add_typer(context.app, name="context", help="Output structured musical context for AI agent consumption.")
 cli.add_typer(divergence.app, name="divergence", help="Show how two branches have diverged musically.")
+cli.add_typer(timeline.app, name="timeline", help="Visualize musical evolution chronologically.")
 
 
 if __name__ == "__main__":

--- a/maestro/muse_cli/commands/timeline.py
+++ b/maestro/muse_cli/commands/timeline.py
@@ -1,0 +1,322 @@
+"""muse timeline — visualize musical evolution chronologically.
+
+Renders a commit-by-commit chronological view of a composition's creative
+arc with music-semantic metadata: emotion tags, section grouping, and
+per-track activity.  This is the "album liner notes" view of a project's
+evolution — no Git equivalent exists.
+
+Default output (text)::
+
+    2026-02-01  abc1234  Initial drum arrangement    [drums]        [melancholic]  ████
+    2026-02-02  def5678  Add bass line               [bass]         [melancholic]  ██████
+    2026-02-03  ghi9012  Chorus melody               [keys,vocals]  [joyful]       █████████
+
+Flags
+-----
+--emotion     Add emotion indicator column (shown by default when tags exist).
+--sections    Group commits under section headers (e.g. ── chorus ──).
+--tracks      Show per-track activity column.
+--json        Machine-readable JSON for UI rendering or agent consumption.
+--limit N     Cap the commit walk (default: 1000).
+[<range>]     Optional commit range for future ``HEAD~10..HEAD`` syntax.
+              Currently accepted but reserved (full history is always shown).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.services.muse_timeline import (
+    MuseTimelineEntry,
+    MuseTimelineResult,
+    build_timeline,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+_DEFAULT_LIMIT = 1000
+
+# Unicode block characters for activity density bars.
+_BLOCK = "█"
+_MAX_BLOCKS = 10
+_MIN_BLOCKS = 1
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _activity_bar(activity: int, max_activity: int) -> str:
+    """Render a Unicode block bar proportional to *activity*.
+
+    Width is scaled so the most-active commit gets ``_MAX_BLOCKS`` blocks
+    and the least-active gets at least ``_MIN_BLOCKS``.  Returns a blank
+    string when ``max_activity`` is 0.
+    """
+    if max_activity == 0:
+        return _BLOCK * _MIN_BLOCKS
+    scaled = max(
+        _MIN_BLOCKS,
+        round(_MAX_BLOCKS * activity / max_activity),
+    )
+    return _BLOCK * scaled
+
+
+def _load_muse_state(root: pathlib.Path) -> tuple[str, str, str]:
+    """Read branch name, HEAD ref, and head_commit_id from ``.muse/``.
+
+    Returns ``(branch, head_ref, head_commit_id)``.  ``head_commit_id``
+    is an empty string when the branch has no commits yet.
+    """
+    import json as _json
+
+    muse_dir = root / ".muse"
+    head_ref = (muse_dir / "HEAD").read_text().strip()
+    branch = head_ref.rsplit("/", 1)[-1] if "/" in head_ref else head_ref
+    ref_path = muse_dir / pathlib.Path(head_ref)
+    head_commit_id = ref_path.read_text().strip() if ref_path.exists() else ""
+    repo_data: dict[str, str] = _json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]
+    return repo_id, branch, head_commit_id
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def _render_text(
+    result: MuseTimelineResult,
+    *,
+    show_emotion: bool,
+    show_sections: bool,
+    show_tracks: bool,
+) -> None:
+    """Render the timeline as a human-readable terminal table.
+
+    Columns (left to right):
+    - Date (YYYY-MM-DD)
+    - Short ID (7 chars)
+    - Message (truncated to 30 chars)
+    - Tracks (comma-joined, or — if none)
+    - Emotion (or — if none) [when show_emotion or show_sections are on]
+    - Unicode activity bar
+
+    When ``show_sections`` is True, a section header line is printed
+    whenever the section set changes.
+    """
+    entries = result.entries
+    if not entries:
+        typer.echo("No commits in timeline.")
+        return
+
+    typer.echo(f"Timeline — branch: {result.branch}  ({result.total_commits} commit(s))")
+    typer.echo("")
+
+    max_activity = max(e.activity for e in entries) if entries else 1
+
+    prev_sections: tuple[str, ...] = ()
+
+    for entry in entries:
+        if show_sections and entry.sections != prev_sections:
+            sections_label = ", ".join(entry.sections) if entry.sections else "—"
+            typer.echo(f"  ── {sections_label} ──")
+            prev_sections = entry.sections
+
+        date_str = entry.committed_at.strftime("%Y-%m-%d")
+        short_id = entry.short_id
+        message = entry.message[:30].ljust(30)
+        bar = _activity_bar(entry.activity, max_activity)
+
+        tracks_col = ""
+        if show_tracks:
+            tracks_label = ",".join(entry.tracks) if entry.tracks else "—"
+            tracks_col = f"  [{tracks_label:<20}]"
+
+        emotion_col = ""
+        if show_emotion:
+            emotion_label = entry.emotion or "—"
+            emotion_col = f"  [{emotion_label:<15}]"
+
+        typer.echo(
+            f"{date_str}  {short_id}  {message}{tracks_col}{emotion_col}  {bar}"
+        )
+
+    typer.echo("")
+    if result.emotion_arc:
+        typer.echo(f"Emotion arc: {' → '.join(result.emotion_arc)}")
+    if result.section_order:
+        typer.echo(f"Sections:    {' → '.join(result.section_order)}")
+
+
+def _entry_to_dict(entry: MuseTimelineEntry) -> dict[str, object]:
+    """Serialize a :class:`MuseTimelineEntry` to a JSON-safe dict."""
+    return {
+        "commit_id": entry.commit_id,
+        "short_id": entry.short_id,
+        "committed_at": entry.committed_at.isoformat(),
+        "message": entry.message,
+        "emotion": entry.emotion,
+        "sections": list(entry.sections),
+        "tracks": list(entry.tracks),
+        "activity": entry.activity,
+    }
+
+
+def _render_json(result: MuseTimelineResult) -> None:
+    """Emit the timeline as a JSON object for UI rendering or agent consumption."""
+    payload: dict[str, object] = {
+        "branch": result.branch,
+        "total_commits": result.total_commits,
+        "emotion_arc": list(result.emotion_arc),
+        "section_order": list(result.section_order),
+        "entries": [_entry_to_dict(e) for e in result.entries],
+    }
+    typer.echo(json.dumps(payload, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _timeline_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    commit_range: Optional[str],
+    show_emotion: bool,
+    show_sections: bool,
+    show_tracks: bool,
+    as_json: bool,
+    limit: int,
+) -> MuseTimelineResult:
+    """Core timeline logic — fully injectable for tests.
+
+    Reads repo state from ``.muse/``, loads commits + tags from the DB
+    session, then renders the result.  Returns the :class:`MuseTimelineResult`
+    so callers can inspect it without parsing printed output.
+
+    Args:
+        root:          Repository root (contains ``.muse/``).
+        session:       Open async DB session.
+        commit_range:  Optional range string (reserved for future use).
+        show_emotion:  Include emotion column in text output.
+        show_sections: Group commits by section in text output.
+        show_tracks:   Include tracks column in text output.
+        as_json:       Emit JSON instead of the text table.
+        limit:         Maximum commits to include.
+
+    Returns:
+        :class:`MuseTimelineResult` (oldest-first).
+    """
+    repo_id, branch, head_commit_id = _load_muse_state(root)
+
+    if not head_commit_id:
+        typer.echo(f"No commits yet on branch {branch} — timeline is empty.")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    if commit_range is not None:
+        typer.echo(
+            f"⚠️  Commit range '{commit_range}' is reserved for a future iteration. "
+            "Showing full history."
+        )
+
+    result = await build_timeline(
+        session,
+        repo_id=repo_id,
+        branch=branch,
+        head_commit_id=head_commit_id,
+        limit=limit,
+    )
+
+    if as_json:
+        _render_json(result)
+    else:
+        _render_text(
+            result,
+            show_emotion=show_emotion,
+            show_sections=show_sections,
+            show_tracks=show_tracks,
+        )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def timeline(
+    ctx: typer.Context,
+    commit_range: Optional[str] = typer.Argument(
+        None,
+        help="Commit range (reserved — full history is always shown for now).",
+        metavar="RANGE",
+    ),
+    show_emotion: bool = typer.Option(
+        False,
+        "--emotion",
+        help="Add an emotion column (derived from emotion:* tags).",
+    ),
+    show_sections: bool = typer.Option(
+        False,
+        "--sections",
+        help="Group commits under section headers (derived from section:* tags).",
+    ),
+    show_tracks: bool = typer.Option(
+        False,
+        "--tracks",
+        help="Show per-track activity column (derived from track:* tags).",
+    ),
+    as_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit structured JSON suitable for UI rendering or agent consumption.",
+    ),
+    limit: int = typer.Option(
+        _DEFAULT_LIMIT,
+        "--limit",
+        "-n",
+        help="Maximum number of commits to walk.",
+        min=1,
+    ),
+) -> None:
+    """Visualize the musical evolution of a composition chronologically."""
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _timeline_async(
+                root=root,
+                session=session,
+                commit_range=commit_range,
+                show_emotion=show_emotion,
+                show_sections=show_sections,
+                show_tracks=show_tracks,
+                as_json=as_json,
+                limit=limit,
+            )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse timeline failed: {exc}")
+        logger.error("❌ muse timeline error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/services/muse_timeline.py
+++ b/maestro/services/muse_timeline.py
@@ -1,0 +1,258 @@
+"""Muse Timeline — chronological view of a composition's musical evolution.
+
+Builds a commit-by-commit timeline from oldest to newest, enriching each
+commit with music-semantic metadata extracted from associated tags
+(emotion:*, section:*, track:*).  This is the "album liner notes" view of
+a project's creative arc.
+
+The service queries:
+1. ``muse_cli_commits`` — ordered chronologically (oldest-first).
+2. ``muse_cli_tags``    — joined to extract emotion, section, and track tags
+   per commit.
+
+Emotion tags (``emotion:melancholic``), section tags (``section:chorus``),
+and track tags (``track:bass``) are extracted by namespace prefix.  When no
+tags exist the corresponding fields default to ``None`` / empty lists.
+
+Result types
+------------
+- :class:`MuseTimelineEntry`  — a single commit in the timeline.
+- :class:`MuseTimelineResult` — the full ordered collection + section/emotion
+  summary computed across all entries.
+
+Callers
+-------
+``maestro.muse_cli.commands.timeline`` is the primary consumer.  Future
+agents may call :func:`build_timeline` directly to derive emotion arcs or
+section progress maps for generative decisions.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.models import MuseCliCommit, MuseCliTag
+
+logger = logging.getLogger(__name__)
+
+_EMOTION_PREFIX = "emotion:"
+_SECTION_PREFIX = "section:"
+_TRACK_PREFIX = "track:"
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MuseTimelineEntry:
+    """A single commit in the musical timeline.
+
+    All music-semantic fields are derived from tags attached to the commit.
+    Missing tags produce ``None`` (emotion, section) or empty lists (tracks).
+
+    Fields
+    ------
+    commit_id:      Full SHA-256 commit ID.
+    short_id:       First 7 characters for display purposes.
+    committed_at:   Commit timestamp (UTC).
+    message:        Commit message (the human-authored intent label).
+    emotion:        First ``emotion:*`` tag value, stripped of the prefix.
+    sections:       All ``section:*`` tag values, stripped of the prefix.
+    tracks:         All ``track:*`` tag values, stripped of the prefix.
+    activity:       Number of tracks modified — used to compute block width.
+    """
+
+    commit_id: str
+    short_id: str
+    committed_at: datetime
+    message: str
+    emotion: str | None
+    sections: tuple[str, ...]
+    tracks: tuple[str, ...]
+    activity: int
+
+
+@dataclass(frozen=True)
+class MuseTimelineResult:
+    """Full chronological timeline for a single repository branch.
+
+    ``entries`` is oldest-first.  ``emotion_arc`` lists the unique
+    emotion values in chronological order of first appearance.
+    ``section_order`` lists section names in order of first commit.
+
+    Fields
+    ------
+    entries:       Ordered timeline entries (oldest → newest).
+    branch:        Branch name this timeline was built from.
+    emotion_arc:   Ordered sequence of unique emotion labels (oldest first).
+    section_order: Ordered sequence of unique section names (oldest first).
+    total_commits: Total number of commits in the timeline.
+    """
+
+    entries: tuple[MuseTimelineEntry, ...]
+    branch: str
+    emotion_arc: tuple[str, ...]
+    section_order: tuple[str, ...]
+    total_commits: int
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_prefix(tag: str, prefix: str) -> str | None:
+    """Return the value after *prefix* if *tag* starts with it, else None."""
+    if tag.startswith(prefix):
+        return tag[len(prefix):]
+    return None
+
+
+def _group_tags_by_commit(
+    tags: list[MuseCliTag],
+) -> dict[str, list[str]]:
+    """Build a mapping of commit_id → list of tag strings."""
+    grouped: dict[str, list[str]] = {}
+    for t in tags:
+        grouped.setdefault(t.commit_id, []).append(t.tag)
+    return grouped
+
+
+def _make_entry(
+    commit: MuseCliCommit,
+    tag_strings: list[str],
+) -> MuseTimelineEntry:
+    """Construct a :class:`MuseTimelineEntry` from a commit row and its tags."""
+    emotions: list[str] = []
+    sections: list[str] = []
+    tracks: list[str] = []
+
+    for tag in tag_strings:
+        emotion_val = _extract_prefix(tag, _EMOTION_PREFIX)
+        if emotion_val is not None:
+            emotions.append(emotion_val)
+            continue
+        section_val = _extract_prefix(tag, _SECTION_PREFIX)
+        if section_val is not None:
+            sections.append(section_val)
+            continue
+        track_val = _extract_prefix(tag, _TRACK_PREFIX)
+        if track_val is not None:
+            tracks.append(track_val)
+
+    return MuseTimelineEntry(
+        commit_id=commit.commit_id,
+        short_id=commit.commit_id[:7],
+        committed_at=commit.committed_at,
+        message=commit.message,
+        emotion=emotions[0] if emotions else None,
+        sections=tuple(sections),
+        tracks=tuple(tracks),
+        activity=len(tracks) if tracks else 1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def build_timeline(
+    session: AsyncSession,
+    repo_id: str,
+    branch: str,
+    head_commit_id: str,
+    limit: int = 1000,
+) -> MuseTimelineResult:
+    """Build a chronological musical timeline for *branch* in *repo_id*.
+
+    Walks the parent chain from *head_commit_id* (oldest-first after
+    reversal) then queries associated tags in a single batch to avoid N+1
+    round-trips.
+
+    Args:
+        session:        Open async SQLAlchemy session.
+        repo_id:        Repository scope.
+        branch:         Branch name for display in the result.
+        head_commit_id: SHA-256 of the branch HEAD commit.
+        limit:          Maximum commits to walk (default 1000).
+
+    Returns:
+        :class:`MuseTimelineResult` sorted oldest-first.
+    """
+    # --- Walk the parent chain newest-first (same pattern as muse log) ---
+    commits_newest_first: list[MuseCliCommit] = []
+    current_id: str | None = head_commit_id
+    while current_id and len(commits_newest_first) < limit:
+        commit = await session.get(MuseCliCommit, current_id)
+        if commit is None:
+            logger.warning("⚠️ Timeline: commit %s not found — chain broken", current_id[:8])
+            break
+        commits_newest_first.append(commit)
+        current_id = commit.parent_commit_id
+
+    # Reverse to oldest-first for timeline display.
+    commits: list[MuseCliCommit] = list(reversed(commits_newest_first))
+
+    if not commits:
+        return MuseTimelineResult(
+            entries=(),
+            branch=branch,
+            emotion_arc=(),
+            section_order=(),
+            total_commits=0,
+        )
+
+    # --- Batch-fetch all tags for the commit set ---
+    commit_ids = [c.commit_id for c in commits]
+    tag_stmt = select(MuseCliTag).where(
+        MuseCliTag.repo_id == repo_id,
+        MuseCliTag.commit_id.in_(commit_ids),
+    )
+    tag_result = await session.execute(tag_stmt)
+    all_tags: list[MuseCliTag] = list(tag_result.scalars().all())
+    tags_by_commit = _group_tags_by_commit(all_tags)
+
+    # --- Build entries ---
+    entries: list[MuseTimelineEntry] = [
+        _make_entry(c, tags_by_commit.get(c.commit_id, []))
+        for c in commits
+    ]
+
+    # --- Derive summaries ---
+    emotion_arc: list[str] = []
+    seen_emotions: set[str] = set()
+    section_order: list[str] = []
+    seen_sections: set[str] = set()
+
+    for entry in entries:
+        if entry.emotion and entry.emotion not in seen_emotions:
+            emotion_arc.append(entry.emotion)
+            seen_emotions.add(entry.emotion)
+        for sec in entry.sections:
+            if sec not in seen_sections:
+                section_order.append(sec)
+                seen_sections.add(sec)
+
+    logger.info(
+        "✅ muse timeline: %d commit(s), %d emotion(s), %d section(s) (repo=%s branch=%s)",
+        len(entries),
+        len(emotion_arc),
+        len(section_order),
+        repo_id[:8],
+        branch,
+    )
+
+    return MuseTimelineResult(
+        entries=tuple(entries),
+        branch=branch,
+        emotion_arc=tuple(emotion_arc),
+        section_order=tuple(section_order),
+        total_commits=len(entries),
+    )

--- a/tests/test_muse_timeline.py
+++ b/tests/test_muse_timeline.py
@@ -1,0 +1,847 @@
+"""Tests for ``muse timeline`` — service layer, CLI flags, and output format.
+
+Test strategy
+-------------
+- Service layer (:func:`build_timeline`) is tested with real SQLite commits
+  and tags to verify chronological ordering, tag extraction, and summaries.
+- CLI command (``_timeline_async``) is tested with an in-memory SQLite session
+  and a minimal ``.muse/`` layout, exercising every flag combination.
+- CLI integration tests use ``typer.testing.CliRunner`` against the full ``muse``
+  app for argument parsing and exit code verification.
+- Renderers (``_render_text``, ``_render_json``) are tested directly via capsys.
+
+Naming: ``test_<behavior>_<scenario>`` throughout.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+from typer.testing import CliRunner
+
+from maestro.db.database import Base
+import maestro.muse_cli.models  # noqa: F401 — registers models with Base.metadata
+from maestro.muse_cli.app import cli
+from maestro.muse_cli.commands.timeline import (
+    _activity_bar,
+    _entry_to_dict,
+    _render_json,
+    _render_text,
+    _timeline_async,
+)
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot, MuseCliTag
+from maestro.services.muse_timeline import (
+    MuseTimelineEntry,
+    MuseTimelineResult,
+    _extract_prefix,
+    _group_tags_by_commit,
+    _make_entry,
+    build_timeline,
+)
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc(year: int, month: int, day: int) -> datetime:
+    """Return a UTC datetime at midnight on the given date."""
+    return datetime(year, month, day, tzinfo=timezone.utc)
+
+
+def _repo_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _snapshot_id() -> str:
+    return uuid.uuid4().hex * 2  # 64-char hex
+
+
+def _commit_id() -> str:
+    return uuid.uuid4().hex * 2  # 64-char hex
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    """In-memory SQLite session with all Muse tables created."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(bind=engine, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+def _init_muse_repo(
+    root: pathlib.Path,
+    branch: str = "main",
+    repo_id: str | None = None,
+) -> str:
+    """Create a minimal ``.muse/`` directory tree with a repo.json."""
+    rid = repo_id or _repo_id()
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text(f"refs/heads/{branch}")
+    (muse / "refs" / "heads" / branch).write_text("")
+    return rid
+
+
+def _set_head(root: pathlib.Path, commit_id: str, branch: str = "main") -> None:
+    """Write *commit_id* into the branch ref file."""
+    muse = root / ".muse"
+    (muse / "refs" / "heads" / branch).write_text(commit_id)
+
+
+async def _insert_snapshot(session: AsyncSession) -> str:
+    """Insert a blank snapshot and return its ID."""
+    sid = _snapshot_id()
+    snap = MuseCliSnapshot(snapshot_id=sid, manifest={})
+    session.add(snap)
+    await session.flush()
+    return sid
+
+
+async def _insert_commit(
+    session: AsyncSession,
+    repo_id: str,
+    branch: str,
+    message: str,
+    committed_at: datetime,
+    parent_id: str | None = None,
+) -> MuseCliCommit:
+    """Insert a commit row and return the ORM object."""
+    sid = await _insert_snapshot(session)
+    cid = _commit_id()
+    commit = MuseCliCommit(
+        commit_id=cid,
+        repo_id=repo_id,
+        branch=branch,
+        message=message,
+        committed_at=committed_at,
+        parent_commit_id=parent_id,
+        snapshot_id=sid,
+    )
+    session.add(commit)
+    await session.flush()
+    return commit
+
+
+async def _attach_tag(
+    session: AsyncSession,
+    repo_id: str,
+    commit_id: str,
+    tag: str,
+) -> MuseCliTag:
+    """Attach a tag to a commit."""
+    t = MuseCliTag(repo_id=repo_id, commit_id=commit_id, tag=tag)
+    session.add(t)
+    await session.flush()
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Unit — service helpers
+# ---------------------------------------------------------------------------
+
+
+def test_extract_prefix_matches_known_prefix() -> None:
+    """_extract_prefix returns the value after a matching prefix."""
+    assert _extract_prefix("emotion:melancholic", "emotion:") == "melancholic"
+    assert _extract_prefix("section:chorus", "section:") == "chorus"
+    assert _extract_prefix("track:bass", "track:") == "bass"
+
+
+def test_extract_prefix_returns_none_for_mismatch() -> None:
+    """_extract_prefix returns None when the prefix doesn't match."""
+    assert _extract_prefix("stage:rough-mix", "emotion:") is None
+    assert _extract_prefix("", "emotion:") is None
+
+
+def test_group_tags_by_commit_groups_correctly() -> None:
+    """_group_tags_by_commit maps commit IDs to their tag lists."""
+    tags = [
+        MuseCliTag(repo_id="r1", commit_id="aaa", tag="emotion:joyful"),
+        MuseCliTag(repo_id="r1", commit_id="aaa", tag="section:chorus"),
+        MuseCliTag(repo_id="r1", commit_id="bbb", tag="emotion:melancholic"),
+    ]
+    grouped = _group_tags_by_commit(tags)
+    assert set(grouped["aaa"]) == {"emotion:joyful", "section:chorus"}
+    assert grouped["bbb"] == ["emotion:melancholic"]
+
+
+def test_make_entry_parses_emotion_and_section_and_tracks() -> None:
+    """_make_entry extracts emotion, sections, and tracks from tags."""
+    snap_id = _snapshot_id()
+    commit = MuseCliCommit(
+        commit_id="a" * 64,
+        repo_id="r1",
+        branch="main",
+        message="Add chorus melody",
+        committed_at=_utc(2026, 2, 3),
+        snapshot_id=snap_id,
+    )
+    tags = ["emotion:joyful", "section:chorus", "track:keys", "track:vocals"]
+    entry = _make_entry(commit, tags)
+
+    assert entry.short_id == "aaaaaaa"
+    assert entry.emotion == "joyful"
+    assert entry.sections == ("chorus",)
+    assert set(entry.tracks) == {"keys", "vocals"}
+    assert entry.activity == 2  # two tracks
+
+
+def test_make_entry_defaults_when_no_tags() -> None:
+    """_make_entry with no tags sets emotion=None, sections/tracks empty, activity=1."""
+    snap_id = _snapshot_id()
+    commit = MuseCliCommit(
+        commit_id="b" * 64,
+        repo_id="r1",
+        branch="main",
+        message="Initial take",
+        committed_at=_utc(2026, 2, 1),
+        snapshot_id=snap_id,
+    )
+    entry = _make_entry(commit, [])
+    assert entry.emotion is None
+    assert entry.sections == ()
+    assert entry.tracks == ()
+    assert entry.activity == 1
+
+
+# ---------------------------------------------------------------------------
+# Unit — activity_bar
+# ---------------------------------------------------------------------------
+
+
+def test_activity_bar_max_activity_produces_max_blocks() -> None:
+    """The most-active commit gets the maximum block count."""
+    bar = _activity_bar(10, 10)
+    assert len(bar) == 10
+    assert bar == "█" * 10
+
+
+def test_activity_bar_scales_proportionally() -> None:
+    """Half-max activity should produce ~half the blocks."""
+    bar = _activity_bar(5, 10)
+    assert 4 <= len(bar) <= 6  # allow rounding
+
+
+def test_activity_bar_zero_max_returns_minimum() -> None:
+    """Zero max_activity is handled gracefully with min blocks."""
+    bar = _activity_bar(0, 0)
+    assert len(bar) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Unit — service: build_timeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_timeline_outputs_chronological_history(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """build_timeline returns entries in oldest-first order.
+
+    Regression test: ensures chronological ordering is preserved regardless
+    of DB insertion order.
+    """
+    rid = _repo_id()
+    c1 = await _insert_commit(db_session, rid, "main", "Init", _utc(2026, 2, 1))
+    c2 = await _insert_commit(db_session, rid, "main", "Add bass", _utc(2026, 2, 2), c1.commit_id)
+    c3 = await _insert_commit(db_session, rid, "main", "Chorus", _utc(2026, 2, 3), c2.commit_id)
+    await db_session.commit()
+
+    result = await build_timeline(
+        db_session, repo_id=rid, branch="main", head_commit_id=c3.commit_id
+    )
+
+    assert result.total_commits == 3
+    assert result.entries[0].commit_id == c1.commit_id   # oldest first
+    assert result.entries[1].commit_id == c2.commit_id
+    assert result.entries[2].commit_id == c3.commit_id   # newest last
+
+
+@pytest.mark.anyio
+async def test_timeline_empty_when_no_commits(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """build_timeline with a non-existent head_commit_id returns an empty result."""
+    rid = _repo_id()
+    result = await build_timeline(
+        db_session, repo_id=rid, branch="main", head_commit_id="nonexistent"
+    )
+    assert result.total_commits == 0
+    assert result.entries == ()
+
+
+@pytest.mark.anyio
+async def test_timeline_extracts_emotion_arc(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+) -> None:
+    """build_timeline computes emotion_arc as ordered unique emotion labels."""
+    rid = _repo_id()
+    c1 = await _insert_commit(db_session, rid, "main", "Init", _utc(2026, 2, 1))
+    await _attach_tag(db_session, rid, c1.commit_id, "emotion:melancholic")
+    c2 = await _insert_commit(db_session, rid, "main", "Chorus", _utc(2026, 2, 2), c1.commit_id)
+    await _attach_tag(db_session, rid, c2.commit_id, "emotion:joyful")
+    c3 = await _insert_commit(db_session, rid, "main", "Bridge", _utc(2026, 2, 3), c2.commit_id)
+    await _attach_tag(db_session, rid, c3.commit_id, "emotion:tense")
+    await db_session.commit()
+
+    result = await build_timeline(
+        db_session, repo_id=rid, branch="main", head_commit_id=c3.commit_id
+    )
+    assert result.emotion_arc == ("melancholic", "joyful", "tense")
+
+
+@pytest.mark.anyio
+async def test_timeline_deduplicated_emotion_arc(
+    db_session: AsyncSession,
+) -> None:
+    """build_timeline deduplicates emotion_arc — repeated emotions appear once."""
+    rid = _repo_id()
+    c1 = await _insert_commit(db_session, rid, "main", "Init", _utc(2026, 2, 1))
+    await _attach_tag(db_session, rid, c1.commit_id, "emotion:melancholic")
+    c2 = await _insert_commit(db_session, rid, "main", "Add keys", _utc(2026, 2, 2), c1.commit_id)
+    await _attach_tag(db_session, rid, c2.commit_id, "emotion:melancholic")
+    await db_session.commit()
+
+    result = await build_timeline(
+        db_session, repo_id=rid, branch="main", head_commit_id=c2.commit_id
+    )
+    assert result.emotion_arc == ("melancholic",)
+
+
+@pytest.mark.anyio
+async def test_timeline_section_order(
+    db_session: AsyncSession,
+) -> None:
+    """build_timeline records section_order in order of first appearance."""
+    rid = _repo_id()
+    c1 = await _insert_commit(db_session, rid, "main", "Verse 1", _utc(2026, 2, 1))
+    await _attach_tag(db_session, rid, c1.commit_id, "section:verse")
+    c2 = await _insert_commit(db_session, rid, "main", "Chorus", _utc(2026, 2, 2), c1.commit_id)
+    await _attach_tag(db_session, rid, c2.commit_id, "section:chorus")
+    await db_session.commit()
+
+    result = await build_timeline(
+        db_session, repo_id=rid, branch="main", head_commit_id=c2.commit_id
+    )
+    assert result.section_order == ("verse", "chorus")
+
+
+@pytest.mark.anyio
+async def test_timeline_limit_caps_entries(
+    db_session: AsyncSession,
+) -> None:
+    """build_timeline respects the limit parameter."""
+    rid = _repo_id()
+    prev_id: str | None = None
+    last_commit: MuseCliCommit | None = None
+    for i in range(5):
+        c = await _insert_commit(
+            db_session, rid, "main", f"commit {i}", _utc(2026, 2, i + 1), prev_id
+        )
+        prev_id = c.commit_id
+        last_commit = c
+    await db_session.commit()
+
+    assert last_commit is not None
+    result = await build_timeline(
+        db_session, repo_id=rid, branch="main",
+        head_commit_id=last_commit.commit_id, limit=3
+    )
+    assert result.total_commits == 3
+
+
+# ---------------------------------------------------------------------------
+# Unit — renderers
+# ---------------------------------------------------------------------------
+
+
+def test_render_text_outputs_header(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_text prints branch name and commit count header."""
+    entry = MuseTimelineEntry(
+        commit_id="a" * 64,
+        short_id="aaaaaaa",
+        committed_at=_utc(2026, 2, 1),
+        message="Initial drums",
+        emotion=None,
+        sections=(),
+        tracks=(),
+        activity=1,
+    )
+    result = MuseTimelineResult(
+        entries=(entry,),
+        branch="main",
+        emotion_arc=(),
+        section_order=(),
+        total_commits=1,
+    )
+    _render_text(result, show_emotion=False, show_sections=False, show_tracks=False)
+    out = capsys.readouterr().out
+    assert "main" in out
+    assert "1 commit" in out
+    assert "aaaaaaa" in out
+    assert "2026-02-01" in out
+
+
+def test_render_text_no_commits(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_text with empty entries prints the empty message."""
+    result = MuseTimelineResult(
+        entries=(), branch="main", emotion_arc=(), section_order=(), total_commits=0
+    )
+    _render_text(result, show_emotion=False, show_sections=False, show_tracks=False)
+    out = capsys.readouterr().out
+    assert "No commits" in out
+
+
+def test_render_text_show_emotion_column(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_text with show_emotion=True includes emotion values in output."""
+    entry = MuseTimelineEntry(
+        commit_id="b" * 64,
+        short_id="bbbbbbb",
+        committed_at=_utc(2026, 2, 2),
+        message="Add chorus",
+        emotion="joyful",
+        sections=("chorus",),
+        tracks=("keys",),
+        activity=1,
+    )
+    result = MuseTimelineResult(
+        entries=(entry,),
+        branch="main",
+        emotion_arc=("joyful",),
+        section_order=("chorus",),
+        total_commits=1,
+    )
+    _render_text(result, show_emotion=True, show_sections=False, show_tracks=False)
+    out = capsys.readouterr().out
+    assert "joyful" in out
+    assert "Emotion arc" in out
+
+
+def test_render_text_show_sections_header(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_text with show_sections=True prints section header lines."""
+    e1 = MuseTimelineEntry(
+        commit_id="c" * 64,
+        short_id="ccccccc",
+        committed_at=_utc(2026, 2, 1),
+        message="Verse start",
+        emotion=None,
+        sections=("verse",),
+        tracks=(),
+        activity=1,
+    )
+    e2 = MuseTimelineEntry(
+        commit_id="d" * 64,
+        short_id="ddddddd",
+        committed_at=_utc(2026, 2, 2),
+        message="Chorus start",
+        emotion=None,
+        sections=("chorus",),
+        tracks=(),
+        activity=1,
+    )
+    result = MuseTimelineResult(
+        entries=(e1, e2),
+        branch="main",
+        emotion_arc=(),
+        section_order=("verse", "chorus"),
+        total_commits=2,
+    )
+    _render_text(result, show_emotion=False, show_sections=True, show_tracks=False)
+    out = capsys.readouterr().out
+    assert "verse" in out
+    assert "chorus" in out
+    assert "──" in out
+
+
+def test_render_text_show_tracks_column(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_text with show_tracks=True includes track names in output."""
+    entry = MuseTimelineEntry(
+        commit_id="e" * 64,
+        short_id="eeeeeee",
+        committed_at=_utc(2026, 2, 1),
+        message="Add bass",
+        emotion=None,
+        sections=(),
+        tracks=("bass", "drums"),
+        activity=2,
+    )
+    result = MuseTimelineResult(
+        entries=(entry,),
+        branch="main",
+        emotion_arc=(),
+        section_order=(),
+        total_commits=1,
+    )
+    _render_text(result, show_emotion=False, show_sections=False, show_tracks=True)
+    out = capsys.readouterr().out
+    assert "bass" in out
+    assert "drums" in out
+
+
+def test_render_json_is_valid_and_complete(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_json emits valid JSON with expected top-level keys and entry fields."""
+    entry = MuseTimelineEntry(
+        commit_id="f" * 64,
+        short_id="fffffff",
+        committed_at=_utc(2026, 2, 3),
+        message="Chorus melody",
+        emotion="joyful",
+        sections=("chorus",),
+        tracks=("keys", "vocals"),
+        activity=2,
+    )
+    result = MuseTimelineResult(
+        entries=(entry,),
+        branch="main",
+        emotion_arc=("joyful",),
+        section_order=("chorus",),
+        total_commits=1,
+    )
+    _render_json(result)
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+
+    assert payload["branch"] == "main"
+    assert payload["total_commits"] == 1
+    assert payload["emotion_arc"] == ["joyful"]
+    assert payload["section_order"] == ["chorus"]
+    assert len(payload["entries"]) == 1
+
+    e = payload["entries"][0]
+    assert e["short_id"] == "fffffff"
+    assert e["emotion"] == "joyful"
+    assert e["sections"] == ["chorus"]
+    assert set(e["tracks"]) == {"keys", "vocals"}
+    assert e["activity"] == 2
+
+
+def test_entry_to_dict_serializes_all_fields() -> None:
+    """_entry_to_dict includes all required fields with correct types."""
+    entry = MuseTimelineEntry(
+        commit_id="a" * 64,
+        short_id="aaaaaaa",
+        committed_at=_utc(2026, 2, 1),
+        message="Init",
+        emotion=None,
+        sections=(),
+        tracks=(),
+        activity=1,
+    )
+    d = _entry_to_dict(entry)
+    assert "commit_id" in d
+    assert "short_id" in d
+    assert "committed_at" in d
+    assert "message" in d
+    assert "emotion" in d
+    assert "sections" in d
+    assert "tracks" in d
+    assert "activity" in d
+    assert d["emotion"] is None
+    assert isinstance(d["sections"], list)
+    assert isinstance(d["tracks"], list)
+
+
+# ---------------------------------------------------------------------------
+# Async core — _timeline_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_timeline_async_default_output(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_timeline_async default text mode shows all commits chronologically."""
+    rid = _init_muse_repo(tmp_path)
+    c1 = await _insert_commit(db_session, rid, "main", "Init", _utc(2026, 2, 1))
+    c2 = await _insert_commit(db_session, rid, "main", "Bass", _utc(2026, 2, 2), c1.commit_id)
+    await db_session.commit()
+    _set_head(tmp_path, c2.commit_id)
+
+    result = await _timeline_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range=None,
+        show_emotion=False,
+        show_sections=False,
+        show_tracks=False,
+        as_json=False,
+        limit=1000,
+    )
+
+    assert result.total_commits == 2
+    assert result.entries[0].commit_id == c1.commit_id  # oldest first
+    out = capsys.readouterr().out
+    assert "main" in out
+    assert "2026-02-01" in out
+
+
+@pytest.mark.anyio
+async def test_timeline_async_json_mode(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_timeline_async --json emits valid JSON with all entries."""
+    rid = _init_muse_repo(tmp_path)
+    c1 = await _insert_commit(db_session, rid, "main", "Init", _utc(2026, 2, 1))
+    c2 = await _insert_commit(db_session, rid, "main", "Chorus", _utc(2026, 2, 2), c1.commit_id)
+    await db_session.commit()
+    _set_head(tmp_path, c2.commit_id)
+
+    await _timeline_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range=None,
+        show_emotion=False,
+        show_sections=False,
+        show_tracks=False,
+        as_json=True,
+        limit=1000,
+    )
+
+    raw = capsys.readouterr().out
+    payload = json.loads(raw)
+    assert payload["total_commits"] == 2
+    assert len(payload["entries"]) == 2
+
+
+@pytest.mark.anyio
+async def test_timeline_async_no_commits_exits_success(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_timeline_async exits 0 with an informative message when branch has no commits."""
+    _init_muse_repo(tmp_path)
+    # No _set_head — branch ref stays empty.
+
+    import typer
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _timeline_async(
+            root=tmp_path,
+            session=db_session,
+            commit_range=None,
+            show_emotion=False,
+            show_sections=False,
+            show_tracks=False,
+            as_json=False,
+            limit=1000,
+        )
+    assert exc_info.value.exit_code == int(ExitCode.SUCCESS)
+    out = capsys.readouterr().out
+    assert "empty" in out.lower() or "no commits" in out.lower()
+
+
+@pytest.mark.anyio
+async def test_timeline_async_commit_range_reserved_warns(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_timeline_async emits a stub warning when commit_range is supplied."""
+    rid = _init_muse_repo(tmp_path)
+    c1 = await _insert_commit(db_session, rid, "main", "Init", _utc(2026, 2, 1))
+    await db_session.commit()
+    _set_head(tmp_path, c1.commit_id)
+
+    await _timeline_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range="HEAD~5..HEAD",
+        show_emotion=False,
+        show_sections=False,
+        show_tracks=False,
+        as_json=False,
+        limit=1000,
+    )
+
+    out = capsys.readouterr().out
+    assert "reserved" in out.lower() or "HEAD~5..HEAD" in out
+
+
+@pytest.mark.anyio
+async def test_timeline_async_emotion_flag_shows_tags(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_timeline_async --emotion includes emotion values in text output."""
+    rid = _init_muse_repo(tmp_path)
+    c1 = await _insert_commit(db_session, rid, "main", "Intro", _utc(2026, 2, 1))
+    await _attach_tag(db_session, rid, c1.commit_id, "emotion:melancholic")
+    await db_session.commit()
+    _set_head(tmp_path, c1.commit_id)
+
+    await _timeline_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range=None,
+        show_emotion=True,
+        show_sections=False,
+        show_tracks=False,
+        as_json=False,
+        limit=1000,
+    )
+
+    out = capsys.readouterr().out
+    assert "melancholic" in out
+
+
+@pytest.mark.anyio
+async def test_timeline_async_sections_flag_groups_commits(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_timeline_async --sections prints section header lines."""
+    rid = _init_muse_repo(tmp_path)
+    c1 = await _insert_commit(db_session, rid, "main", "Verse", _utc(2026, 2, 1))
+    await _attach_tag(db_session, rid, c1.commit_id, "section:verse")
+    c2 = await _insert_commit(db_session, rid, "main", "Chorus", _utc(2026, 2, 2), c1.commit_id)
+    await _attach_tag(db_session, rid, c2.commit_id, "section:chorus")
+    await db_session.commit()
+    _set_head(tmp_path, c2.commit_id)
+
+    await _timeline_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range=None,
+        show_emotion=False,
+        show_sections=True,
+        show_tracks=False,
+        as_json=False,
+        limit=1000,
+    )
+
+    out = capsys.readouterr().out
+    assert "verse" in out
+    assert "chorus" in out
+    assert "──" in out
+
+
+@pytest.mark.anyio
+async def test_timeline_async_tracks_flag_shows_track_column(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_timeline_async --tracks includes track names in text output."""
+    rid = _init_muse_repo(tmp_path)
+    c1 = await _insert_commit(db_session, rid, "main", "Add bass", _utc(2026, 2, 1))
+    await _attach_tag(db_session, rid, c1.commit_id, "track:bass")
+    await _attach_tag(db_session, rid, c1.commit_id, "track:drums")
+    await db_session.commit()
+    _set_head(tmp_path, c1.commit_id)
+
+    await _timeline_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range=None,
+        show_emotion=False,
+        show_sections=False,
+        show_tracks=True,
+        as_json=False,
+        limit=1000,
+    )
+
+    out = capsys.readouterr().out
+    assert "bass" in out
+    assert "drums" in out
+
+
+@pytest.mark.anyio
+async def test_timeline_async_graceful_with_no_metadata_tags(
+    tmp_path: pathlib.Path,
+    db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """_timeline_async renders commits with no tags without crashing (shows '—')."""
+    rid = _init_muse_repo(tmp_path)
+    c1 = await _insert_commit(db_session, rid, "main", "Raw commit", _utc(2026, 2, 1))
+    await db_session.commit()
+    _set_head(tmp_path, c1.commit_id)
+
+    result = await _timeline_async(
+        root=tmp_path,
+        session=db_session,
+        commit_range=None,
+        show_emotion=True,
+        show_sections=True,
+        show_tracks=True,
+        as_json=False,
+        limit=1000,
+    )
+    # Should not crash and should show the commit.
+    assert result.total_commits == 1
+    out = capsys.readouterr().out
+    assert "Raw commit" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — CliRunner
+# ---------------------------------------------------------------------------
+
+
+def test_cli_timeline_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse timeline`` exits 2 when invoked outside a Muse repository."""
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["timeline"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+    assert result.exit_code == int(ExitCode.REPO_NOT_FOUND)
+    assert "not a muse repository" in result.output.lower()
+
+
+def test_cli_timeline_help_lists_all_flags() -> None:
+    """``muse timeline --help`` shows all documented flags."""
+    result = runner.invoke(cli, ["timeline", "--help"])
+    assert result.exit_code == 0
+    for flag in ("--emotion", "--sections", "--tracks", "--json", "--limit"):
+        assert flag in result.output, f"Flag '{flag}' not in help"
+
+
+def test_cli_timeline_appears_in_muse_help() -> None:
+    """``muse --help`` lists the timeline subcommand."""
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "timeline" in result.output


### PR DESCRIPTION
## Summary
Closes #97 — Implement `muse timeline` command to visualize musical evolution chronologically.

## Root Cause / Motivation
No chronological view of a composition's creative arc existed. Users and agents had no way to see how key musical properties — emotion, sections, track activity — changed over time across commits. The `muse timeline` command fills this gap as the "album liner notes" view of a project's evolution.

## Solution

### New files
- **`maestro/services/muse_timeline.py`**: Service layer with typed result types `MuseTimelineEntry` and `MuseTimelineResult`. `build_timeline()` walks the parent chain from HEAD (oldest-first) then batch-fetches all tags in a single query to avoid N+1 round-trips. Emotion arc and section order are derived as ordered unique sequences.
- **`maestro/muse_cli/commands/timeline.py`**: CLI command with `--emotion`, `--sections`, `--tracks`, `--json`, and `--limit` flags. Text mode renders Unicode block activity bars (`████`) scaled to the most-active commit. JSON mode emits structured output for UI rendering or agent consumption.
- **`tests/test_muse_timeline.py`**: 32 tests covering service helpers, renderers, async core with real SQLite fixtures, and CLI integration via `CliRunner`.

### Modified files
- **`maestro/muse_cli/app.py`**: Registers `timeline` subcommand.
- **`docs/architecture/muse_vcs.md`**: Adds `muse timeline` command reference with flags table, terminal output example, JSON output example, and agent use case.
- **`docs/reference/type_contracts.md`**: Registers `MuseTimelineEntry` and `MuseTimelineResult` type contracts.

## Layers Affected
- [x] Muse VCS (new CLI command + service)
- [ ] Intent Engine
- [ ] Pipeline
- [ ] Maestro Handlers
- [ ] Agent Teams
- [ ] Storpheus Client
- [ ] MCP
- [ ] DAW Adapter
- [ ] Auth / Budget
- [ ] RAG
- [ ] Variation
- [ ] SSE Protocol

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (495 files)
- [x] `docker compose exec storpheus mypy .` — clean
- [x] 32 timeline tests pass
- [x] Docs updated (`muse_vcs.md`, `type_contracts.md`)

## Tests Added
- `test_timeline_outputs_chronological_history` — regression: oldest-first ordering preserved
- `test_timeline_empty_when_no_commits` — empty result for non-existent HEAD
- `test_timeline_extracts_emotion_arc` — emotion arc from commit tags
- `test_timeline_deduplicated_emotion_arc` — repeated emotions deduped
- `test_timeline_section_order` — section order from commit tags
- `test_timeline_limit_caps_entries` — limit parameter respected
- `test_render_text_*` — all text renderer scenarios (header, no commits, emotion/sections/tracks columns)
- `test_render_json_is_valid_and_complete` — JSON structure and field completeness
- `test_timeline_async_*` — all flag combinations via injectable async core
- `test_cli_timeline_*` — CLI integration via CliRunner

## Handoff
N/A — no SSE/MCP protocol change.