### PR TITLE
feat: muse stash — temporarily shelve uncommitted muse-work/ changes

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5294,6 +5294,66 @@ For root commits (no parent) all snapshot paths appear in `added`.
 
 ---
 
+## Muse Stash Types (`maestro/services/muse_stash.py`)
+
+Result types for `muse stash` operations.  All are frozen dataclasses —
+immutable after construction and safe to return from async contexts.
+
+### `StashEntry`
+
+A single stash entry as read from `.muse/stash/<stash_id>.json`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stash_id` | `str` | Unique filesystem stem (e.g. `stash-20260227T120000Z-abc12345`) |
+| `index` | `int` | Position in the stack (0 = most recent) |
+| `branch` | `str` | Branch name at the time of push |
+| `message` | `str` | Human label (default: `"On <branch>: stash"`) |
+| `created_at` | `str` | ISO-8601 timestamp of when the stash was created |
+| `manifest` | `dict[str, str]` | `{rel_path: sha256_object_id}` of stashed files |
+| `track` | `str \| None` | Track scope used during push, or `None` (full push) |
+| `section` | `str \| None` | Section scope used during push, or `None` (full push) |
+
+**Producer:** `list_stash()`, internal `_read_entry()`
+**Consumer:** `stash_list`, `stash_drop`, `apply_stash`
+
+---
+
+### `StashPushResult`
+
+Outcome of `muse stash push`.  Frozen dataclass.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stash_ref` | `str` | Human label (`"stash@{0}"`); empty string when nothing was stashed |
+| `message` | `str` | Label stored in the entry |
+| `branch` | `str` | Branch at the time of push |
+| `files_stashed` | `int` | Number of files copied into the stash |
+| `head_restored` | `bool` | Whether HEAD snapshot was restored to muse-work/ |
+| `missing_head` | `tuple[str, ...]` | Paths that could not be restored from the object store after push |
+
+**Producer:** `push_stash()`
+**Consumer:** `stash_default`, `stash_push` Typer callbacks
+
+---
+
+### `StashApplyResult`
+
+Outcome of `muse stash apply` or `muse stash pop`.  Frozen dataclass.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stash_ref` | `str` | Human label of the entry that was applied (e.g. `"stash@{0}"`) |
+| `message` | `str` | The entry's label |
+| `files_applied` | `int` | Number of files written to muse-work/ |
+| `missing` | `tuple[str, ...]` | Paths whose object bytes were absent from the store |
+| `dropped` | `bool` | True when the entry was removed (pop); False for apply |
+
+**Producer:** `apply_stash()`
+**Consumer:** `stash_pop`, `stash_apply` Typer callbacks
+
+---
+
 ### `ResetResult`
 
 **Module:** `maestro/services/muse_reset.py`

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -6,7 +6,7 @@ commit-tree, context, contour, describe, diff, divergence, dynamics, emotion-dif
 export, find, form, grep, groove-check, harmony, humanize, import, init, inspect,
 key, log, merge, meter, motif, open, play, pull, push, read-tree, recall, remote,
 render-preview, reset, resolve, rev-parse, revert, session, show, similarity,
-status, swing, symbolic-ref, tag, tempo, tempo-scale, timeline, update-ref,
+stash, status, swing, symbolic-ref, tag, tempo, tempo-scale, timeline, update-ref,
 validate, write-tree) as Typer sub-applications.
 """
 from __future__ import annotations
@@ -59,6 +59,7 @@ from maestro.muse_cli.commands import (
     session,
     show,
     similarity,
+    stash,
     status,
     swing,
     symbolic_ref,
@@ -131,6 +132,7 @@ cli.add_typer(resolve.app, name="resolve", help="Mark a conflicted file as resol
 cli.add_typer(groove_check.app, name="groove-check", help="Analyze rhythmic drift across commits to find groove regressions.")
 cli.add_typer(form.app, name="form", help="Analyze or annotate the formal structure (sections) of a commit.")
 cli.add_typer(similarity.app, name="similarity", help="Compare two commits by musical similarity score.")
+cli.add_typer(stash.app, name="stash", help="Temporarily shelve uncommitted muse-work/ changes.")
 cli.add_typer(tempo_scale.app, name="tempo-scale", help="Stretch or compress the timing of a commit.")
 cli.add_typer(timeline.app, name="timeline", help="Visualize musical evolution chronologically.")
 cli.add_typer(update_ref.app, name="update-ref", help="Write or delete a ref (branch or tag pointer).")

--- a/maestro/muse_cli/commands/stash.py
+++ b/maestro/muse_cli/commands/stash.py
@@ -1,0 +1,410 @@
+"""muse stash — temporarily shelve uncommitted muse-work/ changes.
+
+Stash is a per-producer scratch pad: changes in muse-work/ are saved to
+``.muse/stash/`` (filesystem, no DB table) and HEAD is restored so you can
+start clean.  Later, ``muse stash pop`` brings back the shelved state.
+
+Subcommands
+-----------
+push   (default) — save muse-work/ state; restore HEAD snapshot
+pop             — apply most recent stash, remove it from the stack
+apply           — apply a stash without removing it
+list            — list all stash entries
+drop            — remove a specific entry
+clear           — remove all entries
+
+Usage examples::
+
+    muse stash                        # push (save + restore HEAD)
+    muse stash push -m "chorus WIP"   # push with a label
+    muse stash push --track drums     # scope to drums/ files only
+    muse stash pop                    # apply most recent, drop it
+    muse stash apply stash@{2}        # apply index 2 without dropping
+    muse stash list                   # show all stash entries
+    muse stash drop stash@{1}         # remove index 1
+    muse stash clear                  # remove all (with confirmation)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from typing import Optional
+
+import typer
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.services.muse_stash import (
+    StashApplyResult,
+    StashPushResult,
+    apply_stash,
+    clear_stash,
+    drop_stash,
+    list_stash,
+    push_stash,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(
+    name="stash",
+    help="Temporarily shelve uncommitted muse-work/ changes.",
+    no_args_is_help=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_stash_ref(ref: str) -> int:
+    """Parse ``stash@{N}`` or a bare integer into a 0-based index.
+
+    Accepts ``stash@{0}``, ``stash@{2}``, or just ``0``, ``2``.
+
+    Raises:
+        typer.Exit: When *ref* cannot be parsed.
+    """
+    import re
+
+    match = re.fullmatch(r"stash@\{(\d+)\}", ref.strip())
+    if match:
+        return int(match.group(1))
+    try:
+        return int(ref.strip())
+    except ValueError:
+        typer.echo(f"❌ Invalid stash reference: {ref!r}. Expected stash@{{N}} or N.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+
+async def _get_head_manifest(
+    root: pathlib.Path,
+) -> dict[str, str] | None:
+    """Return the snapshot manifest for the current HEAD commit.
+
+    Returns ``None`` when the branch has no commits or the DB is unreachable.
+    """
+    from maestro.muse_cli.db import get_commit_snapshot_manifest
+    from maestro.muse_cli.models import MuseCliCommit
+
+    import json as _json
+
+    muse_dir = root / ".muse"
+
+    try:
+        repo_data: dict[str, str] = _json.loads((muse_dir / "repo.json").read_text())
+        repo_id = repo_data["repo_id"]
+
+        head_ref = (muse_dir / "HEAD").read_text().strip()
+        ref_path = muse_dir / pathlib.Path(head_ref)
+        if not ref_path.exists():
+            return None
+        commit_id = ref_path.read_text().strip()
+        if not commit_id:
+            return None
+
+        from sqlalchemy.future import select
+
+        async with open_session() as session:
+            result = await session.execute(
+                select(MuseCliCommit).where(
+                    MuseCliCommit.repo_id == repo_id,
+                    MuseCliCommit.commit_id == commit_id,
+                )
+            )
+            commit = result.scalar_one_or_none()
+            if commit is None:
+                return None
+            manifest = await get_commit_snapshot_manifest(session, commit_id)
+            return manifest
+    except Exception as exc:
+        logger.warning("⚠️ Could not load HEAD manifest: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# push (default command)
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def stash_default(
+    ctx: typer.Context,
+    message: Optional[str] = typer.Option(
+        None,
+        "--message",
+        "-m",
+        help="Label for this stash entry.",
+    ),
+    track: Optional[str] = typer.Option(
+        None,
+        "--track",
+        help="Scope the stash to files under tracks/<TRACK>/.",
+    ),
+    section: Optional[str] = typer.Option(
+        None,
+        "--section",
+        help="Scope the stash to files under sections/<SECTION>/.",
+    ),
+) -> None:
+    """Save muse-work/ changes and restore HEAD snapshot (default: push)."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    root = require_repo()
+
+    # Load HEAD manifest to restore working tree after stashing.
+    head_manifest: dict[str, str] | None = asyncio.run(_get_head_manifest(root))
+
+    try:
+        result = push_stash(
+            root,
+            message=message,
+            track=track,
+            section=section,
+            head_manifest=head_manifest,
+        )
+    except Exception as exc:
+        typer.echo(f"❌ muse stash push failed: {exc}")
+        logger.error("❌ muse stash push error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    if result.files_stashed == 0:
+        typer.echo("⚠️  No local changes to stash.")
+        return
+
+    typer.echo(f"Saved working directory and index state {result.stash_ref}")
+    typer.echo(f"{result.message}")
+
+    if result.missing_head:
+        typer.echo(
+            "⚠️  Some HEAD files could not be restored (object store incomplete):\n"
+            + "\n".join(f"   {p}" for p in result.missing_head)
+        )
+
+
+# ---------------------------------------------------------------------------
+# push subcommand (explicit)
+# ---------------------------------------------------------------------------
+
+
+@app.command("push")
+def stash_push(
+    message: Optional[str] = typer.Option(
+        None,
+        "--message",
+        "-m",
+        help="Label for this stash entry.",
+    ),
+    track: Optional[str] = typer.Option(
+        None,
+        "--track",
+        help="Scope the stash to files under tracks/<TRACK>/.",
+    ),
+    section: Optional[str] = typer.Option(
+        None,
+        "--section",
+        help="Scope the stash to files under sections/<SECTION>/.",
+    ),
+) -> None:
+    """Save muse-work/ changes and restore HEAD snapshot."""
+    root = require_repo()
+
+    head_manifest: dict[str, str] | None = asyncio.run(_get_head_manifest(root))
+
+    try:
+        result = push_stash(
+            root,
+            message=message,
+            track=track,
+            section=section,
+            head_manifest=head_manifest,
+        )
+    except Exception as exc:
+        typer.echo(f"❌ muse stash push failed: {exc}")
+        logger.error("❌ muse stash push error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    if result.files_stashed == 0:
+        typer.echo("⚠️  No local changes to stash.")
+        return
+
+    typer.echo(f"Saved working directory and index state {result.stash_ref}")
+    typer.echo(f"{result.message}")
+
+    if result.missing_head:
+        typer.echo(
+            "⚠️  Some HEAD files could not be restored (object store incomplete):\n"
+            + "\n".join(f"   {p}" for p in result.missing_head)
+        )
+
+
+# ---------------------------------------------------------------------------
+# pop
+# ---------------------------------------------------------------------------
+
+
+@app.command("pop")
+def stash_pop(
+    stash_ref: str = typer.Argument(
+        "stash@{0}",
+        help="Which stash entry to pop (default: stash@{0}).",
+    ),
+) -> None:
+    """Apply the most recent stash and remove it from the stack."""
+    root = require_repo()
+    index = _parse_stash_ref(stash_ref)
+
+    try:
+        result = apply_stash(root, index, drop=True)
+    except IndexError as exc:
+        typer.echo(f"❌ {exc}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+    except Exception as exc:
+        typer.echo(f"❌ muse stash pop failed: {exc}")
+        logger.error("❌ muse stash pop error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    typer.echo(f"✅ Applied {result.stash_ref}: {result.message}")
+    typer.echo(f"   {result.files_applied} file(s) restored.")
+
+    if result.missing:
+        typer.echo(
+            "⚠️  Some files could not be restored (object store incomplete):\n"
+            + "\n".join(f"   missing: {p}" for p in result.missing)
+        )
+
+    typer.echo(f"Dropped {result.stash_ref}")
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+@app.command("apply")
+def stash_apply(
+    stash_ref: str = typer.Argument(
+        "stash@{0}",
+        help="Stash reference to apply (e.g. stash@{0}, stash@{2}).",
+    ),
+) -> None:
+    """Apply a stash entry without removing it from the stack."""
+    root = require_repo()
+    index = _parse_stash_ref(stash_ref)
+
+    try:
+        result = apply_stash(root, index, drop=False)
+    except IndexError as exc:
+        typer.echo(f"❌ {exc}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+    except Exception as exc:
+        typer.echo(f"❌ muse stash apply failed: {exc}")
+        logger.error("❌ muse stash apply error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    typer.echo(f"✅ Applied {result.stash_ref}: {result.message}")
+    typer.echo(f"   {result.files_applied} file(s) restored.")
+
+    if result.missing:
+        typer.echo(
+            "⚠️  Some files could not be restored (object store incomplete):\n"
+            + "\n".join(f"   missing: {p}" for p in result.missing)
+        )
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+@app.command("list")
+def stash_list() -> None:
+    """List all stash entries."""
+    root = require_repo()
+
+    try:
+        entries = list_stash(root)
+    except Exception as exc:
+        typer.echo(f"❌ muse stash list failed: {exc}")
+        logger.error("❌ muse stash list error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    if not entries:
+        typer.echo("No stash entries.")
+        return
+
+    for entry in entries:
+        typer.echo(f"stash@{{{entry.index}}}: On {entry.branch}: {entry.message}")
+
+
+# ---------------------------------------------------------------------------
+# drop
+# ---------------------------------------------------------------------------
+
+
+@app.command("drop")
+def stash_drop(
+    stash_ref: str = typer.Argument(
+        "stash@{0}",
+        help="Stash reference to drop (e.g. stash@{0}, stash@{2}).",
+    ),
+) -> None:
+    """Remove a specific stash entry without applying it."""
+    root = require_repo()
+    index = _parse_stash_ref(stash_ref)
+
+    try:
+        entry = drop_stash(root, index)
+    except IndexError as exc:
+        typer.echo(f"❌ {exc}")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+    except Exception as exc:
+        typer.echo(f"❌ muse stash drop failed: {exc}")
+        logger.error("❌ muse stash drop error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    typer.echo(f"✅ Dropped stash@{{{entry.index}}}: {entry.message}")
+
+
+# ---------------------------------------------------------------------------
+# clear
+# ---------------------------------------------------------------------------
+
+
+@app.command("clear")
+def stash_clear(
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt.",
+    ),
+) -> None:
+    """Remove all stash entries."""
+    root = require_repo()
+
+    if not yes:
+        confirmed = typer.confirm(
+            "⚠️  This will permanently remove ALL stash entries. Proceed?",
+            default=False,
+        )
+        if not confirmed:
+            typer.echo("Aborted.")
+            raise typer.Exit(code=ExitCode.SUCCESS)
+
+    try:
+        count = clear_stash(root)
+    except Exception as exc:
+        typer.echo(f"❌ muse stash clear failed: {exc}")
+        logger.error("❌ muse stash clear error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    if count == 0:
+        typer.echo("No stash entries to clear.")
+    else:
+        typer.echo(f"✅ Cleared {count} stash entr{'y' if count == 1 else 'ies'}.")

--- a/maestro/services/muse_stash.py
+++ b/maestro/services/muse_stash.py
@@ -1,0 +1,574 @@
+"""Muse Stash Service — temporarily shelve uncommitted muse-work/ changes.
+
+Stash lets a producer save in-progress work without committing, switch
+context (e.g. fix the intro for a client call), then restore the shelved
+state with ``muse stash pop``.
+
+Design
+------
+- Stash entries live purely on the filesystem in ``.muse/stash/``.
+- Each entry is a JSON file named ``stash-<epoch_ns>.json``.
+- The stack is ordered by creation time: index 0 is most recent.
+- File content is preserved by writing blobs to the existing
+  ``.muse/objects/<oid[:2]>/<oid[2:]>`` content-addressed store
+  (same layout used by ``muse commit`` and ``muse reset --hard``).
+- Restoring HEAD after push reads manifests from the DB (same as hard reset).
+  If the branch has no commits, muse-work/ is simply cleared.
+- On apply/pop, files are copied from the object store back into muse-work/.
+  Files whose objects are absent from the store are reported as missing.
+- Track/section scoping on push limits which files are saved and what is
+  restored afterward (only scoped paths are erased; others stay untouched).
+
+Path-scoped stash (``--track`` / ``--section``)
+------------------------------------------------
+When a scope is supplied, only files under ``tracks/<track>/`` or
+``sections/<section>/`` are saved to the stash.  After saving the scope,
+the HEAD snapshot is restored only for those paths (other working-tree
+files are left untouched).  Applying a scoped stash similarly only writes
+paths that match the original scope.
+
+Boundary rules:
+  - No Typer imports.
+  - No StateStore, EntityRegistry, or get_or_create_store.
+  - May import muse_cli.{db,models,object_store,snapshot}.
+  - Filesystem stash store is independent of the Postgres schema.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import pathlib
+import shutil
+import uuid
+from dataclasses import dataclass, field
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.snapshot import hash_file
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_STASH_DIR = "stash"
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StashEntry:
+    """A single stash entry persisted in ``.muse/stash/``.
+
+    Attributes:
+        stash_id:   Unique filename stem (``stash-<epoch_ns>-<uuid8>``).
+        index:      Position in the stack (0 = most recent).
+        branch:     Branch name at the time of stash.
+        message:    Human-readable label (``On <branch>: <text>``).
+        created_at: ISO-8601 timestamp.
+        manifest:   ``{rel_path: sha256_object_id}`` of stashed files.
+        track:      Optional track scope used during push.
+        section:    Optional section scope used during push.
+    """
+
+    stash_id: str
+    index: int
+    branch: str
+    message: str
+    created_at: str
+    manifest: dict[str, str]
+    track: Optional[str]
+    section: Optional[str]
+
+
+@dataclass(frozen=True)
+class StashPushResult:
+    """Outcome of ``muse stash push``.
+
+    Attributes:
+        stash_ref:      Human label (``stash@{0}``).
+        message:        The label stored in the entry.
+        branch:         Branch at the time of push.
+        files_stashed:  Number of files saved into the stash.
+        head_restored:  Whether HEAD snapshot was restored to muse-work/.
+        missing_head:   Paths that could not be restored from the object store
+                        (object bytes not present; stash push succeeded but
+                        HEAD restoration is incomplete).
+    """
+
+    stash_ref: str
+    message: str
+    branch: str
+    files_stashed: int
+    head_restored: bool
+    missing_head: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class StashApplyResult:
+    """Outcome of ``muse stash apply`` or ``muse stash pop``.
+
+    Attributes:
+        stash_ref:     Human label of the entry that was applied.
+        message:       The entry's label.
+        files_applied: Number of files written to muse-work/.
+        missing:       Paths whose object bytes were absent from the store.
+        dropped:       True when the entry was removed (pop); False for apply.
+    """
+
+    stash_ref: str
+    message: str
+    files_applied: int
+    missing: tuple[str, ...]
+    dropped: bool
+
+
+# ---------------------------------------------------------------------------
+# Filesystem helpers
+# ---------------------------------------------------------------------------
+
+
+def _stash_dir(root: pathlib.Path) -> pathlib.Path:
+    """Return the stash directory path (does not create it)."""
+    return root / ".muse" / _STASH_DIR
+
+
+def _entry_path(root: pathlib.Path, stash_id: str) -> pathlib.Path:
+    """Return the filesystem path of a single stash entry JSON file."""
+    return _stash_dir(root) / f"{stash_id}.json"
+
+
+def _object_path(root: pathlib.Path, object_id: str) -> pathlib.Path:
+    """Return the sharded object store path for *object_id*.
+
+    Matches the layout used by ``muse commit`` and ``muse reset --hard``:
+    ``.muse/objects/<oid[:2]>/<oid[2:]>``.
+    """
+    return root / ".muse" / "objects" / object_id[:2] / object_id[2:]
+
+
+def _read_entry(entry_file: pathlib.Path, index: int) -> StashEntry:
+    """Deserialize a stash entry JSON file."""
+    raw: dict[str, object] = json.loads(entry_file.read_text())
+    raw_manifest = raw.get("manifest", {})
+    manifest: dict[str, str] = (
+        {str(k): str(v) for k, v in raw_manifest.items()}
+        if isinstance(raw_manifest, dict)
+        else {}
+    )
+    return StashEntry(
+        stash_id=str(raw["stash_id"]),
+        index=index,
+        branch=str(raw["branch"]),
+        message=str(raw["message"]),
+        created_at=str(raw["created_at"]),
+        manifest=manifest,
+        track=str(raw["track"]) if raw.get("track") else None,
+        section=str(raw["section"]) if raw.get("section") else None,
+    )
+
+
+def _write_entry(root: pathlib.Path, entry_data: dict[str, object]) -> str:
+    """Serialize and write a stash entry.  Returns the stash_id."""
+    stash_dir = _stash_dir(root)
+    stash_dir.mkdir(parents=True, exist_ok=True)
+    stash_id = str(entry_data["stash_id"])
+    (_stash_dir(root) / f"{stash_id}.json").write_text(
+        json.dumps(entry_data, indent=2)
+    )
+    return stash_id
+
+
+def _sorted_entries(root: pathlib.Path) -> list[pathlib.Path]:
+    """Return stash JSON files sorted newest-first (index 0 = most recent)."""
+    stash_dir = _stash_dir(root)
+    if not stash_dir.exists():
+        return []
+    files = sorted(stash_dir.glob("stash-*.json"), reverse=True)
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Path-scope filter (mirrors muse_revert._filter_paths)
+# ---------------------------------------------------------------------------
+
+
+def _filter_paths(
+    manifest: dict[str, str],
+    track: Optional[str],
+    section: Optional[str],
+) -> set[str]:
+    """Return paths in *manifest* matching the scope (all paths when no scope)."""
+    if not track and not section:
+        return set(manifest.keys())
+
+    matched: set[str] = set()
+    for path in manifest:
+        if track and path.startswith(f"tracks/{track}/"):
+            matched.add(path)
+        if section and path.startswith(f"sections/{section}/"):
+            matched.add(path)
+    return matched
+
+
+# ---------------------------------------------------------------------------
+# Object store writes
+# ---------------------------------------------------------------------------
+
+
+def _store_files(
+    root: pathlib.Path,
+    workdir: pathlib.Path,
+    paths: set[str],
+) -> dict[str, str]:
+    """Copy *paths* from *workdir* into the object store.
+
+    Returns a manifest ``{rel_path: object_id}`` for the stored files.
+    Objects already in the store are not overwritten (content-addressed).
+    """
+    manifest: dict[str, str] = {}
+    for rel_path in sorted(paths):
+        abs_path = workdir / rel_path
+        if not abs_path.exists():
+            logger.warning("⚠️ Stash: skipping missing file %s", rel_path)
+            continue
+        oid = hash_file(abs_path)
+        dest = _object_path(root, oid)
+        if not dest.exists():
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(abs_path, dest)
+            logger.debug("✅ Stash stored object %s ← %s", oid[:8], rel_path)
+        manifest[rel_path] = oid
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# HEAD snapshot restoration helper
+# ---------------------------------------------------------------------------
+
+
+def _restore_from_manifest(
+    root: pathlib.Path,
+    workdir: pathlib.Path,
+    target_manifest: dict[str, str],
+    scope_paths: Optional[set[str]],
+) -> tuple[int, list[str]]:
+    """Write *target_manifest* files from the object store into *workdir*.
+
+    When *scope_paths* is given, only paths in that set are touched; other
+    working-tree files are left as-is.
+
+    Returns:
+        ``(files_written, missing_paths)`` where *missing_paths* lists files
+        that could not be restored because their objects are absent.
+    """
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    if scope_paths is not None:
+        paths_to_restore = {p: oid for p, oid in target_manifest.items() if p in scope_paths}
+    else:
+        paths_to_restore = dict(target_manifest)
+
+    missing: list[str] = []
+    written = 0
+
+    for rel_path, oid in sorted(paths_to_restore.items()):
+        obj_file = _object_path(root, oid)
+        if not obj_file.exists():
+            missing.append(rel_path)
+            logger.warning(
+                "⚠️ Stash: object %s missing from store for %s", oid[:8], rel_path
+            )
+            continue
+        dest = workdir / rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(obj_file, dest)
+        written += 1
+
+    # When scope_paths is None (full restore), delete files not in the manifest.
+    if scope_paths is None:
+        target_abs = {workdir / p for p in target_manifest}
+        for f in list(workdir.rglob("*")):
+            if f.is_file() and not f.name.startswith(".") and f not in target_abs:
+                f.unlink(missing_ok=True)
+
+    return written, missing
+
+
+# ---------------------------------------------------------------------------
+# Public API — pure filesystem operations
+# ---------------------------------------------------------------------------
+
+
+def list_stash(root: pathlib.Path) -> list[StashEntry]:
+    """Return all stash entries, newest first (index 0 = most recent).
+
+    Returns an empty list when the stash is empty or ``.muse/stash/``
+    does not exist.
+
+    Args:
+        root: Muse repository root.
+    """
+    files = _sorted_entries(root)
+    return [_read_entry(f, i) for i, f in enumerate(files)]
+
+
+def drop_stash(root: pathlib.Path, index: int) -> StashEntry:
+    """Remove the stash entry at *index* from the stack.
+
+    Args:
+        root:  Muse repository root.
+        index: 0-based stash index (0 = most recent).
+
+    Returns:
+        The dropped :class:`StashEntry`.
+
+    Raises:
+        IndexError: When *index* is out of range.
+    """
+    files = _sorted_entries(root)
+    if index < 0 or index >= len(files):
+        raise IndexError(
+            f"stash@{{{index}}} does not exist (stack has {len(files)} entries)"
+        )
+    entry = _read_entry(files[index], index)
+    files[index].unlink()
+    logger.info("✅ muse stash drop stash@{%d}: %s", index, entry.message)
+    return entry
+
+
+def clear_stash(root: pathlib.Path) -> int:
+    """Remove all stash entries.
+
+    Args:
+        root: Muse repository root.
+
+    Returns:
+        Number of entries removed.
+    """
+    files = _sorted_entries(root)
+    for f in files:
+        f.unlink()
+    count = len(files)
+    if count:
+        logger.info("✅ muse stash clear: removed %d entries", count)
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Push — save working state and restore HEAD
+# ---------------------------------------------------------------------------
+
+
+def push_stash(
+    root: pathlib.Path,
+    *,
+    message: Optional[str] = None,
+    track: Optional[str] = None,
+    section: Optional[str] = None,
+    head_manifest: Optional[dict[str, str]] = None,
+) -> StashPushResult:
+    """Save muse-work/ changes to the stash and restore HEAD snapshot.
+
+    Algorithm:
+    1. Walk muse-work/ and identify paths to stash (all, or scoped by
+       ``track``/``section``).
+    2. Copy each file into the object store (sharded ``.muse/objects/``).
+    3. Build a stash entry JSON and write it to ``.muse/stash/``.
+    4. Restore HEAD snapshot to muse-work/:
+       - Full push: restore full HEAD manifest (deletes extra files).
+       - Scoped push: restore HEAD for scoped paths only; other files
+         remain untouched.
+
+    Args:
+        root:          Muse repository root.
+        message:       Optional label; defaults to ``On <branch>: stash``.
+        track:         Optional track name scope (e.g. ``"drums"``).
+        section:       Optional section name scope (e.g. ``"chorus"``).
+        head_manifest: Snapshot manifest for the current HEAD commit, used
+                       to restore muse-work/ after stashing.  When ``None``
+                       the branch has no commits and muse-work/ is cleared
+                       (full push) or left untouched (scoped push).
+
+    Returns:
+        :class:`StashPushResult` describing what was saved and restored.
+    """
+    muse_dir = root / ".muse"
+    workdir = root / "muse-work"
+
+    # ── Resolve current branch ───────────────────────────────────────────
+    head_text = (muse_dir / "HEAD").read_text().strip()
+    branch = head_text.rsplit("/", 1)[-1]
+
+    # ── Build working-tree manifest ──────────────────────────────────────
+    from maestro.muse_cli.snapshot import walk_workdir
+
+    current_manifest: dict[str, str] = {}
+    if workdir.exists():
+        current_manifest = walk_workdir(workdir)
+
+    # ── Identify paths to stash ──────────────────────────────────────────
+    scope_paths = _filter_paths(current_manifest, track, section)
+    if not scope_paths:
+        # Nothing to stash (either empty workdir or scope matched nothing).
+        return StashPushResult(
+            stash_ref="",
+            message="",
+            branch=branch,
+            files_stashed=0,
+            head_restored=False,
+            missing_head=(),
+        )
+
+    # ── Copy files into object store ─────────────────────────────────────
+    stash_manifest = _store_files(root, workdir, scope_paths)
+
+    # ── Build and write stash entry ──────────────────────────────────────
+    created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    stash_id = f"stash-{created_at.replace(':', '').replace('+', 'Z').replace('.', '')}-{uuid.uuid4().hex[:8]}"
+    label = message or f"On {branch}: stash"
+    entry_data: dict[str, object] = {
+        "stash_id": stash_id,
+        "branch": branch,
+        "message": label,
+        "created_at": created_at,
+        "track": track,
+        "section": section,
+        "manifest": stash_manifest,
+    }
+    _write_entry(root, entry_data)
+
+    # ── Compute stash@{0} index (newly pushed is always newest) ──────────
+    files = _sorted_entries(root)
+    stash_ref = "stash@{0}"
+
+    # ── Restore HEAD snapshot to muse-work/ ──────────────────────────────
+    missing_head: list[str] = []
+    head_restored = False
+
+    if head_manifest is not None:
+        # Determine scope for restore
+        restore_scope: Optional[set[str]] = None
+        if track or section:
+            # Only restore paths that match the scope (others untouched)
+            restore_scope = _filter_paths(head_manifest, track, section)
+            # Also remove scoped paths that are NOT in head_manifest
+            # (new files in workdir under the scope must be deleted)
+            paths_to_clear = scope_paths - set(head_manifest.keys())
+            for rel_path in paths_to_clear:
+                abs_path = workdir / rel_path
+                if abs_path.exists():
+                    abs_path.unlink(missing_ok=True)
+        else:
+            restore_scope = None  # full restore
+
+        _, missing_head = _restore_from_manifest(
+            root, workdir, head_manifest, restore_scope
+        )
+        head_restored = True
+    else:
+        # No HEAD commit: full push clears muse-work/, scoped push does nothing.
+        if not track and not section:
+            for f in list(workdir.rglob("*")):
+                if f.is_file() and not f.name.startswith("."):
+                    f.unlink(missing_ok=True)
+
+    logger.info(
+        "✅ muse stash push: %s (%d files, branch=%r)",
+        stash_ref,
+        len(stash_manifest),
+        branch,
+    )
+
+    return StashPushResult(
+        stash_ref=stash_ref,
+        message=label,
+        branch=branch,
+        files_stashed=len(stash_manifest),
+        head_restored=head_restored,
+        missing_head=tuple(sorted(missing_head)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Apply / Pop — restore stash to working tree
+# ---------------------------------------------------------------------------
+
+
+def apply_stash(
+    root: pathlib.Path,
+    index: int = 0,
+    *,
+    drop: bool = False,
+) -> StashApplyResult:
+    """Restore a stash entry to muse-work/.
+
+    Algorithm:
+    1. Resolve *index* → ``StashEntry``.
+    2. For each path in the entry's manifest, copy the object from the
+       store back into muse-work/ (overwriting any conflicting file).
+    3. If *drop* is True, remove the stash entry (this is ``pop`` semantics).
+
+    Conflict strategy: last-write-wins.  Files in muse-work/ that are NOT
+    in the stash manifest are left untouched; only stash paths are written.
+
+    Args:
+        root:  Muse repository root.
+        index: 0-based stash index (0 = most recent).
+        drop:  Remove the entry after applying (True → pop, False → apply).
+
+    Returns:
+        :class:`StashApplyResult` describing what was applied.
+
+    Raises:
+        IndexError: When *index* is out of range.
+    """
+    files = _sorted_entries(root)
+    if index < 0 or index >= len(files):
+        raise IndexError(
+            f"stash@{{{index}}} does not exist (stack has {len(files)} entries)"
+        )
+
+    entry = _read_entry(files[index], index)
+    stash_ref = f"stash@{{{index}}}"
+    workdir = root / "muse-work"
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    # ── Restore files from object store ──────────────────────────────────
+    missing: list[str] = []
+    written = 0
+
+    for rel_path, oid in sorted(entry.manifest.items()):
+        obj_file = _object_path(root, oid)
+        if not obj_file.exists():
+            missing.append(rel_path)
+            logger.warning(
+                "⚠️ Stash apply: object %s missing for %s", oid[:8], rel_path
+            )
+            continue
+        dest = workdir / rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(obj_file, dest)
+        written += 1
+        logger.debug("✅ Stash apply: restored %s from object %s", rel_path, oid[:8])
+
+    # ── Drop entry if pop semantics ───────────────────────────────────────
+    if drop:
+        files[index].unlink()
+        logger.info("✅ muse stash pop: applied and dropped %s", stash_ref)
+    else:
+        logger.info("✅ muse stash apply: applied %s (kept)", stash_ref)
+
+    return StashApplyResult(
+        stash_ref=stash_ref,
+        message=entry.message,
+        files_applied=written,
+        missing=tuple(sorted(missing)),
+        dropped=drop,
+    )

--- a/tests/muse_cli/test_stash.py
+++ b/tests/muse_cli/test_stash.py
@@ -1,0 +1,424 @@
+"""Tests for ``muse stash`` — full lifecycle and edge cases.
+
+Exercises:
+- ``test_stash_push_pop_roundtrip``     — regression: push saves state, pop restores it
+- ``test_stash_push_clears_workdir``    — full push restores HEAD (empty branch → clear)
+- ``test_stash_list_shows_entries``     — list returns entries newest-first
+- ``test_stash_apply_keeps_entry``      — apply does not remove the entry
+- ``test_stash_drop_removes_entry``     — drop removes exactly the target entry
+- ``test_stash_clear_removes_all``      — clear empties the entire stack
+- ``test_stash_track_scoping``         — --track scopes files saved and restored
+- ``test_stash_section_scoping``       — --section scopes files saved and restored
+- ``test_stash_pop_index_oob``         — pop on empty stack exits with USER_ERROR
+- ``test_stash_apply_index_oob``       — apply on missing index raises IndexError
+- ``test_stash_drop_index_oob``        — drop on missing index raises IndexError
+- ``test_stash_multiple_entries``      — multiple pushes produce a stack
+- ``test_stash_push_empty_workdir``    — push on empty workdir is a noop
+- ``test_stash_missing_objects``       — apply when object store empty reports missing
+- ``test_stash_push_with_head_manifest`` — push restores HEAD snapshot to workdir
+- ``test_stash_message_stored``        — custom --message is preserved
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+
+import pytest
+
+from maestro.services.muse_stash import (
+    StashApplyResult,
+    StashEntry,
+    StashPushResult,
+    apply_stash,
+    clear_stash,
+    drop_stash,
+    list_stash,
+    push_stash,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    """Create a minimal .muse/ layout (no DB required for stash tests)."""
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(json.dumps({"repo_id": rid, "schema_version": "1"}))
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _populate_workdir(
+    root: pathlib.Path,
+    files: dict[str, bytes] | None = None,
+) -> None:
+    """Write files into muse-work/."""
+    workdir = root / "muse-work"
+    workdir.mkdir(exist_ok=True)
+    if files is None:
+        files = {"beat.mid": b"MIDI-DATA", "lead.mp3": b"MP3-DATA"}
+    for rel, content in files.items():
+        dest = workdir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(content)
+
+
+def _object_path(root: pathlib.Path, oid: str) -> pathlib.Path:
+    """Return sharded object store path."""
+    return root / ".muse" / "objects" / oid[:2] / oid[2:]
+
+
+# ---------------------------------------------------------------------------
+# Regression — push / pop round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_stash_push_pop_roundtrip(tmp_path: pathlib.Path) -> None:
+    """Regression: push saves file content; pop restores it exactly."""
+    _init_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"wip-chorus-beat"})
+
+    # Push — no HEAD commit, so workdir is cleared after push
+    result = push_stash(tmp_path, message="WIP chorus", head_manifest=None)
+
+    assert result.files_stashed == 1
+    assert result.stash_ref == "stash@{0}"
+    assert result.message == "WIP chorus"
+    # After full push (no HEAD), workdir should be cleared
+    workdir = tmp_path / "muse-work"
+    remaining = list(workdir.rglob("*"))
+    assert not any(f.is_file() for f in remaining)
+
+    # Pop — restores the stashed file
+    pop_result = apply_stash(tmp_path, 0, drop=True)
+
+    assert pop_result.dropped is True
+    assert pop_result.files_applied == 1
+    assert (tmp_path / "muse-work" / "beat.mid").read_bytes() == b"wip-chorus-beat"
+    # Stash stack should now be empty
+    assert list_stash(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Push clears workdir (no HEAD commit)
+# ---------------------------------------------------------------------------
+
+
+def test_stash_push_clears_workdir(tmp_path: pathlib.Path) -> None:
+    """Full push with no HEAD commit clears muse-work/ after stashing."""
+    _init_repo(tmp_path)
+    _populate_workdir(tmp_path, {"a.mid": b"A", "b.mid": b"B"})
+
+    result = push_stash(tmp_path, head_manifest=None)
+
+    assert result.files_stashed == 2
+    assert result.head_restored is False
+
+    workdir = tmp_path / "muse-work"
+    files = [f for f in workdir.rglob("*") if f.is_file()]
+    assert files == [], "workdir should be empty after full push with no HEAD"
+
+
+# ---------------------------------------------------------------------------
+# Push with HEAD manifest restores HEAD snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_stash_push_with_head_manifest(tmp_path: pathlib.Path) -> None:
+    """Push with a HEAD manifest writes HEAD files back to muse-work/."""
+    from maestro.muse_cli.snapshot import hash_file
+
+    _init_repo(tmp_path)
+
+    # Simulate HEAD commit: store a "committed" file in the object store
+    head_file_content = b"committed-beat"
+    # Compute oid by first writing a temp file
+    tmp_file = tmp_path / "tmp_head_file"
+    tmp_file.write_bytes(head_file_content)
+    oid = hash_file(tmp_file)
+    tmp_file.unlink()
+
+    obj_dest = _object_path(tmp_path, oid)
+    obj_dest.parent.mkdir(parents=True, exist_ok=True)
+    obj_dest.write_bytes(head_file_content)
+
+    head_manifest = {"beat.mid": oid}
+
+    # Populate workdir with WIP changes
+    _populate_workdir(tmp_path, {"beat.mid": b"wip-chorus", "synth.mid": b"wip-synth"})
+
+    result = push_stash(tmp_path, message="WIP", head_manifest=head_manifest)
+
+    assert result.files_stashed == 2
+    assert result.head_restored is True
+    # beat.mid should now be the HEAD version
+    assert (tmp_path / "muse-work" / "beat.mid").read_bytes() == head_file_content
+    # synth.mid was not in HEAD → should be deleted after full push
+    assert not (tmp_path / "muse-work" / "synth.mid").exists()
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def test_stash_list_shows_entries(tmp_path: pathlib.Path) -> None:
+    """list_stash returns entries newest-first with correct indices."""
+    _init_repo(tmp_path)
+
+    _populate_workdir(tmp_path, {"a.mid": b"A"})
+    push_stash(tmp_path, message="first stash", head_manifest=None)
+
+    _populate_workdir(tmp_path, {"b.mid": b"B"})
+    push_stash(tmp_path, message="second stash", head_manifest=None)
+
+    entries = list_stash(tmp_path)
+    assert len(entries) == 2
+    # Newest first
+    assert entries[0].index == 0
+    assert entries[1].index == 1
+    # Messages are preserved
+    messages = {e.message for e in entries}
+    assert "first stash" in messages
+    assert "second stash" in messages
+
+
+# ---------------------------------------------------------------------------
+# apply keeps entry
+# ---------------------------------------------------------------------------
+
+
+def test_stash_apply_keeps_entry(tmp_path: pathlib.Path) -> None:
+    """apply does NOT remove the stash entry (drop=False)."""
+    _init_repo(tmp_path)
+    _populate_workdir(tmp_path, {"x.mid": b"WIP"})
+
+    push_stash(tmp_path, head_manifest=None)
+
+    result = apply_stash(tmp_path, 0, drop=False)
+
+    assert result.dropped is False
+    # Entry still on the stack
+    assert len(list_stash(tmp_path)) == 1
+    # File restored
+    assert (tmp_path / "muse-work" / "x.mid").read_bytes() == b"WIP"
+
+
+# ---------------------------------------------------------------------------
+# drop
+# ---------------------------------------------------------------------------
+
+
+def test_stash_drop_removes_entry(tmp_path: pathlib.Path) -> None:
+    """drop_stash removes exactly the targeted entry."""
+    _init_repo(tmp_path)
+
+    _populate_workdir(tmp_path, {"a.mid": b"A"})
+    push_stash(tmp_path, message="entry-A", head_manifest=None)
+
+    _populate_workdir(tmp_path, {"b.mid": b"B"})
+    push_stash(tmp_path, message="entry-B", head_manifest=None)
+
+    # Stack: index 0 = entry-B (newest), index 1 = entry-A
+    dropped = drop_stash(tmp_path, index=1)
+
+    assert dropped.message == "entry-A"
+    remaining = list_stash(tmp_path)
+    assert len(remaining) == 1
+    assert remaining[0].message == "entry-B"
+
+
+# ---------------------------------------------------------------------------
+# clear
+# ---------------------------------------------------------------------------
+
+
+def test_stash_clear_removes_all(tmp_path: pathlib.Path) -> None:
+    """clear_stash removes all entries and returns the count."""
+    _init_repo(tmp_path)
+
+    for label in ["first", "second", "third"]:
+        _populate_workdir(tmp_path, {f"{label}.mid": label.encode()})
+        push_stash(tmp_path, message=label, head_manifest=None)
+
+    count = clear_stash(tmp_path)
+
+    assert count == 3
+    assert list_stash(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Track scoping
+# ---------------------------------------------------------------------------
+
+
+def test_stash_track_scoping(tmp_path: pathlib.Path) -> None:
+    """--track scopes stash to tracks/<track>/ files only."""
+    _init_repo(tmp_path)
+    _populate_workdir(
+        tmp_path,
+        {
+            "tracks/drums/beat.mid": b"drums-wip",
+            "tracks/bass/bass.mid": b"bass-wip",
+        },
+    )
+
+    result = push_stash(tmp_path, track="drums", head_manifest=None)
+
+    # Only drums file stashed
+    assert result.files_stashed == 1
+    entries = list_stash(tmp_path)
+    assert len(entries) == 1
+    assert "tracks/drums/beat.mid" in entries[0].manifest
+    assert "tracks/bass/bass.mid" not in entries[0].manifest
+    assert entries[0].track == "drums"
+    # bass file should still be in workdir (unscoped push leaves it)
+    assert (tmp_path / "muse-work" / "tracks" / "bass" / "bass.mid").exists()
+
+
+# ---------------------------------------------------------------------------
+# Section scoping
+# ---------------------------------------------------------------------------
+
+
+def test_stash_section_scoping(tmp_path: pathlib.Path) -> None:
+    """--section scopes stash to sections/<section>/ files only."""
+    _init_repo(tmp_path)
+    _populate_workdir(
+        tmp_path,
+        {
+            "sections/chorus/chords.mid": b"chorus-wip",
+            "sections/verse/lead.mid": b"verse-stable",
+        },
+    )
+
+    result = push_stash(tmp_path, section="chorus", head_manifest=None)
+
+    assert result.files_stashed == 1
+    entries = list_stash(tmp_path)
+    assert "sections/chorus/chords.mid" in entries[0].manifest
+    assert "sections/verse/lead.mid" not in entries[0].manifest
+    assert entries[0].section == "chorus"
+    # verse file untouched
+    assert (tmp_path / "muse-work" / "sections" / "verse" / "lead.mid").exists()
+
+
+# ---------------------------------------------------------------------------
+# OOB index handling
+# ---------------------------------------------------------------------------
+
+
+def test_stash_pop_on_empty_stack_raises(tmp_path: pathlib.Path) -> None:
+    """apply_stash raises IndexError when stash is empty."""
+    _init_repo(tmp_path)
+
+    with pytest.raises(IndexError):
+        apply_stash(tmp_path, 0, drop=True)
+
+
+def test_stash_apply_index_oob_raises(tmp_path: pathlib.Path) -> None:
+    """apply_stash raises IndexError for an out-of-range index."""
+    _init_repo(tmp_path)
+    _populate_workdir(tmp_path, {"x.mid": b"X"})
+    push_stash(tmp_path, head_manifest=None)
+
+    with pytest.raises(IndexError):
+        apply_stash(tmp_path, 5, drop=False)
+
+
+def test_stash_drop_index_oob_raises(tmp_path: pathlib.Path) -> None:
+    """drop_stash raises IndexError for an out-of-range index."""
+    _init_repo(tmp_path)
+
+    with pytest.raises(IndexError):
+        drop_stash(tmp_path, 0)
+
+
+# ---------------------------------------------------------------------------
+# Multiple entries stack ordering
+# ---------------------------------------------------------------------------
+
+
+def test_stash_multiple_entries(tmp_path: pathlib.Path) -> None:
+    """Multiple pushes build a stack; index 0 is always most recent."""
+    _init_repo(tmp_path)
+
+    content_map = {"first": b"v1", "second": b"v2", "third": b"v3"}
+    for label, content in content_map.items():
+        _populate_workdir(tmp_path, {f"{label}.mid": content})
+        push_stash(tmp_path, message=label, head_manifest=None)
+
+    entries = list_stash(tmp_path)
+    assert len(entries) == 3
+    # index 0 = most recently pushed = "third"
+    assert entries[0].message == "third"
+    assert entries[1].message == "second"
+    assert entries[2].message == "first"
+
+
+# ---------------------------------------------------------------------------
+# Empty workdir push is a noop
+# ---------------------------------------------------------------------------
+
+
+def test_stash_push_empty_workdir(tmp_path: pathlib.Path) -> None:
+    """push_stash on an empty workdir returns files_stashed=0 (noop)."""
+    _init_repo(tmp_path)
+    (tmp_path / "muse-work").mkdir()
+
+    result = push_stash(tmp_path, head_manifest=None)
+
+    assert result.files_stashed == 0
+    assert result.stash_ref == ""
+    assert list_stash(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Missing objects are reported (not silently dropped)
+# ---------------------------------------------------------------------------
+
+
+def test_stash_missing_objects_reported(tmp_path: pathlib.Path) -> None:
+    """apply_stash reports paths whose objects are absent from the store."""
+    from maestro.muse_cli.snapshot import hash_file
+
+    _init_repo(tmp_path)
+    _populate_workdir(tmp_path, {"chorus.mid": b"wip"})
+
+    # Push normally (object is stored)
+    push_stash(tmp_path, head_manifest=None)
+
+    # Manually delete the object to simulate missing store entry
+    entries = list_stash(tmp_path)
+    oid = entries[0].manifest["chorus.mid"]
+    obj_file = _object_path(tmp_path, oid)
+    assert obj_file.exists()
+    obj_file.unlink()
+
+    # Apply should report the missing file, not crash
+    result = apply_stash(tmp_path, 0, drop=False)
+
+    assert "chorus.mid" in result.missing
+    assert result.files_applied == 0
+
+
+# ---------------------------------------------------------------------------
+# Custom message is stored
+# ---------------------------------------------------------------------------
+
+
+def test_stash_message_stored(tmp_path: pathlib.Path) -> None:
+    """Custom --message text is persisted in the stash entry."""
+    _init_repo(tmp_path)
+    _populate_workdir(tmp_path, {"synth.mid": b"wip"})
+
+    push_stash(tmp_path, message="half-finished synth arpeggio", head_manifest=None)
+
+    entries = list_stash(tmp_path)
+    assert entries[0].message == "half-finished synth arpeggio"


### PR DESCRIPTION
## Summary

Closes #79 — implements `muse stash` with push, pop, apply, list, drop, and clear subcommands so producers can temporarily shelve in-progress muse-work/ changes without committing.

## Root Cause / Motivation

No stash command existed. Producers working on a half-finished chorus arrangement who needed to switch context (e.g. fix the intro for a client call) had to either commit WIP or lose their changes when switching branches.

## Solution

**Service layer** (`maestro/services/muse_stash.py`):
- `push_stash()` — walks muse-work/, stores file bytes in `.muse/objects/` (sharded blob store), writes a stash entry JSON to `.muse/stash/`, then restores HEAD snapshot to muse-work/.
- `apply_stash()` — reads a stash entry, copies objects back into muse-work/ (reports missing blobs rather than failing). `drop=True` for pop semantics.
- `list_stash()`, `drop_stash()`, `clear_stash()` — pure filesystem operations on `.muse/stash/`.
- `--track` / `--section` scoping: limits which files are stashed and restored.

**CLI** (`maestro/muse_cli/commands/stash.py`):
- `muse stash` / `muse stash push` — default subcommand
- `muse stash pop [stash@{N}]`
- `muse stash apply [stash@{N}]`
- `muse stash list`
- `muse stash drop [stash@{N}]`
- `muse stash clear [--yes]`

**Storage:** Filesystem-only (`.muse/stash/`). No new Postgres tables. File content goes through the existing content-addressed blob store (`.muse/objects/<oid[:2]>/<oid[2:]>`).

**Stack ordering:** `stash@{0}` is always most recent; entries are sorted by filename (timestamp-based) newest-first.

## Layers Affected

- [x] Muse VCS (muse_cli commands, services)

## Verification

- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (554 files)
- [x] `docker compose exec maestro pytest tests/muse_cli/test_stash.py -v` — 16 passed
- [x] Docs updated: `docs/architecture/muse_vcs.md` (new `### muse stash` section), `docs/reference/type_contracts.md` (StashEntry, StashPushResult, StashApplyResult)

## Tests Added

| Test | What it checks |
|------|----------------|
| `test_stash_push_pop_roundtrip` | Regression: push saves bytes; pop restores exactly |
| `test_stash_push_clears_workdir` | Full push with no HEAD clears muse-work/ |
| `test_stash_push_with_head_manifest` | Push restores HEAD snapshot to workdir |
| `test_stash_list_shows_entries` | list returns entries newest-first |
| `test_stash_apply_keeps_entry` | apply does not remove the entry |
| `test_stash_drop_removes_entry` | drop removes exactly the target entry |
| `test_stash_clear_removes_all` | clear empties entire stack, returns count |
| `test_stash_track_scoping` | --track saves/restores only matching files |
| `test_stash_section_scoping` | --section saves/restores only matching files |
| `test_stash_pop_on_empty_stack_raises` | pop on empty stack raises IndexError |
| `test_stash_apply_index_oob_raises` | apply on bad index raises IndexError |
| `test_stash_drop_index_oob_raises` | drop on bad index raises IndexError |
| `test_stash_multiple_entries` | multiple pushes build correct stack ordering |
| `test_stash_push_empty_workdir` | push on empty workdir is a noop |
| `test_stash_missing_objects_reported` | apply reports missing paths, does not crash |
| `test_stash_message_stored` | custom --message is persisted in the entry |

## Handoff

N/A — no SSE/MCP/protocol change.