### PR TITLE
feat: muse release <tag> — export and render a tagged commit as a release artifact

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -4854,3 +4854,81 @@ run `--continue` to record the merged arrangement as an immutable commit.
 **Implementation:** `maestro/muse_cli/commands/merge.py` — `_merge_continue_async(root, session)`.
 
 ---
+
+### `muse release`
+
+**Purpose:** Export a tagged commit as distribution-ready release artifacts — the
+music-native publish step.  Bridges the Muse VCS world and the audio production
+world: a producer says "version 1.0 is done" and `muse release v1.0` produces
+WAV/MIDI/stem files with SHA-256 checksums for distribution.
+
+**Usage:**
+```bash
+muse release <tag> [OPTIONS]
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `<tag>` | positional | required | Tag string (created via `muse tag add`) or short commit SHA prefix |
+| `--render-audio` | flag | off | Render all MIDI to a single audio file via Storpheus |
+| `--render-midi` | flag | off | Bundle all .mid files into a zip archive |
+| `--export-stems` | flag | off | Export each instrument track as a separate audio file |
+| `--format wav\|mp3\|flac` | option | `wav` | Audio output format |
+| `--output-dir PATH` | option | `./releases/<tag>/` | Destination directory for all artifacts |
+| `--json` | flag | off | Emit structured JSON for agent consumption |
+
+**Output layout:**
+```
+<output-dir>/
+    release-manifest.json        # always written; SHA-256 checksums
+    audio/<commit8>.<format>     # --render-audio
+    midi/midi-bundle.zip         # --render-midi
+    stems/<stem>.<format>        # --export-stems
+```
+
+**Output example:**
+```
+✅ Release artifacts for tag 'v1.0' (commit a1b2c3d4):
+   [audio] ./releases/v1.0/audio/a1b2c3d4.wav
+   [midi-bundle] ./releases/v1.0/midi/midi-bundle.zip
+   [manifest] ./releases/v1.0/release-manifest.json
+⚠️  Audio files are MIDI stubs (Storpheus /render endpoint not yet deployed).
+```
+
+**Result type:** `ReleaseResult` — fields: `tag`, `commit_id`, `output_dir`,
+`manifest_path`, `artifacts` (list of `ReleaseArtifact`), `audio_format`, `stubbed`.
+
+**`release-manifest.json` shape:**
+```json
+{
+  "tag": "v1.0",
+  "commit_id": "<full sha256>",
+  "commit_short": "<8-char>",
+  "released_at": "<ISO-8601 UTC>",
+  "audio_format": "wav",
+  "stubbed": true,
+  "files": [
+    {"path": "audio/a1b2c3d4.wav", "sha256": "...", "size_bytes": 4096, "role": "audio"},
+    {"path": "midi/midi-bundle.zip", "sha256": "...", "size_bytes": 1024, "role": "midi-bundle"},
+    {"path": "release-manifest.json", "sha256": "...", "size_bytes": 512, "role": "manifest"}
+  ]
+}
+```
+
+**Agent use case:** An AI music generation agent calls `muse release v1.0 --render-midi --json`
+after tagging a completed composition.  It reads `stubbed` from the JSON output to
+determine whether the audio files are real renders or MIDI placeholders, and inspects
+`files[*].sha256` to verify integrity before uploading to a distribution platform.
+
+**Implementation stub note:** The Storpheus `POST /render` endpoint (MIDI-in → audio-out)
+is not yet deployed.  Until it ships, `--render-audio` and `--export-stems` copy the
+source MIDI file as a placeholder and set `stubbed=true` in the manifest.  The
+`_render_midi_to_audio` function in `maestro/services/muse_release.py` is the only
+site to update when the endpoint becomes available.
+
+**Implementation:** `maestro/muse_cli/commands/release.py` — `_release_async(...)`.
+Service layer: `maestro/services/muse_release.py` — `build_release(...)`.
+
+---

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -30,6 +30,8 @@ This document is the single source of truth for every named entity (TypedDict, d
    - [GrooveStatus](#groovestatuss)
    - [CommitGrooveMetrics](#commitgroovemetrics)
    - [GrooveCheckResult](#groovecheckresult)
+   - [ReleaseArtifact](#releaseartifact)
+   - [ReleaseResult](#releaseresult)
    - [RenderPreviewResult](#renderpreviewresult)
 5. [Variation Layer (`app/variation/`)](#variation-layer)
    - [Event Envelope payloads](#event-envelope-payloads)
@@ -1094,6 +1096,47 @@ On failure: `success=False` plus `error` (and optionally `message`).
 | Property | Returns | Description |
 |----------|---------|-------------|
 | `effective_bpm` | `float \| None` | `tempo_bpm` if set; else `detected_bpm` |
+
+---
+
+### `ReleaseArtifact`
+
+**Path:** `maestro/services/muse_release.py`
+
+`dataclass(frozen=True)` — A single file produced during a `muse release` operation.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | `pathlib.Path` | Absolute path of the written file |
+| `sha256` | `str` | SHA-256 hex digest of the file contents (64 chars) |
+| `size_bytes` | `int` | File size in bytes |
+| `role` | `str` | Human-readable role: `"audio"`, `"midi-bundle"`, `"stem"`, `"manifest"` |
+
+---
+
+### `ReleaseResult`
+
+**Path:** `maestro/services/muse_release.py`
+
+`dataclass` — Result of a complete `muse release` operation.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tag` | `str` | The release tag string (e.g. `"v1.0"`) |
+| `commit_id` | `str` | Full 64-char SHA-256 commit ID of the released snapshot |
+| `output_dir` | `pathlib.Path` | Root directory where all artifacts were written |
+| `manifest_path` | `pathlib.Path` | Path to the `release-manifest.json` file |
+| `artifacts` | `list[ReleaseArtifact]` | All files produced (audio, MIDI bundle, stems, manifest) |
+| `audio_format` | `ReleaseAudioFormat` | Audio format used for rendered files |
+| `stubbed` | `bool` | `True` when Storpheus `/render` is not yet deployed and MIDI was copied as placeholder |
+
+**Companion types:**
+
+- `ReleaseAudioFormat(str, Enum)` — `WAV = "wav"`, `MP3 = "mp3"`, `FLAC = "flac"`.
+- `StorpheusReleaseUnavailableError` — raised when Storpheus health check fails and audio rendering is requested.
+
+**Producer:** `build_release()` in `maestro/services/muse_release.py`
+**Consumer:** `muse release` CLI command (`maestro/muse_cli/commands/release.py`)
 
 ---
 

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -4,10 +4,10 @@ Entry point for the ``muse`` console script. Registers all MVP
 subcommands (amend, arrange, ask, cat-object, checkout, chord-map, commit,
 commit-tree, context, contour, describe, diff, divergence, dynamics, emotion-diff,
 export, find, form, grep, groove-check, harmony, humanize, import, init, inspect,
-key, log, merge, meter, motif, open, play, pull, push, read-tree, recall, remote,
-render-preview, reset, resolve, rev-parse, revert, session, show, similarity,
-status, swing, symbolic-ref, tag, tempo, tempo-scale, timeline, update-ref,
-validate, write-tree) as Typer sub-applications.
+key, log, merge, meter, motif, open, play, pull, push, read-tree, recall, release,
+remote, render-preview, reset, resolve, rev-parse, revert, session, show,
+similarity, status, swing, symbolic-ref, tag, tempo, tempo-scale, timeline,
+update-ref, validate, write-tree) as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -50,6 +50,7 @@ from maestro.muse_cli.commands import (
     push,
     read_tree,
     recall,
+    release,
     remote,
     render_preview,
     reset,
@@ -115,6 +116,7 @@ cli.add_typer(import_cmd.app, name="import", help="Import a MIDI or MusicXML fil
 cli.add_typer(tempo.app, name="tempo", help="Read or set the tempo (BPM) of a commit.")
 cli.add_typer(read_tree.app, name="read-tree", help="Read a snapshot into muse-work/ without updating HEAD.")
 cli.add_typer(recall.app, name="recall", help="Search commit history by natural-language description.")
+cli.add_typer(release.app, name="release", help="Export a tagged commit as distribution-ready release artifacts.")
 cli.add_typer(revert.app, name="revert", help="Create a new commit that undoes a prior commit without rewriting history.")
 cli.add_typer(key.app, name="key", help="Read or annotate the musical key of a commit.")
 cli.add_typer(humanize.app, name="humanize", help="Apply micro-timing and velocity humanization to quantized MIDI.")

--- a/maestro/muse_cli/commands/release.py
+++ b/maestro/muse_cli/commands/release.py
@@ -1,0 +1,369 @@
+"""muse release <tag> — export and render a tagged commit as a release artifact.
+
+This is the music-native publish step: given a tag applied via ``muse tag add``,
+it resolves the tagged commit, fetches its MIDI snapshot, and renders it to
+audio/MIDI artifacts ready for distribution.
+
+Usage::
+
+    muse release v1.0                                    # manifest only (dry run)
+    muse release v1.0 --render-audio                     # single WAV file
+    muse release v1.0 --render-midi                      # zip of all MIDI files
+    muse release v1.0 --export-stems --format flac       # per-track FLAC stems
+    muse release v1.0 --render-audio --render-midi \\
+        --output-dir ./dist/v1.0                         # custom output dir
+
+Flags:
+    <tag>               Music-semantic tag created via ``muse tag add``.
+    --render-audio      Render all MIDI to a single audio file via Storpheus.
+    --render-midi       Bundle all .mid files into a zip archive.
+    --export-stems      Export each track as a separate audio file.
+    --format            Audio output format: wav | mp3 | flac (default: wav).
+    --output-dir PATH   Where to write artifacts (default: ./releases/<tag>/).
+    --json              Emit structured JSON output for agent consumption.
+
+Output layout::
+
+    <output-dir>/
+        release-manifest.json        # always written; SHA-256 checksums
+        audio/<commit8>.<format>     # --render-audio
+        midi/midi-bundle.zip         # --render-midi
+        stems/<stem>.<format>        # --export-stems
+
+This command resolves the tag via the Muse tag database (``muse tag add``).
+If multiple commits share the same tag the most recently committed one is used.
+"""
+from __future__ import annotations
+
+import asyncio
+import json as json_mod
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.config import settings
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import find_commits_by_prefix, get_commit_snapshot_manifest, open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliTag
+from maestro.services.muse_release import (
+    ReleaseAudioFormat,
+    ReleaseResult,
+    StorpheusReleaseUnavailableError,
+    build_release,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+_DEFAULT_RELEASES_DIR = "releases"
+
+
+def _default_output_dir(tag: str) -> pathlib.Path:
+    """Return the default output directory for a release.
+
+    Pattern: ``./releases/<tag>/``.  Safe for any tag string that is a valid
+    directory name — callers should sanitise the tag before passing here.
+
+    Args:
+        tag: Release tag string (e.g. ``"v1.0"``).
+
+    Returns:
+        A Path relative to the current working directory.
+    """
+    safe_tag = tag.replace("/", "_").replace("\\", "_")
+    return pathlib.Path(_DEFAULT_RELEASES_DIR) / safe_tag
+
+
+async def _resolve_tag_to_commit(
+    session: AsyncSession,
+    root: pathlib.Path,
+    tag: str,
+) -> str:
+    """Resolve a music-semantic tag string to a full commit ID.
+
+    Queries the ``muse_cli_tags`` table for commits carrying *tag*.  When
+    multiple commits share the tag, the most recently committed one is returned
+    — this matches the producer's expectation that ``v1.0`` refers to the
+    latest commit labelled with that tag.
+
+    Falls back to prefix-based commit lookup when no tag record is found, so
+    producers can also pass a raw commit SHA prefix directly.
+
+    Args:
+        session: Open async DB session.
+        root: Muse repository root (used to read repo.json).
+        tag: Tag string (e.g. ``"v1.0"``) or short commit SHA prefix.
+
+    Returns:
+        Full 64-character commit ID.
+
+    Raises:
+        typer.Exit: With ``USER_ERROR`` when the tag/prefix cannot be resolved.
+    """
+    import json
+
+    # Read repo_id for scoped tag lookup.
+    repo_json = root / ".muse" / "repo.json"
+    repo_id: str | None = None
+    if repo_json.exists():
+        data: dict[str, str] = json.loads(repo_json.read_text())
+        repo_id = data.get("repo_id")
+
+    # 1. Tag-based lookup (join MuseCliTag → MuseCliCommit).
+    if repo_id is not None:
+        tag_result = await session.execute(
+            select(MuseCliTag.commit_id)
+            .where(MuseCliTag.repo_id == repo_id, MuseCliTag.tag == tag)
+        )
+        tag_commit_ids: list[str] = list(tag_result.scalars().all())
+
+        if tag_commit_ids:
+            if len(tag_commit_ids) == 1:
+                return tag_commit_ids[0]
+
+            # Multiple commits share the tag — return the most recently committed.
+            commits_result = await session.execute(
+                select(MuseCliCommit)
+                .where(MuseCliCommit.commit_id.in_(tag_commit_ids))
+                .order_by(MuseCliCommit.committed_at.desc())
+                .limit(1)
+            )
+            latest = commits_result.scalar_one_or_none()
+            if latest is not None:
+                logger.warning(
+                    "⚠️ release: tag %r exists on %d commits — using most recent: %s",
+                    tag,
+                    len(tag_commit_ids),
+                    latest.commit_id[:8],
+                )
+                return latest.commit_id
+
+    # 2. Prefix-based fallback — treat <tag> as a short commit SHA.
+    prefix_matches = await find_commits_by_prefix(session, tag)
+    if len(prefix_matches) == 1:
+        return prefix_matches[0].commit_id
+    if len(prefix_matches) > 1:
+        typer.echo(
+            f"❌ Ambiguous commit prefix '{tag[:8]}' "
+            f"— matches {len(prefix_matches)} commits:"
+        )
+        for c in prefix_matches:
+            typer.echo(f"   {c.commit_id[:8]}  {c.message[:60]}")
+        typer.echo("Use a longer prefix or an exact tag string to disambiguate.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    typer.echo(
+        f"❌ No commit found for tag or prefix '{tag}'. "
+        "Create the tag first: muse tag add <tag> [<commit>]"
+    )
+    raise typer.Exit(code=ExitCode.USER_ERROR)
+
+
+async def _release_async(
+    *,
+    tag: str,
+    audio_format: ReleaseAudioFormat,
+    output_dir: Optional[pathlib.Path],
+    render_audio: bool,
+    render_midi: bool,
+    export_stems: bool,
+    root: pathlib.Path,
+    session: AsyncSession,
+) -> ReleaseResult:
+    """Core release logic — injectable for tests.
+
+    Resolves the tag to a commit ID, loads the snapshot manifest, and
+    delegates to ``build_release`` in the service layer.
+
+    Args:
+        tag: Tag string or short commit SHA prefix.
+        audio_format: Target audio format for rendered files.
+        output_dir: Explicit output directory or None for the default path.
+        render_audio: Whether to render the primary MIDI to an audio file.
+        render_midi: Whether to bundle all MIDI files into a zip archive.
+        export_stems: Whether to export each MIDI track as a separate audio file.
+        root: Muse repository root.
+        session: Open async DB session.
+
+    Returns:
+        ReleaseResult describing what was written.
+
+    Raises:
+        typer.Exit: On user errors (missing tag, empty snapshot, etc.).
+        StorpheusReleaseUnavailableError: When audio render is requested and
+            Storpheus is unreachable.
+    """
+    full_commit_id = await _resolve_tag_to_commit(session, root, tag)
+
+    manifest = await get_commit_snapshot_manifest(session, full_commit_id)
+    if manifest is None:
+        typer.echo(f"❌ Commit {full_commit_id[:8]} not found in database.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    if not manifest:
+        typer.echo(
+            f"⚠️  Snapshot for commit {full_commit_id[:8]} is empty — nothing to release."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    out_dir = output_dir if output_dir is not None else _default_output_dir(tag)
+    storpheus_url = settings.storpheus_base_url
+
+    return build_release(
+        tag=tag,
+        commit_id=full_commit_id,
+        manifest=manifest,
+        root=root,
+        output_dir=out_dir,
+        audio_format=audio_format,
+        render_audio=render_audio,
+        render_midi=render_midi,
+        export_stems=export_stems,
+        storpheus_url=storpheus_url,
+    )
+
+
+@app.callback(invoke_without_command=True)
+def release(
+    ctx: typer.Context,
+    tag: str = typer.Argument(
+        ...,
+        help=(
+            "Tag or commit prefix to release (e.g. v1.0). "
+            "Tags are created via 'muse tag add <tag>'."
+        ),
+    ),
+    render_audio: bool = typer.Option(
+        False,
+        "--render-audio",
+        help="Render all MIDI snapshots to a single audio file via Storpheus.",
+    ),
+    render_midi: bool = typer.Option(
+        False,
+        "--render-midi",
+        help="Bundle all .mid files from the snapshot into a zip archive.",
+    ),
+    export_stems: bool = typer.Option(
+        False,
+        "--export-stems",
+        help="Export each instrument track as a separate audio file.",
+    ),
+    audio_format: ReleaseAudioFormat = typer.Option(
+        ReleaseAudioFormat.WAV,
+        "--format",
+        "-f",
+        help="Audio output format: wav | mp3 | flac (default: wav).",
+        case_sensitive=False,
+    ),
+    output_dir: Optional[pathlib.Path] = typer.Option(
+        None,
+        "--output-dir",
+        "-o",
+        help="Where to write release artifacts (default: ./releases/<tag>/).",
+    ),
+    as_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit structured JSON output for agent consumption.",
+    ),
+) -> None:
+    """Export a tagged commit as distribution-ready release artifacts.
+
+    Resolves TAG to a commit (via ``muse tag add``), fetches its snapshot,
+    and produces the requested artifacts under the output directory.  Always
+    writes a ``release-manifest.json`` with SHA-256 checksums.
+
+    Examples::
+
+        muse release v1.0 --render-audio
+        muse release v1.0 --render-midi --export-stems --format flac
+        muse release v1.0 --render-audio --output-dir ~/dist/v1.0
+    """
+    root = require_repo()
+
+    async def _run() -> ReleaseResult:
+        async with open_session() as session:
+            return await _release_async(
+                tag=tag,
+                audio_format=audio_format,
+                output_dir=output_dir,
+                render_audio=render_audio,
+                render_midi=render_midi,
+                export_stems=export_stems,
+                root=root,
+                session=session,
+            )
+
+    try:
+        result = asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except StorpheusReleaseUnavailableError as exc:
+        typer.echo(f"❌ Storpheus not reachable — audio render aborted.\n{exc}")
+        logger.error("muse release: Storpheus unavailable: %s", exc)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+    except ValueError as exc:
+        typer.echo(f"❌ {exc}")
+        logger.error("muse release: %s", exc)
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+    except Exception as exc:
+        typer.echo(f"❌ muse release failed: {exc}")
+        logger.error("muse release error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    if as_json:
+        payload = {
+            "tag": result.tag,
+            "commit_id": result.commit_id,
+            "commit_short": result.commit_id[:8],
+            "output_dir": str(result.output_dir),
+            "manifest_path": str(result.manifest_path),
+            "audio_format": result.audio_format.value,
+            "stubbed": result.stubbed,
+            "artifacts": [
+                {
+                    "path": str(a.path),
+                    "sha256": a.sha256,
+                    "size_bytes": a.size_bytes,
+                    "role": a.role,
+                }
+                for a in result.artifacts
+            ],
+        }
+        typer.echo(json_mod.dumps(payload, indent=2))
+    else:
+        non_manifest = [a for a in result.artifacts if a.role != "manifest"]
+        if non_manifest:
+            typer.echo(
+                f"✅ Release artifacts for tag {result.tag!r} "
+                f"(commit {result.commit_id[:8]}):"
+            )
+            for a in non_manifest:
+                typer.echo(f"   [{a.role}] {a.path}")
+        else:
+            typer.echo(
+                f"⚠️  No render flags specified — only manifest written for tag {result.tag!r}."
+                "\nUse --render-audio, --render-midi, or --export-stems."
+            )
+
+        typer.echo(f"   [manifest] {result.manifest_path}")
+
+        if result.stubbed:
+            typer.echo(
+                "⚠️  Audio files are MIDI stubs (Storpheus /render endpoint not yet deployed)."
+            )
+
+    logger.info(
+        "muse release: tag=%r commit=%s output_dir=%s artifacts=%d stubbed=%s",
+        result.tag,
+        result.commit_id[:8],
+        result.output_dir,
+        len(result.artifacts),
+        result.stubbed,
+    )

--- a/maestro/services/muse_release.py
+++ b/maestro/services/muse_release.py
@@ -1,0 +1,486 @@
+"""Muse Release Service — export a tagged commit as distribution-ready artifacts.
+
+This service is the music-native publish step: given a tag (applied via
+``muse tag add``) it resolves the tagged commit, fetches its MIDI snapshot,
+and renders it to audio/MIDI artifacts for distribution.
+
+Boundary contract:
+- Input:  tag string, snapshot manifest, output directory, release options.
+- Output: ``ReleaseResult`` — paths written, manifest JSON path, format,
+          commit short ID, and a ``stubbed`` flag when Storpheus audio render
+          is not yet available.
+- Side effects:  Writes files under ``output_dir``.  Never modifies the Muse
+  repository or the database.
+
+Output layout::
+
+    <output_dir>/
+        release-manifest.json        # always written; includes SHA-256 checksums
+        audio/<commit8>.<format>     # --render-audio
+        midi/<stem>.mid (zipped)     # --render-midi  → midi-bundle.zip
+        stems/<stem>.<format>        # --export-stems (one file per track)
+
+Storpheus render status:
+  The Storpheus service exposes MIDI generation at ``POST /generate``.
+  A dedicated ``POST /render`` endpoint (MIDI-in → audio-out) is planned but
+  not yet deployed.  Until that endpoint ships this module performs a health
+  check, then copies the first MIDI file to the audio output path as a stub.
+  When ``/render`` is available, replace ``_render_midi_to_audio`` with a
+  real POST call and set ``stubbed=False`` on the result.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import pathlib
+import shutil
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+class ReleaseAudioFormat(str, Enum):
+    """Audio output format for release artifacts."""
+
+    WAV = "wav"
+    MP3 = "mp3"
+    FLAC = "flac"
+
+
+@dataclass(frozen=True)
+class ReleaseArtifact:
+    """A single file produced during a release operation.
+
+    Attributes:
+        path: Absolute path of the written file.
+        sha256: SHA-256 hex digest of the file contents.
+        size_bytes: File size in bytes.
+        role: Human-readable role label (e.g. ``"audio"``, ``"midi-bundle"``,
+              ``"stem"``, ``"manifest"``).
+    """
+
+    path: pathlib.Path
+    sha256: str
+    size_bytes: int
+    role: str
+
+
+@dataclass
+class ReleaseResult:
+    """Result of a ``muse release`` operation.
+
+    Attributes:
+        tag: The release tag string (e.g. ``"v1.0"``).
+        commit_id: Full commit ID of the released snapshot.
+        output_dir: Root directory where all artifacts were written.
+        manifest_path: Path to the ``release-manifest.json`` file.
+        artifacts: All files produced (audio, MIDI bundle, stems, manifest).
+        audio_format: Audio format used for rendered files.
+        stubbed: True when the Storpheus ``/render`` endpoint is not yet
+            available and MIDI was copied as an audio placeholder.
+    """
+
+    tag: str
+    commit_id: str
+    output_dir: pathlib.Path
+    manifest_path: pathlib.Path
+    artifacts: list[ReleaseArtifact] = field(default_factory=list)
+    audio_format: ReleaseAudioFormat = ReleaseAudioFormat.WAV
+    stubbed: bool = True
+
+
+class StorpheusReleaseUnavailableError(Exception):
+    """Raised when Storpheus is not reachable and audio rendering is requested.
+
+    The CLI catches this and surfaces a clear human-readable message rather
+    than an unhandled traceback.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+_MIDI_SUFFIXES: frozenset[str] = frozenset({".mid", ".midi"})
+
+
+def _collect_midi_paths(
+    manifest: dict[str, str],
+    root: pathlib.Path,
+    track: Optional[str] = None,
+    section: Optional[str] = None,
+) -> tuple[list[pathlib.Path], int]:
+    """Collect MIDI file paths from the snapshot manifest.
+
+    Applies optional track/section substring filters.  Missing files are
+    counted in the skipped total and logged at WARNING level.
+
+    Args:
+        manifest: ``{rel_path: object_id}`` snapshot manifest.
+        root: Muse repository root; MIDI files live under ``<root>/muse-work/``.
+        track: Optional case-insensitive track name substring filter.
+        section: Optional case-insensitive section name substring filter.
+
+    Returns:
+        Tuple of (list[pathlib.Path], skipped_count).
+    """
+    workdir = root / "muse-work"
+    midi_paths: list[pathlib.Path] = []
+    skipped = 0
+
+    for rel_path in sorted(manifest.keys()):
+        path_lower = rel_path.lower()
+        if track is not None and track.lower() not in path_lower:
+            skipped += 1
+            continue
+        if section is not None and section.lower() not in path_lower:
+            skipped += 1
+            continue
+        if pathlib.PurePosixPath(rel_path).suffix.lower() not in _MIDI_SUFFIXES:
+            skipped += 1
+            continue
+        src = workdir / rel_path
+        if not src.exists():
+            skipped += 1
+            logger.warning("⚠️ release: MIDI source missing: %s", src)
+            continue
+        midi_paths.append(src)
+
+    return midi_paths, skipped
+
+
+def _sha256_file(path: pathlib.Path) -> str:
+    """Compute the SHA-256 hex digest of *path*.
+
+    Reads the file in 64 KiB chunks to avoid loading large audio files into
+    memory at once.
+
+    Args:
+        path: File to hash.
+
+    Returns:
+        Lowercase hex digest string (64 chars).
+    """
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _make_artifact(path: pathlib.Path, role: str) -> ReleaseArtifact:
+    """Build a ``ReleaseArtifact`` for a file that was just written.
+
+    Args:
+        path: Absolute path of the written file (must exist).
+        role: Role label for the artifact.
+
+    Returns:
+        ReleaseArtifact with SHA-256 checksum and size.
+    """
+    return ReleaseArtifact(
+        path=path,
+        sha256=_sha256_file(path),
+        size_bytes=path.stat().st_size,
+        role=role,
+    )
+
+
+def _check_storpheus_reachable(storpheus_url: str) -> None:
+    """Probe Storpheus health endpoint; raise ``StorpheusReleaseUnavailableError`` if down.
+
+    Uses a 3-second probe timeout so the CLI fails fast when Storpheus is not
+    running rather than hanging for the full generation timeout.
+
+    Args:
+        storpheus_url: Base URL for the Storpheus service.
+
+    Raises:
+        StorpheusReleaseUnavailableError: When the service is unreachable.
+    """
+    probe_timeout = httpx.Timeout(connect=3.0, read=3.0, write=3.0, pool=3.0)
+    try:
+        with httpx.Client(timeout=probe_timeout) as client:
+            resp = client.get(f"{storpheus_url.rstrip('/')}/health")
+            reachable = resp.status_code == 200
+    except Exception as exc:
+        raise StorpheusReleaseUnavailableError(
+            f"Storpheus is not reachable at {storpheus_url}: {exc}\n"
+            "Start Storpheus (docker compose up storpheus) and retry."
+        ) from exc
+
+    if not reachable:
+        raise StorpheusReleaseUnavailableError(
+            f"Storpheus health check returned non-200 at {storpheus_url}/health.\n"
+            "Check Storpheus logs: docker compose logs storpheus"
+        )
+
+
+def _render_midi_to_audio(
+    midi_path: pathlib.Path,
+    output_path: pathlib.Path,
+    fmt: ReleaseAudioFormat,
+    storpheus_url: str,
+) -> bool:
+    """Render a MIDI file to audio via Storpheus ``POST /render``.
+
+    This is a *stub implementation*: the Storpheus ``/render`` endpoint
+    (MIDI-in → audio-out) is not yet deployed.  Until it ships the function
+    copies the MIDI file to ``output_path`` as a placeholder and returns
+    ``True`` (stubbed=True).
+
+    When the endpoint is available, implement::
+
+        POST {storpheus_url}/render
+        Content-Type: multipart/form-data
+        Body: {midi: <bytes>, format: <fmt.value>}
+        → writes response body to output_path, returns False (stubbed=False).
+
+    Args:
+        midi_path: Source MIDI file path.
+        output_path: Destination audio file path.
+        fmt: Target audio format.
+        storpheus_url: Storpheus base URL.
+
+    Returns:
+        True when the output is a MIDI stub (no real audio render occurred).
+    """
+    logger.warning(
+        "⚠️ Storpheus /render endpoint not yet available — "
+        "copying MIDI as placeholder for %s",
+        output_path.name,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(midi_path, output_path)
+    logger.info(
+        "✅ release stub: %s copied to %s [format=%s]",
+        midi_path.name,
+        output_path,
+        fmt.value,
+    )
+    return True
+
+
+def _write_release_manifest(
+    output_dir: pathlib.Path,
+    tag: str,
+    commit_id: str,
+    audio_format: ReleaseAudioFormat,
+    artifacts: list[ReleaseArtifact],
+    stubbed: bool,
+) -> pathlib.Path:
+    """Write the ``release-manifest.json`` to *output_dir*.
+
+    The manifest is the authoritative index of everything produced by
+    ``muse release``.  It is always the last artifact written so that its
+    presence signals a complete, consistent release directory.
+
+    Manifest shape::
+
+        {
+          "tag": "v1.0",
+          "commit_id": "<full sha>",
+          "commit_short": "<8-char>",
+          "released_at": "<ISO-8601 UTC>",
+          "audio_format": "wav",
+          "stubbed": false,
+          "files": [
+            {"path": "audio/abc123.wav", "sha256": "...", "size_bytes": ..., "role": "audio"},
+            ...
+          ]
+        }
+
+    Args:
+        output_dir: Root release directory.
+        tag: Release tag string.
+        commit_id: Full commit ID.
+        audio_format: Audio format used for rendered files.
+        artifacts: All non-manifest artifacts already written.
+        stubbed: Whether audio renders are stub copies.
+
+    Returns:
+        Path of the written manifest file.
+    """
+    manifest_path = output_dir / "release-manifest.json"
+    files_list = [
+        {
+            "path": str(a.path.relative_to(output_dir)),
+            "sha256": a.sha256,
+            "size_bytes": a.size_bytes,
+            "role": a.role,
+        }
+        for a in artifacts
+    ]
+    payload: dict[str, object] = {
+        "tag": tag,
+        "commit_id": commit_id,
+        "commit_short": commit_id[:8],
+        "released_at": datetime.now(timezone.utc).isoformat(),
+        "audio_format": audio_format.value,
+        "stubbed": stubbed,
+        "files": files_list,
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(payload, indent=2))
+    logger.info("✅ release: manifest written to %s", manifest_path)
+    return manifest_path
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_release(
+    *,
+    tag: str,
+    commit_id: str,
+    manifest: dict[str, str],
+    root: pathlib.Path,
+    output_dir: pathlib.Path,
+    audio_format: ReleaseAudioFormat = ReleaseAudioFormat.WAV,
+    render_audio: bool = False,
+    render_midi: bool = False,
+    export_stems: bool = False,
+    storpheus_url: str = "http://localhost:10002",
+) -> ReleaseResult:
+    """Build a release artifact bundle from a tagged Muse commit snapshot.
+
+    Entry point for the ``muse release`` command.  Depending on the flags
+    passed it:
+
+    - Renders the primary MIDI file to audio via Storpheus (``render_audio``).
+    - Bundles all MIDI files into a zip archive (``render_midi``).
+    - Exports each MIDI file as a separate audio stem (``export_stems``).
+    - Always writes a ``release-manifest.json`` with SHA-256 checksums.
+
+    At least one of ``render_audio``, ``render_midi``, or ``export_stems``
+    must be True; otherwise only the manifest is written (which is useful
+    for dry-run validation but not an interesting release).
+
+    Args:
+        tag: Release tag string (e.g. ``"v1.0"``).
+        commit_id: Full commit ID of the snapshot to release.
+        manifest: ``{rel_path: object_id}`` snapshot manifest.
+        root: Muse repository root.
+        output_dir: Destination directory for all artifacts.
+        audio_format: Audio format for rendered files (wav / mp3 / flac).
+        render_audio: Render primary MIDI to a single audio file.
+        render_midi: Bundle all MIDI files into a zip archive.
+        export_stems: Export each MIDI track as a separate audio file.
+        storpheus_url: Storpheus base URL (overridable in tests).
+
+    Returns:
+        ReleaseResult describing everything that was written.
+
+    Raises:
+        StorpheusReleaseUnavailableError: When audio render is requested and
+            Storpheus health check fails.
+        ValueError: When no MIDI files are found in the snapshot.
+    """
+    midi_paths, _skipped = _collect_midi_paths(manifest, root)
+
+    if not midi_paths:
+        raise ValueError(
+            f"No MIDI files found in snapshot for commit {commit_id[:8]}. "
+            "Check muse-work/ for MIDI content before releasing."
+        )
+
+    needs_storpheus = render_audio or export_stems
+    if needs_storpheus:
+        _check_storpheus_reachable(storpheus_url)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifacts: list[ReleaseArtifact] = []
+    any_stubbed = False
+
+    # --- Render audio: primary MIDI → single audio file ---
+    if render_audio:
+        audio_dir = output_dir / "audio"
+        audio_dir.mkdir(parents=True, exist_ok=True)
+        primary_midi = midi_paths[0]
+        audio_out = audio_dir / f"{commit_id[:8]}.{audio_format.value}"
+        stubbed = _render_midi_to_audio(primary_midi, audio_out, audio_format, storpheus_url)
+        if stubbed:
+            any_stubbed = True
+        artifacts.append(_make_artifact(audio_out, "audio"))
+        logger.info(
+            "✅ release: audio rendered %s → %s [stubbed=%s]",
+            primary_midi.name,
+            audio_out,
+            stubbed,
+        )
+
+    # --- Render MIDI bundle: all MIDI files → zip archive ---
+    if render_midi:
+        midi_dir = output_dir / "midi"
+        midi_dir.mkdir(parents=True, exist_ok=True)
+        bundle_path = midi_dir / "midi-bundle.zip"
+        with zipfile.ZipFile(bundle_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            for midi_path in midi_paths:
+                zf.write(midi_path, arcname=midi_path.name)
+        artifacts.append(_make_artifact(bundle_path, "midi-bundle"))
+        logger.info(
+            "✅ release: MIDI bundle written to %s (%d files)", bundle_path, len(midi_paths)
+        )
+
+    # --- Export stems: each MIDI file → separate audio file ---
+    if export_stems:
+        stems_dir = output_dir / "stems"
+        stems_dir.mkdir(parents=True, exist_ok=True)
+        for midi_path in midi_paths:
+            stem_out = stems_dir / f"{midi_path.stem}.{audio_format.value}"
+            stubbed = _render_midi_to_audio(midi_path, stem_out, audio_format, storpheus_url)
+            if stubbed:
+                any_stubbed = True
+            artifacts.append(_make_artifact(stem_out, "stem"))
+            logger.info(
+                "✅ release: stem exported %s → %s [stubbed=%s]",
+                midi_path.name,
+                stem_out,
+                stubbed,
+            )
+
+    # Always write manifest last — its presence signals a complete release.
+    manifest_path = _write_release_manifest(
+        output_dir=output_dir,
+        tag=tag,
+        commit_id=commit_id,
+        audio_format=audio_format,
+        artifacts=artifacts,
+        stubbed=any_stubbed,
+    )
+    manifest_artifact = _make_artifact(manifest_path, "manifest")
+    artifacts.append(manifest_artifact)
+
+    logger.info(
+        "✅ muse release: tag=%r commit=%s output_dir=%s artifacts=%d stubbed=%s",
+        tag,
+        commit_id[:8],
+        output_dir,
+        len(artifacts),
+        any_stubbed,
+    )
+
+    return ReleaseResult(
+        tag=tag,
+        commit_id=commit_id,
+        output_dir=output_dir,
+        manifest_path=manifest_path,
+        artifacts=artifacts,
+        audio_format=audio_format,
+        stubbed=any_stubbed,
+    )

--- a/tests/test_muse_release.py
+++ b/tests/test_muse_release.py
@@ -1,0 +1,565 @@
+"""Tests for ``muse release`` — export a tagged commit as release artifacts.
+
+Verifies:
+- ``build_release`` writes a release-manifest.json when called with no flags.
+- ``build_release --render-midi`` produces a zip archive of all MIDI files.
+- ``build_release --render-audio`` copies the MIDI as an audio stub.
+- ``build_release --export-stems`` produces per-track audio stubs.
+- ``build_release`` raises ``ValueError`` when no MIDI files exist in snapshot.
+- ``build_release`` raises ``StorpheusReleaseUnavailableError`` when Storpheus
+  is down and audio rendering is requested.
+- ``_resolve_tag_to_commit`` resolves a tag to the most recent commit.
+- ``_resolve_tag_to_commit`` falls back to prefix lookup when tag not found.
+- ``_release_async`` (regression): resolves tag, fetches manifest, delegates.
+- Boundary seal (AST): ``from __future__ import annotations`` present.
+"""
+from __future__ import annotations
+
+import ast
+import datetime
+import json
+import pathlib
+import uuid
+import zipfile
+from collections.abc import AsyncGenerator
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from maestro.db.database import Base
+from maestro.muse_cli import models as cli_models  # noqa: F401 — register tables
+from maestro.muse_cli.models import MuseCliCommit, MuseCliObject, MuseCliSnapshot, MuseCliTag
+from maestro.services.muse_release import (
+    ReleaseAudioFormat,
+    ReleaseResult,
+    StorpheusReleaseUnavailableError,
+    _collect_midi_paths,
+    _sha256_file,
+    build_release,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def async_session() -> AsyncGenerator[AsyncSession, None]:
+    """In-memory SQLite session with all CLI tables created."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with Session() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture
+def repo_root(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a minimal Muse repo structure under *tmp_path*."""
+    muse_dir = tmp_path / ".muse"
+    muse_dir.mkdir()
+    (muse_dir / "HEAD").write_text("refs/heads/main")
+    refs_dir = muse_dir / "refs" / "heads"
+    refs_dir.mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture
+def repo_id() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def write_repo_json(repo_root: pathlib.Path, repo_id: str) -> None:
+    """Write .muse/repo.json with a stable repo_id."""
+    (repo_root / ".muse" / "repo.json").write_text(json.dumps({"repo_id": repo_id}))
+
+
+@pytest.fixture
+def midi_repo(repo_root: pathlib.Path) -> dict[str, pathlib.Path]:
+    """Create a muse-work/ directory with two MIDI stub files.
+
+    Returns a dict mapping relative path strings to absolute Path objects.
+    """
+    workdir = repo_root / "muse-work"
+    workdir.mkdir()
+    paths: dict[str, pathlib.Path] = {}
+    for name in ("piano.mid", "bass.mid"):
+        p = workdir / name
+        p.write_bytes(b"MIDI")
+        paths[name] = p
+    return paths
+
+
+async def _insert_commit_with_tag(
+    session: AsyncSession,
+    repo_id: str,
+    repo_root: pathlib.Path,
+    tag: str,
+    manifest: dict[str, str] | None = None,
+    commit_id_char: str = "b",
+) -> str:
+    """Insert a commit + snapshot + tag; return the commit_id."""
+    object_id = "c" * 64
+    snapshot_id = ("s" + commit_id_char) * 32
+    commit_id = commit_id_char * 64
+
+    if not manifest:
+        manifest = {"piano.mid": object_id}
+
+    session.add(MuseCliObject(object_id=object_id, size_bytes=4))
+    session.add(MuseCliSnapshot(snapshot_id=snapshot_id, manifest=manifest))
+    await session.flush()
+
+    committed_at = datetime.datetime.now(datetime.timezone.utc)
+    session.add(
+        MuseCliCommit(
+            commit_id=commit_id,
+            repo_id=repo_id,
+            branch="main",
+            parent_commit_id=None,
+            parent2_commit_id=None,
+            snapshot_id=snapshot_id,
+            message="tagged commit",
+            author="",
+            committed_at=committed_at,
+        )
+    )
+    await session.flush()
+
+    session.add(MuseCliTag(repo_id=repo_id, commit_id=commit_id, tag=tag))
+    await session.flush()
+
+    # Update HEAD pointer
+    ref_path = repo_root / ".muse" / "refs" / "heads" / "main"
+    ref_path.write_text(commit_id)
+    return commit_id
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — service layer (build_release)
+# ---------------------------------------------------------------------------
+
+
+def test_build_release_writes_manifest_only(
+    repo_root: pathlib.Path,
+    midi_repo: dict[str, pathlib.Path],
+    tmp_path: pathlib.Path,
+) -> None:
+    """build_release writes release-manifest.json even when no flags are set."""
+    manifest = {name: "c" * 64 for name in midi_repo}
+    output_dir = tmp_path / "releases" / "v1.0"
+
+    with patch(
+        "maestro.services.muse_release._check_storpheus_reachable"
+    ):  # not called — no audio flags
+        result = build_release(
+            tag="v1.0",
+            commit_id="b" * 64,
+            manifest=manifest,
+            root=repo_root,
+            output_dir=output_dir,
+            render_audio=False,
+            render_midi=False,
+            export_stems=False,
+        )
+
+    assert result.manifest_path.exists()
+    data = json.loads(result.manifest_path.read_text())
+    assert data["tag"] == "v1.0"
+    assert data["commit_id"] == "b" * 64
+    assert data["commit_short"] == "b" * 8
+    assert "released_at" in data
+    assert isinstance(data["files"], list)
+
+
+def test_build_release_render_midi_produces_zip(
+    repo_root: pathlib.Path,
+    midi_repo: dict[str, pathlib.Path],
+    tmp_path: pathlib.Path,
+) -> None:
+    """build_release --render-midi produces a zip containing all MIDI files."""
+    manifest = {name: "c" * 64 for name in midi_repo}
+    output_dir = tmp_path / "releases" / "v1.0"
+
+    result = build_release(
+        tag="v1.0",
+        commit_id="b" * 64,
+        manifest=manifest,
+        root=repo_root,
+        output_dir=output_dir,
+        render_midi=True,
+    )
+
+    bundle_path = output_dir / "midi" / "midi-bundle.zip"
+    assert bundle_path.exists()
+    assert any(a.role == "midi-bundle" for a in result.artifacts)
+
+    with zipfile.ZipFile(bundle_path) as zf:
+        names = zf.namelist()
+    assert "piano.mid" in names
+    assert "bass.mid" in names
+
+
+def test_build_release_render_audio_produces_stub(
+    repo_root: pathlib.Path,
+    midi_repo: dict[str, pathlib.Path],
+    tmp_path: pathlib.Path,
+) -> None:
+    """build_release --render-audio copies MIDI as audio stub when /render not deployed."""
+    manifest = {name: "c" * 64 for name in midi_repo}
+    output_dir = tmp_path / "releases" / "v1.0"
+
+    with patch(
+        "maestro.services.muse_release._check_storpheus_reachable"
+    ):
+        result = build_release(
+            tag="v1.0",
+            commit_id="b" * 64,
+            manifest=manifest,
+            root=repo_root,
+            output_dir=output_dir,
+            render_audio=True,
+        )
+
+    audio_artifact = next(a for a in result.artifacts if a.role == "audio")
+    assert audio_artifact.path.exists()
+    assert audio_artifact.path.suffix == ".wav"
+    assert result.stubbed is True
+
+
+def test_build_release_export_stems_produces_per_track_files(
+    repo_root: pathlib.Path,
+    midi_repo: dict[str, pathlib.Path],
+    tmp_path: pathlib.Path,
+) -> None:
+    """build_release --export-stems writes one audio file per MIDI track."""
+    manifest = {name: "c" * 64 for name in midi_repo}
+    output_dir = tmp_path / "releases" / "v1.0"
+
+    with patch(
+        "maestro.services.muse_release._check_storpheus_reachable"
+    ):
+        result = build_release(
+            tag="v1.0",
+            commit_id="b" * 64,
+            manifest=manifest,
+            root=repo_root,
+            output_dir=output_dir,
+            export_stems=True,
+            audio_format=ReleaseAudioFormat.FLAC,
+        )
+
+    stem_artifacts = [a for a in result.artifacts if a.role == "stem"]
+    assert len(stem_artifacts) == 2
+    for a in stem_artifacts:
+        assert a.path.suffix == ".flac"
+        assert a.path.exists()
+
+
+def test_build_release_manifest_contains_checksums(
+    repo_root: pathlib.Path,
+    midi_repo: dict[str, pathlib.Path],
+    tmp_path: pathlib.Path,
+) -> None:
+    """release-manifest.json includes sha256 checksums for every artifact."""
+    manifest = {name: "c" * 64 for name in midi_repo}
+    output_dir = tmp_path / "releases" / "v1.0"
+
+    result = build_release(
+        tag="v1.0",
+        commit_id="b" * 64,
+        manifest=manifest,
+        root=repo_root,
+        output_dir=output_dir,
+        render_midi=True,
+    )
+
+    data = json.loads(result.manifest_path.read_text())
+    for file_entry in data["files"]:
+        assert "sha256" in file_entry
+        assert len(file_entry["sha256"]) == 64
+        assert "size_bytes" in file_entry
+        assert "role" in file_entry
+
+
+def test_build_release_raises_when_no_midi_files(
+    repo_root: pathlib.Path,
+    tmp_path: pathlib.Path,
+) -> None:
+    """build_release raises ValueError when no MIDI files exist in snapshot."""
+    workdir = repo_root / "muse-work"
+    workdir.mkdir()
+    (workdir / "notes.json").write_text("{}")  # not a MIDI file
+
+    manifest = {"notes.json": "c" * 64}
+    output_dir = tmp_path / "releases" / "v1.0"
+
+    with pytest.raises(ValueError, match="No MIDI files found"):
+        build_release(
+            tag="v1.0",
+            commit_id="b" * 64,
+            manifest=manifest,
+            root=repo_root,
+            output_dir=output_dir,
+            render_audio=True,
+        )
+
+
+def test_build_release_raises_when_storpheus_unreachable(
+    repo_root: pathlib.Path,
+    midi_repo: dict[str, pathlib.Path],
+    tmp_path: pathlib.Path,
+) -> None:
+    """build_release raises StorpheusReleaseUnavailableError when Storpheus is down."""
+    manifest = {name: "c" * 64 for name in midi_repo}
+    output_dir = tmp_path / "releases" / "v1.0"
+
+    with patch(
+        "maestro.services.muse_release._check_storpheus_reachable",
+        side_effect=StorpheusReleaseUnavailableError("Storpheus is down"),
+    ):
+        with pytest.raises(StorpheusReleaseUnavailableError):
+            build_release(
+                tag="v1.0",
+                commit_id="b" * 64,
+                manifest=manifest,
+                root=repo_root,
+                output_dir=output_dir,
+                render_audio=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — SHA-256 helper
+# ---------------------------------------------------------------------------
+
+
+def test_sha256_file_matches_known_digest(tmp_path: pathlib.Path) -> None:
+    """_sha256_file computes the correct SHA-256 for a known byte sequence."""
+    import hashlib
+
+    content = b"MIDI content for hashing"
+    p = tmp_path / "test.mid"
+    p.write_bytes(content)
+
+    expected = hashlib.sha256(content).hexdigest()
+    assert _sha256_file(p) == expected
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _collect_midi_paths
+# ---------------------------------------------------------------------------
+
+
+def test_collect_midi_paths_filters_by_track(
+    repo_root: pathlib.Path,
+    midi_repo: dict[str, pathlib.Path],
+) -> None:
+    """_collect_midi_paths returns only paths matching the track filter."""
+    manifest = {name: "c" * 64 for name in midi_repo}
+    paths, skipped = _collect_midi_paths(manifest, repo_root, track="piano")
+
+    assert len(paths) == 1
+    assert paths[0].name == "piano.mid"
+    assert skipped == 1
+
+
+def test_collect_midi_paths_skips_missing_files(
+    repo_root: pathlib.Path,
+) -> None:
+    """_collect_midi_paths counts missing files in skipped_count."""
+    workdir = repo_root / "muse-work"
+    workdir.mkdir()
+    manifest = {"missing.mid": "c" * 64}  # file does not exist on disk
+
+    paths, skipped = _collect_midi_paths(manifest, repo_root)
+    assert paths == []
+    assert skipped == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — _resolve_tag_to_commit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_resolve_tag_to_commit_finds_tagged_commit(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """_resolve_tag_to_commit resolves a tag string to the correct commit ID."""
+    from maestro.muse_cli.commands.release import _resolve_tag_to_commit
+
+    commit_id = await _insert_commit_with_tag(async_session, repo_id, repo_root, "v1.0")
+
+    resolved = await _resolve_tag_to_commit(async_session, repo_root, "v1.0")
+    assert resolved == commit_id
+
+
+@pytest.mark.anyio
+async def test_resolve_tag_to_commit_uses_most_recent_when_ambiguous(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """When multiple commits share a tag, the most recently committed is returned."""
+    from maestro.muse_cli.commands.release import _resolve_tag_to_commit
+
+    object_id = "c" * 64
+    snap1_id = "s1" * 32
+    snap2_id = "s2" * 32
+    cid1 = "1" * 64
+    cid2 = "2" * 64
+
+    async_session.add(MuseCliObject(object_id=object_id, size_bytes=4))
+    async_session.add(MuseCliSnapshot(snapshot_id=snap1_id, manifest={"a.mid": object_id}))
+    async_session.add(MuseCliSnapshot(snapshot_id=snap2_id, manifest={"b.mid": object_id}))
+    await async_session.flush()
+
+    t1 = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+    t2 = datetime.datetime(2024, 6, 1, tzinfo=datetime.timezone.utc)  # more recent
+
+    async_session.add(
+        MuseCliCommit(
+            commit_id=cid1, repo_id=repo_id, branch="main",
+            parent_commit_id=None, parent2_commit_id=None,
+            snapshot_id=snap1_id, message="old", author="", committed_at=t1,
+        )
+    )
+    async_session.add(
+        MuseCliCommit(
+            commit_id=cid2, repo_id=repo_id, branch="main",
+            parent_commit_id=cid1, parent2_commit_id=None,
+            snapshot_id=snap2_id, message="newer", author="", committed_at=t2,
+        )
+    )
+    await async_session.flush()
+
+    async_session.add(MuseCliTag(repo_id=repo_id, commit_id=cid1, tag="v1.0"))
+    async_session.add(MuseCliTag(repo_id=repo_id, commit_id=cid2, tag="v1.0"))
+    await async_session.flush()
+
+    resolved = await _resolve_tag_to_commit(async_session, repo_root, "v1.0")
+    assert resolved == cid2
+
+
+@pytest.mark.anyio
+async def test_resolve_tag_to_commit_falls_back_to_prefix(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+) -> None:
+    """_resolve_tag_to_commit falls back to commit prefix lookup when tag absent."""
+    from maestro.muse_cli.commands.release import _resolve_tag_to_commit
+
+    commit_id = await _insert_commit_with_tag(async_session, repo_id, repo_root, "v2.0")
+    # Use the commit ID prefix directly (not the tag)
+    resolved = await _resolve_tag_to_commit(async_session, repo_root, commit_id[:8])
+    assert resolved == commit_id
+
+
+# ---------------------------------------------------------------------------
+# Regression test — test_release_resolves_tag_and_exports_manifest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_release_resolves_tag_and_exports_manifest(
+    async_session: AsyncSession,
+    repo_root: pathlib.Path,
+    repo_id: str,
+    write_repo_json: None,
+    midi_repo: dict[str, pathlib.Path],
+    tmp_path: pathlib.Path,
+) -> None:
+    """Regression: _release_async resolves tag, fetches manifest, writes manifest.json.
+
+    This is the primary acceptance criterion for issue #82: a producer runs
+    'muse release v1.0' and receives a release-manifest.json pinning the
+    tagged snapshot.
+    """
+    from maestro.muse_cli.commands.release import _release_async
+
+    manifest = {name: "c" * 64 for name in midi_repo}
+    commit_id = await _insert_commit_with_tag(
+        async_session, repo_id, repo_root, "v1.0", manifest=manifest
+    )
+
+    output_dir = tmp_path / "releases" / "v1.0"
+
+    with patch("maestro.config.settings") as mock_settings:
+        mock_settings.storpheus_base_url = "http://storpheus:10002"
+        result = await _release_async(
+            tag="v1.0",
+            audio_format=ReleaseAudioFormat.WAV,
+            output_dir=output_dir,
+            render_audio=False,
+            render_midi=True,
+            export_stems=False,
+            root=repo_root,
+            session=async_session,
+        )
+
+    assert result.tag == "v1.0"
+    assert result.commit_id == commit_id
+    assert result.manifest_path.exists()
+
+    data = json.loads(result.manifest_path.read_text())
+    assert data["tag"] == "v1.0"
+    assert data["commit_id"] == commit_id
+
+    # MIDI bundle should be present
+    bundle_artifact = next((a for a in result.artifacts if a.role == "midi-bundle"), None)
+    assert bundle_artifact is not None
+    assert bundle_artifact.path.exists()
+
+    with zipfile.ZipFile(bundle_artifact.path) as zf:
+        names = zf.namelist()
+    for midi_name in midi_repo:
+        assert midi_name in names
+
+
+# ---------------------------------------------------------------------------
+# Boundary seal
+# ---------------------------------------------------------------------------
+
+
+def test_future_annotations_in_service() -> None:
+    """``from __future__ import annotations`` is present in muse_release.py."""
+    import maestro.services.muse_release as mod
+
+    src = pathlib.Path(mod.__file__).read_text()
+    tree = ast.parse(src)
+    future_imports = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module == "__future__"
+        and any(alias.name == "annotations" for alias in node.names)
+    ]
+    assert future_imports, "from __future__ import annotations missing in muse_release.py"
+
+
+def test_future_annotations_in_command() -> None:
+    """``from __future__ import annotations`` is present in commands/release.py."""
+    import maestro.muse_cli.commands.release as mod
+
+    src = pathlib.Path(mod.__file__).read_text()
+    tree = ast.parse(src)
+    future_imports = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module == "__future__"
+        and any(alias.name == "annotations" for alias in node.names)
+    ]
+    assert future_imports, "from __future__ import annotations missing in commands/release.py"


### PR DESCRIPTION
## Summary
Closes #82 — adds `muse release <tag>` as the music-native publish step, bridging Muse VCS and audio distribution.

## Root Cause / Motivation
Producers had no way to export a tagged composition version as render-ready artifacts. `muse tag add` let them label commits as versions, but there was no command to act on those labels and produce distributable files.

## Solution
Three new components following established Muse CLI patterns:

**Service layer** (`maestro/services/muse_release.py`):
- `build_release()` — resolves tag → snapshot → artifact pipeline
- `ReleaseArtifact` (frozen dataclass): `path`, `sha256`, `size_bytes`, `role`
- `ReleaseResult` (dataclass): full result including all artifacts, `stubbed` flag, manifest path
- `_render_midi_to_audio()` — stub implementation (copies MIDI as placeholder; ready for Storpheus `/render` when deployed)
- Always writes `release-manifest.json` with SHA-256 checksums as the final step

**CLI command** (`maestro/muse_cli/commands/release.py`):
- `muse release <tag> [--render-audio] [--render-midi] [--export-stems] [--format wav|mp3|flac] [--output-dir PATH] [--json]`
- `_resolve_tag_to_commit()` — queries `MuseCliTag` table; falls back to commit prefix lookup; uses most-recent when tag is on multiple commits
- `_release_async()` — injectable async core for testability

**Registration**: `maestro/muse_cli/app.py` updated.

**Output layout:**
```
<output-dir>/
    release-manifest.json        # always written; SHA-256 checksums
    audio/<commit8>.<format>     # --render-audio
    midi/midi-bundle.zip         # --render-midi
    stems/<stem>.<format>        # --export-stems
```

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (554 files)
- [x] `docker compose exec storpheus mypy .` — clean
- [x] All 16 release tests pass
- [x] Docs updated: `docs/architecture/muse_vcs.md`, `docs/reference/type_contracts.md`

## Tests Added
- `test_build_release_writes_manifest_only` — manifest written even with no flags
- `test_build_release_render_midi_produces_zip` — zip contains all MIDI files
- `test_build_release_render_audio_produces_stub` — audio copy stub + stubbed=True
- `test_build_release_export_stems_produces_per_track_files` — one file per track, correct format suffix
- `test_build_release_manifest_contains_checksums` — sha256 + size_bytes in manifest
- `test_build_release_raises_when_no_midi_files` — ValueError on empty snapshot
- `test_build_release_raises_when_storpheus_unreachable` — StorpheusReleaseUnavailableError propagated
- `test_sha256_file_matches_known_digest` — SHA-256 helper accuracy
- `test_collect_midi_paths_filters_by_track` — track filter reduces results
- `test_collect_midi_paths_skips_missing_files` — missing files counted in skipped
- `test_resolve_tag_to_commit_finds_tagged_commit` — tag lookup works
- `test_resolve_tag_to_commit_uses_most_recent_when_ambiguous` — multi-tag disambiguation
- `test_resolve_tag_to_commit_falls_back_to_prefix` — SHA prefix fallback
- `test_release_resolves_tag_and_exports_manifest` — **regression test** (acceptance criterion)
- `test_future_annotations_in_service` — boundary seal
- `test_future_annotations_in_command` — boundary seal

## Handoff
N/A — no SSE/MCP protocol change. This is a CLI-only command with no DAW adapter impact.