### PR TITLE
feat: muse restore — restore specific files from a commit or index

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -4783,6 +4783,61 @@ No DB interaction at checkout time — the DAG remains intact.
 
 ---
 
+### `muse restore`
+
+**Purpose:** Restore specific files from a commit or index into `muse-work/` without
+touching the branch pointer.  Surgical alternative to `muse reset --hard` — bring
+back "the bass from take 3" while keeping everything else at HEAD.
+
+**Usage:**
+```bash
+muse restore <paths>...                          # restore from HEAD (default)
+muse restore --staged <paths>...                 # restore index entry from HEAD
+muse restore --source <commit> <paths>...        # restore from a specific commit
+muse restore --worktree --source <commit> <paths>...  # explicit worktree restore
+```
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `<paths>...` | positional | — | One or more relative paths within `muse-work/` to restore. Accepts paths with or without the `muse-work/` prefix. |
+| `--staged` | flag | off | Restore the index (snapshot manifest) entry from the source commit. In the current Muse model (no separate staging area) this is equivalent to `--worktree`. |
+| `--worktree` | flag | off | Restore `muse-work/` files from the source snapshot. Default when no mode flag is specified. |
+| `--source / -s` | str | HEAD | Commit reference to restore from: `HEAD`, `HEAD~N`, full SHA, or any unambiguous SHA prefix. |
+
+**Output example:**
+```
+✅ Restored 'bass/bassline.mid' from commit ab12cd34
+```
+
+Multiple files:
+```
+✅ Restored 2 files from commit ab12cd34:
+   • bass/bassline.mid
+   • drums/kick.mid
+```
+
+**Result type:** `RestoreResult` — fields: `source_commit_id` (str), `paths_restored` (list[str]), `staged` (bool).
+
+**Error cases:**
+- `PathNotInSnapshotError` — the requested path does not exist in the source commit's snapshot. Exit code 1.
+- `MissingObjectError` — the required blob is absent from `.muse/objects/`. Exit code 3.
+- Unknown `--source` ref — exits with code 1 and a clear error message.
+
+**Agent use case:** An AI composition agent can selectively restore individual
+instrument tracks from historical commits.  For example, after generating several
+takes, the agent can restore the best bass line from take 3 while keeping drums
+and keys from take 7 — without modifying the branch history.  Use `muse log` to
+identify commit SHAs, then `muse show <commit>` to inspect the snapshot manifest
+before running `muse restore`.
+
+**Implementation:** `maestro/muse_cli/commands/restore.py` (CLI) and
+`maestro/services/muse_restore.py` (service).  Uses the same object store helpers
+as `muse reset --hard`.  Branch pointer is never modified.
+
+---
+
 ### `muse resolve`
 
 **Purpose:** Mark a conflicted file as resolved during a paused `muse merge`.

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5294,6 +5294,40 @@ For root commits (no parent) all snapshot paths appear in `added`.
 
 ---
 
+### `RestoreResult`
+
+**Module:** `maestro/services/muse_restore.py`
+
+Outcome of a completed `muse restore` operation.  Frozen dataclass — immutable
+after construction.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `source_commit_id` | `str` | Full 64-char SHA of the commit files were extracted from |
+| `paths_restored` | `list[str]` | Relative paths (within `muse-work/`) that were written to disk |
+| `staged` | `bool` | Whether `--staged` mode was active |
+
+**Producer:** `perform_restore()`
+**Consumer:** `restore()` Typer callback (CLI display)
+
+---
+
+### `PathNotInSnapshotError`
+
+**Module:** `maestro/services/muse_restore.py`
+
+Raised when a requested path is absent from the source commit's snapshot.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `rel_path` | `str` | The path that was not found in the snapshot |
+| `source_commit_id` | `str` | The commit that was searched |
+
+**Producer:** `perform_restore()`
+**Consumer:** `restore()` Typer callback (exit code 1)
+
+---
+
 ### `ResetResult`
 
 **Module:** `maestro/services/muse_reset.py`

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -5,7 +5,7 @@ subcommands (amend, arrange, ask, cat-object, checkout, chord-map, commit,
 commit-tree, context, contour, describe, diff, divergence, dynamics, emotion-diff,
 export, find, form, grep, groove-check, harmony, humanize, import, init, inspect,
 key, log, merge, meter, motif, open, play, pull, push, read-tree, recall, remote,
-render-preview, reset, resolve, rev-parse, revert, session, show, similarity,
+render-preview, reset, resolve, restore, rev-parse, revert, session, show, similarity,
 status, swing, symbolic-ref, tag, tempo, tempo-scale, timeline, update-ref,
 validate, write-tree) as Typer sub-applications.
 """
@@ -54,6 +54,7 @@ from maestro.muse_cli.commands import (
     render_preview,
     reset,
     resolve,
+    restore,
     rev_parse,
     revert,
     session,
@@ -128,6 +129,7 @@ cli.add_typer(show.app, name="show", help="Inspect a commit: metadata, snapshot,
 cli.add_typer(render_preview.app, name="render-preview", help="Generate an audio preview of a commit's snapshot.")
 cli.add_typer(reset.app, name="reset", help="Reset the branch pointer to a prior commit.")
 cli.add_typer(resolve.app, name="resolve", help="Mark a conflicted file as resolved (--ours or --theirs).")
+cli.add_typer(restore.app, name="restore", help="Restore specific files from a commit or index into muse-work/.")
 cli.add_typer(groove_check.app, name="groove-check", help="Analyze rhythmic drift across commits to find groove regressions.")
 cli.add_typer(form.app, name="form", help="Analyze or annotate the formal structure (sections) of a commit.")
 cli.add_typer(similarity.app, name="similarity", help="Compare two commits by musical similarity score.")

--- a/maestro/muse_cli/commands/restore.py
+++ b/maestro/muse_cli/commands/restore.py
@@ -1,0 +1,132 @@
+"""muse restore — restore specific files from a commit or index.
+
+Surgical file-level restore: bring back "the bass from take 3" without
+touching any other track.  Unlike ``muse reset --hard`` (which resets the
+entire working tree), ``restore`` targets individual paths only.
+
+Usage patterns
+--------------
+Restore from HEAD (default)::
+
+    muse restore muse-work/bass/bassline.mid
+
+Restore the index entry from HEAD (``--staged``)::
+
+    muse restore --staged muse-work/bass/bassline.mid
+
+Restore from a specific commit::
+
+    muse restore --source <commit> muse-work/drums/kick.mid
+
+Restore both worktree and staged (explicit ``--worktree``)::
+
+    muse restore --worktree --source <commit> muse-work/drums/kick.mid muse-work/bass/bassline.mid
+
+Exit codes
+----------
+0  success
+1  user error (path not in snapshot, ref not found, no commits)
+2  not a Muse repo
+3  internal error (DB inconsistency, missing object blobs)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+import typer
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.services.muse_reset import MissingObjectError
+from maestro.services.muse_restore import PathNotInSnapshotError, perform_restore
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+
+@app.callback(invoke_without_command=True)
+def restore(
+    ctx: typer.Context,
+    paths: list[str] = typer.Argument(
+        ...,
+        help=(
+            "One or more relative paths within muse-work/ to restore. "
+            "Accepts paths with or without the 'muse-work/' prefix."
+        ),
+    ),
+    staged: bool = typer.Option(
+        False,
+        "--staged",
+        help=(
+            "Restore the index (snapshot manifest) entry for the path from "
+            "the source commit rather than muse-work/. In the current Muse "
+            "model (no separate staging area) this is equivalent to --worktree."
+        ),
+    ),
+    worktree: bool = typer.Option(
+        False,
+        "--worktree",
+        help=(
+            "Restore muse-work/ files from the source snapshot. "
+            "This is the default behaviour when no mode flag is specified."
+        ),
+    ),
+    source: Optional[str] = typer.Option(
+        None,
+        "--source",
+        "-s",
+        help=(
+            "Commit reference to restore from: HEAD, HEAD~N, a full SHA, or "
+            "any unambiguous SHA prefix. Defaults to HEAD when omitted."
+        ),
+    ),
+) -> None:
+    """Restore specific files from a commit or index into muse-work/."""
+    if not paths:
+        typer.echo("❌ At least one path is required.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    root = require_repo()
+
+    async def _run() -> None:
+        async with open_session() as session:
+            result = await perform_restore(
+                root=root,
+                session=session,
+                paths=paths,
+                source_ref=source,
+                staged=staged,
+            )
+
+        short_id = result.source_commit_id[:8]
+        if len(result.paths_restored) == 1:
+            typer.echo(
+                f"✅ Restored {result.paths_restored[0]!r} from commit {short_id}"
+            )
+        else:
+            typer.echo(
+                f"✅ Restored {len(result.paths_restored)} files from commit {short_id}:"
+            )
+            for p in result.paths_restored:
+                typer.echo(f"   • {p}")
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except PathNotInSnapshotError as exc:
+        typer.echo(f"❌ {exc}")
+        logger.error("❌ muse restore: %s", exc)
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+    except MissingObjectError as exc:
+        typer.echo(f"❌ {exc}")
+        logger.error("❌ muse restore: missing object: %s", exc)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+    except Exception as exc:
+        typer.echo(f"❌ muse restore failed: {exc}")
+        logger.error("❌ muse restore error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/services/muse_restore.py
+++ b/maestro/services/muse_restore.py
@@ -1,0 +1,225 @@
+"""Muse Restore Service — restore specific files from a commit or index.
+
+``muse restore`` is surgical: restore one instrument track from a specific
+commit while keeping everything else at HEAD.  Critical for music production
+where you want "the bass from take 3, everything else from take 7."
+
+Restore modes
+-------------
+**worktree** (default, ``--worktree``)
+    Copy the file content recorded in the *source* snapshot directly into
+    ``muse-work/``.  Branch pointer and index are not changed.  This is the
+    primary use case: "put the bass from take 3 back into my working tree."
+
+**staged** (``--staged``)
+    In a full VCS with an explicit staging area this would reset the index
+    entry for the path from the source snapshot without touching ``muse-work/``.
+    In the current Muse model (no separate staging area) ``--staged`` is
+    documented for forward-compatibility and behaves identically to
+    ``--worktree``: it restores the file in ``muse-work/`` from the source
+    snapshot.  When a staging index is added this module will be updated.
+
+**source** (``--source <commit>``)
+    Selects which snapshot to extract the file from.  Defaults to ``HEAD``
+    when omitted.
+
+Object store contract
+---------------------
+Restore reads objects from ``.muse/objects/`` exactly like ``muse reset
+--hard``.  If an object is missing, :class:`MissingObjectError` is raised
+and ``muse-work/`` is left unchanged (the restore is atomic per path).
+
+This module is a pure service layer — no Typer, no CLI, no StateStore.
+Import boundary: may import muse_cli.{db,models}, muse_reset (for object
+helpers), but NOT executor, maestro_handlers, mcp, or StateStore.
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+import shutil
+from dataclasses import dataclass, field
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.db import get_commit_snapshot_manifest
+from maestro.services.muse_reset import (
+    MissingObjectError,
+    object_store_path,
+    resolve_ref,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RestoreResult:
+    """Outcome of a completed ``muse restore`` operation.
+
+    Attributes:
+        source_commit_id: Full SHA of the commit the files were extracted from.
+        paths_restored:   Relative paths (within ``muse-work/``) that were
+                          written to disk.
+        staged:           Whether ``--staged`` mode was active.
+    """
+
+    source_commit_id: str
+    paths_restored: list[str] = field(default_factory=list)
+    staged: bool = False
+
+
+class PathNotInSnapshotError(Exception):
+    """Raised when a requested path is absent from the source snapshot.
+
+    Attributes:
+        rel_path:         The path that was not found.
+        source_commit_id: The commit that was searched.
+    """
+
+    def __init__(self, rel_path: str, source_commit_id: str) -> None:
+        super().__init__(
+            f"Path {rel_path!r} not found in snapshot of commit "
+            f"{source_commit_id[:8]}. "
+            "Use 'muse log' to list commits and 'muse show <commit>' to inspect "
+            "the snapshot manifest."
+        )
+        self.rel_path = rel_path
+        self.source_commit_id = source_commit_id
+
+
+# ---------------------------------------------------------------------------
+# Core restore logic
+# ---------------------------------------------------------------------------
+
+
+async def perform_restore(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+    paths: list[str],
+    source_ref: str | None,
+    staged: bool,
+) -> RestoreResult:
+    """Restore specific files from a source commit into ``muse-work/``.
+
+    Resolves the source commit reference, validates that every requested path
+    exists in the snapshot manifest, verifies all required objects are present
+    in the object store (fail-fast before touching ``muse-work/``), then copies
+    each file atomically.
+
+    The branch pointer is never modified — only ``muse-work/`` files are written.
+
+    Args:
+        root:       Muse repository root (directory containing ``.muse/``).
+        session:    Open async DB session.
+        paths:      Relative paths within ``muse-work/`` to restore.  Must be
+                    non-empty.  Paths may be given as ``muse-work/bass/bassline.mid``
+                    or bare ``bass/bassline.mid`` — the ``muse-work/`` prefix is
+                    stripped if present.
+        source_ref: Commit reference to restore from (``HEAD``, ``HEAD~N``, SHA,
+                    or ``None`` for HEAD).
+        staged:     When ``True``, ``--staged`` mode is active.  In the current
+                    Muse model (no separate staging area) this is semantically
+                    equivalent to ``--worktree``.
+
+    Returns:
+        :class:`RestoreResult` describing the completed operation.
+
+    Raises:
+        typer.Exit:              On user-facing errors (ref not found, no commits).
+        PathNotInSnapshotError:  When any requested path is absent from the source.
+        MissingObjectError:      When a required blob is absent from the object store.
+    """
+    import json
+
+    import typer
+
+    from maestro.muse_cli.errors import ExitCode
+
+    muse_dir = root / ".muse"
+
+    # ── Repo identity ────────────────────────────────────────────────────
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]
+
+    # ── Current branch ───────────────────────────────────────────────────
+    head_ref = (muse_dir / "HEAD").read_text().strip()  # "refs/heads/main"
+    branch = head_ref.rsplit("/", 1)[-1]  # "main"
+    ref_path = muse_dir / pathlib.Path(head_ref)
+
+    if not ref_path.exists() or not ref_path.read_text().strip():
+        typer.echo("❌ Current branch has no commits. Nothing to restore.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # ── Resolve source commit ─────────────────────────────────────────────
+    effective_ref = source_ref if source_ref is not None else "HEAD"
+    source_commit = await resolve_ref(session, repo_id, branch, effective_ref)
+    if source_commit is None:
+        typer.echo(f"❌ Could not resolve source ref: {effective_ref!r}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    source_commit_id = source_commit.commit_id
+
+    # ── Load snapshot manifest ────────────────────────────────────────────
+    manifest = await get_commit_snapshot_manifest(session, source_commit_id)
+    if manifest is None:
+        typer.echo(
+            f"❌ Could not load snapshot for commit {source_commit_id[:8]}. "
+            "Database may be corrupt."
+        )
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    # ── Normalise paths — strip leading "muse-work/" prefix if present ────
+    normalised: list[str] = []
+    for p in paths:
+        stripped = p.removeprefix("muse-work/")
+        normalised.append(stripped)
+
+    # ── Validate: every path must be in the manifest ─────────────────────
+    for rel_path in normalised:
+        if rel_path not in manifest:
+            raise PathNotInSnapshotError(rel_path, source_commit_id)
+
+    # ── Validate: every object must exist (fail-fast before touching disk) ─
+    for rel_path in normalised:
+        object_id = manifest[rel_path]
+        obj_path = object_store_path(root, object_id)
+        if not obj_path.exists():
+            raise MissingObjectError(object_id, rel_path)
+
+    # ── Restore files into muse-work/ ─────────────────────────────────────
+    workdir = root / "muse-work"
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    restored: list[str] = []
+    for rel_path in normalised:
+        object_id = manifest[rel_path]
+        obj_path = object_store_path(root, object_id)
+        dest = workdir / rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(obj_path, dest)
+        restored.append(rel_path)
+        logger.debug(
+            "✅ Restored %s from object %s (commit %s)",
+            rel_path,
+            object_id[:8],
+            source_commit_id[:8],
+        )
+
+    mode_label = "--staged" if staged else "--worktree"
+    logger.info(
+        "✅ muse restore %s: %d file(s) from commit %s",
+        mode_label,
+        len(restored),
+        source_commit_id[:8],
+    )
+
+    return RestoreResult(
+        source_commit_id=source_commit_id,
+        paths_restored=restored,
+        staged=staged,
+    )

--- a/tests/test_muse_restore.py
+++ b/tests/test_muse_restore.py
@@ -1,0 +1,637 @@
+"""Tests for ``muse restore`` — surgical file-level restore from a snapshot.
+
+Verifies:
+- test_muse_restore_from_head                   — default restore from HEAD
+- test_muse_restore_staged_equivalent           — --staged behaves like --worktree (current model)
+- test_muse_restore_source_commit               — --source <commit> extracts from historical snapshot
+- test_muse_restore_multiple_paths              — multiple paths restored in one call
+- test_muse_restore_muse_work_prefix_stripped   — "muse-work/" prefix is normalised away
+- test_muse_restore_errors_on_missing_path      — PathNotInSnapshotError when path absent
+- test_muse_restore_source_missing_path         — PathNotInSnapshotError on historical commit
+- test_muse_restore_missing_object_store        — MissingObjectError when blob absent
+- test_muse_restore_ref_not_found               — unknown source ref exits USER_ERROR
+- test_muse_restore_no_commits                  — branch with no commits exits USER_ERROR
+- test_muse_restore_result_fields               — RestoreResult fields are correct
+- test_muse_restore_result_frozen               — RestoreResult is immutable
+- test_boundary_no_forbidden_imports            — AST boundary seal
+- test_restore_service_has_future_import        — from __future__ import annotations present
+- test_restore_command_has_future_import        — CLI command has future import
+"""
+from __future__ import annotations
+
+import ast
+import datetime
+import json
+import pathlib
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from maestro.db.database import Base
+from maestro.muse_cli import models as cli_models  # noqa: F401 — register tables
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliObject, MuseCliSnapshot
+from maestro.services.muse_reset import MissingObjectError, object_store_path
+from maestro.services.muse_restore import (
+    PathNotInSnapshotError,
+    RestoreResult,
+    perform_restore,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def async_session() -> AsyncGenerator[AsyncSession, None]:
+    """In-memory SQLite session with all CLI tables created."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with Session() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture
+def repo_id() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def repo_root(tmp_path: pathlib.Path, repo_id: str) -> pathlib.Path:
+    """Minimal Muse repository structure with repo.json."""
+    muse_dir = tmp_path / ".muse"
+    muse_dir.mkdir()
+    (muse_dir / "HEAD").write_text("refs/heads/main")
+    (muse_dir / "refs" / "heads").mkdir(parents=True)
+    (muse_dir / "refs" / "heads" / "main").write_text("")
+    (muse_dir / "repo.json").write_text(json.dumps({"repo_id": repo_id}))
+    return tmp_path
+
+
+def _sha(prefix: str, length: int = 64) -> str:
+    """Build a deterministic fake SHA of exactly *length* hex chars."""
+    return (prefix * (length // len(prefix) + 1))[:length]
+
+
+async def _add_commit(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    branch: str = "main",
+    message: str = "commit",
+    manifest: dict[str, str] | None = None,
+    parent_commit_id: str | None = None,
+    committed_at: datetime.datetime | None = None,
+) -> MuseCliCommit:
+    """Insert a commit + its snapshot into the in-memory DB and return the commit."""
+    snapshot_id = _sha(str(uuid.uuid4()).replace("-", ""))
+    commit_id = _sha(str(uuid.uuid4()).replace("-", ""))
+    file_manifest: dict[str, str] = manifest or {"track.mid": _sha("ab")}
+
+    for object_id in file_manifest.values():
+        existing = await session.get(MuseCliObject, object_id)
+        if existing is None:
+            session.add(MuseCliObject(object_id=object_id, size_bytes=10))
+
+    session.add(MuseCliSnapshot(snapshot_id=snapshot_id, manifest=file_manifest))
+    await session.flush()
+
+    ts = committed_at or datetime.datetime.now(datetime.timezone.utc)
+    commit = MuseCliCommit(
+        commit_id=commit_id,
+        repo_id=repo_id,
+        branch=branch,
+        parent_commit_id=parent_commit_id,
+        snapshot_id=snapshot_id,
+        message=message,
+        author="",
+        committed_at=ts,
+    )
+    session.add(commit)
+    await session.flush()
+    return commit
+
+
+def _write_ref(root: pathlib.Path, branch: str, commit_id: str) -> None:
+    """Update .muse/refs/heads/<branch> with *commit_id*."""
+    ref_path = root / ".muse" / "refs" / "heads" / branch
+    ref_path.parent.mkdir(parents=True, exist_ok=True)
+    ref_path.write_text(commit_id)
+
+
+def _seed_object_store(root: pathlib.Path, object_id: str, content: bytes) -> None:
+    """Manually write a blob into the .muse/objects/ store."""
+    dest = object_store_path(root, object_id)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(content)
+
+
+# ---------------------------------------------------------------------------
+# Core restore tests
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreFromHead:
+
+    @pytest.mark.anyio
+    async def test_muse_restore_from_head(
+        self,
+        async_session: AsyncSession,
+        repo_id: str,
+        repo_root: pathlib.Path,
+    ) -> None:
+        """Default restore (no source) extracts the file from HEAD snapshot."""
+        object_id = "aa" * 32
+        content = b"MIDI bass take 7"
+        _seed_object_store(repo_root, object_id, content)
+
+        commit = await _add_commit(
+            async_session,
+            repo_id=repo_id,
+            message="take 7",
+            manifest={"bass/bassline.mid": object_id},
+        )
+        _write_ref(repo_root, "main", commit.commit_id)
+
+        # muse-work/ currently has stale content
+        workdir = repo_root / "muse-work" / "bass"
+        workdir.mkdir(parents=True)
+        (workdir / "bassline.mid").write_bytes(b"stale content")
+
+        result = await perform_restore(
+            root=repo_root,
+            session=async_session,
+            paths=["bass/bassline.mid"],
+            source_ref=None,
+            staged=False,
+        )
+
+        assert result.source_commit_id == commit.commit_id
+        assert result.paths_restored == ["bass/bassline.mid"]
+        assert result.staged is False
+        assert (repo_root / "muse-work" / "bass" / "bassline.mid").read_bytes() == content
+
+    @pytest.mark.anyio
+    async def test_muse_restore_staged_equivalent(
+        self,
+        async_session: AsyncSession,
+        repo_id: str,
+        repo_root: pathlib.Path,
+    ) -> None:
+        """--staged behaves identically to --worktree in the current Muse model."""
+        object_id = "bb" * 32
+        content = b"drums take 3"
+        _seed_object_store(repo_root, object_id, content)
+
+        commit = await _add_commit(
+            async_session,
+            repo_id=repo_id,
+            message="take 3",
+            manifest={"drums/kick.mid": object_id},
+        )
+        _write_ref(repo_root, "main", commit.commit_id)
+
+        workdir = repo_root / "muse-work" / "drums"
+        workdir.mkdir(parents=True)
+        (workdir / "kick.mid").write_bytes(b"wrong version")
+
+        result = await perform_restore(
+            root=repo_root,
+            session=async_session,
+            paths=["drums/kick.mid"],
+            source_ref=None,
+            staged=True,
+        )
+
+        assert result.staged is True
+        assert result.paths_restored == ["drums/kick.mid"]
+        assert (repo_root / "muse-work" / "drums" / "kick.mid").read_bytes() == content
+
+
+class TestRestoreSourceCommit:
+
+    @pytest.mark.anyio
+    async def test_muse_restore_source_commit(
+        self,
+        async_session: AsyncSession,
+        repo_id: str,
+        repo_root: pathlib.Path,
+    ) -> None:
+        """--source <commit> restores a file from a historical snapshot."""
+        obj_take3 = "cc" * 32
+        content_take3 = b"bass take 3"
+        _seed_object_store(repo_root, obj_take3, content_take3)
+
+        obj_take7 = "dd" * 32
+        content_take7 = b"bass take 7"
+        _seed_object_store(repo_root, obj_take7, content_take7)
+
+        t0 = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+        take3 = await _add_commit(
+            async_session,
+            repo_id=repo_id,
+            message="take 3",
+            manifest={"bass/bassline.mid": obj_take3},
+            committed_at=t0,
+        )
+
+        t1 = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
+        take7 = await _add_commit(
+            async_session,
+            repo_id=repo_id,
+            message="take 7",
+            manifest={"bass/bassline.mid": obj_take7},
+            parent_commit_id=take3.commit_id,
+            committed_at=t1,
+        )
+        _write_ref(repo_root, "main", take7.commit_id)
+
+        # muse-work/ currently has take7 content
+        workdir = repo_root / "muse-work" / "bass"
+        workdir.mkdir(parents=True)
+        (workdir / "bassline.mid").write_bytes(content_take7)
+
+        # Restore take3's bass file while HEAD is at take7
+        result = await perform_restore(
+            root=repo_root,
+            session=async_session,
+            paths=["bass/bassline.mid"],
+            source_ref=take3.commit_id,
+            staged=False,
+        )
+
+        assert result.source_commit_id == take3.commit_id
+        assert result.paths_restored == ["bass/bassline.mid"]
+        # The bass file is now take3's content
+        assert (repo_root / "muse-work" / "bass" / "bassline.mid").read_bytes() == content_take3
+
+    @pytest.mark.anyio
+    async def test_muse_restore_source_abbreviated_sha(
+        self,
+        async_session: AsyncSession,
+        repo_id: str,
+        repo_root: pathlib.Path,
+    ) -> None:
+        """An abbreviated SHA is accepted as a --source ref."""
+        object_id = "ee" * 32
+        content = b"abbreviated"
+        _seed_object_store(repo_root, object_id, content)
+
+        commit = await _add_commit(
+            async_session,
+            repo_id=repo_id,
+            message="v1",
+            manifest={"track.mid": object_id},
+        )
+        _write_ref(repo_root, "main", commit.commit_id)
+
+        workdir = repo_root / "muse-work"
+        workdir.mkdir()
+        (workdir / "track.mid").write_bytes(b"old")
+
+        result = await perform_restore(
+            root=repo_root,
+            session=async_session,
+            paths=["track.mid"],
+            source_ref=commit.commit_id[:10],
+            staged=False,
+        )
+
+        assert result.source_commit_id == commit.commit_id
+        assert (repo_root / "muse-work" / "track.mid").read_bytes() == content
+
+
+class TestRestoreMultiplePaths:
+
+    @pytest.mark.anyio
+    async def test_muse_restore_multiple_paths(
+        self,
+        async_session: AsyncSession,
+        repo_id: str,
+        repo_root: pathlib.Path,
+    ) -> None:
+        """Multiple paths are restored atomically in one call."""
+        obj_bass = "11" * 32
+        obj_drums = "22" * 32
+        _seed_object_store(repo_root, obj_bass, b"bass v1")
+        _seed_object_store(repo_root, obj_drums, b"drums v1")
+
+        commit = await _add_commit(
+            async_session,
+            repo_id=repo_id,
+            message="v1",
+            manifest={"bass.mid": obj_bass, "drums.mid": obj_drums},
+        )
+        _write_ref(repo_root, "main", commit.commit_id)
+
+        workdir = repo_root / "muse-work"
+        workdir.mkdir()
+        (workdir / "bass.mid").write_bytes(b"stale")
+        (workdir / "drums.mid").write_bytes(b"stale")
+
+        result = await perform_restore(
+            root=repo_root,
+            session=async_session,
+            paths=["bass.mid", "drums.mid"],
+            source_ref=None,
+            staged=False,
+        )
+
+        assert sorted(result.paths_restored) == ["bass.mid", "drums.mid"]
+        assert (workdir / "bass.mid").read_bytes() == b"bass v1"
+        assert (workdir / "drums.mid").read_bytes() == b"drums v1"
+
+    @pytest.mark.anyio
+    async def test_muse_restore_muse_work_prefix_stripped(
+        self,
+        async_session: AsyncSession,
+        repo_id: str,
+        repo_root: pathlib.Path,
+    ) -> None:
+        """Paths given with 'muse-work/' prefix are normalised correctly."""
+        object_id = "33" * 32
+        content = b"prefix test"
+        _seed_object_store(repo_root, object_id, content)
+
+        commit = await _add_commit(
+            async_session,
+            repo_id=repo_id,
+            manifest={"lead.mid": object_id},
+        )
+        _write_ref(repo_root, "main", commit.commit_id)
+
+        workdir = repo_root / "muse-work"
+        workdir.mkdir()
+        (workdir / "lead.mid").write_bytes(b"old")
+
+        result = await perform_restore(
+            root=repo_root,
+            session=async_session,
+            paths=["muse-work/lead.mid"],  # with prefix
+            source_ref=None,
+            staged=False,
+        )
+
+        assert result.paths_restored == ["lead.mid"]
+        assert (workdir / "lead.mid").read_bytes() == content
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreErrors:
+
+    @pytest.mark.anyio
+    async def test_muse_restore_errors_on_missing_path(
+        self,
+        async_session: AsyncSession,
+        repo_id: str,
+        repo_root: pathlib.Path,
+    ) -> None:
+        """PathNotInSnapshotError raised when path absent from HEAD snapshot."""
+        object_id = "44" * 32
+        _seed_object_store(repo_root, object_id, b"only track")
+
+        commit = await _add_commit(
+            async_session,
+            repo_id=repo_id,
+            manifest={"track.mid": object_id},
+        )
+        _write_ref(repo_root, "main", commit.commit_id)
+
+        with pytest.raises(PathNotInSnapshotError) as exc_info:
+            await perform_restore(
+                root=repo_root,
+                session=async_session,
+                paths=["nonexistent.mid"],
+                source_ref=None,
+                staged=False,
+            )
+
+        assert "nonexistent.mid" in str(exc_info.value)
+        assert exc_info.value.rel_path == "nonexistent.mid"
+        assert exc_info.value.source_commit_id == commit.commit_id
+
+    @pytest.mark.anyio
+    async def test_muse_restore_source_missing_path(
+        self,
+        async_session: AsyncSession,
+        repo_id: str,
+        repo_root: pathlib.Path,
+    ) -> None:
+        """PathNotInSnapshotError when path absent from historical commit."""
+        obj_old = "55" * 32
+        _seed_object_store(repo_root, obj_old, b"old track")
+
+        t0 = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+        old_commit = await _add_commit(
+            async_session,
+            repo_id=repo_id,
+            message="old",
+            manifest={"old_track.mid": obj_old},
+            committed_at=t0,
+        )
+
+        obj_new = "66" * 32
+        _seed_object_store(repo_root, obj_new, b"new track")
+        t1 = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
+        new_commit = await _add_commit(
+            async_session,
+            repo_id=repo_id,
+            message="new",
+            manifest={"new_track.mid": obj_new},
+            parent_commit_id=old_commit.commit_id,
+            committed_at=t1,
+        )
+        _write_ref(repo_root, "main", new_commit.commit_id)
+
+        with pytest.raises(PathNotInSnapshotError) as exc_info:
+            await perform_restore(
+                root=repo_root,
+                session=async_session,
+                paths=["new_track.mid"],  # not in old_commit's snapshot
+                source_ref=old_commit.commit_id,
+                staged=False,
+            )
+
+        assert "new_track.mid" in str(exc_info.value)
+
+    @pytest.mark.anyio
+    async def test_muse_restore_missing_object_store(
+        self,
+        async_session: AsyncSession,
+        repo_id: str,
+        repo_root: pathlib.Path,
+    ) -> None:
+        """MissingObjectError raised when blob absent from object store."""
+        missing_id = "77" * 32
+        # Intentionally NOT seeding the object store
+
+        commit = await _add_commit(
+            async_session,
+            repo_id=repo_id,
+            manifest={"lead.mid": missing_id},
+        )
+        _write_ref(repo_root, "main", commit.commit_id)
+
+        with pytest.raises(MissingObjectError) as exc_info:
+            await perform_restore(
+                root=repo_root,
+                session=async_session,
+                paths=["lead.mid"],
+                source_ref=None,
+                staged=False,
+            )
+
+        assert missing_id[:8] in str(exc_info.value)
+
+    @pytest.mark.anyio
+    async def test_muse_restore_ref_not_found(
+        self,
+        async_session: AsyncSession,
+        repo_id: str,
+        repo_root: pathlib.Path,
+    ) -> None:
+        """An unknown source ref exits with USER_ERROR via typer.Exit."""
+        import typer
+
+        object_id = "88" * 32
+        _seed_object_store(repo_root, object_id, b"content")
+        commit = await _add_commit(
+            async_session,
+            repo_id=repo_id,
+            manifest={"track.mid": object_id},
+        )
+        _write_ref(repo_root, "main", commit.commit_id)
+
+        with pytest.raises(typer.Exit) as exc_info:
+            await perform_restore(
+                root=repo_root,
+                session=async_session,
+                paths=["track.mid"],
+                source_ref="deadbeef1234",
+                staged=False,
+            )
+
+        assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+    @pytest.mark.anyio
+    async def test_muse_restore_no_commits(
+        self,
+        async_session: AsyncSession,
+        repo_id: str,
+        repo_root: pathlib.Path,
+    ) -> None:
+        """Branch with no commits exits with USER_ERROR."""
+        import typer
+
+        # repo_root fixture has empty main ref
+        with pytest.raises(typer.Exit) as exc_info:
+            await perform_restore(
+                root=repo_root,
+                session=async_session,
+                paths=["track.mid"],
+                source_ref=None,
+                staged=False,
+            )
+
+        assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# RestoreResult type
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreResult:
+
+    def test_muse_restore_result_fields(self) -> None:
+        """RestoreResult carries commit ID, paths, and staged flag."""
+        r = RestoreResult(
+            source_commit_id="a" * 64,
+            paths_restored=["bass.mid", "drums.mid"],
+            staged=True,
+        )
+        assert r.source_commit_id == "a" * 64
+        assert r.paths_restored == ["bass.mid", "drums.mid"]
+        assert r.staged is True
+
+    def test_muse_restore_result_frozen(self) -> None:
+        """RestoreResult is immutable (frozen dataclass)."""
+        r = RestoreResult(source_commit_id="b" * 64)
+        with pytest.raises(Exception):
+            r.staged = True  # type: ignore[misc]
+
+    def test_muse_restore_result_defaults(self) -> None:
+        """RestoreResult has sensible defaults for optional fields."""
+        r = RestoreResult(source_commit_id="c" * 64)
+        assert r.paths_restored == []
+        assert r.staged is False
+
+
+# ---------------------------------------------------------------------------
+# PathNotInSnapshotError type
+# ---------------------------------------------------------------------------
+
+
+class TestPathNotInSnapshotError:
+
+    def test_error_message_contains_path_and_commit(self) -> None:
+        """Error message references the missing path and abbreviated commit ID."""
+        exc = PathNotInSnapshotError("bass/bassline.mid", "abcd1234" * 8)
+        msg = str(exc)
+        assert "bass/bassline.mid" in msg
+        assert "abcd1234" in msg
+
+
+# ---------------------------------------------------------------------------
+# Boundary seal — AST checks
+# ---------------------------------------------------------------------------
+
+
+class TestBoundarySeals:
+
+    def _parse(self, rel_path: str) -> ast.Module:
+        root = pathlib.Path(__file__).resolve().parent.parent
+        return ast.parse((root / rel_path).read_text())
+
+    def test_boundary_no_forbidden_imports(self) -> None:
+        """muse_restore service must not import executor, state_store, mcp, or maestro_handlers."""
+        tree = self._parse("maestro/services/muse_restore.py")
+        forbidden = {"state_store", "executor", "maestro_handlers", "mcp"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                for fb in forbidden:
+                    assert fb not in node.module, (
+                        f"muse_restore imports forbidden module: {node.module}"
+                    )
+
+    def test_restore_service_has_future_import(self) -> None:
+        """muse_restore.py starts with 'from __future__ import annotations'."""
+        tree = self._parse("maestro/services/muse_restore.py")
+        first_import = next(
+            (n for n in ast.walk(tree) if isinstance(n, ast.ImportFrom)),
+            None,
+        )
+        assert first_import is not None
+        assert first_import.module == "__future__"
+
+    def test_restore_command_has_future_import(self) -> None:
+        """restore.py CLI command starts with 'from __future__ import annotations'."""
+        tree = self._parse("maestro/muse_cli/commands/restore.py")
+        first_import = next(
+            (n for n in ast.walk(tree) if isinstance(n, ast.ImportFrom)),
+            None,
+        )
+        assert first_import is not None
+        assert first_import.module == "__future__"


### PR DESCRIPTION
## Summary
Closes #70 — adds `muse restore` for surgical file-level restore from any commit or HEAD snapshot.

## Root Cause / Motivation
No `muse restore` command existed. Producers needed to restore individual instrument
tracks (e.g. "bass from take 3") without resetting the entire working tree or
rewriting branch history. The only alternative was `muse reset --hard` (which
wipes all files) or manually copying blobs — both unsuitable for production use.

## Solution
Implements `muse restore` as a pure-service + Typer CLI following the same
patterns as `muse reset`:

- **`maestro/services/muse_restore.py`** — async `perform_restore()` service:
  - Resolves source ref (HEAD / HEAD~N / SHA / abbreviated SHA)
  - Normalises paths (strips `muse-work/` prefix if present)
  - Validates all requested paths exist in the source snapshot (fail-fast)
  - Validates all required blobs exist in `.muse/objects/` (fail-fast before touching disk)
  - Copies blobs into `muse-work/` atomically; branch pointer never modified
  - `--staged` flag: semantically documented for forward-compat with a future staging area; currently equivalent to `--worktree`

- **`maestro/muse_cli/commands/restore.py`** — Typer CLI wrapper with full flag set:
  - `<paths>...` positional (one or more)
  - `--staged` / `--worktree` / `--source <commit>`

- **`maestro/muse_cli/app.py`** — registered as `muse restore`

- **`docs/architecture/muse_vcs.md`** — full command reference section added

- **`docs/reference/type_contracts.md`** — `RestoreResult` and `PathNotInSnapshotError` registered

## Layers Affected
- [x] Muse VCS

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (555 files)
- [x] All 18 tests pass
- [x] Docs updated

## Tests Added
- `test_muse_restore_from_head` — default restore from HEAD
- `test_muse_restore_staged_equivalent` — --staged behaves like --worktree
- `test_muse_restore_source_commit` — --source <commit> extracts from historical snapshot
- `test_muse_restore_source_abbreviated_sha` — abbreviated SHA accepted as source ref
- `test_muse_restore_multiple_paths` — multiple paths restored atomically
- `test_muse_restore_muse_work_prefix_stripped` — muse-work/ prefix normalised
- `test_muse_restore_errors_on_missing_path` — PathNotInSnapshotError when path absent
- `test_muse_restore_source_missing_path` — PathNotInSnapshotError on historical commit
- `test_muse_restore_missing_object_store` — MissingObjectError when blob absent
- `test_muse_restore_ref_not_found` — unknown source ref exits USER_ERROR
- `test_muse_restore_no_commits` — branch with no commits exits USER_ERROR
- `test_muse_restore_result_fields/frozen/defaults` — RestoreResult type tests
- `test_error_message_contains_path_and_commit` — PathNotInSnapshotError type test
- `test_boundary_no_forbidden_imports` — AST boundary seal
- `test_restore_service_has_future_import` — future import guard (service)
- `test_restore_command_has_future_import` — future import guard (CLI)

## Handoff
N/A — no SSE/MCP protocol change.