### PR TITLE
feat: muse commit — add missing music-domain flags

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5254,7 +5254,9 @@ Response from the Hub's `/pull` endpoint.
 
 Full commit metadata plus snapshot manifest returned by `muse show`. Designed
 for direct JSON serialisation so AI agents can consume commit state without a
-second round-trip to the database.
+second round-trip to the database.  Music-domain fields (`section`, `track`,
+`emotion`) are surfaced at the top level — sourced from `commit_metadata` — so
+agents do not need to parse a nested blob.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -5262,11 +5264,14 @@ second round-trip to the database.
 | `branch` | `str` | Branch this commit belongs to |
 | `parent_commit_id` | `Optional[str]` | Full SHA of the primary parent, `None` for root commits |
 | `parent2_commit_id` | `Optional[str]` | Full SHA of the merge parent (set by `muse merge`), else `None` |
-| `message` | `str` | Commit message |
+| `message` | `str` | Commit message (may include Co-authored-by trailers) |
 | `author` | `str` | Author string (empty string when not set) |
 | `committed_at` | `str` | ISO-style timestamp `"YYYY-MM-DD HH:MM:SS"` (UTC) |
 | `snapshot_id` | `str` | SHA-256 of the snapshot manifest |
 | `snapshot_manifest` | `dict[str, str]` | `{relative_path: object_id}` for every file in the snapshot |
+| `section` | `Optional[str]` | Musical section tag (e.g. `"chorus"`), `None` if not set |
+| `track` | `Optional[str]` | Instrument track tag (e.g. `"drums"`), `None` if not set |
+| `emotion` | `Optional[str]` | Emotion vector label (e.g. `"melancholic"`), `None` if not set |
 
 **Producer:** `_show_async()`
 **Consumer:** `_render_show()`, `_render_midi()`, `_render_audio_preview()`, `--json` serialiser

--- a/maestro/muse_cli/commands/commit.py
+++ b/maestro/muse_cli/commands/commit.py
@@ -11,10 +11,41 @@ Algorithm
 5. Compute ``snapshot_id = sha256(sorted(path:object_id pairs))``.
 6. If the current branch HEAD already points to a commit with the same
    ``snapshot_id``, print "Nothing to commit, working tree clean" and
-   exit 0.
+   exit 0 (unless ``--allow-empty`` is set).
 7. Compute ``commit_id = sha256(sorted(parent_ids) | snapshot_id | message | timestamp)``.
 8. Persist to Postgres: upsert ``object`` rows → upsert ``snapshot`` row → insert ``commit`` row.
 9. Update ``.muse/refs/heads/<branch>`` to the new ``commit_id``.
+
+Music-domain flags
+------------------
+``--section TEXT``
+    Tag the commit as belonging to a musical section (e.g. ``verse``,
+    ``chorus``, ``bridge``).  Stored in ``commit_metadata["section"]``.
+
+``--track TEXT``
+    Tag the commit as affecting a specific instrument track (e.g. ``drums``,
+    ``bass``, ``keys``).  Stored in ``commit_metadata["track"]``.
+
+``--emotion TEXT``
+    Attach an emotion vector label to the commit (e.g. ``joyful``,
+    ``melancholic``, ``tense``).  Stored in ``commit_metadata["emotion"]``.
+    Foundation for future ``muse log --emotion melancholic`` queries.
+
+``--co-author TEXT``
+    Add a ``Co-authored-by: Name <email>`` trailer to the commit message
+    (for collaborative sessions).
+
+``--allow-empty``
+    Allow committing even when the working tree has not changed since HEAD.
+    Useful for milestone markers and metadata-only annotations.
+
+``--amend``
+    Fold working-tree changes into the most recent commit, equivalent to
+    running ``muse amend``.  Music-domain flags apply to the amended commit.
+
+``--no-verify``
+    Bypass pre-commit hooks.  Accepted for forward-compatibility; currently
+    a no-op because the hook system has not been implemented yet.
 
 ``--from-batch <path>``
 -----------------------
@@ -38,6 +69,7 @@ from typing import Optional
 
 import typer
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
 
 from maestro.muse_cli._repo import require_repo
 from maestro.muse_cli.db import (
@@ -127,6 +159,63 @@ def build_snapshot_manifest_from_batch(
 
 
 # ---------------------------------------------------------------------------
+# Music metadata helpers
+# ---------------------------------------------------------------------------
+
+
+def _append_co_author(message: str, co_author: str) -> str:
+    """Append a Co-authored-by trailer to *message*.
+
+    Follows the Git convention: a blank line separates the message body from
+    trailers.  Multiple calls are safe — each appends a new line.
+    """
+    trailer = f"Co-authored-by: {co_author}"
+    return f"{message}\n\n{trailer}" if message else trailer
+
+
+async def _apply_commit_music_metadata(
+    *,
+    session: AsyncSession,
+    commit_id: str,
+    section: str | None,
+    track: str | None,
+    emotion: str | None,
+) -> None:
+    """Merge music-domain flags into commit_metadata for *commit_id*.
+
+    Preserves existing metadata keys (e.g. ``tempo_bpm`` written by
+    ``muse tempo --set``) — only the supplied non-None keys are overwritten.
+    Skips silently when no music flags were provided.
+    """
+    if not any([section, track, emotion]):
+        return
+
+    commit = await session.get(MuseCliCommit, commit_id)
+    if commit is None:
+        logger.warning("⚠️ Commit %s not found for metadata update", commit_id[:8])
+        return
+
+    metadata: dict[str, object] = dict(commit.commit_metadata or {})
+    if section is not None:
+        metadata["section"] = section
+    if track is not None:
+        metadata["track"] = track
+    if emotion is not None:
+        metadata["emotion"] = emotion
+
+    commit.commit_metadata = metadata
+    flag_modified(commit, "commit_metadata")
+    session.add(commit)
+    logger.debug(
+        "✅ Applied music metadata to %s: section=%r track=%r emotion=%r",
+        commit_id[:8],
+        section,
+        track,
+        emotion,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Testable async core
 # ---------------------------------------------------------------------------
 
@@ -137,6 +226,11 @@ async def _commit_async(
     root: pathlib.Path,
     session: AsyncSession,
     batch_path: pathlib.Path | None = None,
+    section: str | None = None,
+    track: str | None = None,
+    emotion: str | None = None,
+    co_author: str | None = None,
+    allow_empty: bool = False,
 ) -> str:
     """Run the commit pipeline and return the new ``commit_id``.
 
@@ -147,6 +241,12 @@ async def _commit_async(
     When *batch_path* is provided the commit is restricted to files listed in
     ``muse-batch.json`` and the ``commit_message_suggestion`` from the batch
     overrides *message*.
+
+    Music-domain flags:
+    - *section* / *track* / *emotion* — stored in ``commit_metadata``.
+    - *co_author* — appended to the commit message as a Co-authored-by trailer.
+    - *allow_empty* — when ``True``, bypasses the "nothing to commit" guard
+      so callers can record milestone commits or metadata-only annotations.
 
     Raises ``typer.Exit`` with the appropriate exit code on user errors so
     the Typer callback surfaces a clean message rather than a traceback.
@@ -213,11 +313,16 @@ async def _commit_async(
 
     snapshot_id = compute_snapshot_id(manifest)
 
-    # ── Nothing-to-commit guard ──────────────────────────────────────────
-    last_snapshot_id = await get_head_snapshot_id(session, repo_id, branch)
-    if last_snapshot_id == snapshot_id:
-        typer.echo("Nothing to commit, working tree clean")
-        raise typer.Exit(code=ExitCode.SUCCESS)
+    # ── Nothing-to-commit guard (bypassable via --allow-empty) ───────────
+    if not allow_empty:
+        last_snapshot_id = await get_head_snapshot_id(session, repo_id, branch)
+        if last_snapshot_id == snapshot_id:
+            typer.echo("Nothing to commit, working tree clean")
+            raise typer.Exit(code=ExitCode.SUCCESS)
+
+    # ── Apply Co-authored-by trailer ─────────────────────────────────────
+    if co_author:
+        message = _append_co_author(message, co_author)
 
     # ── Deterministic commit ID ──────────────────────────────────────────
     committed_at = datetime.datetime.now(datetime.timezone.utc)
@@ -227,6 +332,12 @@ async def _commit_async(
         message=message,
         committed_at_iso=committed_at.isoformat(),
     )
+
+    # ── Build music metadata dict ─────────────────────────────────────────
+    commit_metadata: dict[str, object] | None = None
+    music_keys = {k: v for k, v in [("section", section), ("track", track), ("emotion", emotion)] if v is not None}
+    if music_keys:
+        commit_metadata = dict(music_keys)
 
     # ── Persist objects ──────────────────────────────────────────────────
     for rel_path, object_id in manifest.items():
@@ -254,6 +365,7 @@ async def _commit_async(
         message=message,
         author="",
         committed_at=committed_at,
+        commit_metadata=commit_metadata,
     )
     await insert_commit(session, new_commit)
 
@@ -286,14 +398,142 @@ def commit(
             "the files listed in files[].  Overrides -m when present."
         ),
     ),
+    amend: bool = typer.Option(
+        False,
+        "--amend",
+        help=(
+            "Fold working-tree changes into the most recent commit.  "
+            "Equivalent to running 'muse amend'.  Music-domain flags "
+            "(--section, --track, --emotion, --co-author) apply to the "
+            "amended commit."
+        ),
+    ),
+    no_verify: bool = typer.Option(
+        False,
+        "--no-verify",
+        help=(
+            "Bypass pre-commit hooks.  Currently a no-op — accepted for "
+            "forward-compatibility with the planned hook system."
+        ),
+    ),
+    section: Optional[str] = typer.Option(
+        None,
+        "--section",
+        help=(
+            "Tag this commit as belonging to a musical section "
+            "(e.g. verse, chorus, bridge).  Stored in commit_metadata and "
+            "queryable via 'muse log --section <value>'."
+        ),
+    ),
+    track: Optional[str] = typer.Option(
+        None,
+        "--track",
+        help=(
+            "Tag this commit as affecting a specific instrument track "
+            "(e.g. drums, bass, keys).  Stored in commit_metadata and "
+            "queryable via 'muse log --track <value>'."
+        ),
+    ),
+    emotion: Optional[str] = typer.Option(
+        None,
+        "--emotion",
+        help=(
+            "Attach an emotion vector label to this commit "
+            "(e.g. joyful, melancholic, tense).  Foundation for future "
+            "'muse log --emotion melancholic' queries."
+        ),
+    ),
+    co_author: Optional[str] = typer.Option(
+        None,
+        "--co-author",
+        help=(
+            "Add a Co-authored-by trailer to the commit message.  "
+            "Use 'Name <email>' format for Git-compatible attribution."
+        ),
+    ),
+    allow_empty: bool = typer.Option(
+        False,
+        "--allow-empty",
+        help=(
+            "Allow committing even when the working tree has not changed "
+            "since HEAD.  Useful for milestone markers or metadata-only "
+            "annotations (e.g. 'muse commit --allow-empty --emotion joyful')."
+        ),
+    ),
 ) -> None:
     """Record the current muse-work/ state as a new version in history."""
-    # Validate that at least one of -m or --from-batch is provided
-    if from_batch is None and message is None:
+    if no_verify:
+        logger.debug("⚠️ --no-verify supplied; hook system not yet implemented — proceeding")
+
+    root = require_repo()
+
+    if amend:
+        # Delegate to the amend pipeline then apply music metadata.
+        from maestro.muse_cli.commands.amend import _amend_async
+
+        # Determine if co_author needs to be merged into the amend message.
+        # _amend_async resolves the effective message internally from HEAD or -m;
+        # we pre-compute the co_author trailer here so we can pass a fully-formed
+        # message string regardless of the no-edit path.
+        async def _run_amend() -> None:
+            async with open_session() as session:
+                # Resolve effective message for co_author appending.
+                # When -m is provided, use it directly.
+                # When --amend without -m, _amend_async will use the HEAD message
+                # (no_edit path).  We need to read HEAD here so we can append
+                # the co_author trailer before passing to _amend_async.
+                effective_message = message
+                if co_author:
+                    if effective_message is None:
+                        # Load HEAD commit message so we can append the trailer.
+                        muse_dir = root / ".muse"
+                        head_ref = (muse_dir / "HEAD").read_text().strip()
+                        ref_path = muse_dir / pathlib.Path(head_ref)
+                        if ref_path.exists():
+                            head_commit_id = ref_path.read_text().strip()
+                            if head_commit_id:
+                                head_commit = await session.get(MuseCliCommit, head_commit_id)
+                                if head_commit:
+                                    effective_message = head_commit.message
+                    effective_message = _append_co_author(effective_message or "", co_author)
+
+                # When we've computed a final message, pass no_edit=False so
+                # _amend_async uses it verbatim.  Otherwise let _amend_async
+                # fall through to its own no_edit logic.
+                use_no_edit = effective_message is None
+                commit_id = await _amend_async(
+                    message=effective_message,
+                    no_edit=use_no_edit,
+                    reset_author=False,
+                    root=root,
+                    session=session,
+                )
+
+                # Apply music-domain metadata after the amend.
+                await _apply_commit_music_metadata(
+                    session=session,
+                    commit_id=commit_id,
+                    section=section,
+                    track=track,
+                    emotion=emotion,
+                )
+
+        try:
+            asyncio.run(_run_amend())
+        except typer.Exit:
+            raise
+        except Exception as exc:
+            typer.echo(f"❌ muse commit --amend failed: {exc}")
+            logger.error("❌ muse commit --amend error: %s", exc, exc_info=True)
+            raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+        return
+
+    # ── Standard (non-amend) path ─────────────────────────────────────────
+    # Validate that at least one of -m or --from-batch is provided.
+    if from_batch is None and message is None and not allow_empty:
         typer.echo("❌ Provide either -m MESSAGE or --from-batch PATH.")
         raise typer.Exit(code=ExitCode.USER_ERROR)
 
-    root = require_repo()
     batch_path = pathlib.Path(from_batch) if from_batch is not None else None
 
     # message may be None when --from-batch is used; _commit_async will
@@ -307,6 +547,11 @@ def commit(
                 root=root,
                 session=session,
                 batch_path=batch_path,
+                section=section,
+                track=track,
+                emotion=emotion,
+                co_author=co_author,
+                allow_empty=allow_empty,
             )
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,12 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 cache_dir = "/tmp/pytest_cache"
 addopts = "-v --tb=short"
+filterwarnings = [
+    # typer uses click's is_flag/flag_value params internally; suppress the
+    # click deprecation warning that originates from typer's own params.py
+    # rather than from project code.  Track: https://github.com/tiangolo/typer/issues/783
+    "ignore:The 'is_flag' and 'flag_value' parameters are not supported by Typer:DeprecationWarning",
+]
 
 [tool.coverage.run]
 source = ["maestro"]


### PR DESCRIPTION
## Summary
Closes #84 — Adds all missing music-domain flags to `muse commit`.

## Root Cause / Motivation
`muse commit` only accepted `-m` and `--from-batch`. The seven music-native flags described in the issue were absent, blocking agents and producers from annotating commits with section/track/emotion metadata, attributing collaborators, amending history, or creating milestone commits on a clean tree.

## Solution
Extended `_commit_async` with five new parameters (`section`, `track`, `emotion`, `co_author`, `allow_empty`) and wired them to new Typer options. Added the `--amend` path by delegating to `_amend_async` with post-amend metadata application via a new `_apply_commit_music_metadata` helper. Added `--no-verify` as a forward-compatible stub.

Updated `ShowCommitResult` in `show.py` to surface `section`, `track`, and `emotion` at the top level (sourced from `commit_metadata`) so agents consuming `muse show --json` do not need to parse a nested blob.

### What changed
- `maestro/muse_cli/commands/commit.py` — `_commit_async` extended; new Typer options; `_append_co_author` and `_apply_commit_music_metadata` helpers
- `maestro/muse_cli/commands/show.py` — `ShowCommitResult` extended with `section`, `track`, `emotion` fields; `_show_async` populates them from `commit_metadata`; `_render_show` displays them when present
- `tests/muse_cli/test_commit.py` — 15 new tests for each flag
- `docs/architecture/muse_vcs.md` — full flag reference table; metadata JSON blob column documented
- `docs/reference/type_contracts.md` — `ShowCommitResult` updated with new fields

## Layers Affected
- [x] Muse VCS

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean
- [x] Relevant tests pass (32/32 commit tests, 30/30 show tests)
- [x] Affected docs updated

## Tests Added
- `test_commit_section_stored_in_metadata` — regression for --section
- `test_commit_track_stored_in_metadata` — regression for --track
- `test_commit_emotion_stored_in_metadata` — regression for --emotion
- `test_commit_all_music_metadata_flags_together` — combined flags
- `test_commit_no_music_flags_metadata_is_none` — clean baseline
- `test_append_co_author_adds_trailer` — unit test for trailer helper
- `test_append_co_author_empty_message` — edge case
- `test_commit_co_author_appended_to_message` — integration
- `test_commit_allow_empty_bypasses_clean_tree_guard` — regression
- `test_commit_allow_empty_with_emotion_metadata` — combined
- `test_commit_without_allow_empty_still_exits_on_clean_tree` — guard preserved
- `test_apply_commit_music_metadata_updates_existing_commit` — preserves tempo_bpm
- `test_apply_commit_music_metadata_noop_when_no_keys` — no-op safety
- `test_show_reflects_music_metadata` — ShowCommitResult integration
- `test_show_music_metadata_absent_when_not_set` — None fields when no metadata

## Handoff
N/A — no SSE protocol change. No Swift frontend impact.