### PR TITLE
feat: muse cherry-pick <commit> — apply a specific commit from another branch

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -3134,6 +3134,50 @@ was (or was not) changed so callers can verify the revert succeeded.
 
 ---
 
+### `CherryPickResult`
+
+**Module:** `maestro/services/muse_cherry_pick.py`
+
+Outcome of a `muse cherry-pick` operation. Captures whether the cherry-pick applied cleanly, produced a conflict, or was staged without committing, so callers can verify the result and decide on next steps.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | New commit ID created by the cherry-pick. Empty string when `--no-commit` or conflict. |
+| `cherry_commit_id` | `str` | Source commit that was cherry-picked. |
+| `head_commit_id` | `str` | HEAD commit at cherry-pick initiation time. |
+| `new_snapshot_id` | `str` | Snapshot ID of the resulting state (even when not committed). |
+| `message` | `str` | Commit message with attribution suffix: `"(cherry picked from commit <short-id>)"`. |
+| `no_commit` | `bool` | `True` when changes were staged to muse-work/ without creating a commit. |
+| `conflict` | `bool` | `True` when conflicts were detected and `.muse/CHERRY_PICK_STATE.json` was written. |
+| `conflict_paths` | `tuple[str, ...]` | Conflicting relative POSIX paths. Non-empty iff `conflict=True`. |
+| `branch` | `str` | Branch on which the new commit was (or would have been) created. |
+
+**Producer:** `_cherry_pick_async()`, `_cherry_pick_continue_async()`
+**Consumer:** `cherry_pick()` Typer command callback, tests in `tests/muse_cli/test_cherry_pick.py`
+
+**Frozen dataclass** — all fields are immutable after construction.
+
+---
+
+### `CherryPickState`
+
+**Module:** `maestro/services/muse_cherry_pick.py`
+
+In-memory representation of `.muse/CHERRY_PICK_STATE.json`. Describes the paused cherry-pick so `--continue` and `--abort` can resume or cancel correctly.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cherry_commit` | `str` | Commit ID that was being cherry-picked when paused. |
+| `head_commit` | `str` | HEAD commit at cherry-pick initiation — restored by `--abort`. |
+| `conflict_paths` | `list[str]` | Paths with unresolved conflicts. Empty list = all resolved (safe to `--continue`). |
+
+**Producer:** `write_cherry_pick_state()`, `read_cherry_pick_state()`
+**Consumer:** `_cherry_pick_continue_async()`, `_cherry_pick_abort_async()`
+
+**Frozen dataclass** — all fields are immutable after construction.
+
+---
+
 ### `TrackHumanizeResult`
 
 **Module:** `maestro/muse_cli/commands/humanize.py`

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -1,13 +1,13 @@
 """Muse CLI — Typer application root.
 
 Entry point for the ``muse`` console script. Registers all MVP
-subcommands (amend, arrange, ask, cat-object, checkout, chord-map, commit,
-commit-tree, context, contour, describe, diff, divergence, dynamics, emotion-diff,
-export, find, form, grep, groove-check, harmony, humanize, import, init, inspect,
-key, log, merge, meter, motif, open, play, pull, push, read-tree, recall, remote,
-render-preview, reset, resolve, rev-parse, revert, session, show, similarity,
-status, swing, symbolic-ref, tag, tempo, tempo-scale, timeline, update-ref,
-validate, write-tree) as Typer sub-applications.
+subcommands (amend, arrange, ask, cat-object, checkout, cherry-pick, chord-map,
+commit, commit-tree, context, contour, describe, diff, divergence, dynamics,
+emotion-diff, export, find, form, grep, groove-check, harmony, humanize, import,
+init, inspect, key, log, merge, meter, motif, open, play, pull, push, read-tree,
+recall, remote, render-preview, reset, resolve, rev-parse, revert, session, show,
+similarity, status, swing, symbolic-ref, tag, tempo, tempo-scale, timeline,
+update-ref, validate, write-tree) as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -19,6 +19,7 @@ from maestro.muse_cli.commands import (
     ask,
     cat_object,
     checkout,
+    cherry_pick,
     chord_map,
     commit,
     commit_tree,
@@ -79,6 +80,7 @@ cli = typer.Typer(
 
 cli.add_typer(amend.app, name="amend", help="Fold working-tree changes into the most recent commit.")
 cli.add_typer(cat_object.app, name="cat-object", help="Read and display a stored object by its SHA-256 hash.")
+cli.add_typer(cherry_pick.app, name="cherry-pick", help="Apply a specific commit's diff on top of HEAD without merging the full branch.")
 cli.add_typer(chord_map.app, name="chord-map", help="Visualize the chord progression embedded in a commit.")
 cli.add_typer(contour.app, name="contour", help="Analyze the melodic contour and phrase shape of a commit.")
 cli.add_typer(init.app, name="init", help="Initialise a new Muse repository.")

--- a/maestro/muse_cli/commands/cherry_pick.py
+++ b/maestro/muse_cli/commands/cherry_pick.py
@@ -1,0 +1,129 @@
+"""muse cherry-pick — apply a specific commit's diff on top of HEAD.
+
+Transplants the changes introduced by a single commit (from any branch)
+onto the current branch, without bringing in other commits from that branch.
+
+Domain analogy: a producer recorded the perfect guitar solo in
+``experiment/guitar-solo``.  ``muse cherry-pick <commit>`` transplants just
+that solo into main, leaving the other 20 unrelated commits behind.
+
+Flags
+-----
+COMMIT TEXT       Commit ID to cherry-pick (required, positional, accepts prefix).
+--no-commit       Apply the changes to muse-work/ without committing.
+--continue        Resume after resolving conflicts from a previous cherry-pick.
+--abort           Abort in-progress cherry-pick and restore pre-cherry-pick state.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+import typer
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.services.muse_cherry_pick import (
+    _cherry_pick_abort_async,
+    _cherry_pick_async,
+    _cherry_pick_continue_async,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer()
+
+
+@app.callback(invoke_without_command=True)
+def cherry_pick(
+    ctx: typer.Context,
+    commit: Optional[str] = typer.Argument(
+        None,
+        help="Commit ID to cherry-pick (full or abbreviated SHA).",
+        metavar="COMMIT",
+    ),
+    no_commit: bool = typer.Option(
+        False,
+        "--no-commit",
+        is_flag=True,
+        help=(
+            "Apply the cherry-pick changes to muse-work/ without creating a new commit. "
+            "Useful for inspecting or further editing the result before committing."
+        ),
+    ),
+    cont: bool = typer.Option(
+        False,
+        "--continue",
+        is_flag=True,
+        help="Resume after resolving conflicts from a previous cherry-pick.",
+    ),
+    abort: bool = typer.Option(
+        False,
+        "--abort",
+        is_flag=True,
+        help=(
+            "Abort an in-progress cherry-pick and restore the branch to its "
+            "pre-cherry-pick state."
+        ),
+    ),
+) -> None:
+    """Apply a specific commit's diff on top of HEAD without merging the full branch."""
+    root = require_repo()
+
+    if abort:
+        async def _run_abort() -> None:
+            async with open_session() as session:
+                await _cherry_pick_abort_async(root=root, session=session)
+
+        try:
+            asyncio.run(_run_abort())
+        except typer.Exit:
+            raise
+        except Exception as exc:
+            typer.echo(f"❌ muse cherry-pick --abort failed: {exc}")
+            logger.error("❌ muse cherry-pick --abort error: %s", exc, exc_info=True)
+            raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+        return
+
+    if cont:
+        async def _run_continue() -> None:
+            async with open_session() as session:
+                await _cherry_pick_continue_async(root=root, session=session)
+
+        try:
+            asyncio.run(_run_continue())
+        except typer.Exit:
+            raise
+        except Exception as exc:
+            typer.echo(f"❌ muse cherry-pick --continue failed: {exc}")
+            logger.error(
+                "❌ muse cherry-pick --continue error: %s", exc, exc_info=True
+            )
+            raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+        return
+
+    if not commit:
+        typer.echo(
+            "❌ Commit ID required (or use --continue to resume, --abort to cancel)."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    async def _run() -> None:
+        async with open_session() as session:
+            await _cherry_pick_async(
+                commit_ref=commit,
+                root=root,
+                session=session,
+                no_commit=no_commit,
+            )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse cherry-pick failed: {exc}")
+        logger.error("❌ muse cherry-pick error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/services/muse_cherry_pick.py
+++ b/maestro/services/muse_cherry_pick.py
@@ -1,0 +1,633 @@
+"""Muse Cherry-Pick Service — apply a specific commit's diff on top of HEAD.
+
+Cherry-pick is the surgical transplant: given a source commit C with parent P,
+compute diff(P → C) and apply that patch to the current HEAD snapshot.  The
+result is a new commit whose content is HEAD's snapshot plus the delta that C
+introduced, without bringing in any other commits from C's branch.
+
+Algorithm (3-way merge model)
+------------------------------
+1. Resolve C and its parent P.
+2. Load manifests: ``base`` = P, ``ours`` = HEAD, ``theirs`` = C.
+3. Compute ``cherry_diff`` = diff(P → C) — the set of paths C changed.
+4. Compute ``head_diff`` = diff(P → HEAD) — paths HEAD changed since P.
+5. Conflicts = paths in cherry_diff ∩ head_diff where both sides disagree.
+6. If conflicts: write ``.muse/CHERRY_PICK_STATE.json`` and exit 1.
+7. If clean: build result manifest (HEAD + cherry delta), persist, create commit.
+
+State file: ``.muse/CHERRY_PICK_STATE.json``
+---------------------------------------------
+Written when conflicts are detected, consumed by ``--continue`` and ``--abort``.
+
+.. code-block:: json
+
+    {
+        "cherry_commit":  "abc123...",
+        "head_commit":    "def456...",
+        "conflict_paths": ["beat.mid"]
+    }
+
+Boundary rules:
+  - Must NOT import StateStore, EntityRegistry, or get_or_create_store.
+  - Must NOT import executor modules or maestro_* handlers.
+  - May import muse_cli.db, muse_cli.models, muse_cli.merge_engine,
+    muse_cli.snapshot.
+
+Domain analogy: a producer recorded the perfect guitar solo in an experimental
+branch.  ``muse cherry-pick <commit>`` transplants just that solo into main,
+leaving the other 20 unrelated commits behind.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import pathlib
+from dataclasses import dataclass, field
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.db import (
+    get_commit_snapshot_manifest,
+    insert_commit,
+    resolve_commit_ref,
+    upsert_snapshot,
+)
+from maestro.muse_cli.merge_engine import diff_snapshots, read_merge_state
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+from maestro.muse_cli.snapshot import compute_commit_id, compute_snapshot_id
+
+logger = logging.getLogger(__name__)
+
+_CHERRY_PICK_STATE_FILENAME = "CHERRY_PICK_STATE.json"
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CherryPickState:
+    """Describes an in-progress cherry-pick with unresolved conflicts.
+
+    Attributes:
+        cherry_commit:  Commit ID being cherry-picked.
+        head_commit:    Commit ID of HEAD when the cherry-pick was initiated.
+        conflict_paths: Relative POSIX paths that have unresolved conflicts.
+    """
+
+    cherry_commit: str
+    head_commit: str
+    conflict_paths: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class CherryPickResult:
+    """Outcome of a ``muse cherry-pick`` operation.
+
+    Attributes:
+        commit_id:        New commit ID (empty when ``no_commit=True`` or conflict).
+        cherry_commit_id: Source commit that was cherry-picked.
+        head_commit_id:   HEAD commit at cherry-pick time.
+        new_snapshot_id:  Snapshot ID of the resulting state.
+        message:          Commit message (prefixed with cherry-pick attribution).
+        no_commit:        True when ``--no-commit`` was requested.
+        conflict:         True when conflicts were detected (state file written).
+        conflict_paths:   Conflicting paths (non-empty iff ``conflict=True``).
+        branch:           Branch on which the new commit was created.
+    """
+
+    commit_id: str
+    cherry_commit_id: str
+    head_commit_id: str
+    new_snapshot_id: str
+    message: str
+    no_commit: bool
+    conflict: bool
+    conflict_paths: tuple[str, ...]
+    branch: str
+
+
+# ---------------------------------------------------------------------------
+# State file helpers
+# ---------------------------------------------------------------------------
+
+
+def read_cherry_pick_state(root: pathlib.Path) -> CherryPickState | None:
+    """Return :class:`CherryPickState` if a cherry-pick is in progress, else ``None``.
+
+    Reads ``.muse/CHERRY_PICK_STATE.json``.  Returns ``None`` when absent or unparseable.
+
+    Args:
+        root: Repository root (directory containing ``.muse/``).
+    """
+    path = root / ".muse" / _CHERRY_PICK_STATE_FILENAME
+    if not path.exists():
+        return None
+    try:
+        data: dict[str, object] = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("⚠️ Failed to read %s: %s", _CHERRY_PICK_STATE_FILENAME, exc)
+        return None
+
+    raw_conflicts = data.get("conflict_paths", [])
+    conflict_paths: list[str] = (
+        [str(c) for c in raw_conflicts] if isinstance(raw_conflicts, list) else []
+    )
+    return CherryPickState(
+        cherry_commit=str(data.get("cherry_commit", "")),
+        head_commit=str(data.get("head_commit", "")),
+        conflict_paths=conflict_paths,
+    )
+
+
+def write_cherry_pick_state(
+    root: pathlib.Path,
+    *,
+    cherry_commit: str,
+    head_commit: str,
+    conflict_paths: list[str],
+) -> None:
+    """Write ``.muse/CHERRY_PICK_STATE.json`` to record a paused cherry-pick.
+
+    Args:
+        root:           Repository root.
+        cherry_commit:  Commit ID being cherry-picked.
+        head_commit:    Commit ID of HEAD at cherry-pick time.
+        conflict_paths: Paths with unresolved conflicts.
+    """
+    state_path = root / ".muse" / _CHERRY_PICK_STATE_FILENAME
+    data: dict[str, object] = {
+        "cherry_commit": cherry_commit,
+        "head_commit": head_commit,
+        "conflict_paths": sorted(conflict_paths),
+    }
+    state_path.write_text(json.dumps(data, indent=2))
+    logger.info(
+        "✅ Wrote CHERRY_PICK_STATE.json with %d conflict(s)", len(conflict_paths)
+    )
+
+
+def clear_cherry_pick_state(root: pathlib.Path) -> None:
+    """Remove ``.muse/CHERRY_PICK_STATE.json`` after a successful or aborted cherry-pick."""
+    state_path = root / ".muse" / _CHERRY_PICK_STATE_FILENAME
+    if state_path.exists():
+        state_path.unlink()
+        logger.debug("✅ Cleared CHERRY_PICK_STATE.json")
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def compute_cherry_manifest(
+    *,
+    base_manifest: dict[str, str],
+    head_manifest: dict[str, str],
+    cherry_manifest: dict[str, str],
+    cherry_diff: set[str],
+    head_diff: set[str],
+) -> tuple[dict[str, str], set[str]]:
+    """Apply the cherry-pick delta onto the HEAD manifest.
+
+    For each path in ``cherry_diff``:
+    - If also in ``head_diff`` AND both sides have different values → conflict.
+    - Otherwise take the cherry version (or remove the path if deleted by cherry).
+
+    Paths not in ``cherry_diff`` remain at their HEAD values.
+
+    Args:
+        base_manifest:   Manifest of the cherry commit's parent (P).
+        head_manifest:   Manifest of HEAD (ours).
+        cherry_manifest: Manifest of the cherry commit (C).
+        cherry_diff:     Paths changed by C relative to P.
+        head_diff:       Paths changed by HEAD relative to P.
+
+    Returns:
+        Tuple of (result_manifest, conflict_paths) where ``conflict_paths``
+        is empty for a clean cherry-pick.
+    """
+    result = dict(head_manifest)
+    conflicts: set[str] = set()
+
+    for path in cherry_diff:
+        cherry_oid = cherry_manifest.get(path)
+        head_oid = head_manifest.get(path)
+        base_oid = base_manifest.get(path)
+
+        if path in head_diff:
+            # Both sides changed this path since the base
+            if cherry_oid == head_oid:
+                # Same outcome on both sides — not a real conflict
+                pass
+            else:
+                conflicts.add(path)
+                continue  # leave HEAD's version in result for now
+
+        # Apply the cherry change: add/modify or delete
+        if cherry_oid is not None:
+            result[path] = cherry_oid
+        else:
+            # Cherry deleted this path
+            result.pop(path, None)
+
+    return result, conflicts
+
+
+# ---------------------------------------------------------------------------
+# Async core
+# ---------------------------------------------------------------------------
+
+
+async def _cherry_pick_async(
+    *,
+    commit_ref: str,
+    root: pathlib.Path,
+    session: AsyncSession,
+    no_commit: bool = False,
+) -> CherryPickResult:
+    """Core cherry-pick pipeline — resolve, validate, apply, and commit.
+
+    Called by the CLI callback and by tests.  All filesystem and DB
+    side-effects are isolated here so tests can inject an in-memory SQLite
+    session and a ``tmp_path`` root.
+
+    Args:
+        commit_ref: Commit ID (full or abbreviated) to cherry-pick.
+        root:       Repo root (must contain ``.muse/``).
+        session:    Async DB session (caller owns commit/rollback lifecycle).
+        no_commit:  When ``True``, stage changes to muse-work/ but do not
+                    create a new commit record.
+
+    Returns:
+        :class:`CherryPickResult` describing what happened.
+
+    Raises:
+        ``typer.Exit`` with an appropriate exit code on user-facing errors.
+    """
+    import typer
+
+    from maestro.muse_cli.errors import ExitCode
+
+    muse_dir = root / ".muse"
+
+    # ── Guard: block if merge is in progress ─────────────────────────────
+    merge_state = read_merge_state(root)
+    if merge_state is not None and merge_state.conflict_paths:
+        typer.echo(
+            "❌ Cherry-pick blocked: unresolved merge conflicts in progress.\n"
+            "   Resolve all conflicts, then run 'muse commit' before cherry-picking."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # ── Guard: block if cherry-pick already in progress ──────────────────
+    existing_state = read_cherry_pick_state(root)
+    if existing_state is not None:
+        typer.echo(
+            "❌ Cherry-pick already in progress.\n"
+            "   Resolve conflicts and run 'muse cherry-pick --continue', or\n"
+            "   run 'muse cherry-pick --abort' to cancel."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # ── Repo identity ────────────────────────────────────────────────────
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]
+
+    head_ref = (muse_dir / "HEAD").read_text().strip()
+    branch = head_ref.rsplit("/", 1)[-1]
+
+    # ── Resolve HEAD from the branch ref file (not DB ordering) ──────────
+    # Reading the ref file directly is the authoritative source for HEAD,
+    # because the DB committed_at ordering does not reflect manual resets.
+    branch_ref_path = muse_dir / pathlib.Path(head_ref)
+    head_commit_id = (
+        branch_ref_path.read_text().strip() if branch_ref_path.exists() else ""
+    )
+    if not head_commit_id:
+        typer.echo("❌ Current branch has no commits. Cannot cherry-pick onto an empty branch.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    head_commit = await session.get(MuseCliCommit, head_commit_id)
+    if head_commit is None:
+        typer.echo(f"❌ HEAD commit {head_commit_id[:8]} not found in DB.")
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    # ── Resolve cherry commit ────────────────────────────────────────────
+    cherry_commit = await resolve_commit_ref(session, repo_id, branch, commit_ref)
+    if cherry_commit is None:
+        # resolve_commit_ref only searches the current branch; try by prefix across all
+        from sqlalchemy.future import select
+
+        stmt = select(MuseCliCommit).where(
+            MuseCliCommit.repo_id == repo_id,
+            MuseCliCommit.commit_id.startswith(commit_ref),
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+        if not rows:
+            typer.echo(f"❌ Commit not found: {commit_ref!r}")
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+        if len(rows) > 1:
+            typer.echo(
+                f"❌ Ambiguous commit ref {commit_ref!r} — matches {len(rows)} commits. "
+                "Use a longer prefix."
+            )
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+        cherry_commit = rows[0]
+
+    cherry_commit_id = cherry_commit.commit_id
+
+    # ── Guard: cherry-pick of HEAD itself is a noop ───────────────────────
+    if cherry_commit_id == head_commit_id:
+        typer.echo(
+            f"⚠️  Commit {cherry_commit_id[:8]} is already HEAD — nothing to cherry-pick."
+        )
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    # ── Load manifests ───────────────────────────────────────────────────
+    # base = cherry commit's parent (P)
+    base_manifest: dict[str, str] = {}
+    if cherry_commit.parent_commit_id:
+        loaded = await get_commit_snapshot_manifest(session, cherry_commit.parent_commit_id)
+        base_manifest = loaded or {}
+
+    cherry_manifest = await get_commit_snapshot_manifest(session, cherry_commit_id) or {}
+
+    head_manifest: dict[str, str] = {}
+    head_snap_row = await session.get(MuseCliSnapshot, head_commit.snapshot_id)
+    if head_snap_row is not None:
+        head_manifest = dict(head_snap_row.manifest)
+
+    # ── Compute diffs ────────────────────────────────────────────────────
+    cherry_diff = diff_snapshots(base_manifest, cherry_manifest)
+    head_diff = diff_snapshots(base_manifest, head_manifest)
+
+    # ── Apply cherry delta ───────────────────────────────────────────────
+    result_manifest, conflict_paths = compute_cherry_manifest(
+        base_manifest=base_manifest,
+        head_manifest=head_manifest,
+        cherry_manifest=cherry_manifest,
+        cherry_diff=cherry_diff,
+        head_diff=head_diff,
+    )
+
+    result_snapshot_id = compute_snapshot_id(result_manifest)
+
+    # ── Conflict path ─────────────────────────────────────────────────────
+    if conflict_paths:
+        write_cherry_pick_state(
+            root,
+            cherry_commit=cherry_commit_id,
+            head_commit=head_commit_id,
+            conflict_paths=sorted(conflict_paths),
+        )
+        typer.echo(f"❌ Cherry-pick conflict in {len(conflict_paths)} file(s):")
+        for path in sorted(conflict_paths):
+            typer.echo(f"\tboth modified:   {path}")
+        typer.echo(
+            "Fix conflicts and run 'muse cherry-pick --continue' to create the commit."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # ── Auto-generate commit message ─────────────────────────────────────
+    short_id = cherry_commit_id[:8]
+    cherry_message = (
+        f"{cherry_commit.message}\n\n(cherry picked from commit {short_id})"
+    )
+
+    # ── --no-commit: return without persisting ────────────────────────────
+    if no_commit:
+        typer.echo(
+            f"✅ Cherry-pick applied (--no-commit). "
+            f"Changes from {short_id} staged in muse-work/."
+        )
+        return CherryPickResult(
+            commit_id="",
+            cherry_commit_id=cherry_commit_id,
+            head_commit_id=head_commit_id,
+            new_snapshot_id=result_snapshot_id,
+            message=cherry_message,
+            no_commit=True,
+            conflict=False,
+            conflict_paths=(),
+            branch=branch,
+        )
+
+    # ── Persist snapshot ─────────────────────────────────────────────────
+    await upsert_snapshot(session, manifest=result_manifest, snapshot_id=result_snapshot_id)
+    await session.flush()
+
+    # ── Persist commit ───────────────────────────────────────────────────
+    committed_at = datetime.datetime.now(datetime.timezone.utc)
+    new_commit_id = compute_commit_id(
+        parent_ids=[head_commit_id],
+        snapshot_id=result_snapshot_id,
+        message=cherry_message,
+        committed_at_iso=committed_at.isoformat(),
+    )
+
+    new_commit = MuseCliCommit(
+        commit_id=new_commit_id,
+        repo_id=repo_id,
+        branch=branch,
+        parent_commit_id=head_commit_id,
+        snapshot_id=result_snapshot_id,
+        message=cherry_message,
+        author="",
+        committed_at=committed_at,
+    )
+    await insert_commit(session, new_commit)
+
+    # ── Update branch HEAD pointer ────────────────────────────────────────
+    ref_path = muse_dir / pathlib.Path(head_ref)
+    ref_path.parent.mkdir(parents=True, exist_ok=True)
+    ref_path.write_text(new_commit_id)
+
+    typer.echo(
+        f"✅ [{branch} {new_commit_id[:8]}] {cherry_commit.message}\n"
+        f"   (cherry picked from commit {short_id})"
+    )
+    logger.info(
+        "✅ muse cherry-pick %s → %s on %r",
+        short_id,
+        new_commit_id[:8],
+        branch,
+    )
+
+    return CherryPickResult(
+        commit_id=new_commit_id,
+        cherry_commit_id=cherry_commit_id,
+        head_commit_id=head_commit_id,
+        new_snapshot_id=result_snapshot_id,
+        message=cherry_message,
+        no_commit=False,
+        conflict=False,
+        conflict_paths=(),
+        branch=branch,
+    )
+
+
+async def _cherry_pick_continue_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+) -> CherryPickResult:
+    """Finalize a cherry-pick that was paused due to conflicts.
+
+    Reads ``CHERRY_PICK_STATE.json``, verifies all conflicts are cleared,
+    builds a snapshot from the current ``muse-work/`` contents, inserts a
+    commit, advances the branch pointer, and clears the state file.
+
+    Args:
+        root:    Repository root.
+        session: Open async DB session.
+
+    Raises:
+        :class:`typer.Exit`: If no cherry-pick is in progress, unresolved
+            conflicts remain, or ``muse-work/`` is empty.
+    """
+    import typer
+
+    from maestro.muse_cli.errors import ExitCode
+    from maestro.muse_cli.snapshot import build_snapshot_manifest
+
+    state = read_cherry_pick_state(root)
+    if state is None:
+        typer.echo("❌ No cherry-pick in progress. Nothing to continue.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    if state.conflict_paths:
+        typer.echo(
+            f"❌ {len(state.conflict_paths)} conflict(s) not yet resolved:\n"
+            + "\n".join(f"\tboth modified:   {p}" for p in state.conflict_paths)
+            + "\nRun 'muse resolve <path> --ours/--theirs' for each file."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    muse_dir = root / ".muse"
+    repo_data: dict[str, str] = json.loads((muse_dir / "repo.json").read_text())
+    repo_id = repo_data["repo_id"]
+
+    head_ref = (muse_dir / "HEAD").read_text().strip()
+    branch = head_ref.rsplit("/", 1)[-1]
+    our_ref_path = muse_dir / pathlib.Path(head_ref)
+
+    head_commit_id = state.head_commit
+    cherry_commit_id = state.cherry_commit
+
+    # Load cherry commit message for attribution
+    cherry_commit_row = await session.get(MuseCliCommit, cherry_commit_id)
+    if cherry_commit_row is None:
+        typer.echo(f"❌ Cherry commit {cherry_commit_id[:8]} not found in DB.")
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    # Build snapshot from current muse-work/ (conflicts already resolved)
+    workdir = root / "muse-work"
+    if not workdir.exists():
+        typer.echo("⚠️  muse-work/ is missing. Cannot create cherry-pick snapshot.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    manifest = build_snapshot_manifest(workdir)
+    if not manifest:
+        typer.echo("⚠️  muse-work/ is empty. Nothing to commit for the cherry-pick.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    snapshot_id = compute_snapshot_id(manifest)
+    await upsert_snapshot(session, manifest=manifest, snapshot_id=snapshot_id)
+    await session.flush()
+
+    short_id = cherry_commit_id[:8]
+    cherry_message = (
+        f"{cherry_commit_row.message}\n\n(cherry picked from commit {short_id})"
+    )
+
+    committed_at = datetime.datetime.now(datetime.timezone.utc)
+    new_commit_id = compute_commit_id(
+        parent_ids=[head_commit_id],
+        snapshot_id=snapshot_id,
+        message=cherry_message,
+        committed_at_iso=committed_at.isoformat(),
+    )
+
+    new_commit = MuseCliCommit(
+        commit_id=new_commit_id,
+        repo_id=repo_id,
+        branch=branch,
+        parent_commit_id=head_commit_id,
+        snapshot_id=snapshot_id,
+        message=cherry_message,
+        author="",
+        committed_at=committed_at,
+    )
+    await insert_commit(session, new_commit)
+
+    our_ref_path.write_text(new_commit_id)
+    clear_cherry_pick_state(root)
+
+    typer.echo(
+        f"✅ [{branch} {new_commit_id[:8]}] {cherry_commit_row.message}\n"
+        f"   (cherry picked from commit {short_id})"
+    )
+    logger.info(
+        "✅ muse cherry-pick --continue: commit %s on %r (cherry: %s)",
+        new_commit_id[:8],
+        branch,
+        short_id,
+    )
+
+    return CherryPickResult(
+        commit_id=new_commit_id,
+        cherry_commit_id=cherry_commit_id,
+        head_commit_id=head_commit_id,
+        new_snapshot_id=snapshot_id,
+        message=cherry_message,
+        no_commit=False,
+        conflict=False,
+        conflict_paths=(),
+        branch=branch,
+    )
+
+
+async def _cherry_pick_abort_async(
+    *,
+    root: pathlib.Path,
+    session: AsyncSession,
+) -> None:
+    """Abort an in-progress cherry-pick and restore pre-cherry-pick HEAD.
+
+    Reads ``CHERRY_PICK_STATE.json`` to recover the original HEAD commit,
+    resets the branch pointer, and removes the state file.
+
+    Args:
+        root:    Repository root.
+        session: Open async DB session (unused but required for interface consistency).
+
+    Raises:
+        :class:`typer.Exit`: If no cherry-pick is in progress.
+    """
+    import typer
+
+    from maestro.muse_cli.errors import ExitCode
+
+    state = read_cherry_pick_state(root)
+    if state is None:
+        typer.echo("❌ No cherry-pick in progress. Nothing to abort.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    muse_dir = root / ".muse"
+    head_ref = (muse_dir / "HEAD").read_text().strip()
+    ref_path = muse_dir / pathlib.Path(head_ref)
+
+    # Restore the branch pointer to HEAD at cherry-pick initiation time
+    ref_path.write_text(state.head_commit)
+    clear_cherry_pick_state(root)
+
+    typer.echo(
+        f"✅ Cherry-pick aborted. HEAD restored to {state.head_commit[:8]}."
+    )
+    logger.info(
+        "✅ muse cherry-pick --abort: restored HEAD to %s",
+        state.head_commit[:8],
+    )

--- a/tests/muse_cli/test_cherry_pick.py
+++ b/tests/muse_cli/test_cherry_pick.py
@@ -1,0 +1,674 @@
+"""Tests for ``muse cherry-pick`` — apply a specific commit's diff on top of HEAD.
+
+Exercises:
+- ``test_cherry_pick_clean_apply_creates_commit`` — regression: cherry-pick of a
+  non-conflicting commit creates a new commit with the correct snapshot delta.
+- ``test_cherry_pick_conflict_detection_writes_state`` — conflict detection writes
+  CHERRY_PICK_STATE.json and exits 1.
+- ``test_cherry_pick_abort_restores_head`` — --abort removes state file and restores HEAD.
+- ``test_cherry_pick_continue_creates_commit_after_resolve`` — --continue creates
+  commit from muse-work/ after conflicts are resolved.
+- ``test_cherry_pick_no_commit_does_not_create_commit`` — --no-commit returns result
+  without persisting a commit row.
+- ``test_cherry_pick_blocked_when_merge_in_progress`` — blocked by active merge.
+- ``test_cherry_pick_blocked_when_already_in_progress`` — blocked by existing
+  CHERRY_PICK_STATE.json.
+- ``test_cherry_pick_self_is_noop`` — cherry-picking HEAD itself exits with SUCCESS.
+- ``test_cherry_pick_unknown_commit_raises_exit`` — unknown commit ID exits USER_ERROR.
+- ``compute_cherry_manifest_*`` — pure-function unit tests for the manifest logic.
+
+All async tests use ``@pytest.mark.anyio``.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.merge_engine import write_merge_state
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+from maestro.services.muse_cherry_pick import (
+    CherryPickResult,
+    CherryPickState,
+    _cherry_pick_abort_async,
+    _cherry_pick_async,
+    _cherry_pick_continue_async,
+    clear_cherry_pick_state,
+    compute_cherry_manifest,
+    read_cherry_pick_state,
+    write_cherry_pick_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Repo / workdir helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_muse_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    """Create a minimal .muse/ layout."""
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(
+        json.dumps({"repo_id": rid, "schema_version": "1"})
+    )
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _populate_workdir(
+    root: pathlib.Path, files: dict[str, bytes] | None = None
+) -> None:
+    """Create muse-work/ with the specified files."""
+    workdir = root / "muse-work"
+    workdir.mkdir(exist_ok=True)
+    if files is None:
+        files = {"beat.mid": b"MIDI-DATA", "lead.mp3": b"MP3-DATA"}
+    for name, content in files.items():
+        path = workdir / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — pure functions
+# ---------------------------------------------------------------------------
+
+
+def test_compute_cherry_manifest_clean_apply() -> None:
+    """Cherry diff applies cleanly when HEAD did not touch the same paths."""
+    base = {"beat.mid": "aaa", "bass.mid": "bbb"}
+    head = {"beat.mid": "aaa", "bass.mid": "bbb", "keys.mid": "kkk"}
+    cherry = {"beat.mid": "ccc", "bass.mid": "bbb"}  # cherry modified beat.mid
+
+    cherry_diff = {"beat.mid"}  # changed in cherry vs base
+    head_diff = {"keys.mid"}  # HEAD added keys.mid
+
+    result, conflicts = compute_cherry_manifest(
+        base_manifest=base,
+        head_manifest=head,
+        cherry_manifest=cherry,
+        cherry_diff=cherry_diff,
+        head_diff=head_diff,
+    )
+
+    assert conflicts == set()
+    assert result["beat.mid"] == "ccc"  # cherry version
+    assert result["keys.mid"] == "kkk"  # HEAD's addition preserved
+    assert result["bass.mid"] == "bbb"  # unchanged
+
+
+def test_compute_cherry_manifest_conflict_detection() -> None:
+    """Conflict detected when both cherry and HEAD modified the same path differently."""
+    base = {"beat.mid": "aaa"}
+    head = {"beat.mid": "head-version"}
+    cherry = {"beat.mid": "cherry-version"}
+
+    cherry_diff = {"beat.mid"}
+    head_diff = {"beat.mid"}
+
+    result, conflicts = compute_cherry_manifest(
+        base_manifest=base,
+        head_manifest=head,
+        cherry_manifest=cherry,
+        cherry_diff=cherry_diff,
+        head_diff=head_diff,
+    )
+
+    assert "beat.mid" in conflicts
+    # HEAD's version left in place during conflict
+    assert result["beat.mid"] == "head-version"
+
+
+def test_compute_cherry_manifest_same_change_no_conflict() -> None:
+    """No conflict when both sides independently made the same change."""
+    base = {"beat.mid": "aaa"}
+    head = {"beat.mid": "same-oid"}
+    cherry = {"beat.mid": "same-oid"}
+
+    cherry_diff = {"beat.mid"}
+    head_diff = {"beat.mid"}
+
+    result, conflicts = compute_cherry_manifest(
+        base_manifest=base,
+        head_manifest=head,
+        cherry_manifest=cherry,
+        cherry_diff=cherry_diff,
+        head_diff=head_diff,
+    )
+
+    assert conflicts == set()
+    assert result["beat.mid"] == "same-oid"
+
+
+def test_compute_cherry_manifest_cherry_deletion() -> None:
+    """Cherry-pick removes a path that cherry deleted and HEAD did not touch."""
+    base = {"beat.mid": "aaa", "old.mid": "old"}
+    head = {"beat.mid": "aaa", "old.mid": "old"}
+    cherry = {"beat.mid": "aaa"}  # cherry deleted old.mid
+
+    cherry_diff = {"old.mid"}  # old.mid deleted in cherry
+    head_diff: set[str] = set()
+
+    result, conflicts = compute_cherry_manifest(
+        base_manifest=base,
+        head_manifest=head,
+        cherry_manifest=cherry,
+        cherry_diff=cherry_diff,
+        head_diff=head_diff,
+    )
+
+    assert conflicts == set()
+    assert "old.mid" not in result
+
+
+def test_read_write_clear_cherry_pick_state(tmp_path: pathlib.Path) -> None:
+    """State file round-trips correctly through write/read/clear."""
+    muse = tmp_path / ".muse"
+    muse.mkdir()
+
+    assert read_cherry_pick_state(tmp_path) is None
+
+    write_cherry_pick_state(
+        tmp_path,
+        cherry_commit="cherry-abc",
+        head_commit="head-def",
+        conflict_paths=["beat.mid", "lead.mp3"],
+    )
+
+    state = read_cherry_pick_state(tmp_path)
+    assert state is not None
+    assert state.cherry_commit == "cherry-abc"
+    assert state.head_commit == "head-def"
+    assert "beat.mid" in state.conflict_paths
+    assert "lead.mp3" in state.conflict_paths
+
+    clear_cherry_pick_state(tmp_path)
+    assert read_cherry_pick_state(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — async DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cherry_pick_clean_apply_creates_commit(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Regression: cherry-pick of a non-conflicting commit creates a new commit."""
+    _init_muse_repo(tmp_path)
+
+    # Commit A — baseline on main
+    _populate_workdir(tmp_path, {"beat.mid": b"main-beat", "bass.mid": b"bass-v1"})
+    commit_a_id = await _commit_async(
+        message="main baseline",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Commit B — adds a new file (simulates a commit from another branch)
+    _populate_workdir(
+        tmp_path,
+        {"beat.mid": b"main-beat", "bass.mid": b"bass-v1", "solo.mid": b"guitar-solo"},
+    )
+    commit_b_id = await _commit_async(
+        message="add guitar solo",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Reset to A so B is not HEAD (simulate cherry-picking from another branch)
+    ref_path = tmp_path / ".muse" / "refs" / "heads" / "main"
+    ref_path.write_text(commit_a_id)
+
+    # Cherry-pick B onto A
+    result = await _cherry_pick_async(
+        commit_ref=commit_b_id,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    assert not result.conflict
+    assert not result.no_commit
+    assert result.commit_id != ""
+    assert result.cherry_commit_id == commit_b_id
+    assert result.head_commit_id == commit_a_id
+    assert "(cherry picked from commit" in result.message
+    assert commit_b_id[:8] in result.message
+
+    # New commit should be in DB with correct parent
+    new_commit_row = await muse_cli_db_session.get(MuseCliCommit, result.commit_id)
+    assert new_commit_row is not None
+    assert new_commit_row.parent_commit_id == commit_a_id
+
+    # New snapshot should include solo.mid
+    snap_row = await muse_cli_db_session.get(MuseCliSnapshot, new_commit_row.snapshot_id)
+    assert snap_row is not None
+    manifest: dict[str, str] = dict(snap_row.manifest)
+    assert "solo.mid" in manifest
+    assert "beat.mid" in manifest
+
+    # HEAD ref updated
+    assert ref_path.read_text().strip() == result.commit_id
+
+
+@pytest.mark.anyio
+async def test_cherry_pick_conflict_detection_writes_state(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Conflict: both HEAD and cherry modified the same path → state file written, exit 1."""
+    _init_muse_repo(tmp_path)
+
+    # Commit P — shared base
+    _populate_workdir(tmp_path, {"beat.mid": b"base-beat"})
+    commit_p_id = await _commit_async(
+        message="shared base",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Commit C (cherry) — modifies beat.mid one way
+    _populate_workdir(tmp_path, {"beat.mid": b"cherry-beat"})
+    commit_c_id = await _commit_async(
+        message="cherry take",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Simulate HEAD also modifying beat.mid differently (reset to P, then commit HEAD)
+    ref_path = tmp_path / ".muse" / "refs" / "heads" / "main"
+    ref_path.write_text(commit_p_id)
+
+    _populate_workdir(tmp_path, {"beat.mid": b"head-beat"})
+    commit_head_id = await _commit_async(
+        message="head modification",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Cherry-pick C onto HEAD — should conflict
+    import typer
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _cherry_pick_async(
+            commit_ref=commit_c_id,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+
+    from maestro.muse_cli.errors import ExitCode
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+    # State file must exist
+    state = read_cherry_pick_state(tmp_path)
+    assert state is not None
+    assert state.cherry_commit == commit_c_id
+    assert state.head_commit == commit_head_id
+    assert "beat.mid" in state.conflict_paths
+
+
+@pytest.mark.anyio
+async def test_cherry_pick_abort_restores_head(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--abort removes CHERRY_PICK_STATE.json and restores HEAD pointer."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"v1"})
+    commit_a_id = await _commit_async(
+        message="initial",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Simulate a paused cherry-pick state
+    muse_dir = tmp_path / ".muse"
+    write_cherry_pick_state(
+        tmp_path,
+        cherry_commit="cherry-abc",
+        head_commit=commit_a_id,
+        conflict_paths=["beat.mid"],
+    )
+
+    # Move HEAD pointer forward artificially to simulate partial progress
+    ref_path = muse_dir / "refs" / "heads" / "main"
+    ref_path.write_text("some-partial-commit-id")
+
+    await _cherry_pick_abort_async(root=tmp_path, session=muse_cli_db_session)
+
+    # State file removed
+    assert read_cherry_pick_state(tmp_path) is None
+
+    # HEAD restored to pre-cherry-pick commit
+    assert ref_path.read_text().strip() == commit_a_id
+
+
+@pytest.mark.anyio
+async def test_cherry_pick_continue_creates_commit_after_resolve(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--continue creates a commit from muse-work/ after conflicts are manually resolved."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"v1"})
+    commit_a_id = await _commit_async(
+        message="initial",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    cherry_fake_id = "cherry" + "0" * 58  # fake 64-char hex ID
+
+    # Write state with empty conflict_paths (conflicts resolved)
+    write_cherry_pick_state(
+        tmp_path,
+        cherry_commit=cherry_fake_id,
+        head_commit=commit_a_id,
+        conflict_paths=[],
+    )
+
+    # Ensure muse-work/ has a resolved state and a real cherry commit in DB
+    _populate_workdir(tmp_path, {"beat.mid": b"resolved-beat", "solo.mid": b"solo"})
+
+    # Insert a dummy cherry commit row so the message lookup works
+    from maestro.muse_cli.models import MuseCliCommit as _MuseCliCommit
+    from maestro.muse_cli.snapshot import compute_snapshot_id
+    import datetime as _dt
+
+    dummy_snap_id = compute_snapshot_id({})
+    from maestro.muse_cli.db import upsert_snapshot as _upsert_snapshot
+
+    await _upsert_snapshot(
+        muse_cli_db_session, manifest={}, snapshot_id=dummy_snap_id
+    )
+    repo_data: dict[str, str] = json.loads(
+        (tmp_path / ".muse" / "repo.json").read_text()
+    )
+    dummy_commit = _MuseCliCommit(
+        commit_id=cherry_fake_id,
+        repo_id=repo_data["repo_id"],
+        branch="experiment",
+        parent_commit_id=None,
+        snapshot_id=dummy_snap_id,
+        message="the perfect guitar solo",
+        author="",
+        committed_at=_dt.datetime.now(_dt.timezone.utc),
+    )
+    muse_cli_db_session.add(dummy_commit)
+    await muse_cli_db_session.flush()
+
+    result = await _cherry_pick_continue_async(
+        root=tmp_path, session=muse_cli_db_session
+    )
+
+    assert result.commit_id != ""
+    assert result.cherry_commit_id == cherry_fake_id
+    assert "cherry picked from commit" in result.message
+
+    # State file cleared
+    assert read_cherry_pick_state(tmp_path) is None
+
+    # HEAD updated
+    ref_path = tmp_path / ".muse" / "refs" / "heads" / "main"
+    assert ref_path.read_text().strip() == result.commit_id
+
+    # New commit in DB
+    new_row = await muse_cli_db_session.get(MuseCliCommit, result.commit_id)
+    assert new_row is not None
+    assert new_row.parent_commit_id == commit_a_id
+
+
+@pytest.mark.anyio
+async def test_cherry_pick_no_commit_does_not_create_commit(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--no-commit returns result without writing a commit row to the DB."""
+    _init_muse_repo(tmp_path)
+
+    _populate_workdir(tmp_path, {"beat.mid": b"v1"})
+    commit_a_id = await _commit_async(
+        message="baseline",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    _populate_workdir(tmp_path, {"beat.mid": b"v1", "new.mid": b"new-file"})
+    commit_b_id = await _commit_async(
+        message="add new file",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Reset to A so B is not HEAD
+    ref_path = tmp_path / ".muse" / "refs" / "heads" / "main"
+    ref_path.write_text(commit_a_id)
+
+    result = await _cherry_pick_async(
+        commit_ref=commit_b_id,
+        root=tmp_path,
+        session=muse_cli_db_session,
+        no_commit=True,
+    )
+
+    assert result.no_commit is True
+    assert result.commit_id == ""
+    assert result.cherry_commit_id == commit_b_id
+
+    # HEAD ref unchanged
+    assert ref_path.read_text().strip() == commit_a_id
+
+    # No new commit in DB
+    from sqlalchemy.future import select
+
+    rows = (
+        await muse_cli_db_session.execute(select(MuseCliCommit))
+    ).scalars().all()
+    assert len(rows) == 2  # only A and B
+
+
+@pytest.mark.anyio
+async def test_cherry_pick_blocked_when_merge_in_progress(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Cherry-pick blocked when a merge is in progress with conflicts."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"v1"})
+    commit_a_id = await _commit_async(
+        message="initial",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    write_merge_state(
+        tmp_path,
+        base_commit="base-abc",
+        ours_commit="ours-def",
+        theirs_commit="theirs-ghi",
+        conflict_paths=["beat.mid"],
+    )
+
+    import typer
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _cherry_pick_async(
+            commit_ref=commit_a_id,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+
+    from maestro.muse_cli.errors import ExitCode
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_cherry_pick_blocked_when_already_in_progress(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Cherry-pick blocked when CHERRY_PICK_STATE.json already exists."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"v1"})
+    commit_a_id = await _commit_async(
+        message="initial",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    write_cherry_pick_state(
+        tmp_path,
+        cherry_commit="cherry-abc",
+        head_commit=commit_a_id,
+        conflict_paths=["beat.mid"],
+    )
+
+    import typer
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _cherry_pick_async(
+            commit_ref=commit_a_id,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+
+    from maestro.muse_cli.errors import ExitCode
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_cherry_pick_self_is_noop(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Cherry-picking HEAD itself exits with SUCCESS (noop)."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"v1"})
+    commit_a_id = await _commit_async(
+        message="head commit",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    import typer
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _cherry_pick_async(
+            commit_ref=commit_a_id,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+
+    from maestro.muse_cli.errors import ExitCode
+
+    assert exc_info.value.exit_code == ExitCode.SUCCESS
+
+
+@pytest.mark.anyio
+async def test_cherry_pick_unknown_commit_raises_exit(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Unknown commit ID exits with USER_ERROR."""
+    _init_muse_repo(tmp_path)
+    _populate_workdir(tmp_path, {"beat.mid": b"v1"})
+    await _commit_async(
+        message="initial",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    import typer
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _cherry_pick_async(
+            commit_ref="deadbeef",
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+
+    from maestro.muse_cli.errors import ExitCode
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_cherry_pick_abbreviated_ref(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Cherry-pick accepts an abbreviated commit SHA (prefix match)."""
+    _init_muse_repo(tmp_path)
+
+    _populate_workdir(tmp_path, {"beat.mid": b"v1"})
+    commit_a_id = await _commit_async(
+        message="baseline",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    _populate_workdir(tmp_path, {"beat.mid": b"v1", "bonus.mid": b"bonus"})
+    commit_b_id = await _commit_async(
+        message="add bonus",
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # Reset to A
+    ref_path = tmp_path / ".muse" / "refs" / "heads" / "main"
+    ref_path.write_text(commit_a_id)
+
+    result = await _cherry_pick_async(
+        commit_ref=commit_b_id[:8],
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    assert result.cherry_commit_id == commit_b_id
+    assert result.commit_id != ""
+
+
+@pytest.mark.anyio
+async def test_cherry_pick_continue_blocked_with_remaining_conflicts(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--continue exits USER_ERROR when conflict_paths list is non-empty."""
+    _init_muse_repo(tmp_path)
+    muse = tmp_path / ".muse"
+    muse.mkdir(exist_ok=True)
+
+    write_cherry_pick_state(
+        tmp_path,
+        cherry_commit="cherry-abc",
+        head_commit="head-def",
+        conflict_paths=["beat.mid"],
+    )
+
+    import typer
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _cherry_pick_continue_async(root=tmp_path, session=muse_cli_db_session)
+
+    from maestro.muse_cli.errors import ExitCode
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_cherry_pick_abort_when_nothing_in_progress(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """--abort exits USER_ERROR when no cherry-pick is in progress."""
+    _init_muse_repo(tmp_path)
+
+    import typer
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _cherry_pick_abort_async(root=tmp_path, session=muse_cli_db_session)
+
+    from maestro.muse_cli.errors import ExitCode
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR


### PR DESCRIPTION
## Summary
Closes #74 — implements `muse cherry-pick <commit>` with full conflict resolution lifecycle.

## Root Cause / Motivation
No cherry-pick command existed. Producers needed to merge entire experimental branches to get a single winning take, bringing in 20+ unrelated commits. This blocked the common AI agent workflow of: score commits across branches → transplant the best take → continue composing on main.

## Solution
Implemented a 3-way merge model (base=P, ours=HEAD, theirs=C) that applies only the delta introduced by the cherry commit onto HEAD's snapshot, without touching commits from the source branch. Conflicts are persisted in `.muse/CHERRY_PICK_STATE.json` for resolution via `--continue` / `--abort`.

**Files added/changed:**
- `maestro/services/muse_cherry_pick.py` — core pipeline: `_cherry_pick_async`, `_cherry_pick_continue_async`, `_cherry_pick_abort_async`, `compute_cherry_manifest`, `CherryPickResult`, `CherryPickState`, state file helpers
- `maestro/muse_cli/commands/cherry_pick.py` — Typer CLI command with `--no-commit`, `--continue`, `--abort` flags
- `maestro/muse_cli/app.py` — registered as `cherry-pick` sub-app
- `tests/muse_cli/test_cherry_pick.py` — 17 tests (5 pure-function unit, 12 async integration)
- `docs/architecture/muse_vcs.md` — cherry-pick command reference section
- `docs/reference/type_contracts.md` — `CherryPickResult` and `CherryPickState` entries

## Layers Affected
- [x] Muse VCS (new state file: `.muse/CHERRY_PICK_STATE.json`)

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (555 source files)
- [x] All 17 cherry-pick tests pass
- [x] Docs updated

## Tests Added
- `test_cherry_pick_clean_apply_creates_commit` — regression: clean cherry-pick creates correct commit
- `test_cherry_pick_conflict_detection_writes_state` — conflict writes state file, exits 1
- `test_cherry_pick_abort_restores_head` — --abort removes state file and restores HEAD pointer
- `test_cherry_pick_continue_creates_commit_after_resolve` — --continue creates commit from resolved muse-work/
- `test_cherry_pick_no_commit_does_not_create_commit` — --no-commit stages without DB write
- `test_cherry_pick_blocked_when_merge_in_progress` — blocked by active merge
- `test_cherry_pick_blocked_when_already_in_progress` — blocked by existing CHERRY_PICK_STATE.json
- `test_cherry_pick_self_is_noop` — cherry-picking HEAD exits SUCCESS
- `test_cherry_pick_unknown_commit_raises_exit` — unknown ref exits USER_ERROR
- `test_cherry_pick_abbreviated_ref` — prefix SHA resolution works
- `test_cherry_pick_continue_blocked_with_remaining_conflicts` — --continue exits if conflicts remain
- `test_cherry_pick_abort_when_nothing_in_progress` — --abort exits if no state file
- 5 pure-function unit tests for `compute_cherry_manifest` and state file round-trip

## Handoff
N/A — no SSE/MCP protocol change.