### PR TITLE
feat: muse amend — amend the most recent commit

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -3034,3 +3034,54 @@ the computed values will change when the full implementation is wired in.
 (`REPO_NOT_FOUND`), 3 internal error (`INTERNAL_ERROR`).
 
 ---
+
+## `muse amend` — Amend the Most Recent Commit
+
+**Purpose:** Fold working-tree changes into the most recent commit, replacing
+it with a new commit that has the same parent.  Equivalent to
+`git commit --amend`.  The original HEAD commit becomes an orphan (unreachable
+from any branch ref) and remains in the database for forensic traceability.
+
+**Usage:**
+```bash
+muse amend [OPTIONS]
+```
+
+**Flags:**
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-m / --message TEXT` | string | — | Replace the commit message |
+| `--no-edit` | flag | off | Keep the original commit message (default when `-m` is omitted; takes precedence over `-m` when both are provided) |
+| `--reset-author` | flag | off | Reset the author field to the current user (stub: sets to empty string until a user-identity system is implemented) |
+
+**Output example:**
+```
+✅ [main a1b2c3d4] updated groove pattern (amended)
+```
+
+**Behaviour:**
+1. Re-snapshots `muse-work/` using the same content-addressed pipeline as
+   `muse commit` (sha256 per file, deterministic snapshot_id).
+2. Computes a new `commit_id` using the *original commit's parent* (not the
+   original itself), the new snapshot, the effective message, and the current
+   timestamp.
+3. Writes the new commit row to Postgres and updates
+   `.muse/refs/heads/<branch>` to the new commit ID.
+4. **Blocked** when a merge is in progress (`.muse/MERGE_STATE.json` exists).
+5. **Blocked** when there are no commits yet on the current branch.
+6. **Blocked** when `muse-work/` does not exist or is empty.
+
+**Result types:**
+- Returns the new `commit_id` (64-char sha256 hex string) from `_amend_async`.
+- Exit codes: 0 success, 1 user error (`USER_ERROR`), 2 outside repo
+  (`REPO_NOT_FOUND`), 3 internal error (`INTERNAL_ERROR`).
+
+**Agent use case:** A producer adjusts a MIDI note quantization setting, then
+runs `muse amend --no-edit` to fold the change silently into the last commit
+without cluttering history with a second "tweak quantization" entry.  An
+automated agent can call `muse amend -m "fix: tighten quantization on drums"`
+to improve the commit message after inspection.
+
+**Implementation:** `maestro/muse_cli/commands/amend.py` —
+`_amend_async(message, no_edit, reset_author, root, session)`.
+Tests: `tests/muse_cli/test_amend.py`.

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -1,16 +1,17 @@
 """Muse CLI — Typer application root.
 
 Entry point for the ``muse`` console script. Registers all MVP
-subcommands (arrange, ask, checkout, chord-map, commit, context, contour,
-describe, diff, divergence, dynamics, export, find, grep, humanize, import,
-init, key, log, merge, meter, open, play, pull, push, recall, remote, session,
-status, swing, tag, tempo, tempo-scale) as Typer sub-applications.
+subcommands (amend, arrange, ask, checkout, chord-map, commit, context,
+contour, describe, diff, divergence, dynamics, export, find, grep, humanize,
+import, init, key, log, merge, meter, open, play, pull, push, recall, remote,
+session, status, swing, tag, tempo, tempo-scale) as Typer sub-applications.
 """
 from __future__ import annotations
 
 import typer
 
 from maestro.muse_cli.commands import (
+    amend,
     arrange,
     ask,
     checkout,
@@ -52,6 +53,7 @@ cli = typer.Typer(
     no_args_is_help=True,
 )
 
+cli.add_typer(amend.app, name="amend", help="Fold working-tree changes into the most recent commit.")
 cli.add_typer(chord_map.app, name="chord-map", help="Visualize the chord progression embedded in a commit.")
 cli.add_typer(contour.app, name="contour", help="Analyze the melodic contour and phrase shape of a commit.")
 cli.add_typer(init.app, name="init", help="Initialise a new Muse repository.")

--- a/maestro/muse_cli/commands/amend.py
+++ b/maestro/muse_cli/commands/amend.py
@@ -1,0 +1,257 @@
+"""muse amend — fold working-tree changes into the most recent commit.
+
+Equivalent to ``git commit --amend``.  The original HEAD commit is replaced
+by a new commit that shares the same *parent* as the original, effectively
+orphaning the original HEAD.  The amended commit is a fresh object with a
+new deterministic ``commit_id``.
+
+Flag summary
+------------
+- ``-m / --message TEXT``  — use TEXT as the new commit message.
+- ``--no-edit``            — keep the original commit message (default when
+                             ``-m`` is omitted).  When both ``-m`` and
+                             ``--no-edit`` are supplied, ``--no-edit`` wins.
+- ``--reset-author``       — reset the author field to the current user
+                             (stub: sets author to empty string until a user
+                             identity system is implemented).
+
+Behaviour
+---------
+1. A new snapshot is taken of ``muse-work/`` using the same content-addressed
+   logic as ``muse commit``.
+2. A new ``commit_id`` is computed with the *original commit's parent* as the
+   parent, the current timestamp, and the effective message.
+3. ``.muse/refs/heads/<branch>`` is updated to the new commit ID.
+4. Blocked when a merge is in progress (``.muse/MERGE_STATE.json`` exists).
+5. Blocked when there are no commits yet on the current branch.
+
+The original HEAD commit becomes an orphan: it is no longer reachable from
+any branch ref but remains in the database for forensic traceability.  A
+future ``muse gc`` pass may prune it.
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime
+import json
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import (
+    insert_commit,
+    open_session,
+    upsert_object,
+    upsert_snapshot,
+)
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.merge_engine import read_merge_state
+from maestro.muse_cli.models import MuseCliCommit
+from maestro.muse_cli.snapshot import (
+    build_snapshot_manifest,
+    compute_commit_id,
+    compute_snapshot_id,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+
+# ---------------------------------------------------------------------------
+# Testable async core
+# ---------------------------------------------------------------------------
+
+
+async def _amend_async(
+    *,
+    message: str | None,
+    no_edit: bool,
+    reset_author: bool,
+    root: pathlib.Path,
+    session: AsyncSession,
+) -> str:
+    """Run the amend pipeline and return the new ``commit_id``.
+
+    All filesystem and DB side-effects are isolated here so tests can inject
+    an in-memory SQLite session and a ``tmp_path`` root without touching a
+    real database.
+
+    Args:
+        message:      New commit message, or ``None`` to keep the original.
+                      Ignored when *no_edit* is ``True``.
+        no_edit:      When ``True``, keep the original commit message even if
+                      *message* is also supplied.
+        reset_author: When ``True``, reset the author field (stub: empty string
+                      until a user-identity system is introduced).
+        root:         Repository root (directory containing ``.muse/``).
+        session:      An open async DB session.
+
+    Returns:
+        The new ``commit_id`` (64-char sha256 hex string).
+
+    Raises:
+        typer.Exit: On any user-facing error (merge in progress, no commits,
+                    empty working tree, DB inconsistency).
+    """
+    muse_dir = root / ".muse"
+
+    # ── Guard: block amend while a conflicted merge is in progress ──────
+    merge_state = read_merge_state(root)
+    if merge_state is not None:
+        typer.echo(
+            "❌ A merge is in progress — amend is not allowed.\n"
+            "   Resolve any conflicts and run 'muse commit', or abort the merge first."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # ── Repo identity ────────────────────────────────────────────────────
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]
+
+    # ── Current branch ───────────────────────────────────────────────────
+    head_ref = (muse_dir / "HEAD").read_text().strip()   # "refs/heads/main"
+    branch = head_ref.rsplit("/", 1)[-1]                 # "main"
+    ref_path = muse_dir / pathlib.Path(head_ref)
+
+    if not ref_path.exists() or not ref_path.read_text().strip():
+        typer.echo(
+            "❌ Nothing to amend — no commits yet on this branch.\n"
+            "   Run 'muse commit -m <message>' to create the first commit."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    head_commit_id = ref_path.read_text().strip()
+
+    # ── Load HEAD commit to get its parent and original message ──────────
+    head_commit = await session.get(MuseCliCommit, head_commit_id)
+    if head_commit is None:
+        typer.echo(
+            f"❌ HEAD commit {head_commit_id[:8]} not found in database.\n"
+            "   Repository may be in an inconsistent state."
+        )
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    # ── Determine effective commit message ────────────────────────────────
+    # --no-edit (or no -m supplied) → keep original; -m TEXT → use TEXT.
+    if no_edit or message is None:
+        effective_message = head_commit.message
+    else:
+        effective_message = message
+
+    # ── Build new snapshot from muse-work/ ───────────────────────────────
+    workdir = root / "muse-work"
+    if not workdir.exists():
+        typer.echo(
+            "⚠️  No muse-work/ directory found — nothing to snapshot.\n"
+            "     Generate some artifacts before running 'muse amend'."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    manifest = build_snapshot_manifest(workdir)
+    if not manifest:
+        typer.echo("⚠️  muse-work/ is empty — cannot amend with an empty snapshot.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    snapshot_id = compute_snapshot_id(manifest)
+
+    # ── Compute new commit ID (same parent as the original HEAD) ─────────
+    # The amended commit inherits the original commit's *parent*, keeping
+    # the linear chain intact and orphaning the original HEAD.
+    parent_commit_id = head_commit.parent_commit_id
+    parent_ids = [parent_commit_id] if parent_commit_id else []
+
+    committed_at = datetime.datetime.now(datetime.timezone.utc)
+    new_commit_id = compute_commit_id(
+        parent_ids=parent_ids,
+        snapshot_id=snapshot_id,
+        message=effective_message,
+        committed_at_iso=committed_at.isoformat(),
+    )
+
+    # ── Persist objects ──────────────────────────────────────────────────
+    for rel_path, object_id in manifest.items():
+        file_path = workdir / rel_path
+        size = file_path.stat().st_size
+        await upsert_object(session, object_id=object_id, size_bytes=size)
+
+    # ── Persist snapshot ─────────────────────────────────────────────────
+    await upsert_snapshot(session, manifest=manifest, snapshot_id=snapshot_id)
+    # Flush so the snapshot FK constraint is satisfied before inserting the commit.
+    await session.flush()
+
+    # ── Persist amended commit ────────────────────────────────────────────
+    author = "" if not reset_author else ""  # stub: no user-identity system yet
+    new_commit = MuseCliCommit(
+        commit_id=new_commit_id,
+        repo_id=repo_id,
+        branch=branch,
+        parent_commit_id=parent_commit_id,
+        snapshot_id=snapshot_id,
+        message=effective_message,
+        author=author,
+        committed_at=committed_at,
+    )
+    await insert_commit(session, new_commit)
+
+    # ── Update branch HEAD pointer ─────────────────────────────────────────
+    ref_path.write_text(new_commit_id)
+
+    typer.echo(f"✅ [{branch} {new_commit_id[:8]}] {effective_message} (amended)")
+    logger.info(
+        "✅ muse amend %s → %s on %r: %s",
+        head_commit_id[:8],
+        new_commit_id[:8],
+        branch,
+        effective_message,
+    )
+    return new_commit_id
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def amend(
+    ctx: typer.Context,
+    message: Optional[str] = typer.Option(
+        None, "-m", "--message", help="Replace the commit message."
+    ),
+    no_edit: bool = typer.Option(
+        False,
+        "--no-edit",
+        help="Keep the original commit message. Takes precedence over -m.",
+    ),
+    reset_author: bool = typer.Option(
+        False,
+        "--reset-author",
+        help="Reset the author field to the current user.",
+    ),
+) -> None:
+    """Fold working-tree changes into the most recent commit."""
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _amend_async(
+                message=message,
+                no_edit=no_edit,
+                reset_author=reset_author,
+                root=root,
+                session=session,
+            )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse amend failed: {exc}")
+        logger.error("❌ muse amend error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/muse_cli/commands/amend.py
+++ b/maestro/muse_cli/commands/amend.py
@@ -185,7 +185,7 @@ async def _amend_async(
     await session.flush()
 
     # ── Persist amended commit ────────────────────────────────────────────
-    author = "" if not reset_author else ""  # stub: no user-identity system yet
+    author = ""  # stub: no user-identity system yet; reset_author is a no-op for now
     new_commit = MuseCliCommit(
         commit_id=new_commit_id,
         repo_id=repo_id,

--- a/tests/muse_cli/test_amend.py
+++ b/tests/muse_cli/test_amend.py
@@ -1,0 +1,434 @@
+"""Tests for ``muse amend``.
+
+Exercises ``_amend_async`` directly with an in-memory SQLite session so no
+real Postgres instance is required.  The ``muse_cli_db_session`` fixture
+(defined in tests/muse_cli/conftest.py) provides the isolated session.
+
+Test coverage
+-------------
+- ``test_muse_amend_updates_last_commit``  — regression: amend replaces HEAD ref
+- ``test_muse_amend_message_only``         — -m flag updates message
+- ``test_muse_amend_blocked_during_merge`` — blocked when MERGE_STATE.json exists
+- Plus: no-commits guard, parent inheritance, --no-edit, --reset-author,
+        outside-repo exit code, empty muse-work/ guard, missing muse-work/ guard.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+
+import pytest
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from maestro.muse_cli.commands.amend import _amend_async
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors commit tests to keep the fixture surface minimal)
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    """Create a minimal .muse/ layout so _amend_async can read repo state."""
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")  # no commits yet
+    return rid
+
+
+def _populate_workdir(root: pathlib.Path, files: dict[str, bytes] | None = None) -> None:
+    """Create muse-work/ with one or more files."""
+    workdir = root / "muse-work"
+    workdir.mkdir(exist_ok=True)
+    if files is None:
+        files = {"beat.mid": b"MIDI-DATA", "lead.mp3": b"MP3-DATA"}
+    for name, content in files.items():
+        (workdir / name).write_bytes(content)
+
+
+async def _make_commit(
+    root: pathlib.Path,
+    session: AsyncSession,
+    *,
+    message: str = "initial commit",
+    files: dict[str, bytes] | None = None,
+) -> str:
+    """Helper: populate workdir and run _commit_async, return commit_id."""
+    _populate_workdir(root, files=files)
+    return await _commit_async(message=message, root=root, session=session)
+
+
+# ---------------------------------------------------------------------------
+# Core regression tests (named per issue acceptance criteria)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_muse_amend_updates_last_commit(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Amend re-snapshots muse-work/ and updates .muse/refs/heads/<branch>."""
+    _init_muse_repo(tmp_path)
+    original_id = await _make_commit(
+        tmp_path, muse_cli_db_session, message="original", files={"a.mid": b"V1"}
+    )
+
+    # Modify the working tree
+    (tmp_path / "muse-work" / "a.mid").write_bytes(b"V2")
+
+    new_id = await _amend_async(
+        message=None,
+        no_edit=True,
+        reset_author=False,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # HEAD ref must point to the new commit
+    ref_content = (tmp_path / ".muse" / "refs" / "heads" / "main").read_text().strip()
+    assert ref_content == new_id
+    assert new_id != original_id
+
+
+@pytest.mark.anyio
+async def test_muse_amend_message_only(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Amend with -m replaces the commit message."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(tmp_path, muse_cli_db_session, message="old message")
+
+    new_id = await _amend_async(
+        message="new message",
+        no_edit=False,
+        reset_author=False,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == new_id)
+    )
+    row = result.scalar_one()
+    assert row.message == "new message"
+
+
+@pytest.mark.anyio
+async def test_muse_amend_blocked_during_merge(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Amend is blocked when MERGE_STATE.json exists (merge in progress)."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(tmp_path, muse_cli_db_session)
+
+    # Simulate an in-progress merge
+    merge_state = {
+        "base_commit": "abc",
+        "ours_commit": "def",
+        "theirs_commit": "ghi",
+        "conflict_paths": ["beat.mid"],
+        "other_branch": "feature/x",
+    }
+    (tmp_path / ".muse" / "MERGE_STATE.json").write_text(json.dumps(merge_state))
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _amend_async(
+            message=None,
+            no_edit=True,
+            reset_author=False,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Guard: no commits yet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_muse_amend_no_commits_exits_1(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Amend with no prior commits exits USER_ERROR."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _amend_async(
+            message="oops",
+            no_edit=False,
+            reset_author=False,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Parent inheritance — amended commit keeps original's parent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_muse_amend_preserves_grandparent(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """The amended commit's parent is the *original commit's parent*, not the original itself."""
+    _init_muse_repo(tmp_path)
+
+    # Commit 1
+    cid1 = await _make_commit(
+        tmp_path, muse_cli_db_session, message="commit 1", files={"a.mid": b"V1"}
+    )
+
+    # Commit 2 (this is HEAD, the one we will amend)
+    (tmp_path / "muse-work" / "a.mid").write_bytes(b"V2")
+    _cid2 = await _commit_async(
+        message="commit 2", root=tmp_path, session=muse_cli_db_session
+    )
+
+    # Amend commit 2
+    (tmp_path / "muse-work" / "a.mid").write_bytes(b"V3")
+    amended_id = await _amend_async(
+        message="commit 2 amended",
+        no_edit=False,
+        reset_author=False,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == amended_id)
+    )
+    amended_row = result.scalar_one()
+    # The amended commit's parent must be commit 1, not commit 2
+    assert amended_row.parent_commit_id == cid1
+
+
+@pytest.mark.anyio
+async def test_muse_amend_first_commit_has_no_parent(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Amending the very first commit produces a root commit (parent_commit_id is None)."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(tmp_path, muse_cli_db_session, message="root commit")
+
+    # Amend — workdir unchanged, just new message
+    amended_id = await _amend_async(
+        message="root amended",
+        no_edit=False,
+        reset_author=False,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == amended_id)
+    )
+    row = result.scalar_one()
+    assert row.parent_commit_id is None
+
+
+# ---------------------------------------------------------------------------
+# --no-edit keeps original message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_muse_amend_no_edit_keeps_original_message(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--no-edit preserves the original commit message even when -m is also provided."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(tmp_path, muse_cli_db_session, message="keep this message")
+
+    # Modify workdir so we get a new snapshot
+    (tmp_path / "muse-work" / "beat.mid").write_bytes(b"UPDATED")
+
+    # Supply -m but also --no-edit; --no-edit wins
+    amended_id = await _amend_async(
+        message="should be ignored",
+        no_edit=True,
+        reset_author=False,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == amended_id)
+    )
+    row = result.scalar_one()
+    assert row.message == "keep this message"
+
+
+@pytest.mark.anyio
+async def test_muse_amend_no_message_flag_keeps_original(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """When neither -m nor --no-edit is supplied, original message is kept."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(tmp_path, muse_cli_db_session, message="original message")
+
+    (tmp_path / "muse-work" / "beat.mid").write_bytes(b"UPDATED")
+
+    amended_id = await _amend_async(
+        message=None,
+        no_edit=False,
+        reset_author=False,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == amended_id)
+    )
+    row = result.scalar_one()
+    assert row.message == "original message"
+
+
+# ---------------------------------------------------------------------------
+# --reset-author (stub: always produces empty author string)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_muse_amend_reset_author_flag_accepted(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--reset-author is accepted without error (stub implementation)."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(tmp_path, muse_cli_db_session)
+
+    (tmp_path / "muse-work" / "beat.mid").write_bytes(b"UPDATED")
+
+    amended_id = await _amend_async(
+        message=None,
+        no_edit=True,
+        reset_author=True,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == amended_id)
+    )
+    row = result.scalar_one()
+    # Stub: always empty string until a user-identity system is added
+    assert row.author == ""
+
+
+# ---------------------------------------------------------------------------
+# Empty / missing muse-work/ guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_muse_amend_missing_workdir_exits_1(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """When muse-work/ does not exist, amend exits USER_ERROR."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(tmp_path, muse_cli_db_session)
+
+    # Remove muse-work/ entirely
+    import shutil
+    shutil.rmtree(tmp_path / "muse-work")
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _amend_async(
+            message=None,
+            no_edit=True,
+            reset_author=False,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_muse_amend_empty_workdir_exits_1(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """When muse-work/ is empty, amend exits USER_ERROR."""
+    _init_muse_repo(tmp_path)
+    await _make_commit(tmp_path, muse_cli_db_session)
+
+    # Empty the workdir
+    import shutil
+    shutil.rmtree(tmp_path / "muse-work")
+    (tmp_path / "muse-work").mkdir()
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _amend_async(
+            message=None,
+            no_edit=True,
+            reset_author=False,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Outside-repo exit code (Typer CLI runner)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_muse_amend_outside_repo_exits_2(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """``muse amend`` exits REPO_NOT_FOUND (2) when not inside a Muse repo."""
+    from typer.testing import CliRunner
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["amend", "--no-edit"], catch_exceptions=False)
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Amended commit is stored in DB and head ref is updated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_muse_amend_new_commit_stored_in_db(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """The amended commit row exists in DB with correct repo_id and branch."""
+    rid = _init_muse_repo(tmp_path)
+    await _make_commit(tmp_path, muse_cli_db_session, message="before amend")
+
+    (tmp_path / "muse-work" / "beat.mid").write_bytes(b"POST-AMEND")
+
+    amended_id = await _amend_async(
+        message="after amend",
+        no_edit=False,
+        reset_author=False,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == amended_id)
+    )
+    row = result.scalar_one_or_none()
+    assert row is not None
+    assert row.repo_id == rid
+    assert row.branch == "main"
+    assert row.message == "after amend"


### PR DESCRIPTION
## Summary
Closes #67 — adds `muse amend` CLI command to fold working-tree changes into the most recent commit.

## Root Cause / Motivation
No `muse amend` existed. Producers frequently make small tweaks and want to fold them into the last commit without cluttering history. Without this command, users had to manually create new commits or edit the Muse graph.

## Solution
New Typer subcommand `muse amend [OPTIONS]` registered in `maestro/muse_cli/app.py`.

**Flags implemented:**
- `-m / --message TEXT` — replace the commit message
- `--no-edit` — keep the original commit message (default when `-m` is omitted; takes precedence over `-m` when both are supplied)
- `--reset-author` — reset the author field (stub: sets to empty string until a user-identity system is introduced)

**Amend pipeline:**
1. Re-snapshots `muse-work/` using the same content-addressed pipeline as `muse commit`
2. Computes a new `commit_id` with the *original commit's parent* (not the original itself), preserving linear history
3. Writes the new commit to Postgres and updates `.muse/refs/heads/<branch>`
4. The original HEAD becomes an orphan (unreachable from branch ref, retained in DB for traceability)

**Guards:**
- Blocked when a merge is in progress (`MERGE_STATE.json` exists)
- Blocked when no commits exist yet on the current branch
- Blocked when `muse-work/` is missing or empty

## Verification
- [x] mypy clean — 497 source files, no issues
- [x] 13 tests pass in `tests/muse_cli/test_amend.py`
- [x] Docs updated — `muse amend` section added to `docs/architecture/muse_vcs.md`
- [x] No protocol changes; no handoff required

## Tests Added
- `test_muse_amend_updates_last_commit` — regression: amend replaces HEAD ref
- `test_muse_amend_message_only` — `-m` flag updates message
- `test_muse_amend_blocked_during_merge` — blocked when MERGE_STATE.json exists
- `test_muse_amend_no_commits_exits_1` — blocked with no prior commits
- `test_muse_amend_preserves_grandparent` — amended commit's parent is original's parent
- `test_muse_amend_first_commit_has_no_parent` — root commit amend has no parent
- `test_muse_amend_no_edit_keeps_original_message` — `--no-edit` wins over `-m`
- `test_muse_amend_no_message_flag_keeps_original` — no `-m` defaults to original message
- `test_muse_amend_reset_author_flag_accepted` — `--reset-author` accepted without error
- `test_muse_amend_missing_workdir_exits_1` — missing `muse-work/` exits 1
- `test_muse_amend_empty_workdir_exits_1` — empty `muse-work/` exits 1
- `test_muse_amend_outside_repo_exits_2` — outside-repo exits 2
- `test_muse_amend_new_commit_stored_in_db` — amended commit stored with correct repo_id/branch