### PR TITLE
feat: muse bisect — binary search for the commit that introduced a regression

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -1561,6 +1561,167 @@ it is working from the latest shared composition state.
 
 ---
 
+## Muse CLI — Bisect Command Reference
+
+`muse bisect` implements a binary search over the commit graph to identify the
+exact commit that introduced a musical regression — a rhythmic drift, mix
+artefact, or tonal shift.  It is the music-domain analogue of `git bisect`.
+
+Session state is persisted in `.muse/BISECT_STATE.json` across shell invocations.
+
+---
+
+### `muse bisect start`
+
+**Purpose:** Open a bisect session and record the pre-bisect HEAD so that
+`muse bisect reset` can cleanly restore the workspace.
+
+**Usage:**
+```bash
+muse bisect start
+```
+
+**Blocked by:** `.muse/MERGE_STATE.json` (merge in progress) or an already-active
+`BISECT_STATE.json`.
+
+**Output example:**
+```
+✅ Bisect session started.
+   Now mark a good commit:  muse bisect good <commit>
+   And a bad commit:        muse bisect bad <commit>
+```
+
+**Agent use case:** An AI agent detects rhythmic drift in the latest mix and
+opens a bisect session to automatically locate the offending commit.
+
+**Implementation:** `maestro/muse_cli/commands/bisect.py`
+
+---
+
+### `muse bisect good <commit>`
+
+**Purpose:** Mark *commit* as a known-good revision.  Once both a good and bad
+bound are set, Muse selects the midpoint commit and checks it out into muse-work/
+for inspection.
+
+**Usage:**
+```bash
+muse bisect good [<commit>]   # default: HEAD
+```
+
+**Flags:**
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `<commit>` | positional | `HEAD` | Commit to mark as good: SHA, branch name, or `HEAD` |
+
+**Output example:**
+```
+✅ Marked a1b2c3d4 as good. Checking out f9e8d7c6 (~2 step(s) remaining, 3 commits in range)
+```
+
+**Agent use case:** After listening to the muse-work/ snapshot and confirming the
+groove is intact, the agent marks the current commit as good and awaits the next
+midpoint checkout.
+
+---
+
+### `muse bisect bad <commit>`
+
+**Purpose:** Mark *commit* as a known-bad revision.  Mirrors `muse bisect good`.
+
+**Usage:**
+```bash
+muse bisect bad [<commit>]   # default: HEAD
+```
+
+---
+
+### `muse bisect run <cmd>`
+
+**Purpose:** Automate the bisect loop.  Runs *cmd* after each checkout; exit 0
+means good, any non-zero exit code means bad.  Stops when the culprit is found.
+
+**Usage:**
+```bash
+muse bisect run <shell-command> [--max-steps N]
+```
+
+**Flags:**
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `<cmd>` | positional | — | Shell command to test each midpoint |
+| `--max-steps` | int | 50 | Safety limit on bisect iterations |
+
+**Output example:**
+```
+⟳  Testing f9e8d7c6…
+   exit=1 → bad
+✅ Marked f9e8d7c6 as bad. Checking out d3c2b1a0 (~1 step(s) remaining, 1 in range)
+⟳  Testing d3c2b1a0…
+   exit=0 → good
+🎯 Bisect complete! First bad commit: f9e8d7c6
+Run 'muse bisect reset' to restore your workspace.
+```
+
+**Result type:** `BisectStepResult` — fields: `culprit` (str | None),
+`next_commit` (str | None), `remaining` (int), `message` (str).
+
+**Agent use case:** An AI orchestrator runs `muse bisect run python check_groove.py`
+to automate the full regression hunt without human input.
+
+---
+
+### `muse bisect reset`
+
+**Purpose:** End the bisect session: restore `.muse/HEAD` and muse-work/ to the
+pre-bisect state, then remove `BISECT_STATE.json`.
+
+**Usage:**
+```bash
+muse bisect reset
+```
+
+**Output example:**
+```
+✅ muse-work/ restored (3 files) from pre-bisect snapshot.
+✅ Bisect session ended.
+```
+
+---
+
+### `muse bisect log`
+
+**Purpose:** Display the verdicts recorded so far and the current good/bad bounds.
+
+**Usage:**
+```bash
+muse bisect log [--json]
+```
+
+**Flags:**
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--json` | flag | off | Emit structured JSON for agent consumption |
+
+**Output example (default):**
+```
+Bisect session state:
+  good:    a1b2c3d4...
+  bad:     f9e8d7c6...
+  current: d3c2b1a0...
+  tested (2 commit(s)):
+    a1b2c3d4  good
+    f9e8d7c6  bad
+```
+
+**Result type:** `BisectState` — fields: `good`, `bad`, `current`, `tested`,
+`pre_bisect_ref`, `pre_bisect_commit`.
+
+**Agent use case:** An agent queries `muse bisect log --json` to resume a
+suspended bisect session and determine the next commit to test.
+
+---
+
 ## Muse CLI — Music Analysis Command Reference
 
 These commands expose musical dimensions across the commit graph — the layer that

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5401,3 +5401,40 @@ Wrapper returned by `GET /api/v1/musehub/repos/{repo_id}/objects`.
 
 **Producer:** `objects.list_objects` route handler
 **Consumer:** Muse Hub web UI; any agent inspecting which artifacts are available for a repo
+
+---
+
+## Muse Bisect Types
+
+Defined in `maestro/services/muse_bisect.py`.
+
+### `BisectState`
+
+Mutable snapshot of an active bisect session.  Persisted in `.muse/BISECT_STATE.json`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `good` | `str \| None` | Commit ID of the last known-good revision |
+| `bad` | `str \| None` | Commit ID of the first known-bad revision |
+| `current` | `str \| None` | Commit ID currently checked out for testing |
+| `tested` | `dict[str, str]` | Map of commit_id → verdict (`"good"` or `"bad"`) |
+| `pre_bisect_ref` | `str` | Symbolic ref HEAD pointed at before bisect started |
+| `pre_bisect_commit` | `str` | Commit ID HEAD resolved to before bisect started |
+
+**Producer:** `write_bisect_state()` in `muse_bisect.py`
+**Consumer:** `muse bisect log --json`, `advance_bisect()`, CLI commands
+
+### `BisectStepResult`
+
+Frozen result of a single bisect step — returned by `advance_bisect()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `culprit` | `str \| None` | Commit ID of the first bad commit if identified, else `None` |
+| `next_commit` | `str \| None` | Commit ID to check out and test next, or `None` when done |
+| `remaining` | `int` | Estimated number of commits still to test (0 when done) |
+| `message` | `str` | Human-readable summary of this step for CLI display |
+
+**Producer:** `advance_bisect()` in `muse_bisect.py`
+**Consumer:** `muse bisect good/bad/run` command handlers; AI agent orchestrators
+

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -1,7 +1,7 @@
 """Muse CLI — Typer application root.
 
 Entry point for the ``muse`` console script. Registers all MVP
-subcommands (amend, arrange, ask, cat-object, checkout, chord-map, commit,
+subcommands (amend, arrange, ask, bisect, cat-object, checkout, chord-map, commit,
 commit-tree, context, contour, describe, diff, divergence, dynamics, emotion-diff,
 export, find, form, grep, groove-check, harmony, humanize, import, init, inspect,
 key, log, merge, meter, motif, open, play, pull, push, read-tree, recall, remote,
@@ -17,6 +17,7 @@ from maestro.muse_cli.commands import (
     amend,
     arrange,
     ask,
+    bisect,
     cat_object,
     checkout,
     chord_map,
@@ -78,6 +79,7 @@ cli = typer.Typer(
 )
 
 cli.add_typer(amend.app, name="amend", help="Fold working-tree changes into the most recent commit.")
+cli.add_typer(bisect.app, name="bisect", help="Binary search for the commit that introduced a regression.")
 cli.add_typer(cat_object.app, name="cat-object", help="Read and display a stored object by its SHA-256 hash.")
 cli.add_typer(chord_map.app, name="chord-map", help="Visualize the chord progression embedded in a commit.")
 cli.add_typer(contour.app, name="contour", help="Analyze the melodic contour and phrase shape of a commit.")

--- a/maestro/muse_cli/commands/bisect.py
+++ b/maestro/muse_cli/commands/bisect.py
@@ -48,10 +48,10 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import pathlib
 import shlex
 import subprocess
-from typing import Optional
 
 import typer
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -400,7 +400,6 @@ def bisect_run(
             _init_state: BisectState = current_state
 
             async def _get_initial() -> BisectStepResult:
-                import math
                 async with open_session() as session:
                     candidates = await get_commits_between(session, _init_good, _init_bad)
                     mid = pick_midpoint(candidates)

--- a/maestro/muse_cli/commands/bisect.py
+++ b/maestro/muse_cli/commands/bisect.py
@@ -1,0 +1,589 @@
+"""muse bisect — binary search for the commit that introduced a regression.
+
+Music-domain analogue of ``git bisect``.  Given a known-good and a known-bad
+commit on the history of a Muse repository, this command binary-searches the
+ancestry path to identify the exact commit that first introduced a rhythmic
+drift, mix regression, or other quality regression.
+
+Subcommands
+-----------
+``muse bisect start``
+    Begin a bisect session.  Records the pre-bisect HEAD ref in
+    ``.muse/BISECT_STATE.json`` so ``reset`` can restore it.  Blocked if a
+    merge is in progress (``.muse/MERGE_STATE.json`` exists).
+
+``muse bisect good <commit>``
+    Mark *commit* as known-good.  If both good and bad are set, checks out
+    the midpoint commit into muse-work/ and reports how many steps remain.
+
+``muse bisect bad <commit>``
+    Mark *commit* as known-bad.  Same auto-advance logic as ``good``.
+
+``muse bisect run <cmd>``
+    Automate the bisect loop.  Runs *cmd* in a shell after each checkout;
+    exit 0 → good, exit 1 (or non-zero) → bad.  Stops when the culprit is
+    identified.
+
+``muse bisect reset``
+    End the session: restore ``.muse/HEAD`` and muse-work/ to the
+    pre-bisect state, then remove BISECT_STATE.json.
+
+``muse bisect log``
+    Print the bisect log (what has been tested and with what verdict).
+
+Session state
+-------------
+Persisted in ``.muse/BISECT_STATE.json`` so the session survives across shell
+invocations.  ``muse bisect start`` blocks if the file already exists.
+
+Exit codes
+----------
+0  — success (or culprit identified)
+1  — user error (bad args, session already active, commit not found)
+2  — not a Muse repository
+3  — internal error
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+import shlex
+import subprocess
+from typing import Optional
+
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.db import open_session
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.object_store import read_object
+from maestro.services.muse_bisect import (
+    BisectState,
+    BisectStepResult,
+    advance_bisect,
+    clear_bisect_state,
+    get_commits_between,
+    pick_midpoint,
+    read_bisect_state,
+    write_bisect_state,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(help="Binary search for the commit that introduced a regression.")
+
+# Minimum abbreviated commit SHA length accepted as user input.
+_MIN_SHA_PREFIX = 4
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_commit_id(root: pathlib.Path, ref: str) -> str:
+    """Resolve *ref* to a full commit ID from filesystem refs.
+
+    Accepts:
+    - ``"HEAD"`` — reads ``.muse/HEAD`` → resolves the symbolic ref.
+    - A branch name — reads ``.muse/refs/heads/<branch>``.
+    - An abbreviated or full commit SHA — returned as-is (validated later).
+
+    Args:
+        root: Repository root.
+        ref:  Commit reference string from the user.
+
+    Returns:
+        The commit ID string (may be an abbreviation; DB validates).
+    """
+    muse_dir = root / ".muse"
+
+    if ref.upper() == "HEAD":
+        head_content = (muse_dir / "HEAD").read_text().strip()
+        if head_content.startswith("refs/"):
+            ref_path = muse_dir / pathlib.Path(head_content)
+            return ref_path.read_text().strip() if ref_path.exists() else head_content
+        return head_content
+
+    # Try branch name first.
+    branch_path = muse_dir / "refs" / "heads" / ref
+    if branch_path.exists():
+        return branch_path.read_text().strip()
+
+    # Assume it's a commit SHA.
+    return ref
+
+
+async def _checkout_snapshot_into_workdir(
+    session: AsyncSession,
+    root: pathlib.Path,
+    commit_id: str,
+) -> int:
+    """Hydrate muse-work/ from the snapshot attached to *commit_id*.
+
+    Reads the snapshot manifest from the DB, then writes each object from
+    ``.muse/objects/`` into muse-work/ (resetting the directory first).
+
+    Returns the number of files written (0 if the snapshot is empty).
+
+    Args:
+        session:   Open async DB session.
+        root:      Repository root.
+        commit_id: Target commit whose snapshot to check out.
+    """
+    from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+
+    commit: MuseCliCommit | None = await session.get(MuseCliCommit, commit_id)
+    if commit is None:
+        typer.echo(f"❌ Commit {commit_id[:8]} not found in database.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    snapshot: MuseCliSnapshot | None = await session.get(MuseCliSnapshot, commit.snapshot_id)
+    if snapshot is None:
+        typer.echo(
+            f"❌ Snapshot {commit.snapshot_id[:8]} for commit {commit_id[:8]} "
+            "not found in database."
+        )
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    manifest: dict[str, str] = dict(snapshot.manifest)
+
+    workdir = root / "muse-work"
+
+    # Clear muse-work/ before populating.
+    if workdir.exists():
+        for existing_file in sorted(workdir.rglob("*")):
+            if existing_file.is_file():
+                existing_file.unlink()
+        for d in sorted(workdir.rglob("*"), reverse=True):
+            if d.is_dir():
+                try:
+                    d.rmdir()
+                except OSError:
+                    pass
+
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    files_written = 0
+    for rel_path, object_id in sorted(manifest.items()):
+        content = read_object(root, object_id)
+        if content is None:
+            logger.warning("⚠️  Object %s missing from local store; skipping", object_id[:8])
+            continue
+        dest = workdir / rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(content)
+        files_written += 1
+
+    return files_written
+
+
+# ---------------------------------------------------------------------------
+# start
+# ---------------------------------------------------------------------------
+
+
+@app.command("start")
+def bisect_start() -> None:
+    """Begin a bisect session from the current HEAD.
+
+    Records the pre-bisect HEAD ref and commit ID in BISECT_STATE.json.
+    Fails if a bisect or merge is already in progress.
+    """
+    root = require_repo()
+    muse_dir = root / ".muse"
+
+    # Guard: block if merge in progress.
+    merge_state_path = muse_dir / "MERGE_STATE.json"
+    if merge_state_path.exists():
+        typer.echo("❌ Merge in progress. Resolve it before starting bisect.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # Guard: block if bisect already active.
+    existing = read_bisect_state(root)
+    if existing is not None:
+        typer.echo(
+            "❌ Bisect already in progress.\n"
+            "   Run 'muse bisect reset' to end the current session first."
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    # Capture current HEAD.
+    head_ref = (muse_dir / "HEAD").read_text().strip()  # e.g. "refs/heads/main"
+    pre_bisect_commit = ""
+    if head_ref.startswith("refs/"):
+        ref_path = muse_dir / pathlib.Path(head_ref)
+        if ref_path.exists():
+            pre_bisect_commit = ref_path.read_text().strip()
+    else:
+        pre_bisect_commit = head_ref  # detached HEAD — store the commit ID directly
+
+    state = BisectState(
+        good=None,
+        bad=None,
+        current=None,
+        tested={},
+        pre_bisect_ref=head_ref,
+        pre_bisect_commit=pre_bisect_commit,
+    )
+    write_bisect_state(root, state)
+
+    typer.echo(
+        "✅ Bisect session started.\n"
+        "   Now mark a good commit:  muse bisect good <commit>\n"
+        "   And a bad commit:        muse bisect bad <commit>"
+    )
+    logger.info("✅ muse bisect start (pre_bisect_ref=%r commit=%s)", head_ref, pre_bisect_commit[:8] if pre_bisect_commit else "none")
+
+
+# ---------------------------------------------------------------------------
+# good / bad  (shared implementation)
+# ---------------------------------------------------------------------------
+
+
+def _bisect_mark(root: pathlib.Path, ref: str, verdict: str) -> None:
+    """Core logic for ``muse bisect good`` and ``muse bisect bad``.
+
+    Resolves *ref* to a commit ID, records the verdict, advances the binary
+    search, and checks out the next midpoint into muse-work/.
+
+    Args:
+        root:    Repository root.
+        ref:     Commit reference from the user (SHA, branch name, ``HEAD``).
+        verdict: Either ``"good"`` or ``"bad"``.
+    """
+    state = read_bisect_state(root)
+    if state is None:
+        typer.echo("❌ No bisect session in progress. Run 'muse bisect start' first.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    commit_id = _resolve_commit_id(root, ref)
+    if len(commit_id) < _MIN_SHA_PREFIX:
+        typer.echo(f"❌ Commit ref '{ref}' could not be resolved to a valid commit ID.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    async def _run() -> BisectStepResult:
+        async with open_session() as session:
+            # Validate commit exists in DB (find by prefix if abbreviated).
+            from maestro.muse_cli.db import find_commits_by_prefix
+            from maestro.muse_cli.models import MuseCliCommit
+
+            if len(commit_id) < 64:
+                matches = await find_commits_by_prefix(session, commit_id)
+                if not matches:
+                    typer.echo(f"❌ No commit found matching '{commit_id[:8]}'.")
+                    raise typer.Exit(code=ExitCode.USER_ERROR)
+                full_id = matches[0].commit_id
+            else:
+                row: MuseCliCommit | None = await session.get(MuseCliCommit, commit_id)
+                if row is None:
+                    typer.echo(f"❌ Commit {commit_id[:8]} not found in database.")
+                    raise typer.Exit(code=ExitCode.USER_ERROR)
+                full_id = commit_id
+
+            result = await advance_bisect(
+                session=session,
+                root=root,
+                commit_id=full_id,
+                verdict=verdict,
+            )
+
+            # If a next commit is identified, check it out.
+            if result.next_commit is not None:
+                files = await _checkout_snapshot_into_workdir(
+                    session, root, result.next_commit
+                )
+                logger.info(
+                    "✅ muse bisect: checked out %s into muse-work/ (%d files)",
+                    result.next_commit[:8],
+                    files,
+                )
+
+            return result
+
+    try:
+        result = asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse bisect {verdict} failed: {exc}")
+        logger.error("❌ muse bisect %s error: %s", verdict, exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+    typer.echo(result.message)
+
+    if result.culprit is not None:
+        logger.info("🎯 muse bisect culprit identified: %s", result.culprit[:8])
+
+
+@app.command("good")
+def bisect_good(
+    commit: str = typer.Argument(
+        "HEAD",
+        help="Commit to mark as good. Accepts HEAD, branch name, full or abbreviated SHA.",
+    ),
+) -> None:
+    """Mark a commit as known-good and advance the binary search."""
+    root = require_repo()
+    _bisect_mark(root, commit, "good")
+
+
+@app.command("bad")
+def bisect_bad(
+    commit: str = typer.Argument(
+        "HEAD",
+        help="Commit to mark as bad. Accepts HEAD, branch name, full or abbreviated SHA.",
+    ),
+) -> None:
+    """Mark a commit as known-bad and advance the binary search."""
+    root = require_repo()
+    _bisect_mark(root, commit, "bad")
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+@app.command("run")
+def bisect_run(
+    cmd: str = typer.Argument(..., help="Shell command to test each midpoint commit."),
+    max_steps: int = typer.Option(
+        50,
+        "--max-steps",
+        help="Safety limit: abort after this many test iterations.",
+    ),
+) -> None:
+    """Automate the bisect loop by running a command after each checkout.
+
+    The command is executed in a shell.  Exit code 0 → good; any non-zero
+    exit code → bad.  The loop stops when the culprit commit is identified
+    or when --max-steps iterations are exhausted.
+
+    Music example::
+
+        muse bisect run python check_groove.py
+    """
+    root = require_repo()
+
+    state = read_bisect_state(root)
+    if state is None:
+        typer.echo("❌ No bisect session in progress. Run 'muse bisect start' first.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    if state.good is None or state.bad is None:
+        typer.echo(
+            "❌ Both good and bad commits must be set before running 'muse bisect run'.\n"
+            "   Mark them first:  muse bisect good <commit>  /  muse bisect bad <commit>"
+        )
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+    steps = 0
+    while steps < max_steps:
+        steps += 1
+
+        # Determine the current commit to test.
+        current_state = read_bisect_state(root)
+        if current_state is None:
+            typer.echo("❌ Bisect session disappeared unexpectedly.")
+            raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+        if current_state.current is None:
+            # First iteration: compute the initial midpoint.
+            # Capture the non-None state fields before entering the nested async scope
+            # so mypy can reason about them without re-checking the union.
+            _init_good: str = current_state.good or ""
+            _init_bad: str = current_state.bad or ""
+            _init_state: BisectState = current_state
+
+            async def _get_initial() -> BisectStepResult:
+                import math
+                async with open_session() as session:
+                    candidates = await get_commits_between(session, _init_good, _init_bad)
+                    mid = pick_midpoint(candidates)
+                    if mid is None:
+                        return BisectStepResult(
+                            culprit=_init_bad,
+                            next_commit=None,
+                            remaining=0,
+                            message=(
+                                f"🎯 Bisect complete! First bad commit: "
+                                f"{_init_bad[:8]}\n"
+                                "Run 'muse bisect reset' to restore your workspace."
+                            ),
+                        )
+                    # Record current and check it out.
+                    _init_state.current = mid.commit_id
+                    write_bisect_state(root, _init_state)
+                    files = await _checkout_snapshot_into_workdir(session, root, mid.commit_id)
+                    logger.info(
+                        "✅ bisect run: checked out %s (%d files)", mid.commit_id[:8], files
+                    )
+                    remaining = len(candidates)
+                    est_steps = math.ceil(math.log2(remaining + 1)) if remaining > 0 else 0
+                    return BisectStepResult(
+                        culprit=None,
+                        next_commit=mid.commit_id,
+                        remaining=remaining,
+                        message=(
+                            f"Checking {mid.commit_id[:8]} "
+                            f"(~{est_steps} step(s), {remaining} in range)"
+                        ),
+                    )
+
+            try:
+                init_result = asyncio.run(_get_initial())
+            except typer.Exit:
+                raise
+            except Exception as exc:
+                typer.echo(f"❌ muse bisect run (init) failed: {exc}")
+                logger.error("❌ bisect run init error: %s", exc, exc_info=True)
+                raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+            if init_result.culprit is not None:
+                typer.echo(init_result.message)
+                return
+
+            typer.echo(init_result.message)
+
+        # Re-read state (current is now set).
+        current_state = read_bisect_state(root)
+        if current_state is None or current_state.current is None:
+            typer.echo("❌ Could not determine current commit to test.")
+            raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+        test_commit = current_state.current
+        typer.echo(f"⟳  Testing {test_commit[:8]}…")
+
+        # Run the user's test command.
+        proc = subprocess.run(cmd, shell=True, cwd=str(root))
+        verdict = "good" if proc.returncode == 0 else "bad"
+        typer.echo(f"   exit={proc.returncode} → {verdict}")
+
+        # Advance the state machine.
+        async def _advance(cid: str, v: str) -> BisectStepResult:
+            async with open_session() as session:
+                result = await advance_bisect(session=session, root=root, commit_id=cid, verdict=v)
+                if result.next_commit is not None:
+                    await _checkout_snapshot_into_workdir(session, root, result.next_commit)
+                return result
+
+        try:
+            step_result = asyncio.run(_advance(test_commit, verdict))
+        except typer.Exit:
+            raise
+        except Exception as exc:
+            typer.echo(f"❌ muse bisect run (advance) failed: {exc}")
+            logger.error("❌ bisect run advance error: %s", exc, exc_info=True)
+            raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+        typer.echo(step_result.message)
+
+        if step_result.culprit is not None:
+            logger.info("🎯 bisect run identified culprit: %s", step_result.culprit[:8])
+            return
+
+    typer.echo(
+        f"⚠️  Safety limit reached ({max_steps} steps). "
+        "Bisect session is still active; inspect manually."
+    )
+    raise typer.Exit(code=ExitCode.USER_ERROR)
+
+
+# ---------------------------------------------------------------------------
+# reset
+# ---------------------------------------------------------------------------
+
+
+@app.command("reset")
+def bisect_reset() -> None:
+    """End the bisect session and restore the pre-bisect HEAD.
+
+    Restores ``.muse/HEAD`` to the ref it pointed at before ``muse bisect
+    start`` was called, repopulates muse-work/ from that snapshot (if
+    objects are available in the local store), and removes BISECT_STATE.json.
+    """
+    root = require_repo()
+
+    state = read_bisect_state(root)
+    if state is None:
+        typer.echo("⚠️  No bisect session in progress. Nothing to reset.")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    muse_dir = root / ".muse"
+
+    # Restore HEAD.
+    if state.pre_bisect_ref:
+        (muse_dir / "HEAD").write_text(f"{state.pre_bisect_ref}\n")
+        logger.info("✅ bisect reset: HEAD restored to %r", state.pre_bisect_ref)
+    else:
+        logger.warning("⚠️  pre_bisect_ref missing from BISECT_STATE.json — HEAD not restored")
+
+    # Restore muse-work/ from pre-bisect snapshot if possible.
+    if state.pre_bisect_commit:
+        async def _restore() -> int:
+            async with open_session() as session:
+                return await _checkout_snapshot_into_workdir(
+                    session, root, state.pre_bisect_commit
+                )
+
+        try:
+            files = asyncio.run(_restore())
+            typer.echo(f"✅ muse-work/ restored ({files} file(s)) from pre-bisect snapshot.")
+        except typer.Exit:
+            pass  # Commit not found — leave muse-work/ as-is; not fatal.
+        except Exception as exc:
+            typer.echo(f"⚠️  Could not restore muse-work/: {exc}")
+            logger.warning("⚠️  bisect reset restore failed: %s", exc)
+    else:
+        typer.echo("⚠️  No pre-bisect commit recorded; muse-work/ not restored.")
+
+    # Remove state file.
+    clear_bisect_state(root)
+    typer.echo("✅ Bisect session ended.")
+    logger.info("✅ muse bisect reset complete")
+
+
+# ---------------------------------------------------------------------------
+# log
+# ---------------------------------------------------------------------------
+
+
+@app.command("log")
+def bisect_log(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit structured JSON for agent consumption.",
+    ),
+) -> None:
+    """Show the bisect log — verdicts recorded so far and current bounds."""
+    root = require_repo()
+
+    state = read_bisect_state(root)
+    if state is None:
+        typer.echo("No bisect session in progress.")
+        raise typer.Exit(code=ExitCode.SUCCESS)
+
+    if json_output:
+        data: dict[str, object] = {
+            "good": state.good,
+            "bad": state.bad,
+            "current": state.current,
+            "tested": state.tested,
+            "pre_bisect_ref": state.pre_bisect_ref,
+            "pre_bisect_commit": state.pre_bisect_commit,
+        }
+        typer.echo(json.dumps(data, indent=2))
+        return
+
+    typer.echo("Bisect session state:")
+    typer.echo(f"  good:    {state.good or '(not set)'}")
+    typer.echo(f"  bad:     {state.bad or '(not set)'}")
+    typer.echo(f"  current: {state.current or '(not set)'}")
+    typer.echo(f"  tested ({len(state.tested)} commit(s)):")
+    for cid, verdict in sorted(state.tested.items()):
+        typer.echo(f"    {cid[:8]}  {verdict}")

--- a/maestro/services/muse_bisect.py
+++ b/maestro/services/muse_bisect.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import pathlib
 from collections import deque
 from dataclasses import dataclass, field
@@ -346,7 +347,6 @@ async def advance_bisect(
     write_bisect_state(root, state)
 
     remaining = len(candidates)
-    import math
     steps = math.ceil(math.log2(remaining + 1)) if remaining > 0 else 0
 
     return BisectStepResult(

--- a/maestro/services/muse_bisect.py
+++ b/maestro/services/muse_bisect.py
@@ -1,0 +1,361 @@
+"""Muse bisect service — binary search over the commit graph for regression hunting.
+
+This service implements the state machine and commit graph traversal logic for
+``muse bisect``.  It is the music-domain analogue of ``git bisect``: given a
+known-good commit and a known-bad commit, it finds the first commit that
+introduced a regression by binary searching the ancestry path.
+
+Typical music QA workflow
+-------------------------
+1. ``muse bisect start``
+2. ``muse bisect good <last_known_good_sha>``
+3. ``muse bisect bad <current_broken_sha>``
+4. Muse checks out the midpoint commit into muse-work/ for inspection.
+5. Producer listens, runs tests, then ``muse bisect good`` or ``muse bisect bad``.
+6. Repeat until the culprit commit is identified.
+7. ``muse bisect reset`` restores the pre-bisect state.
+
+``muse bisect run <cmd>`` automates steps 4-6: it runs the command after each
+checkout and uses the exit code (0 = good, 1 = bad) to advance automatically.
+
+State file schema (BISECT_STATE.json)
+--------------------------------------
+.. code-block:: json
+
+    {
+        "good": "abc123...",
+        "bad": "def456...",
+        "current": "789abc...",
+        "tested": {"commit_id": "good"},
+        "pre_bisect_ref": "refs/heads/main",
+        "pre_bisect_commit": "abc000..."
+    }
+
+``tested`` is a map from commit_id to verdict (``"good"`` or ``"bad"``).
+``pre_bisect_ref`` and ``pre_bisect_commit`` record where HEAD was before the
+session started so ``muse bisect reset`` can cleanly restore the workspace.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+from collections import deque
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from maestro.muse_cli.models import MuseCliCommit
+
+logger = logging.getLogger(__name__)
+
+_BISECT_STATE_FILENAME = "BISECT_STATE.json"
+
+
+# ---------------------------------------------------------------------------
+# BisectState dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BisectState:
+    """Mutable snapshot of an in-progress bisect session.
+
+    Attributes:
+        good:             Commit ID of the last known-good revision.
+        bad:              Commit ID of the first known-bad revision.
+        current:          Commit ID currently checked out for testing.
+        tested:           Map from commit_id to verdict (``"good"`` or ``"bad"``).
+        pre_bisect_ref:   Symbolic ref HEAD pointed at before bisect started
+                          (e.g. ``refs/heads/main``).
+        pre_bisect_commit: Commit ID HEAD resolved to before bisect started.
+    """
+
+    good: str | None = None
+    bad: str | None = None
+    current: str | None = None
+    tested: dict[str, str] = field(default_factory=dict)
+    pre_bisect_ref: str = ""
+    pre_bisect_commit: str = ""
+
+
+# ---------------------------------------------------------------------------
+# BisectStepResult — result type for a single bisect step
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BisectStepResult:
+    """Outcome of advancing the bisect session by one step.
+
+    Returned by :func:`advance_bisect` after marking a commit as good or bad.
+
+    Attributes:
+        culprit:    Commit ID of the first bad commit if identified, else ``None``.
+        next_commit: Commit ID to check out and test next, or ``None`` when done.
+        remaining:  Estimated number of commits still to test (0 when done).
+        message:    Human-readable summary of this step for CLI display.
+    """
+
+    culprit: str | None
+    next_commit: str | None
+    remaining: int
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Filesystem helpers
+# ---------------------------------------------------------------------------
+
+
+def read_bisect_state(root: pathlib.Path) -> BisectState | None:
+    """Return :class:`BisectState` if a bisect is in progress, else ``None``.
+
+    Reads ``.muse/BISECT_STATE.json``.  Returns ``None`` when no file exists
+    (no active session) or when the file cannot be parsed (treated as absent).
+
+    Args:
+        root: Repository root (directory containing ``.muse/``).
+    """
+    state_path = root / ".muse" / _BISECT_STATE_FILENAME
+    if not state_path.exists():
+        return None
+
+    try:
+        raw: dict[str, object] = json.loads(state_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("⚠️  Failed to read %s: %s", _BISECT_STATE_FILENAME, exc)
+        return None
+
+    def _str_or_none(key: str) -> str | None:
+        val = raw.get(key)
+        return str(val) if val is not None else None
+
+    raw_tested = raw.get("tested", {})
+    tested: dict[str, str] = (
+        {str(k): str(v) for k, v in raw_tested.items()}
+        if isinstance(raw_tested, dict)
+        else {}
+    )
+
+    return BisectState(
+        good=_str_or_none("good"),
+        bad=_str_or_none("bad"),
+        current=_str_or_none("current"),
+        tested=tested,
+        pre_bisect_ref=str(raw.get("pre_bisect_ref", "")),
+        pre_bisect_commit=str(raw.get("pre_bisect_commit", "")),
+    )
+
+
+def write_bisect_state(root: pathlib.Path, state: BisectState) -> None:
+    """Persist *state* to ``.muse/BISECT_STATE.json``.
+
+    Args:
+        root:  Repository root (directory containing ``.muse/``).
+        state: Current bisect session state to persist.
+    """
+    state_path = root / ".muse" / _BISECT_STATE_FILENAME
+    data: dict[str, object] = {
+        "good": state.good,
+        "bad": state.bad,
+        "current": state.current,
+        "tested": state.tested,
+        "pre_bisect_ref": state.pre_bisect_ref,
+        "pre_bisect_commit": state.pre_bisect_commit,
+    }
+    state_path.write_text(json.dumps(data, indent=2))
+    logger.debug("✅ Wrote BISECT_STATE.json (good=%s bad=%s)", state.good, state.bad)
+
+
+def clear_bisect_state(root: pathlib.Path) -> None:
+    """Remove ``.muse/BISECT_STATE.json`` after reset or culprit identified."""
+    state_path = root / ".muse" / _BISECT_STATE_FILENAME
+    if state_path.exists():
+        state_path.unlink()
+        logger.debug("✅ Cleared BISECT_STATE.json")
+
+
+# ---------------------------------------------------------------------------
+# Commit graph helpers (require a DB session)
+# ---------------------------------------------------------------------------
+
+
+async def get_commits_between(
+    session: AsyncSession,
+    good_commit_id: str,
+    bad_commit_id: str,
+) -> list[MuseCliCommit]:
+    """Return commits reachable from *bad* but not reachable from *good*.
+
+    Performs two BFS traversals of the Muse commit DAG:
+    1. All ancestors of *good_commit_id* (inclusive) → ``good_ancestors``.
+    2. All ancestors of *bad_commit_id* (inclusive) → filtered by exclusion.
+
+    Returns only commits that are ancestors of *bad* but not of *good*, sorted
+    by ``committed_at`` ascending (oldest first).  These are the commits the
+    bisect session needs to search through.
+
+    An empty list means *good* and *bad* are the same commit or there is no
+    commit between them — the culprit is *bad* itself.
+
+    Args:
+        session:       Open async DB session.
+        good_commit_id: Commit ID of the known-good revision.
+        bad_commit_id:  Commit ID of the known-bad revision.
+
+    Returns:
+        Ordered list of :class:`MuseCliCommit` rows to bisect, oldest first.
+    """
+    from maestro.muse_cli.models import MuseCliCommit
+
+    async def _ancestors(start: str) -> set[str]:
+        """BFS collecting all ancestor commit IDs (inclusive of start)."""
+        visited: set[str] = set()
+        queue: deque[str] = deque([start])
+        while queue:
+            cid = queue.popleft()
+            if cid in visited:
+                continue
+            visited.add(cid)
+            row: MuseCliCommit | None = await session.get(MuseCliCommit, cid)
+            if row is None:
+                continue
+            if row.parent_commit_id:
+                queue.append(row.parent_commit_id)
+            if row.parent2_commit_id:
+                queue.append(row.parent2_commit_id)
+        return visited
+
+    good_set = await _ancestors(good_commit_id)
+    bad_ancestors = await _ancestors(bad_commit_id)
+
+    # Commits between good and bad: reachable from bad, not from good,
+    # and excluding bad itself (bad is known-bad, not a candidate to test).
+    candidate_ids = bad_ancestors - good_set - {bad_commit_id}
+
+    if not candidate_ids:
+        return []
+
+    # Load and sort by committed_at ascending.
+    rows: list[MuseCliCommit] = []
+    for cid in candidate_ids:
+        row = await session.get(MuseCliCommit, cid)
+        if row is not None:
+            rows.append(row)
+
+    rows.sort(key=lambda r: r.committed_at)
+    return rows
+
+
+def pick_midpoint(commits: list[MuseCliCommit]) -> MuseCliCommit | None:
+    """Return the midpoint commit for binary search.
+
+    Selects ``commits[(len(commits) - 1) // 2]`` — the lower-middle element
+    for even-length lists, middle for odd-length.  Returns ``None`` on empty.
+
+    Args:
+        commits: Ordered list of candidate commits (oldest first).
+    """
+    if not commits:
+        return None
+    mid_idx = (len(commits) - 1) // 2
+    return commits[mid_idx]
+
+
+async def advance_bisect(
+    session: AsyncSession,
+    root: pathlib.Path,
+    commit_id: str,
+    verdict: str,
+) -> BisectStepResult:
+    """Record a verdict for *commit_id* and advance the bisect session.
+
+    Updates the ``good`` or ``bad`` bound based on the verdict, computes the
+    remaining candidate range, and selects the next midpoint to test.
+
+    When the candidate range collapses to zero the culprit is identified: it is
+    the ``bad`` bound (the earliest commit we marked bad, or the first bad commit
+    reachable from bad that is not reachable from good).
+
+    Args:
+        session:   Open async DB session.
+        root:      Repository root.
+        commit_id: Commit being marked.
+        verdict:   Either ``"good"`` or ``"bad"``.
+
+    Returns:
+        :class:`BisectStepResult` describing the outcome.
+
+    Raises:
+        ValueError: If *verdict* is not ``"good"`` or ``"bad"``.
+        RuntimeError: If no bisect is in progress.
+    """
+    if verdict not in ("good", "bad"):
+        raise ValueError(f"verdict must be 'good' or 'bad', got {verdict!r}")
+
+    state = read_bisect_state(root)
+    if state is None:
+        raise RuntimeError("No bisect session in progress. Run 'muse bisect start' first.")
+
+    # Record the verdict.
+    state.tested[commit_id] = verdict
+
+    if verdict == "good":
+        state.good = commit_id
+    else:
+        state.bad = commit_id
+
+    # If either bound is still unset we cannot advance yet.
+    if state.good is None or state.bad is None:
+        write_bisect_state(root, state)
+        missing = "bad" if state.bad is None else "good"
+        return BisectStepResult(
+            culprit=None,
+            next_commit=None,
+            remaining=0,
+            message=(
+                f"✅ Marked {commit_id[:8]} as {verdict}. "
+                f"Now mark a {missing} commit to begin bisecting."
+            ),
+        )
+
+    # Recompute remaining candidates.
+    candidates = await get_commits_between(session, state.good, state.bad)
+
+    if not candidates:
+        # No commits left to test — bad is the culprit.
+        culprit = state.bad
+        state.current = None
+        write_bisect_state(root, state)
+        return BisectStepResult(
+            culprit=culprit,
+            next_commit=None,
+            remaining=0,
+            message=(
+                f"🎯 Bisect complete! First bad commit: {culprit[:8]}\n"
+                "Run 'muse bisect reset' to restore your workspace."
+            ),
+        )
+
+    next_commit = pick_midpoint(candidates)
+    assert next_commit is not None  # candidates is non-empty
+    state.current = next_commit.commit_id
+    write_bisect_state(root, state)
+
+    remaining = len(candidates)
+    import math
+    steps = math.ceil(math.log2(remaining + 1)) if remaining > 0 else 0
+
+    return BisectStepResult(
+        culprit=None,
+        next_commit=next_commit.commit_id,
+        remaining=remaining,
+        message=(
+            f"✅ Marked {commit_id[:8]} as {verdict}. "
+            f"Checking out {next_commit.commit_id[:8]} "
+            f"(~{steps} step(s) remaining, {remaining} commit(s) in range)"
+        ),
+    )

--- a/tests/muse_cli/test_bisect.py
+++ b/tests/muse_cli/test_bisect.py
@@ -1,0 +1,549 @@
+"""Tests for ``muse bisect`` — state machine, commit graph traversal, and CLI.
+
+Coverage
+--------
+- :func:`read_bisect_state` / :func:`write_bisect_state` / :func:`clear_bisect_state`
+  round-trip fidelity.
+- :func:`get_commits_between` returns the correct candidate set for both linear
+  and branching histories.
+- :func:`pick_midpoint` selects the lower-middle element.
+- :func:`advance_bisect` state machine: marks verdicts, narrows range,
+  identifies culprit when range collapses.
+- ``test_bisect_state_machine_advances_correctly`` — the primary regression test
+  from the issue spec.
+- Guard: ``muse bisect start`` blocks when a merge is in progress.
+- Guard: ``muse bisect start`` blocks when a bisect is already active.
+- ``muse bisect log --json`` emits valid JSON.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import pathlib
+import uuid
+from typing import Generator
+
+import pytest
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+from maestro.muse_cli.snapshot import compute_snapshot_id
+from maestro.services.muse_bisect import (
+    BisectState,
+    BisectStepResult,
+    advance_bisect,
+    clear_bisect_state,
+    get_commits_between,
+    pick_midpoint,
+    read_bisect_state,
+    write_bisect_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    """Create a minimal .muse/ layout for testing."""
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(json.dumps({"repo_id": rid, "schema_version": "1"}))
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _write_workdir(root: pathlib.Path, files: dict[str, bytes]) -> None:
+    """Overwrite muse-work/ with exactly the given files."""
+    import shutil
+
+    workdir = root / "muse-work"
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir()
+    for name, content in files.items():
+        (workdir / name).write_bytes(content)
+
+
+def _head_commit(root: pathlib.Path, branch: str = "main") -> str:
+    """Return current HEAD commit_id for the branch."""
+    muse = root / ".muse"
+    ref_path = muse / "refs" / "heads" / branch
+    return ref_path.read_text().strip() if ref_path.exists() else ""
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — state file round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_write_read_bisect_state_round_trip(tmp_path: pathlib.Path) -> None:
+    """BisectState survives a write → read cycle with all fields set."""
+    _init_repo(tmp_path)
+
+    state = BisectState(
+        good="goodabc123",
+        bad="baddef456",
+        current="midpoint789",
+        tested={"goodabc123": "good", "midpoint789": "bad"},
+        pre_bisect_ref="refs/heads/main",
+        pre_bisect_commit="originalabc",
+    )
+    write_bisect_state(tmp_path, state)
+    loaded = read_bisect_state(tmp_path)
+
+    assert loaded is not None
+    assert loaded.good == "goodabc123"
+    assert loaded.bad == "baddef456"
+    assert loaded.current == "midpoint789"
+    assert loaded.tested == {"goodabc123": "good", "midpoint789": "bad"}
+    assert loaded.pre_bisect_ref == "refs/heads/main"
+    assert loaded.pre_bisect_commit == "originalabc"
+
+
+def test_read_bisect_state_returns_none_when_absent(tmp_path: pathlib.Path) -> None:
+    """read_bisect_state returns None when no BISECT_STATE.json exists."""
+    _init_repo(tmp_path)
+    assert read_bisect_state(tmp_path) is None
+
+
+def test_clear_bisect_state_removes_file(tmp_path: pathlib.Path) -> None:
+    """clear_bisect_state removes the state file; subsequent read returns None."""
+    _init_repo(tmp_path)
+    write_bisect_state(tmp_path, BisectState())
+    assert read_bisect_state(tmp_path) is not None
+    clear_bisect_state(tmp_path)
+    assert read_bisect_state(tmp_path) is None
+
+
+def test_clear_bisect_state_is_idempotent(tmp_path: pathlib.Path) -> None:
+    """Calling clear_bisect_state when no file exists does not raise."""
+    _init_repo(tmp_path)
+    clear_bisect_state(tmp_path)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — pick_midpoint
+# ---------------------------------------------------------------------------
+
+
+def _make_commit(commit_id: str, offset_seconds: int = 0) -> MuseCliCommit:
+    """Return an unsaved MuseCliCommit stub for midpoint testing."""
+    return MuseCliCommit(
+        commit_id=commit_id,
+        repo_id="test-repo",
+        branch="main",
+        parent_commit_id=None,
+        snapshot_id="snap-" + commit_id[:8],
+        message="test",
+        author="",
+        committed_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        + datetime.timedelta(seconds=offset_seconds),
+    )
+
+
+def test_pick_midpoint_returns_none_on_empty() -> None:
+    assert pick_midpoint([]) is None
+
+
+def test_pick_midpoint_single_element() -> None:
+    c = _make_commit("aaa")
+    assert pick_midpoint([c]) is c
+
+
+def test_pick_midpoint_selects_lower_middle_for_even() -> None:
+    """For a 4-element list, midpoint is index 1 (lower-middle)."""
+    commits = [_make_commit(f"c{i:03d}", i) for i in range(4)]
+    mid = pick_midpoint(commits)
+    assert mid is not None
+    assert mid.commit_id == commits[1].commit_id
+
+
+def test_pick_midpoint_selects_middle_for_odd() -> None:
+    """For a 5-element list, midpoint is index 2."""
+    commits = [_make_commit(f"c{i:03d}", i) for i in range(5)]
+    mid = pick_midpoint(commits)
+    assert mid is not None
+    assert mid.commit_id == commits[2].commit_id
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — commit graph traversal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_commits_between_linear_history(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """get_commits_between returns the inner commits on a linear chain.
+
+    Topology: good → c1 → c2 → c3 → bad
+    Expected result: [c1, c2, c3] (oldest first, excluding good and bad).
+    """
+    _init_repo(tmp_path)
+
+    _write_workdir(tmp_path, {"a.mid": b"GOOD"})
+    await _commit_async(message="good commit", root=tmp_path, session=muse_cli_db_session)
+    good_id = _head_commit(tmp_path)
+
+    _write_workdir(tmp_path, {"a.mid": b"C1"})
+    await _commit_async(message="c1", root=tmp_path, session=muse_cli_db_session)
+    c1_id = _head_commit(tmp_path)
+
+    _write_workdir(tmp_path, {"a.mid": b"C2"})
+    await _commit_async(message="c2", root=tmp_path, session=muse_cli_db_session)
+    c2_id = _head_commit(tmp_path)
+
+    _write_workdir(tmp_path, {"a.mid": b"C3"})
+    await _commit_async(message="c3", root=tmp_path, session=muse_cli_db_session)
+    c3_id = _head_commit(tmp_path)
+
+    _write_workdir(tmp_path, {"a.mid": b"BAD"})
+    await _commit_async(message="bad commit", root=tmp_path, session=muse_cli_db_session)
+    bad_id = _head_commit(tmp_path)
+
+    candidates = await get_commits_between(muse_cli_db_session, good_id, bad_id)
+    candidate_ids = {c.commit_id for c in candidates}
+
+    assert c1_id in candidate_ids
+    assert c2_id in candidate_ids
+    assert c3_id in candidate_ids
+    assert good_id not in candidate_ids
+    assert bad_id not in candidate_ids
+
+    # Must be sorted oldest first.
+    assert [c.commit_id for c in candidates] == [c1_id, c2_id, c3_id]
+
+
+@pytest.mark.anyio
+async def test_get_commits_between_adjacent_commits_returns_empty(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """When good is the direct parent of bad, no commits to bisect."""
+    _init_repo(tmp_path)
+
+    _write_workdir(tmp_path, {"a.mid": b"V1"})
+    await _commit_async(message="good", root=tmp_path, session=muse_cli_db_session)
+    good_id = _head_commit(tmp_path)
+
+    _write_workdir(tmp_path, {"a.mid": b"V2"})
+    await _commit_async(message="bad", root=tmp_path, session=muse_cli_db_session)
+    bad_id = _head_commit(tmp_path)
+
+    candidates = await get_commits_between(muse_cli_db_session, good_id, bad_id)
+    assert candidates == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — advance_bisect state machine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_bisect_state_machine_advances_correctly(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """Regression test: bisect narrows range and identifies the culprit.
+
+    Topology: good → c1 → culprit → c3 → bad  (4 inner commits)
+    Bisect should identify *culprit* after ≤ 2 steps by binary search.
+    """
+    _init_repo(tmp_path)
+
+    _write_workdir(tmp_path, {"beat.mid": b"GOOD"})
+    await _commit_async(message="good groove", root=tmp_path, session=muse_cli_db_session)
+    good_id = _head_commit(tmp_path)
+
+    _write_workdir(tmp_path, {"beat.mid": b"C1"})
+    await _commit_async(message="c1 ok", root=tmp_path, session=muse_cli_db_session)
+    c1_id = _head_commit(tmp_path)
+
+    _write_workdir(tmp_path, {"beat.mid": b"CULPRIT"})
+    await _commit_async(message="culprit: introduced drift", root=tmp_path, session=muse_cli_db_session)
+    culprit_id = _head_commit(tmp_path)
+
+    _write_workdir(tmp_path, {"beat.mid": b"C3"})
+    await _commit_async(message="c3 still broken", root=tmp_path, session=muse_cli_db_session)
+
+    _write_workdir(tmp_path, {"beat.mid": b"BAD"})
+    await _commit_async(message="bad groove", root=tmp_path, session=muse_cli_db_session)
+    bad_id = _head_commit(tmp_path)
+
+    # Start a bisect session.
+    state = BisectState(
+        good=None,
+        bad=None,
+        current=None,
+        tested={},
+        pre_bisect_ref="refs/heads/main",
+        pre_bisect_commit=bad_id,
+    )
+    write_bisect_state(tmp_path, state)
+
+    # Mark good.
+    result = await advance_bisect(
+        session=muse_cli_db_session, root=tmp_path, commit_id=good_id, verdict="good"
+    )
+    # Both bounds not yet set, so no next commit yet.
+    assert result.culprit is None
+
+    # Mark bad.
+    result = await advance_bisect(
+        session=muse_cli_db_session, root=tmp_path, commit_id=bad_id, verdict="bad"
+    )
+    assert result.culprit is None
+    assert result.next_commit is not None
+    midpoint_1 = result.next_commit
+
+    # Midpoint should be inside the range [c1, culprit, c3].
+    candidates_all = await get_commits_between(muse_cli_db_session, good_id, bad_id)
+    candidate_ids_all = {c.commit_id for c in candidates_all}
+    assert midpoint_1 in candidate_ids_all
+
+    # Test the midpoint: if it's culprit or after → bad; before → good.
+    # We need to simulate what a human / script would do.
+    # Strategy: mark commits that come AFTER the culprit (in time) as bad,
+    # and commits before/at culprit as bad too if they ARE the culprit.
+    # Simple rule: commit_id == culprit_id OR is a descendant → bad.
+
+    # Step 1: test the first midpoint.
+    mid1_commit = await muse_cli_db_session.get(MuseCliCommit, midpoint_1)
+    assert mid1_commit is not None
+    # The culprit is the 2nd of 3 inner commits (c1, culprit, c3).
+    # Binary search: midpoint of [c1, culprit, c3] (idx 0,1,2) → idx 1 = culprit.
+    # If midpoint IS the culprit → mark bad.
+    # In our test data the midpoint of 3 elements is index 1 = culprit.
+    if mid1_commit.message == "culprit: introduced drift":
+        # This is the culprit: mark as bad.
+        result2 = await advance_bisect(
+            session=muse_cli_db_session,
+            root=tmp_path,
+            commit_id=midpoint_1,
+            verdict="bad",
+        )
+        # Next candidate: [c1] (commits before culprit but after good).
+        # After marking culprit as bad, range = [c1].
+        # Midpoint of [c1] = c1 itself.
+        if result2.culprit is None:
+            assert result2.next_commit is not None
+            # Mark c1 as good → culprit identified as midpoint_1 (the culprit commit).
+            result3 = await advance_bisect(
+                session=muse_cli_db_session,
+                root=tmp_path,
+                commit_id=result2.next_commit,
+                verdict="good",
+            )
+            assert result3.culprit == midpoint_1
+    else:
+        # c1 is the midpoint — mark it based on its position relative to culprit.
+        # c1 is BEFORE culprit → good.
+        result2 = await advance_bisect(
+            session=muse_cli_db_session,
+            root=tmp_path,
+            commit_id=midpoint_1,
+            verdict="good",
+        )
+        assert result2.culprit is None or result2.culprit == culprit_id
+
+
+@pytest.mark.anyio
+async def test_advance_bisect_with_only_one_inner_commit_finds_culprit(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """When only one commit is between good and bad, it is the culprit immediately."""
+    _init_repo(tmp_path)
+
+    _write_workdir(tmp_path, {"beat.mid": b"GOOD"})
+    await _commit_async(message="good", root=tmp_path, session=muse_cli_db_session)
+    good_id = _head_commit(tmp_path)
+
+    _write_workdir(tmp_path, {"beat.mid": b"CULPRIT"})
+    await _commit_async(message="culprit", root=tmp_path, session=muse_cli_db_session)
+    culprit_id = _head_commit(tmp_path)
+
+    _write_workdir(tmp_path, {"beat.mid": b"BAD"})
+    await _commit_async(message="bad", root=tmp_path, session=muse_cli_db_session)
+    bad_id = _head_commit(tmp_path)
+
+    write_bisect_state(tmp_path, BisectState(
+        good=None, bad=None, current=None, tested={},
+        pre_bisect_ref="refs/heads/main", pre_bisect_commit=bad_id,
+    ))
+
+    await advance_bisect(session=muse_cli_db_session, root=tmp_path, commit_id=good_id, verdict="good")
+    # Mark bad → range = [culprit], midpoint = culprit.
+    result = await advance_bisect(session=muse_cli_db_session, root=tmp_path, commit_id=bad_id, verdict="bad")
+
+    assert result.next_commit == culprit_id
+    # Mark culprit as bad → range collapses.
+    result2 = await advance_bisect(session=muse_cli_db_session, root=tmp_path, commit_id=culprit_id, verdict="bad")
+    assert result2.culprit == culprit_id
+
+
+@pytest.mark.anyio
+async def test_advance_bisect_adjacent_commits_collapses_immediately(
+    tmp_path: pathlib.Path,
+    muse_cli_db_session: AsyncSession,
+) -> None:
+    """When good is the direct parent of bad, culprit is bad itself."""
+    _init_repo(tmp_path)
+
+    _write_workdir(tmp_path, {"a.mid": b"V1"})
+    await _commit_async(message="good", root=tmp_path, session=muse_cli_db_session)
+    good_id = _head_commit(tmp_path)
+
+    _write_workdir(tmp_path, {"a.mid": b"V2"})
+    await _commit_async(message="bad", root=tmp_path, session=muse_cli_db_session)
+    bad_id = _head_commit(tmp_path)
+
+    write_bisect_state(tmp_path, BisectState(
+        good=None, bad=None, current=None, tested={},
+        pre_bisect_ref="refs/heads/main", pre_bisect_commit=bad_id,
+    ))
+
+    await advance_bisect(session=muse_cli_db_session, root=tmp_path, commit_id=good_id, verdict="good")
+    result = await advance_bisect(session=muse_cli_db_session, root=tmp_path, commit_id=bad_id, verdict="bad")
+    # No inner commits → bad is the culprit immediately.
+    assert result.culprit == bad_id
+
+
+# ---------------------------------------------------------------------------
+# CLI guard tests
+# ---------------------------------------------------------------------------
+
+
+def test_bisect_start_blocked_by_merge_in_progress(tmp_path: pathlib.Path) -> None:
+    """muse bisect start exits 1 when MERGE_STATE.json is present."""
+    from typer.testing import CliRunner
+    from maestro.muse_cli.commands.bisect import app as bisect_app
+
+    _init_repo(tmp_path)
+    (tmp_path / ".muse" / "MERGE_STATE.json").write_text(
+        json.dumps({"base_commit": "abc", "ours_commit": "def", "theirs_commit": "ghi", "conflict_paths": []})
+    )
+
+    runner = CliRunner()
+    import os
+
+    old_cwd = pathlib.Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(bisect_app, ["start"])
+    finally:
+        os.chdir(old_cwd)
+
+    assert result.exit_code == ExitCode.USER_ERROR
+
+
+def test_bisect_start_blocked_when_already_active(tmp_path: pathlib.Path) -> None:
+    """muse bisect start exits 1 when BISECT_STATE.json already exists."""
+    from typer.testing import CliRunner
+    from maestro.muse_cli.commands.bisect import app as bisect_app
+
+    _init_repo(tmp_path)
+    write_bisect_state(tmp_path, BisectState(
+        good=None, bad=None, current=None, tested={},
+        pre_bisect_ref="refs/heads/main", pre_bisect_commit="abc",
+    ))
+
+    runner = CliRunner()
+    import os
+
+    old_cwd = pathlib.Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(bisect_app, ["start"])
+    finally:
+        os.chdir(old_cwd)
+
+    assert result.exit_code == ExitCode.USER_ERROR
+
+
+def test_bisect_good_without_active_session_exits_1(tmp_path: pathlib.Path) -> None:
+    """muse bisect good exits 1 when no session is active."""
+    from typer.testing import CliRunner
+    from maestro.muse_cli.commands.bisect import app as bisect_app
+
+    _init_repo(tmp_path)
+
+    runner = CliRunner()
+    import os
+
+    old_cwd = pathlib.Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(bisect_app, ["good", "abc123"])
+    finally:
+        os.chdir(old_cwd)
+
+    assert result.exit_code == ExitCode.USER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# bisect log --json
+# ---------------------------------------------------------------------------
+
+
+def test_bisect_log_json_emits_valid_json(tmp_path: pathlib.Path) -> None:
+    """muse bisect log --json outputs valid JSON with expected fields."""
+    from typer.testing import CliRunner
+    from maestro.muse_cli.commands.bisect import app as bisect_app
+
+    _init_repo(tmp_path)
+    write_bisect_state(tmp_path, BisectState(
+        good="good_sha",
+        bad="bad_sha",
+        current="current_sha",
+        tested={"good_sha": "good"},
+        pre_bisect_ref="refs/heads/main",
+        pre_bisect_commit="orig_sha",
+    ))
+
+    runner = CliRunner()
+    import os
+
+    old_cwd = pathlib.Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(bisect_app, ["log", "--json"])
+    finally:
+        os.chdir(old_cwd)
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["good"] == "good_sha"
+    assert data["bad"] == "bad_sha"
+    assert data["current"] == "current_sha"
+    assert data["tested"] == {"good_sha": "good"}
+
+
+def test_bisect_log_no_active_session(tmp_path: pathlib.Path) -> None:
+    """muse bisect log exits 0 with a message when no session is active."""
+    from typer.testing import CliRunner
+    from maestro.muse_cli.commands.bisect import app as bisect_app
+
+    _init_repo(tmp_path)
+
+    runner = CliRunner()
+    import os
+
+    old_cwd = pathlib.Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(bisect_app, ["log"])
+    finally:
+        os.chdir(old_cwd)
+
+    assert result.exit_code == 0
+    assert "No bisect session" in result.output

--- a/tests/muse_cli/test_bisect.py
+++ b/tests/muse_cli/test_bisect.py
@@ -21,7 +21,6 @@ import datetime
 import json
 import pathlib
 import uuid
-from typing import Generator
 
 import pytest
 import typer


### PR DESCRIPTION
## Summary
Closes #71 — implements `muse bisect` for binary search over the Muse commit graph to identify regression-introducing commits.

## Root Cause / Motivation
No bisect command existed. Music producers had no way to identify which commit introduced a rhythmic drift, mix regression, or tonal shift — they had to check out commits one by one manually.

## Solution
Implemented `muse bisect` as a Typer sub-application with six subcommands:

- `muse bisect start` — opens a session; records pre-bisect HEAD in `.muse/BISECT_STATE.json`
- `muse bisect good <commit>` — marks a commit as known-good; checks out the next midpoint
- `muse bisect bad <commit>` — marks a commit as known-bad; narrows the search range
- `muse bisect run <cmd>` — automates the loop (exit 0 = good, non-zero = bad)
- `muse bisect reset` — restores HEAD and muse-work/ to pre-bisect state; clears state file
- `muse bisect log [--json]` — shows verdicts and current bounds

The bisect engine in `maestro/services/muse_bisect.py` uses BFS over the Muse commit DAG (same pattern as the merge base finder) to compute the candidate set between good and bad bounds, then binary-searches by picking the lower-middle element.

## Layers Affected
- [x] Muse VCS (new service: `muse_bisect.py`)
- [x] Muse CLI (new command: `bisect.py` + `app.py` registration)

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (555 files)
- [x] 18 targeted tests pass: state round-trip, BFS graph traversal, state machine advances, CLI guards, `--json` output
- [x] Docs updated: `docs/architecture/muse_vcs.md` and `docs/reference/type_contracts.md`

## Tests Added
- `test_write_read_bisect_state_round_trip` — state file round-trip
- `test_read_bisect_state_returns_none_when_absent`
- `test_clear_bisect_state_removes_file` / `_is_idempotent`
- `test_pick_midpoint_*` (4 tests) — midpoint selection for empty, single, even, odd lists
- `test_get_commits_between_linear_history` — BFS candidate set for linear topology
- `test_get_commits_between_adjacent_commits_returns_empty`
- `test_bisect_state_machine_advances_correctly` — **primary regression test** (issue spec)
- `test_advance_bisect_with_only_one_inner_commit_finds_culprit`
- `test_advance_bisect_adjacent_commits_collapses_immediately`
- `test_bisect_start_blocked_by_merge_in_progress`
- `test_bisect_start_blocked_when_already_active`
- `test_bisect_good_without_active_session_exits_1`
- `test_bisect_log_json_emits_valid_json`
- `test_bisect_log_no_active_session`

## Handoff
N/A — no protocol change. This is a pure Muse CLI / VCS layer addition.