### PR TITLE
feat: muse blame <path> — annotate files with last-touching commit

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -1958,6 +1958,41 @@ These type aliases replace the repeated pattern `dict[str, list[XxxDict]]` that 
 
 > Added: 2026-02-27 | Types used by the `muse` CLI commands — purely local, never serialised over HTTP.
 
+### `BlameEntry` (`maestro/muse_cli/commands/blame.py`)
+
+`TypedDict` — blame annotation for a single file path returned by `muse blame`.
+Identifies the most recent commit that touched the file, enabling AI agents to
+attribute musical decisions to specific commits.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | `str` | Full relative path of the file (e.g. `muse-work/bass/bassline.mid`) |
+| `commit_id` | `str` | Full 64-char SHA-256 commit ID of the last-touching commit |
+| `commit_short` | `str` | 8-char abbreviated commit ID for human-readable output |
+| `author` | `str` | Author string from the commit; `"(unknown)"` if empty |
+| `committed_at` | `str` | Timestamp formatted as `YYYY-MM-DD HH:MM:SS` |
+| `message` | `str` | Commit message of the last-touching commit |
+| `change_type` | `str` | How the path changed: `"added"` \| `"modified"` \| `"unchanged"` |
+
+**Used by:** `_blame_async`, `_render_blame`.
+
+### `BlameResult` (`maestro/muse_cli/commands/blame.py`)
+
+`TypedDict` — full output of `muse blame`, wrapping a list of `BlameEntry` values
+with the active filter state.  Entries are sorted alphabetically by path.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path_filter` | `str \| None` | Positional path filter passed to the command, or `None` |
+| `track_filter` | `str \| None` | `--track` fnmatch pattern, or `None` |
+| `section_filter` | `str \| None` | `--section` directory name, or `None` |
+| `line_range` | `str \| None` | `--line-range N,M` annotation (informational for binary files), or `None` |
+| `entries` | `list[BlameEntry]` | Blame annotations, sorted by path ascending |
+
+**Used by:** `_blame_async`, `_render_blame`, and JSON serialisation path in `blame()`.
+
+---
+
 ### `HarmonyResult` (`maestro/muse_cli/commands/harmony.py`)
 
 `TypedDict` — harmonic analysis for a single commit returned by `muse harmony`.

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -1,7 +1,7 @@
 """Muse CLI — Typer application root.
 
 Entry point for the ``muse`` console script. Registers all MVP
-subcommands (amend, arrange, ask, cat-object, checkout, chord-map, commit,
+subcommands (amend, arrange, ask, blame, cat-object, checkout, chord-map, commit,
 commit-tree, context, contour, describe, diff, divergence, dynamics, emotion-diff,
 export, find, form, grep, groove-check, harmony, humanize, import, init, inspect,
 key, log, merge, meter, motif, open, play, pull, push, read-tree, recall, remote,
@@ -17,6 +17,7 @@ from maestro.muse_cli.commands import (
     amend,
     arrange,
     ask,
+    blame,
     cat_object,
     checkout,
     chord_map,
@@ -78,6 +79,7 @@ cli = typer.Typer(
 )
 
 cli.add_typer(amend.app, name="amend", help="Fold working-tree changes into the most recent commit.")
+cli.add_typer(blame.app, name="blame", help="Annotate files with the commit that last changed each one.")
 cli.add_typer(cat_object.app, name="cat-object", help="Read and display a stored object by its SHA-256 hash.")
 cli.add_typer(chord_map.app, name="chord-map", help="Visualize the chord progression embedded in a commit.")
 cli.add_typer(contour.app, name="contour", help="Analyze the melodic contour and phrase shape of a commit.")

--- a/maestro/muse_cli/commands/blame.py
+++ b/maestro/muse_cli/commands/blame.py
@@ -1,0 +1,378 @@
+"""muse blame <path> — annotate a file with the commit that last changed it.
+
+For each file path in the current HEAD snapshot (filtered by the positional
+``<path>`` argument and optional ``--track``/``--section`` flags), walks the
+commit graph to find the most recent commit that touched that file.
+
+In music production, blame answers:
+
+- "Whose idea was this bass line?"
+- "Which take introduced this change?"
+- "Which commit first added the bridge strings?"
+
+Output is per-file (not per-line) because MIDI/audio files are binary — the
+meaningful unit of change is a whole file, not a byte offset.
+
+**Algorithm:**
+
+1. Load all commits from HEAD, following ``parent_commit_id`` links.
+2. For each adjacent pair ``(C_i, C_{i-1})`` (newest to oldest), load their
+   snapshot manifests and compare ``object_id`` values per path.
+3. The first pair where a path differs (object_id changed, added, or removed)
+   identifies the most recent commit to have touched that path.
+4. Paths present in the initial commit (no parent) are attributed to it.
+
+This is O(N × F) in commits × files, which is acceptable for DAW session
+history (typically <1 000 commits, <100 files per snapshot).
+
+Flags
+-----
+PATH TEXT         Positional — relative path within muse-work/ to annotate.
+                  Omit to blame all tracked files.
+--track TEXT      Filter to paths whose last component matches this pattern
+                  (fnmatch-style glob, e.g. ``bass*`` or ``*.mid``).
+--section TEXT    Filter to paths whose first directory component equals this
+                  section name (e.g. ``chorus`` or ``bridge``).
+--line-range N,M  Note: MIDI/audio are binary; line-range is recorded in the
+                  output for annotation purposes but does not slice the file.
+--json            Emit structured JSON for agent consumption.
+"""
+from __future__ import annotations
+
+import asyncio
+import fnmatch
+import json
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing_extensions import TypedDict
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+class BlameEntry(TypedDict):
+    """Blame annotation for a single file path.
+
+    ``change_type`` describes how the path changed in ``commit_id``:
+
+    - ``"added"``     — first commit to include this path
+    - ``"modified"``  — object_id changed compared to the parent snapshot
+    - ``"unchanged"`` — fallback when the graph walk finds no modification
+                        (should not occur in a consistent database)
+    """
+
+    path: str
+    commit_id: str
+    commit_short: str
+    author: str
+    committed_at: str
+    message: str
+    change_type: str
+
+
+class BlameResult(TypedDict):
+    """Full output of ``muse blame``.
+
+    ``entries`` is ordered by path (ascending alphabetical).
+    """
+
+    path_filter: Optional[str]
+    track_filter: Optional[str]
+    section_filter: Optional[str]
+    line_range: Optional[str]
+    entries: list[BlameEntry]
+
+
+# ---------------------------------------------------------------------------
+# Core helpers
+# ---------------------------------------------------------------------------
+
+
+async def _load_commit_chain(
+    session: AsyncSession,
+    head_commit_id: str,
+    limit: int = 10_000,
+) -> list[MuseCliCommit]:
+    """Walk the parent chain from *head_commit_id*, returning newest-first.
+
+    Stops when the chain is exhausted or *limit* is reached.
+    """
+    commits: list[MuseCliCommit] = []
+    current_id: str | None = head_commit_id
+    while current_id and len(commits) < limit:
+        commit = await session.get(MuseCliCommit, current_id)
+        if commit is None:
+            logger.warning("⚠️ Commit %s not found — chain broken", current_id[:8])
+            break
+        commits.append(commit)
+        current_id = commit.parent_commit_id
+    return commits
+
+
+async def _load_snapshot_manifest(
+    session: AsyncSession,
+    snapshot_id: str,
+) -> dict[str, str]:
+    """Return the manifest dict for *snapshot_id*, or an empty dict on miss."""
+    snapshot = await session.get(MuseCliSnapshot, snapshot_id)
+    if snapshot is None:
+        logger.warning("⚠️ Snapshot %s not found in DB", snapshot_id[:8])
+        return {}
+    return dict(snapshot.manifest)
+
+
+def _matches_filters(
+    path: str,
+    path_filter: str | None,
+    track_filter: str | None,
+    section_filter: str | None,
+) -> bool:
+    """Return True when *path* passes all active filter criteria.
+
+    Filters are AND-combined: all supplied filters must match.
+
+    - *path_filter*: substring / exact match on the full path string.
+    - *track_filter*: fnmatch pattern applied to the basename.
+    - *section_filter*: exact match on the first directory component.
+    """
+    if path_filter is not None:
+        # Accept both exact match and sub-path match (e.g. "bass" matches
+        # "muse-work/bass/bassline.mid" as a substring)
+        if path_filter not in path and not path.endswith(path_filter):
+            return False
+
+    if track_filter is not None:
+        basename = pathlib.PurePosixPath(path).name
+        if not fnmatch.fnmatch(basename, track_filter):
+            return False
+
+    if section_filter is not None:
+        parts = pathlib.PurePosixPath(path).parts
+        # parts might be ("muse-work", "chorus", "piano.mid") or ("chorus", "piano.mid")
+        # We match the first non-"muse-work" directory component
+        dirs = [p for p in parts[:-1] if p != "muse-work"]
+        if not dirs or dirs[0] != section_filter:
+            return False
+
+    return True
+
+
+async def _blame_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    path_filter: str | None,
+    track_filter: str | None,
+    section_filter: str | None,
+    line_range: str | None,
+) -> BlameResult:
+    """Compute blame annotations for all matching paths.
+
+    Walks the commit graph from HEAD, comparing snapshot manifests between
+    adjacent commits to attribute each file to the most recent commit that
+    touched it.  Returns a :class:`BlameResult` suitable for both human-
+    readable rendering and JSON serialisation.
+    """
+    muse_dir = root / ".muse"
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]  # noqa: F841
+
+    head_ref = (muse_dir / "HEAD").read_text().strip()
+    branch = head_ref.rsplit("/", 1)[-1]
+    ref_path = muse_dir / pathlib.Path(head_ref)
+
+    if not ref_path.exists():
+        typer.echo(f"No commits yet on branch {branch}")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    head_commit_id = ref_path.read_text().strip()
+    if not head_commit_id:
+        typer.echo(f"No commits yet on branch {branch}")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    # Load all commits newest-first
+    commits = await _load_commit_chain(session, head_commit_id)
+    if not commits:
+        typer.echo(f"No commits yet on branch {branch}")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    # Load all manifests up-front (one DB query per snapshot)
+    manifests: list[dict[str, str]] = []
+    for commit in commits:
+        manifest = await _load_snapshot_manifest(session, commit.snapshot_id)
+        manifests.append(manifest)
+
+    # HEAD snapshot defines which paths exist right now
+    head_manifest = manifests[0]
+
+    # blame_map: path → commit (newest commit that changed this path)
+    blame_map: dict[str, tuple[MuseCliCommit, str]] = {}  # path → (commit, change_type)
+
+    # Walk pairs newest→oldest: (commits[i], commits[i+1])
+    for i in range(len(commits) - 1):
+        newer_commit = commits[i]
+        newer_manifest = manifests[i]
+        older_manifest = manifests[i + 1]
+
+        for path in newer_manifest:
+            if path in blame_map:
+                continue  # already attributed to a more recent commit
+            newer_oid = newer_manifest[path]
+            older_oid = older_manifest.get(path)
+            if older_oid is None:
+                # Path was added by newer_commit
+                blame_map[path] = (newer_commit, "added")
+            elif newer_oid != older_oid:
+                # Path was modified by newer_commit
+                blame_map[path] = (newer_commit, "modified")
+
+    # Any path still unattributed was present in the initial commit (C_0)
+    # and never changed after — attribute it to the oldest commit
+    oldest_commit = commits[-1]
+    for path in head_manifest:
+        if path not in blame_map:
+            blame_map[path] = (oldest_commit, "added")
+
+    # Build entries, applying filters
+    entries: list[BlameEntry] = []
+    for path in sorted(head_manifest.keys()):
+        if not _matches_filters(path, path_filter, track_filter, section_filter):
+            continue
+        commit, change_type = blame_map.get(path, (oldest_commit, "unchanged"))
+        entries.append(
+            BlameEntry(
+                path=path,
+                commit_id=commit.commit_id,
+                commit_short=commit.commit_id[:8],
+                author=commit.author or "(unknown)",
+                committed_at=commit.committed_at.strftime("%Y-%m-%d %H:%M:%S"),
+                message=commit.message,
+                change_type=change_type,
+            )
+        )
+
+    if not entries:
+        typer.echo("No matching paths found.")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    return BlameResult(
+        path_filter=path_filter,
+        track_filter=track_filter,
+        section_filter=section_filter,
+        line_range=line_range,
+        entries=entries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def _render_blame(result: BlameResult) -> str:
+    """Format blame output as a human-readable annotated file list.
+
+    Each line shows the short commit ID, author, date, change type, and
+    the file path — analogous to ``git blame`` but per-file rather than
+    per-line, since MIDI and audio files are binary.
+    """
+    lines: list[str] = []
+    if result["line_range"]:
+        lines.append(f"(line-range: {result['line_range']} — informational only for binary files)")
+        lines.append("")
+    for entry in result["entries"]:
+        lines.append(
+            f"{entry['commit_short']}  {entry['author']:<20}  "
+            f"{entry['committed_at']}  ({entry['change_type']:>10})  {entry['path']}"
+        )
+        lines.append(f"    {entry['message']}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def blame(
+    ctx: typer.Context,
+    path: Optional[str] = typer.Argument(
+        None,
+        help="Relative path within muse-work/ to annotate. Omit to blame all tracked files.",
+        metavar="PATH",
+    ),
+    track: Optional[str] = typer.Option(
+        None,
+        "--track",
+        help="Filter to files whose basename matches this fnmatch pattern (e.g. 'bass*' or '*.mid').",
+    ),
+    section: Optional[str] = typer.Option(
+        None,
+        "--section",
+        help="Filter to files within this section directory (first directory component).",
+    ),
+    line_range: Optional[str] = typer.Option(
+        None,
+        "--line-range",
+        help="Annotate sub-range N,M (informational for binary MIDI/audio files).",
+        metavar="N,M",
+    ),
+    as_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit structured JSON for agent consumption.",
+    ),
+) -> None:
+    """Annotate files with the commit that last changed each one.
+
+    Walks the commit graph from HEAD to find the most recent commit that
+    touched each file, answering "whose idea was this bass line?" or
+    "which take introduced this change?"
+
+    Output is per-file (not per-line) because MIDI and audio files are
+    binary — the meaningful unit of change is a whole file.
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            result = await _blame_async(
+                root=root,
+                session=session,
+                path_filter=path,
+                track_filter=track,
+                section_filter=section,
+                line_range=line_range,
+            )
+            if as_json:
+                typer.echo(json.dumps(dict(result), indent=2))
+            else:
+                typer.echo(_render_blame(result))
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse blame failed: {exc}")
+        logger.error("❌ muse blame error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/tests/muse_cli/test_blame.py
+++ b/tests/muse_cli/test_blame.py
@@ -1,0 +1,435 @@
+"""Tests for ``muse blame``.
+
+All async tests call ``_blame_async`` directly with an in-memory SQLite
+session and a ``tmp_path`` repo root — no real Postgres or running process
+required.  Commits are seeded via ``_commit_async`` so blame and commit
+are tested as an integrated pair.
+
+Covered scenarios:
+
+- ``test_blame_returns_last_commit_per_path``  (regression)
+- ``test_blame_path_filter_restricts_output``
+- ``test_blame_track_filter_glob``
+- ``test_blame_section_filter``
+- ``test_blame_json_output``
+- ``test_blame_no_commits_exits_zero``
+- ``test_blame_outside_repo_exits_2``
+- ``test_blame_single_commit_all_added``
+- ``test_blame_unmodified_file_attributes_oldest_commit``
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import uuid
+
+import pytest
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from typer.testing import CliRunner
+
+from maestro.muse_cli.app import cli
+from maestro.muse_cli.commands.blame import _blame_async, _render_blame
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.errors import ExitCode
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _write_file(root: pathlib.Path, rel_path: str, content: bytes) -> None:
+    """Write a file inside muse-work/ at the given relative path."""
+    target = root / "muse-work" / rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+
+
+# ---------------------------------------------------------------------------
+# test_blame_returns_last_commit_per_path (regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_returns_last_commit_per_path(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Blame returns the most-recent commit that changed each path.
+
+    Regression for issue #72: ``muse blame <path>`` must walk the commit
+    graph and return the correct last-change commit, not simply the HEAD
+    commit for all paths.
+    """
+    _init_muse_repo(tmp_path)
+
+    # Commit 1: add two files
+    _write_file(tmp_path, "bass/bassline.mid", b"bass-v1")
+    _write_file(tmp_path, "keys/melody.mid", b"keys-v1")
+    cid1 = await _commit_async(message="initial take", root=tmp_path, session=muse_cli_db_session)
+
+    # Commit 2: modify only bassline
+    _write_file(tmp_path, "bass/bassline.mid", b"bass-v2")
+    cid2 = await _commit_async(message="update bass groove", root=tmp_path, session=muse_cli_db_session)
+
+    result = await _blame_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        path_filter=None,
+        track_filter=None,
+        section_filter=None,
+        line_range=None,
+    )
+
+    entries = {e["path"].split("muse-work/")[-1]: e for e in result["entries"]}
+
+    # bass/bassline.mid was changed in commit 2
+    assert "bass/bassline.mid" in entries
+    assert entries["bass/bassline.mid"]["commit_short"] == cid2[:8]
+    assert entries["bass/bassline.mid"]["change_type"] == "modified"
+
+    # keys/melody.mid was only in commit 1 and not changed in commit 2
+    assert "keys/melody.mid" in entries
+    assert entries["keys/melody.mid"]["commit_short"] == cid1[:8]
+    assert entries["keys/melody.mid"]["change_type"] == "added"
+
+
+# ---------------------------------------------------------------------------
+# test_blame_path_filter_restricts_output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_path_filter_restricts_output(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Positional path filter returns only matching entries."""
+    _init_muse_repo(tmp_path)
+
+    _write_file(tmp_path, "bass/bassline.mid", b"bass")
+    _write_file(tmp_path, "keys/melody.mid", b"keys")
+    await _commit_async(message="init", root=tmp_path, session=muse_cli_db_session)
+
+    result = await _blame_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        path_filter="bassline.mid",
+        track_filter=None,
+        section_filter=None,
+        line_range=None,
+    )
+
+    assert len(result["entries"]) == 1
+    assert "bassline.mid" in result["entries"][0]["path"]
+
+
+# ---------------------------------------------------------------------------
+# test_blame_track_filter_glob
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_track_filter_glob(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """``--track`` filters by basename glob pattern."""
+    _init_muse_repo(tmp_path)
+
+    _write_file(tmp_path, "bass/bassline.mid", b"bass")
+    _write_file(tmp_path, "drums/kick.wav", b"kick")
+    _write_file(tmp_path, "keys/piano.mid", b"piano")
+    await _commit_async(message="init", root=tmp_path, session=muse_cli_db_session)
+
+    result = await _blame_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        path_filter=None,
+        track_filter="*.mid",
+        section_filter=None,
+        line_range=None,
+    )
+
+    # Only .mid files should appear
+    for entry in result["entries"]:
+        assert entry["path"].endswith(".mid"), f"Non-.mid file leaked: {entry['path']}"
+    # Both MIDI files should be present
+    paths = [e["path"] for e in result["entries"]]
+    assert any("bassline.mid" in p for p in paths)
+    assert any("piano.mid" in p for p in paths)
+    assert not any("kick.wav" in p for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# test_blame_section_filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_section_filter(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """``--section`` filters to files inside the named section directory."""
+    _init_muse_repo(tmp_path)
+
+    _write_file(tmp_path, "chorus/lead.mid", b"chorus-lead")
+    _write_file(tmp_path, "verse/rhythm.mid", b"verse-rhythm")
+    _write_file(tmp_path, "chorus/bass.mid", b"chorus-bass")
+    await _commit_async(message="init", root=tmp_path, session=muse_cli_db_session)
+
+    result = await _blame_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        path_filter=None,
+        track_filter=None,
+        section_filter="chorus",
+        line_range=None,
+    )
+
+    paths = [e["path"] for e in result["entries"]]
+    assert all("chorus" in p for p in paths)
+    assert not any("verse" in p for p in paths)
+    assert len(result["entries"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# test_blame_json_output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_json_output(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--json`` flag emits parseable JSON with the correct keys."""
+    _init_muse_repo(tmp_path)
+
+    _write_file(tmp_path, "drums/beat.mid", b"drums")
+    await _commit_async(message="beat commit", root=tmp_path, session=muse_cli_db_session)
+
+    result = await _blame_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        path_filter=None,
+        track_filter=None,
+        section_filter=None,
+        line_range=None,
+    )
+
+    output = json.dumps(dict(result), indent=2)
+    parsed: dict[str, object] = json.loads(output)
+
+    assert "entries" in parsed
+    assert isinstance(parsed["entries"], list)
+    assert len(parsed["entries"]) == 1
+
+    entry = parsed["entries"][0]
+    assert isinstance(entry, dict)
+    for key in ("path", "commit_id", "commit_short", "author", "committed_at", "message", "change_type"):
+        assert key in entry, f"Missing key in BlameEntry: {key}"
+
+
+# ---------------------------------------------------------------------------
+# test_blame_no_commits_exits_zero
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_no_commits_exits_zero(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``muse blame`` on a repo with no commits exits 0 with a friendly message."""
+    _init_muse_repo(tmp_path)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _blame_async(
+            root=tmp_path,
+            session=muse_cli_db_session,
+            path_filter=None,
+            track_filter=None,
+            section_filter=None,
+            line_range=None,
+        )
+
+    assert exc_info.value.exit_code == ExitCode.SUCCESS
+    out = capsys.readouterr().out
+    assert "No commits yet" in out
+
+
+# ---------------------------------------------------------------------------
+# test_blame_outside_repo_exits_2
+# ---------------------------------------------------------------------------
+
+
+def test_blame_outside_repo_exits_2(tmp_path: pathlib.Path) -> None:
+    """``muse blame`` outside a .muse/ directory exits with code 2."""
+    prev = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(cli, ["blame"], catch_exceptions=False)
+    finally:
+        os.chdir(prev)
+
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# test_blame_single_commit_all_added
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_single_commit_all_added(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """All files in a single-commit repo are attributed to that commit as 'added'."""
+    _init_muse_repo(tmp_path)
+
+    _write_file(tmp_path, "bass.mid", b"bass")
+    _write_file(tmp_path, "drums.mid", b"drums")
+    cid = await _commit_async(message="first commit", root=tmp_path, session=muse_cli_db_session)
+
+    result = await _blame_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        path_filter=None,
+        track_filter=None,
+        section_filter=None,
+        line_range=None,
+    )
+
+    assert len(result["entries"]) == 2
+    for entry in result["entries"]:
+        assert entry["commit_short"] == cid[:8]
+        assert entry["change_type"] == "added"
+
+
+# ---------------------------------------------------------------------------
+# test_blame_unmodified_file_attributes_oldest_commit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_unmodified_file_attributes_oldest_commit(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """A file that never changes across three commits is attributed to the first commit."""
+    _init_muse_repo(tmp_path)
+
+    # Commit 1: add stable.mid and volatile.mid
+    _write_file(tmp_path, "stable.mid", b"stable-content-never-changes")
+    _write_file(tmp_path, "volatile.mid", b"volatile-v1")
+    cid1 = await _commit_async(message="initial", root=tmp_path, session=muse_cli_db_session)
+
+    # Commit 2: modify only volatile
+    _write_file(tmp_path, "volatile.mid", b"volatile-v2")
+    await _commit_async(message="update volatile", root=tmp_path, session=muse_cli_db_session)
+
+    # Commit 3: modify only volatile again
+    _write_file(tmp_path, "volatile.mid", b"volatile-v3")
+    cid3 = await _commit_async(message="another volatile update", root=tmp_path, session=muse_cli_db_session)
+
+    result = await _blame_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        path_filter=None,
+        track_filter=None,
+        section_filter=None,
+        line_range=None,
+    )
+
+    entries = {e["path"].split("muse-work/")[-1]: e for e in result["entries"]}
+
+    # stable.mid was never changed — must point to cid1
+    assert "stable.mid" in entries
+    assert entries["stable.mid"]["commit_short"] == cid1[:8]
+
+    # volatile.mid was last changed in cid3
+    assert "volatile.mid" in entries
+    assert entries["volatile.mid"]["commit_short"] == cid3[:8]
+
+
+# ---------------------------------------------------------------------------
+# test_blame_render_human_readable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_render_human_readable(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Human-readable output contains the short commit ID and file path."""
+    _init_muse_repo(tmp_path)
+
+    _write_file(tmp_path, "bass/groove.mid", b"groove")
+    cid = await _commit_async(message="add groove", root=tmp_path, session=muse_cli_db_session)
+
+    result = await _blame_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        path_filter=None,
+        track_filter=None,
+        section_filter=None,
+        line_range=None,
+    )
+
+    rendered = _render_blame(result)
+    assert cid[:8] in rendered
+    assert "groove.mid" in rendered
+    assert "add groove" in rendered
+
+
+# ---------------------------------------------------------------------------
+# test_blame_line_range_recorded_in_output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_line_range_recorded_in_output(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """``--line-range`` is recorded in the result and shown in human-readable output."""
+    _init_muse_repo(tmp_path)
+
+    _write_file(tmp_path, "score.mxl", b"<musicxml/>")
+    await _commit_async(message="add score", root=tmp_path, session=muse_cli_db_session)
+
+    result = await _blame_async(
+        root=tmp_path,
+        session=muse_cli_db_session,
+        path_filter=None,
+        track_filter=None,
+        section_filter=None,
+        line_range="10,20",
+    )
+
+    assert result["line_range"] == "10,20"
+    rendered = _render_blame(result)
+    assert "line-range" in rendered
+    assert "10,20" in rendered


### PR DESCRIPTION
## Summary

Closes #72 — implements `muse blame [PATH] [--track GLOB] [--section DIR] [--line-range N,M] [--json]` end-to-end.

## Root Cause / Motivation

No blame command existed. Producers using Muse VCS had no way to answer "whose idea was this bass line?" or "which take introduced this change?" — a fundamental attribution question for any version-controlled creative workflow.

## Solution

Walks the commit graph from HEAD following `parent_commit_id` links. For each adjacent pair of commits, compares their snapshot manifests (path → object_id maps). The first pair where a file's object_id differs (or the file is introduced) identifies the most recent commit to have touched that file. Files never changed after their initial commit are attributed to the oldest commit in the chain.

### Files changed

| File | Change |
|------|--------|
| `maestro/muse_cli/commands/blame.py` | New command: `BlameEntry`, `BlameResult`, `_load_commit_chain()`, `_load_snapshot_manifest()`, `_matches_filters()`, `_blame_async()`, `_render_blame()`, `blame()` Typer callback |
| `maestro/muse_cli/app.py` | Import + register `blame` sub-app |
| `tests/muse_cli/test_blame.py` | 11 tests covering all acceptance criteria |
| `docs/architecture/muse_vcs.md` | `muse blame` command section with flags table, output example, result type, agent use case |
| `docs/reference/type_contracts.md` | `BlameEntry` and `BlameResult` TypedDict entries |

## Verification

- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (554 source files)
- [x] `docker compose exec storpheus mypy .` — not affected (no storpheus changes)
- [x] All 11 tests pass (`tests/muse_cli/test_blame.py`)
- [x] Docs updated in the same commit as code

## Tests Added

- `test_blame_returns_last_commit_per_path` — **regression**: verifies the graph walk correctly attributes each file to its most recent touching commit, not HEAD for all files
- `test_blame_path_filter_restricts_output` — positional path filter
- `test_blame_track_filter_glob` — `--track *.mid` fnmatch filtering
- `test_blame_section_filter` — `--section chorus` directory filtering
- `test_blame_json_output` — JSON output structure and key presence
- `test_blame_no_commits_exits_zero` — empty repo guard
- `test_blame_outside_repo_exits_2` — exit code 2 outside `.muse/`
- `test_blame_single_commit_all_added` — all files attributed as "added" in single-commit repo
- `test_blame_unmodified_file_attributes_oldest_commit` — stable file across 3 commits points to commit 1
- `test_blame_render_human_readable` — short ID, path, and message appear in text output
- `test_blame_line_range_recorded_in_output` — `--line-range` is annotated in result and rendered

## Handoff

N/A — no SSE/MCP protocol change. Pure CLI addition in the `maestro` container.