### PR TITLE
feat: muse resolve --theirs + muse merge --abort — conflict resolution workflow

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5401,3 +5401,41 @@ Wrapper returned by `GET /api/v1/musehub/repos/{repo_id}/objects`.
 
 **Producer:** `objects.list_objects` route handler
 **Consumer:** Muse Hub web UI; any agent inspecting which artifacts are available for a repo
+
+---
+
+## Muse CLI — Conflict Resolution Types (`maestro/muse_cli/merge_engine.py`)
+
+### `MergeState`
+
+Frozen dataclass representing an in-progress merge with unresolved conflicts.
+Returned by `read_merge_state(root)` when `.muse/MERGE_STATE.json` is present.
+`None` return indicates no merge is in progress.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conflict_paths` | `list[str]` | Relative POSIX paths of files with unresolved conflicts |
+| `base_commit` | `str \| None` | Commit ID of the common ancestor (merge base) |
+| `ours_commit` | `str \| None` | Commit ID of HEAD when the merge was initiated |
+| `theirs_commit` | `str \| None` | Commit ID of the branch being merged in |
+| `other_branch` | `str \| None` | Human-readable name of the branch being merged in |
+
+**Lifecycle:** Created by `write_merge_state()` (called from `_merge_async` on conflict),
+updated by `resolve_conflict_async()` (removes resolved paths from `conflict_paths`),
+cleared by `clear_merge_state()` (called by `_merge_continue_async` and `_merge_abort_async`).
+
+**Agent contract:** When `conflict_paths` is non-empty, the merge is blocked.
+When `conflict_paths == []`, all conflicts are resolved and `muse merge --continue` will succeed.
+Call `is_conflict_resolved(state, path)` to test whether a specific path still needs resolution.
+
+```python
+state = read_merge_state(root)
+if state is not None and state.conflict_paths:
+    for path in state.conflict_paths:
+        # agent inspects each conflict before choosing --ours or --theirs
+        await resolve_conflict_async(file_path=path, ours=True, root=root, session=session)
+```
+
+**Related helpers:**
+- `apply_resolution(root, rel_path, object_id)` — copies an object from the local store to `muse-work/`; used by `--theirs` resolution and `--abort`.
+- `is_conflict_resolved(merge_state, rel_path)` — returns `True` if `rel_path` is not in `conflict_paths`.

--- a/maestro/muse_cli/commands/resolve.py
+++ b/maestro/muse_cli/commands/resolve.py
@@ -4,42 +4,49 @@ Workflow
 --------
 When ``muse merge`` encounters conflicts it writes ``.muse/MERGE_STATE.json``
 and exits.  The user then inspects the listed conflict paths and resolves each
-one — either by keeping their current working-tree version (``--ours``) or by
-manually editing the file to the desired content and then marking it resolved.
+one:
 
-After resolving each file, call::
+- ``--ours``:   Keep the current branch's version already in ``muse-work/``.
+                The file is left untouched; the path is removed from the conflict
+                list in ``MERGE_STATE.json``.
 
-    muse resolve muse-work/meta/section-1.json --ours
+- ``--theirs``: Accept the incoming branch's version.  This command fetches
+                the object from the local store (written when the other branch's
+                commits were made) and writes it to ``muse-work/<path>`` before
+                removing the path from the conflict list.
 
-When all conflicts are cleared, run ``muse merge --continue`` to create the
+After resolving each conflict, run ``muse merge --continue`` to create the
 merge commit.
 
 Resolution strategies
 ---------------------
-- ``--ours``: Accept the current branch's version as-is.  No file is changed;
-              the path is simply removed from ``MERGE_STATE.json``'s conflict
-              list.
-- ``--theirs``: Accept the incoming branch's version.  Because the Muse object
-               store is content-addressed and does not persist raw bytes in the
-               database, the caller must manually copy or write the desired
-               content into ``muse-work/<path>`` before running this command.
-               ``muse resolve --theirs`` marks the path resolved after the file
-               is in place.
+Both strategies ultimately remove the path from ``conflict_paths`` in
+``MERGE_STATE.json``.  When the list reaches zero, ``muse merge --continue``
+can proceed.
 
-In both cases the path is removed from ``conflict_paths`` in
-``MERGE_STATE.json``.  When the list reaches zero, the merge state is cleared
-and ``muse merge --continue`` can proceed.
+The ``--theirs`` strategy requires the theirs commit's objects to be present
+in the local ``.muse/objects/`` store.  Objects are written there when commits
+are made locally; ``muse pull`` fetches them from the remote.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import pathlib
+from typing import TYPE_CHECKING
 
 import typer
 
 from maestro.muse_cli._repo import require_repo
 from maestro.muse_cli.errors import ExitCode
-from maestro.muse_cli.merge_engine import read_merge_state, write_merge_state
+from maestro.muse_cli.merge_engine import (
+    apply_resolution,
+    read_merge_state,
+    write_merge_state,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
@@ -47,34 +54,39 @@ app = typer.Typer()
 
 
 # ---------------------------------------------------------------------------
-# Testable core — no Typer coupling
+# Testable async core — no Typer coupling
 # ---------------------------------------------------------------------------
 
 
-def resolve_conflict(
+async def resolve_conflict_async(
     *,
     file_path: str,
     ours: bool,
     root: pathlib.Path,
+    session: AsyncSession,
 ) -> None:
     """Mark *file_path* as resolved in ``.muse/MERGE_STATE.json``.
 
-    For ``--ours`` no file change is made.  For ``--theirs`` the caller is
-    responsible for ensuring the desired content is already in
-    ``muse-work/<file_path>`` before calling this function.
+    For ``--ours`` no file change is made — the current ``muse-work/`` content
+    is accepted as-is.  For ``--theirs`` this function fetches the theirs
+    branch's object from the local store and writes it to
+    ``muse-work/<file_path>``.
 
     Args:
         file_path: Path of the conflicted file.  Accepted as:
                    - absolute path (converted to relative to ``muse-work/``)
                    - path relative to ``muse-work/`` (e.g. ``meta/foo.json``)
                    - path relative to repo root (e.g. ``muse-work/meta/foo.json``)
-        ours:      ``True`` to accept ours, ``False`` to accept theirs (file
-                   must already be edited to the desired content).
+        ours:      ``True`` to accept ours (no file change); ``False`` to
+                   accept theirs (object is fetched from local store and written
+                   to ``muse-work/<file_path>``).
         root:      Repository root containing ``.muse/``.
+        session:   Open async DB session (used for ``--theirs`` to look up the
+                   theirs commit's snapshot manifest).
 
     Raises:
         :class:`typer.Exit`: On user errors (no merge in progress, path not
-                             in conflict list).
+                             in conflict list, object missing from local store).
     """
     merge_state = read_merge_state(root)
     if merge_state is None:
@@ -105,9 +117,41 @@ def resolve_conflict(
         )
         raise typer.Exit(code=ExitCode.USER_ERROR)
 
-    side = "ours" if ours else "theirs"
-    typer.echo(f"✅ Resolved '{rel_path}' — keeping {side}")
-    logger.info("✅ muse resolve %r ---%s", rel_path, side)
+    # For --theirs, fetch the object from the local store and write to workdir.
+    if not ours:
+        theirs_commit_id = merge_state.theirs_commit
+        if not theirs_commit_id:
+            typer.echo("❌ MERGE_STATE.json is missing theirs_commit. Cannot resolve --theirs.")
+            raise typer.Exit(code=ExitCode.INTERNAL_ERROR)
+
+        from maestro.muse_cli.db import get_commit_snapshot_manifest
+
+        theirs_manifest = (
+            await get_commit_snapshot_manifest(session, theirs_commit_id) or {}
+        )
+        object_id = theirs_manifest.get(rel_path)
+
+        if object_id is None:
+            # Path was deleted on the theirs branch — remove from workdir.
+            dest = workdir / rel_path
+            if dest.exists():
+                dest.unlink()
+            typer.echo(f"✅ Resolved '{rel_path}' — file deleted on theirs branch")
+            logger.info("✅ muse resolve %r --theirs (deleted on theirs)", rel_path)
+        else:
+            try:
+                apply_resolution(root, rel_path, object_id)
+            except FileNotFoundError:
+                typer.echo(
+                    f"❌ Object for '{rel_path}' is not in the local store.\n"
+                    "   Run 'muse pull' to fetch the remote objects, then retry."
+                )
+                raise typer.Exit(code=ExitCode.USER_ERROR)
+            typer.echo(f"✅ Resolved '{rel_path}' — keeping theirs")
+            logger.info("✅ muse resolve %r --theirs", rel_path)
+    else:
+        typer.echo(f"✅ Resolved '{rel_path}' — keeping ours")
+        logger.info("✅ muse resolve %r --ours", rel_path)
 
     remaining = [p for p in merge_state.conflict_paths if p != rel_path]
 
@@ -158,7 +202,7 @@ def resolve(
         False,
         "--theirs",
         is_flag=True,
-        help="Accept the incoming branch's version (edit the file first, then mark resolved).",
+        help="Accept the incoming branch's version (fetched from local object store).",
     ),
 ) -> None:
     """Mark a conflicted file as resolved using --ours or --theirs."""
@@ -167,4 +211,20 @@ def resolve(
         raise typer.Exit(code=ExitCode.USER_ERROR)
 
     root = require_repo()
-    resolve_conflict(file_path=file_path, ours=ours, root=root)
+
+    async def _run() -> None:
+        from maestro.muse_cli.db import open_session
+
+        async with open_session() as session:
+            await resolve_conflict_async(
+                file_path=file_path, ours=ours, root=root, session=session
+            )
+
+    try:
+        asyncio.run(_run())
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse resolve failed: {exc}")
+        logger.error("❌ muse resolve error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/muse_cli/commands/status.py
+++ b/maestro/muse_cli/commands/status.py
@@ -92,7 +92,7 @@ async def _status_async(
         typer.echo(f"On branch {branch}")
         typer.echo("")
         typer.echo("You have unmerged paths.")
-        typer.echo('  (fix conflicts and run "muse commit")')
+        typer.echo('  (fix conflicts and run "muse merge --continue")')
         typer.echo("")
         typer.echo("Unmerged paths:")
         for conflict_path in sorted(merge_state.conflict_paths):

--- a/tests/muse_cli/test_merge_integration.py
+++ b/tests/muse_cli/test_merge_integration.py
@@ -1,0 +1,318 @@
+"""End-to-end integration tests for the full conflict resolution workflow.
+
+These tests exercise the complete cycle:
+
+    muse merge <branch>     → conflict detected, MERGE_STATE.json written
+    muse resolve <path> ... → path removed from conflict list
+    muse merge --continue   → merge commit created, MERGE_STATE.json cleared
+    muse log                → merge commit visible in history
+
+A separate test covers the abort path:
+
+    muse merge <branch>     → conflict detected
+    muse merge --abort      → pre-merge state restored
+
+Both tests require two real branches with divergent commits, making them true
+integration tests rather than unit tests.  They use in-memory SQLite and
+``tmp_path`` — no real database or Docker is needed.
+
+All async tests use ``@pytest.mark.anyio``.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+
+import pytest
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.commands.merge import _merge_abort_async, _merge_async, _merge_continue_async
+from maestro.muse_cli.commands.resolve import resolve_conflict_async
+from maestro.muse_cli.db import get_commit_snapshot_manifest
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.merge_engine import read_merge_state
+from maestro.muse_cli.models import MuseCliCommit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(root: pathlib.Path) -> str:
+    rid = str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(json.dumps({"repo_id": rid, "schema_version": "1"}))
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _write_workdir(root: pathlib.Path, files: dict[str, bytes]) -> None:
+    import shutil
+
+    workdir = root / "muse-work"
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir()
+    for name, content in files.items():
+        (workdir / name).write_bytes(content)
+
+
+def _create_branch(root: pathlib.Path, branch: str, from_branch: str = "main") -> None:
+    muse = root / ".muse"
+    src = muse / "refs" / "heads" / from_branch
+    dst = muse / "refs" / "heads" / branch
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(src.read_text() if src.exists() else "")
+
+
+def _switch_branch(root: pathlib.Path, branch: str) -> None:
+    (root / ".muse" / "HEAD").write_text(f"refs/heads/{branch}")
+
+
+def _head_commit(root: pathlib.Path, branch: str | None = None) -> str:
+    muse = root / ".muse"
+    if branch is None:
+        head_ref = (muse / "HEAD").read_text().strip()
+        branch = head_ref.rsplit("/", 1)[-1]
+    ref_path = muse / "refs" / "heads" / branch
+    return ref_path.read_text().strip() if ref_path.exists() else ""
+
+
+# ---------------------------------------------------------------------------
+# Full conflict → resolve → continue cycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_full_conflict_resolve_cycle(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """End-to-end: merge → conflict → resolve → continue → log shows merge commit.
+
+    Scenario:
+    1. Create base commit on ``main`` with ``beat.mid``.
+    2. Branch ``experiment`` from ``main``.
+    3. Advance ``main``: modify ``beat.mid`` → OURS_VERSION.
+    4. Advance ``experiment``: modify ``beat.mid`` → THEIRS_VERSION.
+    5. Merge ``experiment`` into ``main`` → conflict on ``beat.mid``.
+    6. Resolve via ``--theirs`` (file content replaced in muse-work/).
+    7. Run ``muse merge --continue`` → merge commit created.
+    8. Verify: MERGE_STATE.json cleared, merge commit has two parents, log
+       shows all three commits (base, ours, merge).
+    """
+    _init_repo(tmp_path)
+
+    # --- Step 1: base commit ---
+    _write_workdir(tmp_path, {"beat.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+    base_commit = _head_commit(tmp_path, "main")
+
+    # --- Step 2: branch experiment ---
+    _create_branch(tmp_path, "experiment")
+
+    # --- Step 3: advance main ---
+    _write_workdir(tmp_path, {"beat.mid": b"OURS_VERSION"})
+    await _commit_async(message="main: ours version", root=tmp_path, session=muse_cli_db_session)
+    ours_commit = _head_commit(tmp_path, "main")
+
+    # --- Step 4: advance experiment ---
+    _switch_branch(tmp_path, "experiment")
+    _write_workdir(tmp_path, {"beat.mid": b"THEIRS_VERSION"})
+    await _commit_async(
+        message="experiment: theirs version", root=tmp_path, session=muse_cli_db_session
+    )
+    theirs_commit = _head_commit(tmp_path, "experiment")
+
+    # --- Step 5: merge → conflict ---
+    _switch_branch(tmp_path, "main")
+    _write_workdir(tmp_path, {"beat.mid": b"OURS_VERSION"})  # restore ours in workdir
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _merge_async(
+            branch="experiment", root=tmp_path, session=muse_cli_db_session
+        )
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+    merge_state = read_merge_state(tmp_path)
+    assert merge_state is not None
+    assert "beat.mid" in merge_state.conflict_paths
+
+    # --- Step 6: resolve --theirs (copies THEIRS_VERSION to muse-work) ---
+    await resolve_conflict_async(
+        file_path="beat.mid",
+        ours=False,
+        root=tmp_path,
+        session=muse_cli_db_session,
+    )
+
+    # File must now contain theirs content.
+    assert (tmp_path / "muse-work" / "beat.mid").read_bytes() == b"THEIRS_VERSION"
+
+    # Conflict list must be empty (MERGE_STATE.json still present for --continue).
+    state_after_resolve = read_merge_state(tmp_path)
+    assert state_after_resolve is not None
+    assert state_after_resolve.conflict_paths == []
+
+    # --- Step 7: merge --continue ---
+    await _merge_continue_async(root=tmp_path, session=muse_cli_db_session)
+
+    # MERGE_STATE.json must be gone.
+    assert read_merge_state(tmp_path) is None
+
+    # --- Step 8: verify merge commit ---
+    merge_commit_id = _head_commit(tmp_path, "main")
+    assert merge_commit_id not in (base_commit, ours_commit, theirs_commit)
+
+    result = await muse_cli_db_session.execute(
+        select(MuseCliCommit).where(MuseCliCommit.commit_id == merge_commit_id)
+    )
+    merge_commit = result.scalar_one()
+    # Two parents: ours and theirs.
+    assert merge_commit.parent_commit_id == ours_commit
+    assert merge_commit.parent2_commit_id == theirs_commit
+
+    # Merged snapshot must contain the resolved content (theirs version).
+    merged_manifest = await get_commit_snapshot_manifest(muse_cli_db_session, merge_commit_id)
+    assert merged_manifest is not None
+    assert "beat.mid" in merged_manifest
+
+    # Total commits in DB: base + ours + theirs + merge = 4.
+    all_commits_result = await muse_cli_db_session.execute(select(MuseCliCommit))
+    all_commits = all_commits_result.scalars().all()
+    assert len(all_commits) == 4
+
+
+# ---------------------------------------------------------------------------
+# Full conflict → abort cycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_full_conflict_abort_cycle(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """End-to-end: merge → conflict → abort → pre-merge state restored.
+
+    After abort:
+    - ``muse-work/`` contains the ours version.
+    - ``MERGE_STATE.json`` is gone.
+    - No merge commit was created.
+    """
+    _init_repo(tmp_path)
+
+    # Base commit.
+    _write_workdir(tmp_path, {"beat.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+    _create_branch(tmp_path, "experiment")
+
+    # Advance main.
+    _write_workdir(tmp_path, {"beat.mid": b"OURS_CLEAN"})
+    await _commit_async(message="main", root=tmp_path, session=muse_cli_db_session)
+    ours_commit = _head_commit(tmp_path, "main")
+
+    # Advance experiment.
+    _switch_branch(tmp_path, "experiment")
+    _write_workdir(tmp_path, {"beat.mid": b"THEIRS_CLEAN"})
+    await _commit_async(message="experiment", root=tmp_path, session=muse_cli_db_session)
+
+    # Trigger conflict.
+    _switch_branch(tmp_path, "main")
+    _write_workdir(tmp_path, {"beat.mid": b"OURS_CLEAN"})
+    with pytest.raises(typer.Exit):
+        await _merge_async(
+            branch="experiment", root=tmp_path, session=muse_cli_db_session
+        )
+
+    assert read_merge_state(tmp_path) is not None
+
+    # Simulate partial manual edits (user started editing but wants to abort).
+    (tmp_path / "muse-work" / "beat.mid").write_bytes(b"MESSY_PARTIAL_EDIT")
+
+    # Abort.
+    await _merge_abort_async(root=tmp_path, session=muse_cli_db_session)
+
+    # Post-abort: MERGE_STATE.json cleared.
+    assert read_merge_state(tmp_path) is None
+
+    # Post-abort: muse-work restored to ours (pre-merge) content.
+    assert (tmp_path / "muse-work" / "beat.mid").read_bytes() == b"OURS_CLEAN"
+
+    # No merge commit created — DB has exactly 3 commits (base + main + experiment).
+    all_commits_result = await muse_cli_db_session.execute(select(MuseCliCommit))
+    all_commits = all_commits_result.scalars().all()
+    assert len(all_commits) == 3
+
+    # main HEAD unchanged after abort.
+    assert _head_commit(tmp_path, "main") == ours_commit
+
+
+# ---------------------------------------------------------------------------
+# Multiple conflicts — partial resolution then continue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_partial_resolution_then_continue(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Resolving conflicts one at a time then --continue works correctly."""
+    _init_repo(tmp_path)
+
+    # Base with two files.
+    _write_workdir(tmp_path, {"a.mid": b"BASE_A", "b.mid": b"BASE_B"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+    _create_branch(tmp_path, "feature")
+
+    # Main modifies both files.
+    _write_workdir(tmp_path, {"a.mid": b"MAIN_A", "b.mid": b"MAIN_B"})
+    await _commit_async(message="main", root=tmp_path, session=muse_cli_db_session)
+    ours_commit = _head_commit(tmp_path, "main")
+
+    # Feature also modifies both files.
+    _switch_branch(tmp_path, "feature")
+    _write_workdir(tmp_path, {"a.mid": b"FEAT_A", "b.mid": b"FEAT_B"})
+    await _commit_async(message="feature", root=tmp_path, session=muse_cli_db_session)
+    theirs_commit = _head_commit(tmp_path, "feature")
+
+    # Trigger conflict.
+    _switch_branch(tmp_path, "main")
+    _write_workdir(tmp_path, {"a.mid": b"MAIN_A", "b.mid": b"MAIN_B"})
+    with pytest.raises(typer.Exit):
+        await _merge_async(branch="feature", root=tmp_path, session=muse_cli_db_session)
+
+    state = read_merge_state(tmp_path)
+    assert state is not None
+    assert sorted(state.conflict_paths) == ["a.mid", "b.mid"]
+
+    # Resolve a.mid --ours.
+    await resolve_conflict_async(
+        file_path="a.mid", ours=True, root=tmp_path, session=muse_cli_db_session
+    )
+    # b.mid still in conflict.
+    state2 = read_merge_state(tmp_path)
+    assert state2 is not None
+    assert state2.conflict_paths == ["b.mid"]
+
+    # Resolve b.mid --theirs.
+    await resolve_conflict_async(
+        file_path="b.mid", ours=False, root=tmp_path, session=muse_cli_db_session
+    )
+    # All clear.
+    state3 = read_merge_state(tmp_path)
+    assert state3 is not None
+    assert state3.conflict_paths == []
+    assert (tmp_path / "muse-work" / "b.mid").read_bytes() == b"FEAT_B"
+
+    # Continue.
+    await _merge_continue_async(root=tmp_path, session=muse_cli_db_session)
+    assert read_merge_state(tmp_path) is None
+
+    merge_commit_id = _head_commit(tmp_path, "main")
+    assert merge_commit_id not in (ours_commit, theirs_commit)

--- a/tests/muse_cli/test_resolve.py
+++ b/tests/muse_cli/test_resolve.py
@@ -1,0 +1,611 @@
+"""Unit and integration tests for the ``muse resolve``, ``muse merge --continue``,
+``muse merge --abort``, and conflict-aware ``muse status`` commands.
+
+All async tests use ``@pytest.mark.anyio``.  Tests exercise the testable async
+cores directly with in-memory SQLite and ``tmp_path`` so no real Postgres or
+Docker instance is required.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import uuid
+
+import pytest
+import typer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.muse_cli.commands.commit import _commit_async
+from maestro.muse_cli.commands.merge import _merge_abort_async, _merge_async, _merge_continue_async
+from maestro.muse_cli.commands.resolve import resolve_conflict_async
+from maestro.muse_cli.commands.status import _status_async
+from maestro.muse_cli.errors import ExitCode
+from maestro.muse_cli.merge_engine import (
+    apply_resolution,
+    is_conflict_resolved,
+    read_merge_state,
+    write_merge_state,
+)
+from maestro.muse_cli.object_store import write_object
+
+
+# ---------------------------------------------------------------------------
+# Test helpers (shared with other muse_cli test modules)
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(root: pathlib.Path, repo_id: str | None = None) -> str:
+    """Create minimal ``.muse/`` layout for testing."""
+    rid = repo_id or str(uuid.uuid4())
+    muse = root / ".muse"
+    (muse / "refs" / "heads").mkdir(parents=True)
+    (muse / "repo.json").write_text(json.dumps({"repo_id": rid, "schema_version": "1"}))
+    (muse / "HEAD").write_text("refs/heads/main")
+    (muse / "refs" / "heads" / "main").write_text("")
+    return rid
+
+
+def _write_workdir(root: pathlib.Path, files: dict[str, bytes]) -> None:
+    """Overwrite muse-work/ with exactly the given files."""
+    import shutil
+
+    workdir = root / "muse-work"
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir()
+    for name, content in files.items():
+        (workdir / name).write_bytes(content)
+
+
+def _create_branch(root: pathlib.Path, branch: str, from_branch: str = "main") -> None:
+    muse = root / ".muse"
+    src = muse / "refs" / "heads" / from_branch
+    dst = muse / "refs" / "heads" / branch
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(src.read_text() if src.exists() else "")
+
+
+def _switch_branch(root: pathlib.Path, branch: str) -> None:
+    (root / ".muse" / "HEAD").write_text(f"refs/heads/{branch}")
+
+
+def _head_commit(root: pathlib.Path, branch: str | None = None) -> str:
+    muse = root / ".muse"
+    if branch is None:
+        head_ref = (muse / "HEAD").read_text().strip()
+        branch = head_ref.rsplit("/", 1)[-1]
+    ref_path = muse / "refs" / "heads" / branch
+    return ref_path.read_text().strip() if ref_path.exists() else ""
+
+
+# ---------------------------------------------------------------------------
+# muse status — conflict display during merge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_status_shows_conflicts_during_merge(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Status during a merge shows unmerged paths and the --continue hint."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit="ours111",
+        theirs_commit="their222",
+        conflict_paths=["beat.mid", "lead.mid"],
+        other_branch="experiment",
+    )
+
+    await _status_async(root=tmp_path, session=muse_cli_db_session)
+    output = capsys.readouterr().out
+
+    assert "You have unmerged paths." in output
+    assert "muse merge --continue" in output
+    assert "beat.mid" in output
+    assert "lead.mid" in output
+
+
+# ---------------------------------------------------------------------------
+# muse resolve --ours
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_resolve_ours_removes_from_conflict_list(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """``--ours`` removes the path from MERGE_STATE.json conflict_paths."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"OURS"})
+    await _commit_async(message="initial", root=tmp_path, session=muse_cli_db_session)
+
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit="ours111",
+        theirs_commit="their222",
+        conflict_paths=["beat.mid"],
+    )
+
+    await resolve_conflict_async(
+        file_path="beat.mid", ours=True, root=tmp_path, session=muse_cli_db_session
+    )
+
+    state = read_merge_state(tmp_path)
+    assert state is not None
+    # Path must be gone from conflict_paths but MERGE_STATE.json still present.
+    assert "beat.mid" not in state.conflict_paths
+
+
+@pytest.mark.anyio
+async def test_resolve_ours_does_not_modify_file(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """``--ours`` leaves muse-work/ untouched."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"OUR_CONTENT"})
+    await _commit_async(message="initial", root=tmp_path, session=muse_cli_db_session)
+
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit="ours111",
+        theirs_commit="their222",
+        conflict_paths=["beat.mid"],
+    )
+
+    await resolve_conflict_async(
+        file_path="beat.mid", ours=True, root=tmp_path, session=muse_cli_db_session
+    )
+
+    assert (tmp_path / "muse-work" / "beat.mid").read_bytes() == b"OUR_CONTENT"
+
+
+@pytest.mark.anyio
+async def test_resolve_ours_all_cleared_state_preserved_for_continue(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """When all conflicts resolved via --ours, MERGE_STATE.json stays (for --continue)."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"OURS"})
+    await _commit_async(message="initial", root=tmp_path, session=muse_cli_db_session)
+
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit="ours111",
+        theirs_commit="their222",
+        conflict_paths=["beat.mid"],
+    )
+
+    await resolve_conflict_async(
+        file_path="beat.mid", ours=True, root=tmp_path, session=muse_cli_db_session
+    )
+
+    # MERGE_STATE.json must still exist (--continue reads ours/theirs commit IDs).
+    state = read_merge_state(tmp_path)
+    assert state is not None
+    assert state.ours_commit == "ours111"
+    assert state.theirs_commit == "their222"
+    assert state.conflict_paths == []
+
+
+# ---------------------------------------------------------------------------
+# muse resolve --theirs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_resolve_theirs_applies_their_file(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """``--theirs`` copies the theirs branch's object to muse-work/."""
+    _init_repo(tmp_path)
+
+    # Set up both branches with a conflict on beat.mid.
+    _write_workdir(tmp_path, {"beat.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+    _create_branch(tmp_path, "experiment")
+
+    # Advance main.
+    _write_workdir(tmp_path, {"beat.mid": b"OURS_VERSION"})
+    await _commit_async(message="main step", root=tmp_path, session=muse_cli_db_session)
+    ours_commit = _head_commit(tmp_path, "main")
+
+    # Advance experiment.
+    _switch_branch(tmp_path, "experiment")
+    _write_workdir(tmp_path, {"beat.mid": b"THEIRS_VERSION"})
+    await _commit_async(message="exp step", root=tmp_path, session=muse_cli_db_session)
+    theirs_commit = _head_commit(tmp_path, "experiment")
+
+    # Put ours version back in muse-work (simulating the state after merge conflict).
+    _switch_branch(tmp_path, "main")
+    _write_workdir(tmp_path, {"beat.mid": b"OURS_VERSION"})
+
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit=ours_commit,
+        theirs_commit=theirs_commit,
+        conflict_paths=["beat.mid"],
+    )
+
+    await resolve_conflict_async(
+        file_path="beat.mid", ours=False, root=tmp_path, session=muse_cli_db_session
+    )
+
+    # The file in muse-work must now contain the theirs content.
+    assert (tmp_path / "muse-work" / "beat.mid").read_bytes() == b"THEIRS_VERSION"
+    state = read_merge_state(tmp_path)
+    assert state is not None
+    assert "beat.mid" not in state.conflict_paths
+
+
+@pytest.mark.anyio
+async def test_resolve_theirs_missing_object_exits_1(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """``--theirs`` exits 1 when the object is not in the local store."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+
+    # Build a theirs commit that has a snapshot with beat.mid → some object_id.
+    _create_branch(tmp_path, "experiment")
+    _switch_branch(tmp_path, "experiment")
+    _write_workdir(tmp_path, {"beat.mid": b"THEIRS_CONTENT"})
+    await _commit_async(message="exp step", root=tmp_path, session=muse_cli_db_session)
+    theirs_commit = _head_commit(tmp_path, "experiment")
+
+    # Now delete the object from the local store so it's missing.
+    from maestro.muse_cli.db import get_commit_snapshot_manifest
+    from maestro.muse_cli.object_store import object_path
+
+    theirs_manifest = await get_commit_snapshot_manifest(muse_cli_db_session, theirs_commit)
+    assert theirs_manifest is not None
+    obj_id = theirs_manifest["beat.mid"]
+    obj_file = object_path(tmp_path, obj_id)
+    obj_file.unlink()
+
+    _switch_branch(tmp_path, "main")
+    _write_workdir(tmp_path, {"beat.mid": b"OURS_VERSION"})
+    ours_commit = _head_commit(tmp_path, "main")
+
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit=ours_commit,
+        theirs_commit=theirs_commit,
+        conflict_paths=["beat.mid"],
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await resolve_conflict_async(
+            file_path="beat.mid", ours=False, root=tmp_path, session=muse_cli_db_session
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# muse resolve — error cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_resolve_nonexistent_path_exits_1(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Resolving a path not in conflict_paths exits 1 with a clear error."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"V"})
+    await _commit_async(message="initial", root=tmp_path, session=muse_cli_db_session)
+
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit="ours111",
+        theirs_commit="their222",
+        conflict_paths=["beat.mid"],
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await resolve_conflict_async(
+            file_path="nonexistent.mid",
+            ours=True,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_resolve_no_merge_in_progress_exits_1(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """Resolving when no merge is in progress exits 1."""
+    _init_repo(tmp_path)
+    (tmp_path / ".muse").mkdir(exist_ok=True)  # ensure .muse exists
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await resolve_conflict_async(
+            file_path="beat.mid",
+            ours=True,
+            root=tmp_path,
+            session=muse_cli_db_session,
+        )
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# muse merge --continue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_merge_continue_creates_commit_when_clean(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """``--continue`` creates a merge commit once all conflicts are resolved."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+    base_commit = _head_commit(tmp_path)
+    _create_branch(tmp_path, "experiment")
+
+    # Diverge both branches.
+    _write_workdir(tmp_path, {"beat.mid": b"OURS"})
+    await _commit_async(message="main", root=tmp_path, session=muse_cli_db_session)
+    ours_commit = _head_commit(tmp_path, "main")
+
+    _switch_branch(tmp_path, "experiment")
+    _write_workdir(tmp_path, {"beat.mid": b"THEIRS"})
+    await _commit_async(message="exp", root=tmp_path, session=muse_cli_db_session)
+    theirs_commit = _head_commit(tmp_path, "experiment")
+
+    # Simulate post-conflict state: MERGE_STATE with no remaining conflicts.
+    _switch_branch(tmp_path, "main")
+    _write_workdir(tmp_path, {"beat.mid": b"RESOLVED"})
+    write_merge_state(
+        tmp_path,
+        base_commit=base_commit,
+        ours_commit=ours_commit,
+        theirs_commit=theirs_commit,
+        conflict_paths=[],  # all resolved
+        other_branch="experiment",
+    )
+
+    await _merge_continue_async(root=tmp_path, session=muse_cli_db_session)
+
+    # MERGE_STATE.json must be gone.
+    assert read_merge_state(tmp_path) is None
+
+    # A new merge commit must exist at main HEAD.
+    merge_commit_id = _head_commit(tmp_path, "main")
+    assert merge_commit_id != ours_commit
+
+
+@pytest.mark.anyio
+async def test_merge_continue_fails_with_remaining_conflicts(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """``--continue`` exits 1 when unresolved conflicts remain."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit="ours111",
+        theirs_commit="their222",
+        conflict_paths=["beat.mid"],  # still has conflict
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _merge_continue_async(root=tmp_path, session=muse_cli_db_session)
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_merge_continue_no_merge_in_progress_exits_1(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """``--continue`` exits 1 when no merge is in progress."""
+    _init_repo(tmp_path)
+    (tmp_path / ".muse").mkdir(exist_ok=True)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _merge_continue_async(root=tmp_path, session=muse_cli_db_session)
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# muse merge --abort
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_merge_abort_restores_state(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """``--abort`` restores ours version of conflicted files and deletes MERGE_STATE.json."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"beat.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+    _create_branch(tmp_path, "experiment")
+
+    # Advance main.
+    _write_workdir(tmp_path, {"beat.mid": b"OURS_PRE_MERGE"})
+    await _commit_async(message="main step", root=tmp_path, session=muse_cli_db_session)
+    ours_commit = _head_commit(tmp_path, "main")
+
+    # Advance experiment.
+    _switch_branch(tmp_path, "experiment")
+    _write_workdir(tmp_path, {"beat.mid": b"THEIRS_VERSION"})
+    await _commit_async(message="exp step", root=tmp_path, session=muse_cli_db_session)
+    theirs_commit = _head_commit(tmp_path, "experiment")
+
+    # Simulate post-conflict state: workdir has a messy partially-resolved file.
+    _switch_branch(tmp_path, "main")
+    _write_workdir(tmp_path, {"beat.mid": b"PARTIALLY_RESOLVED_MESS"})
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit=ours_commit,
+        theirs_commit=theirs_commit,
+        conflict_paths=["beat.mid"],
+        other_branch="experiment",
+    )
+
+    await _merge_abort_async(root=tmp_path, session=muse_cli_db_session)
+
+    # MERGE_STATE.json must be cleared.
+    assert read_merge_state(tmp_path) is None
+
+    # muse-work/beat.mid must be restored to the ours (pre-merge) version.
+    assert (tmp_path / "muse-work" / "beat.mid").read_bytes() == b"OURS_PRE_MERGE"
+
+
+@pytest.mark.anyio
+async def test_merge_abort_no_merge_in_progress_exits_1(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """``--abort`` exits 1 when no merge is in progress."""
+    _init_repo(tmp_path)
+    (tmp_path / ".muse").mkdir(exist_ok=True)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _merge_abort_async(root=tmp_path, session=muse_cli_db_session)
+
+    assert exc_info.value.exit_code == ExitCode.USER_ERROR
+
+
+@pytest.mark.anyio
+async def test_merge_abort_removes_theirs_only_file(
+    tmp_path: pathlib.Path, muse_cli_db_session: AsyncSession
+) -> None:
+    """``--abort`` removes files that exist only on the theirs branch (not in ours manifest)."""
+    _init_repo(tmp_path)
+    _write_workdir(tmp_path, {"base.mid": b"BASE"})
+    await _commit_async(message="base", root=tmp_path, session=muse_cli_db_session)
+    _create_branch(tmp_path, "experiment")
+
+    # Main makes no change to theirs-only-file.
+    ours_commit = _head_commit(tmp_path, "main")
+
+    # Experiment adds a new file that main doesn't have.
+    _switch_branch(tmp_path, "experiment")
+    _write_workdir(tmp_path, {"base.mid": b"BASE", "theirs_only.mid": b"EXTRA"})
+    await _commit_async(message="exp adds file", root=tmp_path, session=muse_cli_db_session)
+    theirs_commit = _head_commit(tmp_path, "experiment")
+
+    # Simulate: theirs_only.mid was copied into workdir before the conflict was detected.
+    _switch_branch(tmp_path, "main")
+    _write_workdir(tmp_path, {"base.mid": b"BASE", "theirs_only.mid": b"EXTRA"})
+    write_merge_state(
+        tmp_path,
+        base_commit="base000",
+        ours_commit=ours_commit,
+        theirs_commit=theirs_commit,
+        conflict_paths=["theirs_only.mid"],
+        other_branch="experiment",
+    )
+
+    await _merge_abort_async(root=tmp_path, session=muse_cli_db_session)
+
+    # theirs_only.mid must be gone (it wasn't in ours manifest).
+    assert not (tmp_path / "muse-work" / "theirs_only.mid").exists()
+    assert read_merge_state(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# merge_engine helpers — unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_apply_resolution_writes_file(tmp_path: pathlib.Path) -> None:
+    """apply_resolution() copies object content to muse-work/<rel_path>."""
+    content = b"RESOLVED_CONTENT"
+    object_id = "a" * 64  # fake sha256 (64 hex chars)
+    write_object(tmp_path, object_id, content)
+    (tmp_path / "muse-work").mkdir()
+
+    apply_resolution(tmp_path, "beat.mid", object_id)
+
+    assert (tmp_path / "muse-work" / "beat.mid").read_bytes() == content
+
+
+def test_apply_resolution_missing_object_raises(tmp_path: pathlib.Path) -> None:
+    """apply_resolution() raises FileNotFoundError for missing objects."""
+    (tmp_path / ".muse" / "objects").mkdir(parents=True)
+    (tmp_path / "muse-work").mkdir()
+
+    with pytest.raises(FileNotFoundError):
+        apply_resolution(tmp_path, "beat.mid", "b" * 64)
+
+
+def test_is_conflict_resolved_true_when_absent(tmp_path: pathlib.Path) -> None:
+    """is_conflict_resolved() returns True when path not in conflict list."""
+    (tmp_path / ".muse").mkdir()
+    write_merge_state(
+        tmp_path,
+        base_commit="b",
+        ours_commit="o",
+        theirs_commit="t",
+        conflict_paths=["other.mid"],
+    )
+    state = read_merge_state(tmp_path)
+    assert state is not None
+    assert is_conflict_resolved(state, "beat.mid") is True
+
+
+def test_is_conflict_resolved_false_when_present(tmp_path: pathlib.Path) -> None:
+    """is_conflict_resolved() returns False when path still in conflict list."""
+    (tmp_path / ".muse").mkdir()
+    write_merge_state(
+        tmp_path,
+        base_commit="b",
+        ours_commit="o",
+        theirs_commit="t",
+        conflict_paths=["beat.mid"],
+    )
+    state = read_merge_state(tmp_path)
+    assert state is not None
+    assert is_conflict_resolved(state, "beat.mid") is False
+
+
+# ---------------------------------------------------------------------------
+# CLI — outside-repo guard
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_outside_repo_exits_2() -> None:
+    """``muse resolve`` outside a Muse repo exits 2."""
+    from typer.testing import CliRunner
+
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["resolve", "beat.mid", "--ours"], catch_exceptions=False)
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND
+
+
+def test_merge_abort_outside_repo_exits_2() -> None:
+    """``muse merge --abort`` outside a Muse repo exits 2."""
+    from typer.testing import CliRunner
+
+    from maestro.muse_cli.app import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["merge", "--abort"], catch_exceptions=False)
+    assert result.exit_code == ExitCode.REPO_NOT_FOUND


### PR DESCRIPTION
## Summary
Closes #36 — implements the complete conflict resolution workflow for `muse merge`: automatic file copy for `--theirs`, `muse merge --abort`, and corrected status hint.

## Root Cause / Motivation
After `muse merge` wrote `MERGE_STATE.json` on conflict, producers had no way to complete or cancel the merge. Three gaps existed:
1. `muse resolve --theirs` required manual file editing rather than fetching the incoming object automatically.
2. `muse merge --abort` was not implemented — there was no escape from a conflicted state.
3. `muse status` showed the wrong hint: "fix conflicts and run muse commit" instead of "muse merge --continue".

## Solution

**`maestro/muse_cli/merge_engine.py`**
- Added `apply_resolution(root, rel_path, object_id)` — copies an object from the local content-addressed store (`.muse/objects/`) to `muse-work/<rel_path>`. Used by both `--theirs` resolution and `--abort`.
- Added `is_conflict_resolved(merge_state, rel_path)` — pure predicate for checking whether a path still needs resolution.

**`maestro/muse_cli/commands/resolve.py`**
- Refactored `resolve_conflict` → `resolve_conflict_async` (now takes a DB session).
- `--theirs`: queries the theirs commit's snapshot manifest, reads the object from the local store, writes it to `muse-work/`. No manual file editing needed.
- `--ours`: unchanged — leaves the file in place, removes path from `MERGE_STATE.json`.

**`maestro/muse_cli/commands/merge.py`**
- Added `_merge_abort_async(root, session)`: reads `MERGE_STATE.json`, fetches the ours commit's manifest, restores each conflicted file via `apply_resolution()`, clears `MERGE_STATE.json`.
- Added `--abort` flag to the `merge` Typer callback.

**`maestro/muse_cli/commands/status.py`**
- Fixed hint from `"fix conflicts and run muse commit"` → `"fix conflicts and run muse merge --continue"`.

**Docs**
- `docs/architecture/muse_vcs.md`: updated `muse resolve` section (reflects automatic --theirs copy), updated `muse merge --continue`, added `muse merge --abort` section with full workflow example.
- `docs/reference/type_contracts.md`: registered `MergeState` dataclass and the new `apply_resolution` / `is_conflict_resolved` helpers.

## Verification
- [x] `docker compose exec maestro mypy` — clean (6 source files)
- [x] `tests/muse_cli/test_resolve.py` — 20 tests pass
- [x] `tests/muse_cli/test_merge_integration.py` — 3 end-to-end cycle tests pass
- [x] `tests/muse_cli/test_merge.py` + `test_merge_engine.py` + `test_status.py` — 39 existing tests pass (no regressions)
- [x] Docs updated (muse_vcs.md, type_contracts.md)

## Tests Added
- `test_status_shows_conflicts_during_merge` — status output contains conflict paths and `--continue` hint
- `test_resolve_ours_removes_from_conflict_list` — path removed from MERGE_STATE after `--ours`
- `test_resolve_ours_does_not_modify_file` — muse-work/ untouched by `--ours`
- `test_resolve_ours_all_cleared_state_preserved_for_continue` — MERGE_STATE.json kept for `--continue` commit IDs
- `test_resolve_theirs_applies_their_file` — file content matches theirs version after `--theirs`
- `test_resolve_theirs_missing_object_exits_1` — exits 1 with clear error when object not in local store
- `test_resolve_nonexistent_path_exits_1` — exits 1 for path not in conflict list
- `test_resolve_no_merge_in_progress_exits_1` — exits 1 when no merge active
- `test_merge_continue_creates_commit_when_clean` — merge commit created after all conflicts resolved
- `test_merge_continue_fails_with_remaining_conflicts` — exits 1 when conflicts remain
- `test_merge_continue_no_merge_in_progress_exits_1` — exits 1 with no active merge
- `test_merge_abort_restores_state` — files restored, MERGE_STATE.json deleted
- `test_merge_abort_no_merge_in_progress_exits_1` — exits 1 with no active merge
- `test_merge_abort_removes_theirs_only_file` — theirs-only files removed on abort
- `test_apply_resolution_writes_file` — unit test for merge_engine helper
- `test_apply_resolution_missing_object_raises` — unit test for missing-object error path
- `test_is_conflict_resolved_true_when_absent` / `_false_when_present` — predicate unit tests
- `test_resolve_outside_repo_exits_2` / `test_merge_abort_outside_repo_exits_2` — guard tests
- `test_full_conflict_resolve_cycle` — end-to-end: merge → conflict → resolve → continue → log
- `test_full_conflict_abort_cycle` — end-to-end: merge → conflict → abort → pre-merge restored
- `test_partial_resolution_then_continue` — multi-file: resolve one --ours, one --theirs, then continue

## Handoff
N/A — no SSE/MCP protocol changes. Pure Muse CLI addition.