### PR TITLE
feat: muse remote — add remove, rename, and set-url subcommands

### DIFF
--- a/maestro/muse_cli/commands/remote.py
+++ b/maestro/muse_cli/commands/remote.py
@@ -6,6 +6,15 @@ Subcommands:
       Write ``[remotes.<name>] url = "<url>"`` to ``.muse/config.toml``.
       Creates the config file if it does not exist.
 
+  muse remote remove <name>
+      Remove a configured remote and all its refs/remotes/<name>/ tracking refs.
+
+  muse remote rename <old> <new>
+      Rename a remote in config and move its tracking ref paths.
+
+  muse remote set-url <name> <url>
+      Update the URL of an existing remote without touching tracking refs.
+
   muse remote -v / --verbose
       Print all configured remotes with their URLs.
       Token values in [auth] are masked — this command is safe to run in CI.
@@ -22,7 +31,7 @@ import logging
 import typer
 
 from maestro.muse_cli._repo import require_repo
-from maestro.muse_cli.config import list_remotes, set_remote
+from maestro.muse_cli.config import list_remotes, remove_remote, rename_remote, set_remote
 from maestro.muse_cli.errors import ExitCode
 
 logger = logging.getLogger(__name__)
@@ -87,3 +96,95 @@ def remote_add(
     set_remote(name.strip(), url.strip(), root)
     typer.echo(f"✅ Remote '{name}' set to {url}")
     logger.info("✅ muse remote add %r %s", name, url)
+
+
+@app.command("remove")
+def remote_remove(
+    name: str = typer.Argument(..., help="Remote name to remove (e.g. 'origin')."),
+) -> None:
+    """Remove a configured remote and all its local tracking refs.
+
+    Deletes ``[remotes.<name>]`` from ``.muse/config.toml`` and removes the
+    ``.muse/remotes/<name>/`` directory tree.  Errors if the remote does not
+    exist.
+
+    Example::
+
+        muse remote remove origin
+    """
+    root = require_repo()
+
+    try:
+        remove_remote(name.strip(), root)
+    except KeyError:
+        typer.echo(f"❌ Remote '{name}' does not exist.")
+        raise typer.Exit(code=int(ExitCode.USER_ERROR)) from None
+
+    typer.echo(f"✅ Remote '{name}' removed.")
+    logger.info("✅ muse remote remove %r", name)
+
+
+@app.command("rename")
+def remote_rename(
+    old_name: str = typer.Argument(..., help="Current remote name."),
+    new_name: str = typer.Argument(..., help="New remote name."),
+) -> None:
+    """Rename a remote in config and move its tracking ref paths.
+
+    Updates ``[remotes.<old>]`` → ``[remotes.<new>]`` in ``.muse/config.toml``
+    and moves ``.muse/remotes/<old>/`` → ``.muse/remotes/<new>/``.  Errors if
+    the old remote does not exist or the new name is already taken.
+
+    Example::
+
+        muse remote rename origin upstream
+    """
+    root = require_repo()
+
+    if not new_name.strip():
+        typer.echo("❌ New remote name cannot be empty.")
+        raise typer.Exit(code=int(ExitCode.USER_ERROR))
+
+    try:
+        rename_remote(old_name.strip(), new_name.strip(), root)
+    except KeyError:
+        typer.echo(f"❌ Remote '{old_name}' does not exist.")
+        raise typer.Exit(code=int(ExitCode.USER_ERROR)) from None
+    except ValueError:
+        typer.echo(f"❌ Remote '{new_name}' already exists.")
+        raise typer.Exit(code=int(ExitCode.USER_ERROR)) from None
+
+    typer.echo(f"✅ Remote '{old_name}' renamed to '{new_name}'.")
+    logger.info("✅ muse remote rename %r → %r", old_name, new_name)
+
+
+@app.command("set-url")
+def remote_set_url(
+    name: str = typer.Argument(..., help="Remote name (e.g. 'origin')."),
+    url: str = typer.Argument(..., help="New URL for the remote."),
+) -> None:
+    """Update the URL of an existing remote without touching tracking refs.
+
+    Updates ``[remotes.<name>] url`` in ``.muse/config.toml``.  Unlike
+    ``muse remote add``, this command errors if the remote does not already
+    exist — use ``add`` for first-time registration.
+
+    Example::
+
+        muse remote set-url origin https://new-hub.example.com/musehub/repos/my-repo
+    """
+    root = require_repo()
+
+    if not url.strip().startswith(("http://", "https://")):
+        typer.echo(f"❌ URL must start with http:// or https:// — got: {url!r}")
+        raise typer.Exit(code=int(ExitCode.USER_ERROR))
+
+    from maestro.muse_cli.config import get_remote
+
+    if get_remote(name.strip(), root) is None:
+        typer.echo(f"❌ Remote '{name}' does not exist. Use `muse remote add` to create it.")
+        raise typer.Exit(code=int(ExitCode.USER_ERROR))
+
+    set_remote(name.strip(), url.strip(), root)
+    typer.echo(f"✅ Remote '{name}' URL changed to {url}")
+    logger.info("✅ muse remote set-url %r %s", name, url)

--- a/maestro/muse_cli/commands/remote.py
+++ b/maestro/muse_cli/commands/remote.py
@@ -31,7 +31,7 @@ import logging
 import typer
 
 from maestro.muse_cli._repo import require_repo
-from maestro.muse_cli.config import list_remotes, remove_remote, rename_remote, set_remote
+from maestro.muse_cli.config import get_remote, list_remotes, remove_remote, rename_remote, set_remote
 from maestro.muse_cli.errors import ExitCode
 
 logger = logging.getLogger(__name__)
@@ -178,8 +178,6 @@ def remote_set_url(
     if not url.strip().startswith(("http://", "https://")):
         typer.echo(f"❌ URL must start with http:// or https:// — got: {url!r}")
         raise typer.Exit(code=int(ExitCode.USER_ERROR))
-
-    from maestro.muse_cli.config import get_remote
 
     if get_remote(name.strip(), root) is None:
         typer.echo(f"❌ Remote '{name}' does not exist. Use `muse remote add` to create it.")

--- a/maestro/muse_cli/config.py
+++ b/maestro/muse_cli/config.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import pathlib
+import shutil
 import tomllib
 from typing import TypedDict
 
@@ -246,8 +247,6 @@ def remove_remote(
     root = (repo_root or pathlib.Path.cwd()).resolve()
     refs_dir = root / _MUSE_DIR / "remotes" / name
     if refs_dir.is_dir():
-        import shutil
-
         shutil.rmtree(refs_dir)
         logger.debug("✅ Removed tracking refs dir %s", refs_dir)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,12 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 cache_dir = "/tmp/pytest_cache"
 addopts = "-v --tb=short"
+filterwarnings = [
+    # Typer 0.24.x internally passes is_flag/flag_value through its Click
+    # compatibility layer for boolean options — this is a Typer library issue,
+    # not from project code.
+    "ignore::DeprecationWarning:typer",
+]
 
 [tool.coverage.run]
 source = ["maestro"]


### PR DESCRIPTION
## Summary
Closes #81 — adds `muse remote remove`, `muse remote rename`, and `muse remote set-url` subcommands so producers can fully manage remote Hub configurations after initial registration.

## Root Cause / Motivation
`muse remote` only supported `add` and `-v` (list). Users had no way to remove a stale remote, rename `origin` to `upstream`, or update a Hub URL when migrating to a new instance — leaving them stuck with initial configuration.

## Solution
Added two helper functions to `maestro/muse_cli/config.py`:
- `remove_remote(name, repo_root)` — deletes `[remotes.<name>]` from `config.toml` and removes `.muse/remotes/<name>/` tracking refs tree via `shutil.rmtree`.
- `rename_remote(old_name, new_name, repo_root)` — renames config entry and moves the tracking refs directory.

Added three Typer subcommands to `maestro/muse_cli/commands/remote.py`:
- `remote remove <name>` — removes config + refs; exits 1 if remote absent.
- `remote rename <old> <new>` — renames config + refs; exits 1 if old absent or new already exists.
- `remote set-url <name> <url>` — updates URL only (no ref changes); exits 1 if remote absent or URL scheme invalid.

## Layers Affected
- [x] Muse VCS (config.py helpers)
- [x] Muse CLI (remote.py subcommands)

## Verification
- [x] `docker compose exec maestro mypy maestro/muse_cli/config.py maestro/muse_cli/commands/remote.py tests/muse_cli/test_remote.py` — clean
- [x] `pytest tests/muse_cli/test_remote.py -v` — 18 passed
- [x] Docs updated (docs/architecture/muse_vcs.md — subcommand table, usage, output example, agent use case)

## Tests Added
- `test_remote_remove_cleans_config_and_refs` — regression: remove deletes config entry and tracking refs dir
- `test_remote_remove_leaves_other_remotes` — remove only targets the named remote
- `test_remote_remove_nonexistent_errors` — exits 1 with clear message
- `test_remote_remove_no_refs_dir_succeeds` — remove succeeds even without tracking refs dir
- `test_remote_rename_updates_config_and_ref_paths` — rename moves config entry and refs dir
- `test_remote_rename_nonexistent_errors` — exits 1 when old name absent
- `test_remote_rename_conflict_errors` — exits 1 when new name already exists
- `test_remote_set_url_updates_config_only` — URL updated, tracking refs untouched
- `test_remote_set_url_nonexistent_errors` — exits 1 when remote absent
- `test_remote_set_url_invalid_scheme_errors` — exits 1 for non-http(s) URL

## Handoff
N/A — no SSE/MCP protocol change.