### PR TITLE
feat: muse status — add --short, --branch, --porcelain, --sections, --tracks flags

### DIFF
--- a/maestro/muse_cli/commands/status.py
+++ b/maestro/muse_cli/commands/status.py
@@ -3,12 +3,7 @@
 Output modes
 ------------
 
-**Clean working tree** (no uncommitted changes)::
-
-    On branch main
-    nothing to commit, working tree clean
-
-**Uncommitted changes** (modified / added / deleted files)::
+**Default (verbose, human-readable)**::
 
     On branch main
 
@@ -19,30 +14,56 @@ Output modes
             new file:   lead.mp3
             deleted:    scratch.mid
 
-**In-progress merge** (``MERGE_STATE.json`` present)::
+**--short** (condensed, one file per line)::
+
+    M beat.mid
+    A lead.mp3
+    D scratch.mid
+
+**--porcelain** (machine-readable, stable for scripting, like git status --porcelain)::
+
+    ## main
+     M beat.mid
+     A lead.mp3
+     D scratch.mid
+
+**--branch** (branch and tracking info only)::
 
     On branch main
 
-    You have unmerged paths.
-      (fix conflicts and run "muse commit")
+**--sections** (group output by first directory component — musical sections)::
 
-    Unmerged paths:
-            both modified:   beat.mid
+    On branch main
 
-**No commits yet** (branch has never been committed to)::
+    ## chorus
+    M chorus/bass.mid
+    A chorus/drums.mid
 
-    On branch main, no commits yet
+    ## verse
+    M verse/bass.mid
 
-    Untracked files:
-      (use "muse commit -m <msg>" to record changes)
+**--tracks** (group output by first directory component — instrument tracks)::
 
-            beat.mid
+    On branch main
+
+    ## bass
+    M bass/verse.mid
+    A bass/chorus.mid
+
+    ## drums
+    M drums/verse.mid
+
+Flags are combinable where it makes sense:
+- ``--short --sections`` → short-format codes within section groups
+- ``--porcelain --tracks`` → porcelain codes within track groups
+- ``--branch`` → emits only the branch line regardless of other flags
 """
 from __future__ import annotations
 
 import asyncio
 import json
 import logging
+from collections import defaultdict
 from pathlib import Path
 
 import typer
@@ -58,6 +79,132 @@ logger = logging.getLogger(__name__)
 
 app = typer.Typer()
 
+# ---------------------------------------------------------------------------
+# Status code maps
+# ---------------------------------------------------------------------------
+
+# One-character codes for --short
+_SHORT_CODES: dict[str, str] = {
+    "modified": "M",
+    "added": "A",
+    "deleted": "D",
+    "untracked": "?",
+}
+
+# Two-character codes for --porcelain (index + working-tree columns)
+_PORCELAIN_CODES: dict[str, str] = {
+    "modified": " M",
+    "added": " A",
+    "deleted": " D",
+    "untracked": "??",
+}
+
+# Verbose labels for default output
+_VERBOSE_LABELS: dict[str, str] = {
+    "modified": "modified:  ",
+    "added": "new file:  ",
+    "deleted": "deleted:   ",
+    "untracked": "untracked: ",
+}
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def _status_entries(
+    added: set[str],
+    modified: set[str],
+    deleted: set[str],
+    untracked: set[str],
+) -> list[tuple[str, str]]:
+    """Return a sorted list of (status_type, path) pairs.
+
+    Ordering: modified first, then added, deleted, untracked — mirroring
+    git's display convention of most-relevant changes first.
+    """
+    entries: list[tuple[str, str]] = []
+    for path in sorted(modified):
+        entries.append(("modified", path))
+    for path in sorted(added):
+        entries.append(("added", path))
+    for path in sorted(deleted):
+        entries.append(("deleted", path))
+    for path in sorted(untracked):
+        entries.append(("untracked", path))
+    return entries
+
+
+def _format_line(status: str, path: str, *, short: bool, porcelain: bool) -> str:
+    """Format a single file line according to the active output mode.
+
+    Priority: porcelain → short → verbose.
+
+    Args:
+        status:    One of ``"modified"``, ``"added"``, ``"deleted"``, ``"untracked"``.
+        path:      Repo-relative path (POSIX separators).
+        short:     Emit condensed ``X path`` format.
+        porcelain: Emit stable ``XY path`` format.
+
+    Returns:
+        A formatted line string (no trailing newline).
+    """
+    if porcelain:
+        code = _PORCELAIN_CODES[status]
+        return f"{code} {path}"
+    if short:
+        code = _SHORT_CODES[status]
+        return f"{code} {path}"
+    label = _VERBOSE_LABELS[status]
+    return f"\t{label} {path}"
+
+
+def _group_by_first_dir(entries: list[tuple[str, str]]) -> dict[str, list[tuple[str, str]]]:
+    """Group ``(status, path)`` entries by the first directory component of *path*.
+
+    Files that live directly in the working-tree root (no sub-directory) are
+    placed under the key ``"(root)"``.  This allows section/track grouping to
+    degrade gracefully when users have files at the top level.
+    """
+    groups: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for status, path in entries:
+        slash = path.find("/")
+        key = path[:slash] if slash != -1 else "(root)"
+        groups[key].append((status, path))
+    return dict(groups)
+
+
+def _render_flat(
+    entries: list[tuple[str, str]],
+    *,
+    short: bool,
+    porcelain: bool,
+) -> None:
+    """Write all entries to stdout in flat (non-grouped) order."""
+    for status, path in entries:
+        typer.echo(_format_line(status, path, short=short, porcelain=porcelain))
+
+
+def _render_grouped(
+    entries: list[tuple[str, str]],
+    *,
+    short: bool,
+    porcelain: bool,
+) -> None:
+    """Write entries to stdout grouped under ``## <section>`` headers.
+
+    Grouping is by the first directory component of each path.  Within each
+    group the entries are sorted by path.  An empty line follows each group
+    to improve readability.
+    """
+    groups = _group_by_first_dir(entries)
+    for group_name in sorted(groups.keys()):
+        typer.echo(f"## {group_name}")
+        for status, path in sorted(groups[group_name], key=lambda t: t[1]):
+            typer.echo(_format_line(status, path, short=short, porcelain=porcelain))
+        typer.echo("")
+
 
 # ---------------------------------------------------------------------------
 # Testable async core
@@ -68,6 +215,11 @@ async def _status_async(
     *,
     root: Path,
     session: AsyncSession,
+    short: bool = False,
+    branch_only: bool = False,
+    porcelain: bool = False,
+    sections: bool = False,
+    tracks: bool = False,
 ) -> None:
     """Core status logic — fully injectable for tests.
 
@@ -75,16 +227,39 @@ async def _status_async(
     snapshot manifest, diffs the working tree, and writes formatted output
     via :func:`typer.echo`.
 
+    Output mode selection (evaluated in priority order):
+
+    1. ``branch_only`` → emit only the branch line and return.
+    2. ``porcelain`` → machine-readable ``XY path`` format (stable for scripts).
+    3. ``short`` → condensed ``X path`` format.
+    4. ``sections`` or ``tracks`` → group under ``## <dir>`` headers.
+    5. Default → verbose human-readable format.
+
+    ``sections`` and ``tracks`` are orthogonal to ``short``/``porcelain`` and
+    can be combined with them: e.g. ``--short --sections`` emits short-format
+    lines grouped by section.
+
     Args:
-        root:    Repository root (directory containing ``.muse/``).
-        session: An open async DB session used to load the HEAD snapshot.
+        root:        Repository root (directory containing ``.muse/``).
+        session:     An open async DB session used to load the HEAD snapshot.
+        short:       Emit condensed one-line-per-file output.
+        branch_only: Emit only the branch/tracking line; skip file listing.
+        porcelain:   Emit machine-readable ``XY path`` format with ``## branch`` header.
+        sections:    Group output by first directory component (musical sections).
+        tracks:      Group output by first directory component (instrument tracks).
     """
     muse_dir = root / ".muse"
+    grouped = sections or tracks
 
     # -- Branch name --
     head_path = muse_dir / "HEAD"
     head_ref = head_path.read_text().strip()          # "refs/heads/main"
     branch = head_ref.rsplit("/", 1)[-1] if "/" in head_ref else head_ref
+
+    # --branch: emit only the branch line and return.
+    if branch_only:
+        typer.echo(f"On branch {branch}")
+        return
 
     # -- In-progress merge --
     merge_state = read_merge_state(root)
@@ -107,24 +282,39 @@ async def _status_async(
         head_commit_id = ref_path.read_text().strip()
 
     if not head_commit_id:
-        # No commits yet -- show untracked working-tree files if any.
+        # No commits yet — show untracked working-tree files if any.
         workdir = root / "muse-work"
-        untracked_files: list[str] = []
+        untracked_files: set[str] = set()
         if workdir.exists():
             manifest = walk_workdir(workdir)
-            untracked_files = sorted(manifest.keys())
+            untracked_files = set(manifest.keys())
 
         if untracked_files:
-            typer.echo(f"On branch {branch}, no commits yet")
-            typer.echo("")
-            typer.echo("Untracked files:")
-            typer.echo('  (use "muse commit -m <msg>" to record changes)')
-            typer.echo("")
-            for path in untracked_files:
-                typer.echo(f"\t{path}")
-            typer.echo("")
+            entries = _status_entries(set(), set(), set(), untracked_files)
+            if porcelain:
+                typer.echo(f"## {branch}")
+                _render_flat(entries, short=False, porcelain=True)
+            elif short:
+                typer.echo(f"On branch {branch}, no commits yet")
+                _render_flat(entries, short=True, porcelain=False)
+            elif grouped:
+                typer.echo(f"On branch {branch}, no commits yet")
+                typer.echo("")
+                _render_grouped(entries, short=False, porcelain=False)
+            else:
+                typer.echo(f"On branch {branch}, no commits yet")
+                typer.echo("")
+                typer.echo("Untracked files:")
+                typer.echo('  (use "muse commit -m <msg>" to record changes)')
+                typer.echo("")
+                for path in sorted(untracked_files):
+                    typer.echo(f"\t{path}")
+                typer.echo("")
         else:
-            typer.echo(f"On branch {branch}, no commits yet")
+            if porcelain:
+                typer.echo(f"## {branch}")
+            else:
+                typer.echo(f"On branch {branch}, no commits yet")
         return
 
     # -- Load HEAD snapshot manifest from DB --
@@ -138,11 +328,39 @@ async def _status_async(
     added, modified, deleted, _ = diff_workdir_vs_snapshot(workdir, last_manifest)
 
     if not added and not modified and not deleted:
-        typer.echo(f"On branch {branch}")
-        typer.echo("nothing to commit, working tree clean")
+        if porcelain:
+            typer.echo(f"## {branch}")
+        else:
+            typer.echo(f"On branch {branch}")
+            typer.echo("nothing to commit, working tree clean")
         return
 
-    # -- Display changes --
+    # -- Render based on active output mode --
+    entries = _status_entries(added, modified, deleted, set())
+
+    if porcelain:
+        typer.echo(f"## {branch}")
+        if grouped:
+            _render_grouped(entries, short=False, porcelain=True)
+        else:
+            _render_flat(entries, short=False, porcelain=True)
+        return
+
+    if short:
+        typer.echo(f"On branch {branch}")
+        if grouped:
+            _render_grouped(entries, short=True, porcelain=False)
+        else:
+            _render_flat(entries, short=True, porcelain=False)
+        return
+
+    if grouped:
+        typer.echo(f"On branch {branch}")
+        typer.echo("")
+        _render_grouped(entries, short=False, porcelain=False)
+        return
+
+    # -- Default verbose format --
     typer.echo(f"On branch {branch}")
     typer.echo("")
     typer.echo("Changes since last commit:")
@@ -163,13 +381,50 @@ async def _status_async(
 
 
 @app.callback(invoke_without_command=True)
-def status(ctx: typer.Context) -> None:
+def status(
+    ctx: typer.Context,
+    short: bool = typer.Option(
+        False,
+        "--short",
+        "-s",
+        help="Condensed one-line-per-file output (M=modified, A=added, D=deleted, ?=untracked).",
+    ),
+    branch: bool = typer.Option(
+        False,
+        "--branch",
+        "-b",
+        help="Show only the branch and tracking info line.",
+    ),
+    porcelain: bool = typer.Option(
+        False,
+        "--porcelain",
+        help="Machine-readable output format (stable for scripting, like git status --porcelain).",
+    ),
+    sections: bool = typer.Option(
+        False,
+        "--sections",
+        help="Group output by musical section directory (first path component under muse-work/).",
+    ),
+    tracks: bool = typer.Option(
+        False,
+        "--tracks",
+        help="Group output by instrument track directory (first path component under muse-work/).",
+    ),
+) -> None:
     """Show the current branch and working-tree state relative to HEAD."""
     root = require_repo()
 
     async def _run() -> None:
         async with open_session() as session:
-            await _status_async(root=root, session=session)
+            await _status_async(
+                root=root,
+                session=session,
+                short=short,
+                branch_only=branch,
+                porcelain=porcelain,
+                sections=sections,
+                tracks=tracks,
+            )
 
     try:
         asyncio.run(_run())


### PR DESCRIPTION
## Summary
Closes #86 — Adds `--short`, `--branch`, `--porcelain`, `--sections`, and `--tracks` output flags to `muse status`.

## Root Cause / Motivation
`muse status` previously had only one verbose human-readable output format. AI agents and scripts that consume `muse status` output needed machine-readable and condensed formats (porcelain/short) as well as musically-aware grouping (by section or instrument track) to reason about which parts of a composition have changed.

## Solution
Extended `_status_async` with five boolean keyword parameters (`short`, `branch_only`, `porcelain`, `sections`, `tracks`) and extracted three composable rendering helpers:

- `_format_line` — selects the right format code (porcelain `XY`, short `X`, or verbose label) for a single file
- `_render_flat` — writes all entries in flat order with the chosen format
- `_render_grouped` — writes entries grouped under `## <section>` headers by first path component

Format (short/porcelain/verbose) and grouping (sections/tracks/flat) are orthogonal and fully combinable.

**New flags:**

| Flag | Output |
|------|--------|
| `--short` / `-s` | `M beat.mid` — one file per line |
| `--branch` / `-b` | `On branch main` — branch line only |
| `--porcelain` | `## main\n M beat.mid` — stable, parseable |
| `--sections` | Files grouped under `## verse`, `## chorus` headers |
| `--tracks` | Files grouped under `## bass`, `## drums` headers |

## Layers Affected
- [x] Muse VCS (`maestro/muse_cli/commands/status.py`)

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (552 files)
- [x] `docker compose exec storpheus mypy .` — clean
- [x] 25 tests pass in `tests/muse_cli/test_status.py`
- [x] Docs updated in `docs/architecture/muse_vcs.md`

## Tests Added
- `test_status_short_shows_modified_code` — regression: `M path` emitted, verbose label absent
- `test_status_short_shows_added_code` — `A path` for added file
- `test_status_short_shows_deleted_code` — `D path` for deleted file
- `test_status_short_untracked_shows_question_mark` — `? path` for untracked files
- `test_status_branch_only_shows_branch_line` — branch line only, no file listing
- `test_status_branch_only_no_commits` — branch line on empty repo
- `test_status_porcelain_header_emitted` — `## main` is first status line
- `test_status_porcelain_clean_tree` — only `## main` when tree is clean
- `test_status_porcelain_modified_file` — ` M path` (two-char code)
- `test_status_porcelain_added_file` — ` A path`
- `test_status_porcelain_deleted_file` — ` D path`
- `test_status_porcelain_untracked` — `?? path`
- `test_status_sections_groups_by_first_dir` — `## verse` / `## chorus` headers present
- `test_status_sections_root_files_ungrouped` — root-level files under `## (root)`
- `test_status_tracks_groups_by_first_dir` — `## bass` / `## drums` headers present
- `test_status_short_and_sections_combined` — short codes within section headers
- `test_status_porcelain_and_tracks_combined` — porcelain codes within track headers

## Handoff
N/A — no SSE protocol or MCP tool schema changes.