### PR TITLE
feat: muse revert <commit> — create a new commit that undoes a prior commit

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -2762,6 +2762,34 @@ commit that scored at or above the `--threshold` keyword-overlap cutoff.
 
 ---
 
+### `RevertResult`
+
+**Module:** `maestro/services/muse_revert.py`
+
+Outcome of a `muse revert` operation. Captures the full audit trail of what
+was (or was not) changed so callers can verify the revert succeeded.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | New commit ID created by the revert. Empty string when `--no-commit` or noop. |
+| `target_commit_id` | `str` | The commit that was reverted. |
+| `parent_commit_id` | `str` | Parent of the reverted commit (whose snapshot was restored). Empty string for root commits. |
+| `revert_snapshot_id` | `str` | Snapshot ID of the reverted state (may equal parent's snapshot_id for full reverts). |
+| `message` | `str` | Auto-generated commit message: `"Revert '<original message>'"`. |
+| `no_commit` | `bool` | `True` when staged to muse-work/ without creating a commit. |
+| `noop` | `bool` | `True` when reverting would produce no change (already at target state). |
+| `scoped_paths` | `tuple[str, ...]` | Paths selectively reverted via `--track`/`--section`. Empty tuple = full revert. |
+| `paths_deleted` | `tuple[str, ...]` | Files removed from muse-work/ during `--no-commit`. |
+| `paths_missing` | `tuple[str, ...]` | Files that should be restored but whose bytes are unavailable (no object store). |
+| `branch` | `str` | Branch on which the revert commit was created. |
+
+**Producer:** `_revert_async()`
+**Consumer:** `revert()` Typer command callback, tests in `tests/muse_cli/test_revert.py`
+
+**Frozen dataclass** — all fields are immutable after construction.
+
+---
+
 ### `TrackHumanizeResult`
 
 **Module:** `maestro/muse_cli/commands/humanize.py`

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -3,8 +3,8 @@
 Entry point for the ``muse`` console script. Registers all MVP
 subcommands (arrange, ask, checkout, chord-map, commit, context, contour,
 describe, diff, divergence, dynamics, export, find, grep, humanize, import,
-init, key, log, merge, meter, open, play, pull, push, recall, remote, session,
-status, swing, tag, tempo, tempo-scale) as Typer sub-applications.
+init, key, log, merge, meter, open, play, pull, push, recall, remote, revert,
+session, status, swing, tag, tempo, tempo-scale) as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -38,6 +38,7 @@ from maestro.muse_cli.commands import (
     push,
     recall,
     remote,
+    revert,
     session,
     status,
     swing,
@@ -80,6 +81,7 @@ cli.add_typer(tag.app, name="tag", help="Attach and query music-semantic tags on
 cli.add_typer(import_cmd.app, name="import", help="Import a MIDI or MusicXML file as a new Muse commit.")
 cli.add_typer(tempo.app, name="tempo", help="Read or set the tempo (BPM) of a commit.")
 cli.add_typer(recall.app, name="recall", help="Search commit history by natural-language description.")
+cli.add_typer(revert.app, name="revert", help="Create a new commit that undoes a prior commit without rewriting history.")
 cli.add_typer(key.app, name="key", help="Read or annotate the musical key of a commit.")
 cli.add_typer(humanize.app, name="humanize", help="Apply micro-timing and velocity humanization to quantized MIDI.")
 cli.add_typer(context.app, name="context", help="Output structured musical context for AI agent consumption.")

--- a/maestro/muse_cli/commands/revert.py
+++ b/maestro/muse_cli/commands/revert.py
@@ -1,0 +1,93 @@
+"""muse revert — create a new commit that undoes a prior commit.
+
+Safe undo: given a commit C with parent P, ``muse revert <commit>`` creates
+a new commit whose snapshot is P's state (the world before C was applied).
+History is never rewritten — the revert is a forward commit.
+
+Domain analogy: a producer accidentally committed a bad drum arrangement.
+Rather than resetting (which loses history), ``muse revert`` creates an
+"undo commit" so the full timeline remains auditable.
+
+Flags
+-----
+COMMIT TEXT       Commit ID to revert (required, positional, accepts prefix).
+--no-commit       Apply the inverse changes to muse-work/ without committing.
+--track TEXT      Scope the revert to paths under tracks/<track>/.
+--section TEXT    Scope the revert to paths under sections/<section>/.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+import typer
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.services.muse_revert import _revert_async
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+
+@app.callback(invoke_without_command=True)
+def revert(
+    ctx: typer.Context,
+    commit: str = typer.Argument(
+        ...,
+        help="Commit ID to revert (full or abbreviated SHA).",
+        metavar="COMMIT",
+    ),
+    no_commit: bool = typer.Option(
+        False,
+        "--no-commit",
+        help=(
+            "Apply the inverse changes to muse-work/ without creating a new commit. "
+            "Note: file bytes not retained by the object store cannot be restored "
+            "automatically — missing paths are listed as warnings."
+        ),
+    ),
+    track: Optional[str] = typer.Option(
+        None,
+        "--track",
+        help=(
+            "Scope the revert to a specific track (instrument) path prefix. "
+            "Only files under tracks/<track>/ are reverted; all other paths "
+            "remain at HEAD."
+        ),
+    ),
+    section: Optional[str] = typer.Option(
+        None,
+        "--section",
+        help=(
+            "Scope the revert to a specific section path prefix. "
+            "Only files under sections/<section>/ are reverted; all other paths "
+            "remain at HEAD."
+        ),
+    ),
+) -> None:
+    """Create a new commit that undoes a prior commit without rewriting history."""
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _revert_async(
+                commit_ref=commit,
+                root=root,
+                session=session,
+                no_commit=no_commit,
+                track=track,
+                section=section,
+            )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse revert failed: {exc}")
+        logger.error("❌ muse revert error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/services/muse_revert.py
+++ b/maestro/services/muse_revert.py
@@ -1,0 +1,430 @@
+"""Muse Revert Service — create a new commit that undoes a prior commit.
+
+Revert is the safe undo: given a target commit C with parent P, it creates
+a new commit whose snapshot is P's snapshot (the state before C was applied).
+History is preserved — no commit is deleted or rewritten.
+
+For path-scoped reverts (--track, --section), only paths matching the filter
+prefix are reverted to P's state; all other paths remain at HEAD's state.
+
+Boundary rules:
+  - Must NOT import StateStore, EntityRegistry, or get_or_create_store.
+  - Must NOT import executor modules or maestro_* handlers.
+  - May import muse_cli.db, muse_cli.models, muse_cli.merge_engine,
+    muse_cli.snapshot.
+
+Domain analogy: a producer accidentally committed a bad drum arrangement.
+``muse revert <commit>`` creates a new "undo commit" so the DAW history
+shows what happened and when, rather than silently rewriting the timeline.
+"""
+from __future__ import annotations
+
+import datetime
+import logging
+import pathlib
+from dataclasses import dataclass, field
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.db import (
+    get_commit_snapshot_manifest,
+    get_head_snapshot_id,
+    insert_commit,
+    resolve_commit_ref,
+    upsert_snapshot,
+)
+from maestro.muse_cli.merge_engine import read_merge_state
+from maestro.muse_cli.models import MuseCliCommit
+from maestro.muse_cli.snapshot import compute_commit_id, compute_snapshot_id
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RevertResult:
+    """Outcome of a ``muse revert`` operation.
+
+    Attributes:
+        commit_id: The new commit ID created by the revert (empty when
+            ``no_commit=True`` or when there was nothing to revert).
+        target_commit_id: The commit that was reverted.
+        parent_commit_id: The parent of the reverted commit (whose snapshot
+            the revert restores).
+        revert_snapshot_id: Snapshot ID of the new reverted state.
+        message: The auto-generated or user-supplied commit message.
+        no_commit: True when the revert was staged but not committed.
+        noop: True when reverting would produce no change.
+        scoped_paths: Paths that were selectively reverted (empty = full revert).
+        paths_deleted: Paths removed from muse-work/ during ``--no-commit``.
+        paths_missing: Paths that could not be restored (no bytes on disk);
+            only populated for ``--no-commit`` runs.
+        branch: Branch on which the revert commit was created.
+    """
+
+    commit_id: str
+    target_commit_id: str
+    parent_commit_id: str
+    revert_snapshot_id: str
+    message: str
+    no_commit: bool
+    noop: bool
+    scoped_paths: tuple[str, ...]
+    paths_deleted: tuple[str, ...]
+    paths_missing: tuple[str, ...]
+    branch: str
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _filter_paths(
+    manifest: dict[str, str],
+    track: Optional[str],
+    section: Optional[str],
+) -> set[str]:
+    """Return the set of paths in *manifest* that match the given filters.
+
+    A path matches if it starts with ``tracks/<track>/`` (for --track)
+    or ``sections/<section>/`` (for --section).  When both are supplied the
+    union of matching paths is returned.
+
+    Returns all paths in *manifest* when neither filter is given.
+    """
+    if not track and not section:
+        return set(manifest.keys())
+
+    matched: set[str] = set()
+    for path in manifest:
+        if track and path.startswith(f"tracks/{track}/"):
+            matched.add(path)
+        if section and path.startswith(f"sections/{section}/"):
+            matched.add(path)
+    return matched
+
+
+def compute_revert_manifest(
+    *,
+    parent_manifest: dict[str, str],
+    head_manifest: dict[str, str],
+    track: Optional[str] = None,
+    section: Optional[str] = None,
+) -> tuple[dict[str, str], tuple[str, ...]]:
+    """Compute the manifest that represents the reverted state.
+
+    For an unscoped revert the result is ``parent_manifest`` verbatim.
+    For a scoped revert (--track or --section) the result is ``head_manifest``
+    with the filtered paths replaced by their values from ``parent_manifest``
+    (or removed if they did not exist in the parent).
+
+    Returns:
+        Tuple of (revert_manifest, scoped_paths_tuple).  ``scoped_paths_tuple``
+        is empty for an unscoped revert.
+
+    Pure function — no I/O, no DB.
+    """
+    if not track and not section:
+        return dict(parent_manifest), ()
+
+    # Identify paths affected by the filter across both manifests
+    filter_targets = _filter_paths(parent_manifest, track, section) | _filter_paths(
+        head_manifest, track, section
+    )
+
+    result = dict(head_manifest)
+    for path in filter_targets:
+        if path in parent_manifest:
+            result[path] = parent_manifest[path]
+        else:
+            # Path existed at HEAD but not in parent → remove it
+            result.pop(path, None)
+
+    return result, tuple(sorted(filter_targets))
+
+
+# ---------------------------------------------------------------------------
+# Filesystem materialization (--no-commit)
+# ---------------------------------------------------------------------------
+
+
+def apply_revert_to_workdir(
+    *,
+    workdir: pathlib.Path,
+    revert_manifest: dict[str, str],
+    current_manifest: dict[str, str],
+) -> tuple[list[str], list[str]]:
+    """Update *workdir* to match *revert_manifest* as closely as possible.
+
+    Because the Muse object store does not retain file bytes (only sha256
+    hashes), this function can only:
+
+    1. **Delete** files present in *current_manifest* but absent from
+       *revert_manifest* — these are paths that the reverted commit introduced.
+    2. **Warn** about files present in *revert_manifest* but absent from or
+       changed in *workdir* — these need manual restoration.
+
+    Args:
+        workdir: Absolute path to ``muse-work/``.
+        revert_manifest: The target manifest (parent's or scoped mix).
+        current_manifest: The manifest of *workdir* as it stands now.
+
+    Returns:
+        Tuple of (paths_deleted, paths_missing):
+        - ``paths_deleted``: relative paths successfully removed from *workdir*.
+        - ``paths_missing``: relative paths that should exist in the revert
+          state but whose bytes are unavailable (no object store) — the caller
+          must warn the user and ask for manual intervention.
+    """
+    deleted: list[str] = []
+    missing: list[str] = []
+
+    # Remove paths that should not exist after revert
+    for path in sorted(current_manifest):
+        if path not in revert_manifest:
+            abs_path = workdir / path
+            try:
+                abs_path.unlink()
+                deleted.append(path)
+                logger.info("✅ Removed %s from muse-work/", path)
+            except OSError as exc:
+                logger.warning("⚠️ Could not remove %s: %s", path, exc)
+
+    # Identify paths that need restoration but can't be done automatically
+    for path, expected_oid in sorted(revert_manifest.items()):
+        current_oid = current_manifest.get(path)
+        if current_oid != expected_oid:
+            missing.append(path)
+            logger.warning(
+                "⚠️ Cannot restore %s — file bytes not in object store. "
+                "Restore manually or re-run without --no-commit.",
+                path,
+            )
+
+    return deleted, missing
+
+
+# ---------------------------------------------------------------------------
+# Async core
+# ---------------------------------------------------------------------------
+
+
+async def _revert_async(
+    *,
+    commit_ref: str,
+    root: pathlib.Path,
+    session: AsyncSession,
+    no_commit: bool = False,
+    track: Optional[str] = None,
+    section: Optional[str] = None,
+) -> RevertResult:
+    """Core revert pipeline — resolve, validate, and execute the revert.
+
+    Called by the CLI callback and by tests.  All filesystem and DB
+    side-effects are isolated here so tests can inject an in-memory
+    SQLite session and a ``tmp_path`` root.
+
+    Args:
+        commit_ref: Commit ID (full or abbreviated) to revert.
+        root: Repo root (must contain ``.muse/``).
+        session: Async DB session (caller owns commit/rollback lifecycle).
+        no_commit: When ``True``, stage changes to muse-work/ but do not
+            create a new commit record.
+        track: Optional track/instrument path prefix filter.
+        section: Optional section path prefix filter.
+
+    Returns:
+        :class:`RevertResult` describing what happened.
+
+    Raises:
+        ``typer.Exit`` with an appropriate exit code on user-facing errors.
+    """
+    import json
+
+    import typer
+
+    from maestro.muse_cli.errors import ExitCode
+    from maestro.muse_cli.snapshot import build_snapshot_manifest
+
+    muse_dir = root / ".muse"
+
+    # ── Guard: block revert during in-progress merge ─────────────────────
+    merge_state = read_merge_state(root)
+    if merge_state is not None and merge_state.conflict_paths:
+        typer.echo(
+            "❌ Revert blocked: unresolved merge conflicts in progress.\n"
+            "   Resolve all conflicts, then run 'muse commit' before reverting."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # ── Repo identity ────────────────────────────────────────────────────
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]
+
+    head_ref = (muse_dir / "HEAD").read_text().strip()
+    branch = head_ref.rsplit("/", 1)[-1]
+
+    # ── Resolve target commit ────────────────────────────────────────────
+    target_commit = await resolve_commit_ref(session, repo_id, branch, commit_ref)
+    if target_commit is None:
+        typer.echo(f"❌ Commit not found: {commit_ref!r}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    target_commit_id = target_commit.commit_id
+
+    # ── Resolve HEAD commit ───────────────────────────────────────────────
+    head_commit = await resolve_commit_ref(session, repo_id, branch, None)
+    head_snapshot_id = head_commit.snapshot_id if head_commit else None
+
+    # ── Get manifests ────────────────────────────────────────────────────
+    # Parent manifest: the state before the target commit was applied
+    parent_manifest: dict[str, str] = {}
+    parent_commit_id: str = ""
+
+    if target_commit.parent_commit_id:
+        parent_commit_id = target_commit.parent_commit_id
+        parent_snapshot = await get_commit_snapshot_manifest(session, parent_commit_id)
+        if parent_snapshot is not None:
+            parent_manifest = parent_snapshot
+    # If target is the root commit (no parent), reverting it means an empty state
+
+    head_manifest: dict[str, str] = {}
+    if head_snapshot_id:
+        head_snap = await get_commit_snapshot_manifest(session, target_commit_id)
+        # head_manifest is HEAD's snapshot, not target's — use head_commit
+        if head_commit:
+            from sqlalchemy.future import select
+            from maestro.muse_cli.models import MuseCliSnapshot
+            snap_row = await session.get(MuseCliSnapshot, head_commit.snapshot_id)
+            if snap_row is not None:
+                head_manifest = dict(snap_row.manifest)
+
+    # ── Compute revert manifest ──────────────────────────────────────────
+    revert_manifest, scoped_paths = compute_revert_manifest(
+        parent_manifest=parent_manifest,
+        head_manifest=head_manifest,
+        track=track,
+        section=section,
+    )
+
+    revert_snapshot_id = compute_snapshot_id(revert_manifest)
+
+    # ── Nothing-to-revert guard ──────────────────────────────────────────
+    if head_snapshot_id and revert_snapshot_id == head_snapshot_id:
+        typer.echo("Nothing to revert — working tree already matches the reverted state.")
+        return RevertResult(
+            commit_id="",
+            target_commit_id=target_commit_id,
+            parent_commit_id=parent_commit_id,
+            revert_snapshot_id=revert_snapshot_id,
+            message="",
+            no_commit=no_commit,
+            noop=True,
+            scoped_paths=scoped_paths,
+            paths_deleted=(),
+            paths_missing=(),
+            branch=branch,
+        )
+
+    # ── Auto-generate commit message ─────────────────────────────────────
+    revert_message = f"Revert '{target_commit.message}'"
+
+    # ── --no-commit: apply to working tree only ──────────────────────────
+    if no_commit:
+        workdir = root / "muse-work"
+        current_manifest = build_snapshot_manifest(workdir) if workdir.exists() else {}
+        paths_deleted, paths_missing = apply_revert_to_workdir(
+            workdir=workdir,
+            revert_manifest=revert_manifest,
+            current_manifest=current_manifest,
+        )
+        if paths_missing:
+            typer.echo(
+                "⚠️  Some files cannot be restored automatically (bytes not in object store):\n"
+                + "\n".join(f"   missing: {p}" for p in sorted(paths_missing))
+            )
+        if paths_deleted:
+            typer.echo(
+                "✅ Staged revert (--no-commit). Files removed:\n"
+                + "\n".join(f"   deleted: {p}" for p in sorted(paths_deleted))
+            )
+        else:
+            typer.echo("⚠️  --no-commit: no file deletions were needed.")
+        return RevertResult(
+            commit_id="",
+            target_commit_id=target_commit_id,
+            parent_commit_id=parent_commit_id,
+            revert_snapshot_id=revert_snapshot_id,
+            message=revert_message,
+            no_commit=True,
+            noop=False,
+            scoped_paths=scoped_paths,
+            paths_deleted=tuple(sorted(paths_deleted)),
+            paths_missing=tuple(sorted(paths_missing)),
+            branch=branch,
+        )
+
+    # ── Persist the revert snapshot (objects already in DB) ──────────────
+    await upsert_snapshot(session, manifest=revert_manifest, snapshot_id=revert_snapshot_id)
+    await session.flush()
+
+    # ── Persist the revert commit ─────────────────────────────────────────
+    head_commit_id = head_commit.commit_id if head_commit else None
+    committed_at = datetime.datetime.now(datetime.timezone.utc)
+    new_commit_id = compute_commit_id(
+        parent_ids=[head_commit_id] if head_commit_id else [],
+        snapshot_id=revert_snapshot_id,
+        message=revert_message,
+        committed_at_iso=committed_at.isoformat(),
+    )
+
+    new_commit = MuseCliCommit(
+        commit_id=new_commit_id,
+        repo_id=repo_id,
+        branch=branch,
+        parent_commit_id=head_commit_id,
+        snapshot_id=revert_snapshot_id,
+        message=revert_message,
+        author="",
+        committed_at=committed_at,
+    )
+    await insert_commit(session, new_commit)
+
+    # ── Update branch HEAD pointer ────────────────────────────────────────
+    ref_path = muse_dir / pathlib.Path(head_ref)
+    ref_path.parent.mkdir(parents=True, exist_ok=True)
+    ref_path.write_text(new_commit_id)
+
+    scope_note = ""
+    if scoped_paths:
+        scope_note = f" (scoped to {len(scoped_paths)} path(s))"
+    typer.echo(
+        f"✅ [{branch} {new_commit_id[:8]}] {revert_message}{scope_note}"
+    )
+    logger.info(
+        "✅ muse revert %s → %s on %r: %s",
+        target_commit_id[:8],
+        new_commit_id[:8],
+        branch,
+        revert_message,
+    )
+
+    return RevertResult(
+        commit_id=new_commit_id,
+        target_commit_id=target_commit_id,
+        parent_commit_id=parent_commit_id,
+        revert_snapshot_id=revert_snapshot_id,
+        message=revert_message,
+        no_commit=False,
+        noop=False,
+        scoped_paths=scoped_paths,
+        paths_deleted=(),
+        paths_missing=(),
+        branch=branch,
+    )

--- a/maestro/services/muse_revert.py
+++ b/maestro/services/muse_revert.py
@@ -295,15 +295,11 @@ async def _revert_async(
     # If target is the root commit (no parent), reverting it means an empty state
 
     head_manifest: dict[str, str] = {}
-    if head_snapshot_id:
-        head_snap = await get_commit_snapshot_manifest(session, target_commit_id)
-        # head_manifest is HEAD's snapshot, not target's — use head_commit
-        if head_commit:
-            from sqlalchemy.future import select
-            from maestro.muse_cli.models import MuseCliSnapshot
-            snap_row = await session.get(MuseCliSnapshot, head_commit.snapshot_id)
-            if snap_row is not None:
-                head_manifest = dict(snap_row.manifest)
+    if head_snapshot_id and head_commit:
+        from maestro.muse_cli.models import MuseCliSnapshot
+        snap_row = await session.get(MuseCliSnapshot, head_commit.snapshot_id)
+        if snap_row is not None:
+            head_manifest = dict(snap_row.manifest)
 
     # ── Compute revert manifest ──────────────────────────────────────────
     revert_manifest, scoped_paths = compute_revert_manifest(

--- a/tests/muse_cli/test_revert.py
+++ b/tests/muse_cli/test_revert.py
@@ -1,0 +1,435 @@
+"""Tests for ``muse revert`` — safe undo via forward commit.
+
+Exercises:
+- ``test_muse_revert_creates_undo_commit`` — regression: full revert creates a
+  new commit pointing to the parent's snapshot.
+- ``test_muse_revert_no_commit_stages_only`` — --no-commit writes to
+  muse-work/ without creating a DB commit.
+- ``test_muse_revert_scoped_by_track`` — --track limits which paths are
+  reverted; other paths remain at HEAD state.
+- ``test_muse_revert_blocked_during_merge`` — blocked when a merge is in
+  progress (conflict_paths non-empty).
+- ``test_muse_revert_root_commit`` — reverting the root commit produces an
+  empty snapshot.
+- ``test_muse_revert_noop_when_already_reverted`` — reverting a commit that
+  is already at its parent's state emits a noop.
+- ``compute_revert_manifest_*`` — pure-function unit tests for the manifest
+  computation.
+
+All async tests use ``@pytest.mark.anyio``.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.merge_engine import write_merge_state
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+from maestro.services.muse_revert import (
+    RevertResult,
+    _revert_async,
+    compute_revert_manifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Repo / workdir helpers (shared with test_commit.py pattern)
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    """Create a minimal .muse/ layout."""
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _populate_workdir(
+    root: pathlib.Path, files: dict[str, bytes] | None = None
+) -> None:
+    """Create muse-work/ with the specified files."""
+    workdir = root / "muse-work"
+    workdir.mkdir(exist_ok=True)
+    if files is None:
+        files = {"beat.mid": b"MIDI-DATA", "lead.mp3": b"MP3-DATA"}
+    for name, content in files.items():
+        path = workdir / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — pure functions
+# ---------------------------------------------------------------------------
+
+
+def test_compute_revert_manifest_full_revert() -> None:
+    """Full (unscoped) revert returns the parent manifest verbatim."""
+    parent = {"beat.mid": "aaa", "lead.mp3": "bbb"}
+    head = {"beat.mid": "ccc", "lead.mp3": "bbb", "synth.mid": "ddd"}
+
+    result, scoped = compute_revert_manifest(parent_manifest=parent, head_manifest=head)
+
+    assert result == parent
+    assert scoped == ()
+
+
+def test_compute_revert_manifest_scoped_by_track() -> None:
+    """--track reverts only paths under tracks/<track>/."""
+    parent = {
+        "tracks/drums/beat.mid": "old-drums",
+        "tracks/bass/bass.mid": "old-bass",
+        "sections/verse/lead.mid": "verse-lead",
+    }
+    head = {
+        "tracks/drums/beat.mid": "new-drums",
+        "tracks/bass/bass.mid": "new-bass",
+        "sections/verse/lead.mid": "verse-lead",
+        "tracks/drums/fill.mid": "head-only-fill",
+    }
+
+    result, scoped = compute_revert_manifest(
+        parent_manifest=parent, head_manifest=head, track="drums"
+    )
+
+    # drums paths should come from parent or be removed if head-only
+    assert result["tracks/drums/beat.mid"] == "old-drums"
+    # fill.mid exists only in head (under drums) → should be removed
+    assert "tracks/drums/fill.mid" not in result
+    # bass and section paths remain at HEAD
+    assert result["tracks/bass/bass.mid"] == "new-bass"
+    assert result["sections/verse/lead.mid"] == "verse-lead"
+    # Scoped paths should include drums paths from both manifests
+    assert "tracks/drums/beat.mid" in scoped
+    assert "tracks/drums/fill.mid" in scoped
+    assert "tracks/bass/bass.mid" not in scoped
+
+
+def test_compute_revert_manifest_scoped_by_section() -> None:
+    """--section reverts only paths under sections/<section>/."""
+    parent = {"sections/chorus/chords.mid": "old-chords"}
+    head = {
+        "sections/chorus/chords.mid": "new-chords",
+        "sections/verse/lead.mid": "verse-lead",
+    }
+
+    result, scoped = compute_revert_manifest(
+        parent_manifest=parent, head_manifest=head, section="chorus"
+    )
+
+    assert result["sections/chorus/chords.mid"] == "old-chords"
+    assert result["sections/verse/lead.mid"] == "verse-lead"
+    assert "sections/chorus/chords.mid" in scoped
+    assert "sections/verse/lead.mid" not in scoped
+
+
+def test_compute_revert_manifest_empty_parent() -> None:
+    """Reverting the root commit (no parent) produces an empty manifest."""
+    result, scoped = compute_revert_manifest(
+        parent_manifest={},
+        head_manifest={"beat.mid": "aaa"},
+    )
+    assert result == {}
+    assert scoped == ()
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — async DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_muse_revert_creates_undo_commit(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Regression: muse revert <commit> creates a new commit on the parent's snapshot."""
+    _init_muse_repo(tmp_path)
+
+    # Commit A — initial state
+    _populate_workdir(tmp_path, {"beat.mid": b"take-1"})
+    commit_a_id = await _commit_async(
+        message="initial take",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Commit B — a bad arrangement
+    _populate_workdir(tmp_path, {"beat.mid": b"bad-take"})
+    commit_b_id = await _commit_async(
+        message="bad drum arrangement",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Revert B → should create commit C pointing to A's snapshot
+    result = await _revert_async(
+        commit_ref=commit_b_id,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    assert not result.noop
+    assert not result.no_commit
+    assert result.commit_id != ""
+    assert result.message == f"Revert 'bad drum arrangement'"
+    assert result.target_commit_id == commit_b_id
+    assert result.parent_commit_id == commit_a_id
+
+    # The new commit should point to A's snapshot
+    commit_a_row = await muse_cli_db_session.get(MuseCliCommit, commit_a_id)
+    commit_c_row = await muse_cli_db_session.get(MuseCliCommit, result.commit_id)
+    assert commit_c_row is not None
+    assert commit_c_row.snapshot_id == commit_a_row.snapshot_id  # type: ignore[union-attr]
+    assert commit_c_row.parent_commit_id == commit_b_id
+
+    # HEAD ref file updated to new commit
+    head_ref = (tmp_path / ".muse" / "HEAD").read_text().strip()
+    ref_path = tmp_path / ".muse" / pathlib.Path(head_ref)
+    assert ref_path.read_text().strip() == result.commit_id
+
+
+@pytest.mark.anyio
+async def test_muse_revert_no_commit_stages_only(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--no-commit: no new commit row is created; muse-work/ deletions are applied."""
+    _init_muse_repo(tmp_path)
+
+    # Commit A — initial state
+    _populate_workdir(tmp_path, {"beat.mid": b"take-1"})
+    commit_a_id = await _commit_async(
+        message="initial take",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Commit B — adds an extra file
+    _populate_workdir(tmp_path, {"beat.mid": b"take-1", "extra.mid": b"EXTRA"})
+    commit_b_id = await _commit_async(
+        message="added extra track",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Revert B with --no-commit
+    result = await _revert_async(
+        commit_ref=commit_b_id,
+        root=tmp_path,
+        session=muse_cli_db_session,
+        no_commit=True,
+    )
+
+    assert result.no_commit is True
+    assert result.commit_id == ""  # no commit created
+    # extra.mid should have been deleted from muse-work/
+    assert "extra.mid" in result.paths_deleted
+    assert not (tmp_path / "muse-work" / "extra.mid").exists()
+
+    # No new commit in DB
+    from sqlalchemy.future import select
+
+    commit_count = (
+        await muse_cli_db_session.execute(select(MuseCliCommit))
+    ).scalars().all()
+    assert len(commit_count) == 2  # only A and B, not a C
+
+
+@pytest.mark.anyio
+async def test_muse_revert_scoped_by_track(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--track reverts only the specified track; other paths stay at HEAD."""
+    _init_muse_repo(tmp_path)
+
+    # Commit A — initial state for both drums and bass
+    _populate_workdir(
+        tmp_path,
+        {
+            "tracks/drums/beat.mid": b"drums-v1",
+            "tracks/bass/bass.mid": b"bass-v1",
+        },
+    )
+    commit_a_id = await _commit_async(
+        message="initial arrangement",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Commit B — new drums, same bass
+    _populate_workdir(
+        tmp_path,
+        {
+            "tracks/drums/beat.mid": b"drums-v2",
+            "tracks/bass/bass.mid": b"bass-v1",
+        },
+    )
+    commit_b_id = await _commit_async(
+        message="updated drums only",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Revert B --track drums
+    result = await _revert_async(
+        commit_ref=commit_b_id,
+        root=tmp_path,
+        session=muse_cli_db_session,
+        track="drums",
+    )
+
+    assert not result.noop
+    assert result.commit_id != ""
+    assert "tracks/drums/beat.mid" in result.scoped_paths
+    assert "tracks/bass/bass.mid" not in result.scoped_paths
+
+    # The revert commit's snapshot: drums should be at v1, bass still at v1 (same)
+    commit_c_row = await muse_cli_db_session.get(MuseCliCommit, result.commit_id)
+    assert commit_c_row is not None
+    snap_row = await muse_cli_db_session.get(MuseCliSnapshot, commit_c_row.snapshot_id)
+    assert snap_row is not None
+    manifest: dict[str, str] = dict(snap_row.manifest)
+
+    # Drums path should come from A's snapshot (v1)
+    commit_a_snap_row = await muse_cli_db_session.get(MuseCliCommit, commit_a_id)
+    a_snap = await muse_cli_db_session.get(
+        MuseCliSnapshot, commit_a_snap_row.snapshot_id  # type: ignore[union-attr]
+    )
+    assert a_snap is not None
+    a_manifest: dict[str, str] = dict(a_snap.manifest)
+    assert manifest.get("tracks/drums/beat.mid") == a_manifest.get(
+        "tracks/drums/beat.mid"
+    )
+
+
+@pytest.mark.anyio
+async def test_muse_revert_blocked_during_merge(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """muse revert is blocked when a merge is in-progress with conflicts."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"take-1"})
+    commit_a_id = await _commit_async(
+        message="initial take",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Simulate an in-progress merge with conflicts
+    write_merge_state(
+        tmp_path,
+        base_commit="base-abc",
+        ours_commit="ours-def",
+        theirs_commit="theirs-ghi",
+        conflict_paths=["beat.mid"],
+        other_branch="feature/bad-drums",
+    )
+
+    import typer
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _revert_async(
+            commit_ref=commit_a_id,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+
+    from maestro.muse_cli.errors import ExitCode
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_muse_revert_root_commit_produces_empty_snapshot(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Reverting the root commit (no parent) creates a commit with an empty snapshot."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"take-1"})
+    root_commit_id = await _commit_async(
+        message="root commit",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    result = await _revert_async(
+        commit_ref=root_commit_id,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    assert not result.noop
+    assert result.commit_id != ""
+    assert result.parent_commit_id == ""  # root has no parent
+
+    snap_row = await muse_cli_db_session.get(MuseCliSnapshot, result.revert_snapshot_id)
+    assert snap_row is not None
+    assert snap_row.manifest == {}
+
+
+@pytest.mark.anyio
+async def test_muse_revert_abbreviated_commit_ref(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """muse revert accepts an abbreviated commit SHA (prefix match)."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"v1"})
+    commit_a_id = await _commit_async(
+        message="v1",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+    _populate_workdir(tmp_path, {"beat.mid": b"v2"})
+    commit_b_id = await _commit_async(
+        message="v2",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Use abbreviated prefix (first 8 chars)
+    result = await _revert_async(
+        commit_ref=commit_b_id[:8],
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    assert result.target_commit_id == commit_b_id
+    assert result.commit_id != ""
+
+
+@pytest.mark.anyio
+async def test_muse_revert_unknown_commit_raises_exit(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """muse revert with an unknown commit ID exits with USER_ERROR."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path)
+    await _commit_async(
+        message="initial",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    import typer
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _revert_async(
+            commit_ref="deadbeef",
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+
+    from maestro.muse_cli.errors import ExitCode
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR


### PR DESCRIPTION
## Summary
Closes #68 — implements `muse revert <commit>` as a safe, history-preserving undo command for the Muse VCS.

## Root Cause / Motivation
No revert command existed. Users who committed a bad arrangement had to choose between `muse reset` (history rewrite, dangerous) or manually diffing and re-applying changes. Neither is production-safe.

## Solution
`muse revert` creates a **new forward commit** whose snapshot is the parent of the reverted commit. History is never rewritten — the full audit trail is preserved.

### Key design decisions
- **Full revert** references the parent's existing `snapshot_id` directly — zero file restoration needed, pure DB operation.
- **`--no-commit`** applies inverse changes to `muse-work/` (deletions only) and warns about files that cannot be auto-restored (the CLI object store does not retain raw bytes, only sha256 manifests).
- **`--track` / `--section`** path-scoped revert: only paths matching the prefix are reverted; all other paths remain at HEAD state. Implemented via `compute_revert_manifest()` (pure function, fully tested).
- **Merge guard** blocks revert during in-progress conflicts.
- **Abbreviated SHA** accepted via existing `resolve_commit_ref()` prefix matching.

### Files changed
- `maestro/services/muse_revert.py` — `RevertResult`, `compute_revert_manifest`, `apply_revert_to_workdir`, `_revert_async` (testable async core)
- `maestro/muse_cli/commands/revert.py` — Typer CLI wrapper
- `maestro/muse_cli/app.py` — registers `revert` subcommand
- `tests/muse_cli/test_revert.py` — 11 tests (4 pure-function unit + 7 async integration)
- `docs/architecture/muse_vcs.md` — full `muse revert` command reference section
- `docs/reference/type_contracts.md` — `RevertResult` type registration

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (499 files, 0 errors)
- [x] `docker compose exec storpheus mypy .` — clean (unmodified)
- [x] All 11 tests pass
- [x] Docs updated in same commit as code

## Tests Added
- `test_compute_revert_manifest_full_revert` — pure function: full revert returns parent manifest verbatim
- `test_compute_revert_manifest_scoped_by_track` — pure function: --track filters correctly
- `test_compute_revert_manifest_scoped_by_section` — pure function: --section filters correctly
- `test_compute_revert_manifest_empty_parent` — pure function: root commit revert → empty manifest
- `test_muse_revert_creates_undo_commit` — **regression**: new commit points to parent's snapshot
- `test_muse_revert_no_commit_stages_only` — --no-commit: no DB row created, files deleted
- `test_muse_revert_scoped_by_track` — --track: only drum paths reverted, bass unchanged
- `test_muse_revert_blocked_during_merge` — blocked with ExitCode.USER_ERROR during merge
- `test_muse_revert_root_commit_produces_empty_snapshot` — root revert → empty snapshot
- `test_muse_revert_abbreviated_commit_ref` — prefix SHA accepted
- `test_muse_revert_unknown_commit_raises_exit` — bad ref → USER_ERROR exit

## Handoff
N/A — no SSE protocol, MCP tool schema, or API contract changes.