### PR TITLE
feat: muse push + muse pull — add missing remote sync flags

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5116,22 +5116,45 @@ A single configured remote — name and Hub URL pair as read from `.muse/config.
 
 ---
 
+### `PushTagPayload`
+
+**Module:** `maestro/muse_cli/hub_client.py`
+
+A VCS-style tag ref sent alongside branch commits when `muse push --tags` is used.
+Each file under `.muse/refs/tags/<tag_name>` is serialised as one payload entry.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tag_name` | `str` | Tag name (filename from `.muse/refs/tags/`) |
+| `commit_id` | `str` | Commit ID the tag points to |
+
+**Producer:** `_collect_tag_refs()` in `push.py`
+**Consumer:** Hub `/push` endpoint; included in `PushRequest["tags"]`
+
+---
+
 ### `PushRequest`
 
 **Module:** `maestro/muse_cli/hub_client.py`
 
 Payload sent to `POST <remote>/push`. Carries the local branch tip and all
-commits/objects the remote does not yet have.
+commits/objects the remote does not yet have. Optional fields drive force-push
+and tag-sync behaviour.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `branch` | `str` | Branch name being pushed |
-| `head_commit_id` | `str` | Local branch HEAD commit ID |
-| `commits` | `list[PushCommitPayload]` | Delta commits (chronological, oldest first) |
-| `objects` | `list[PushObjectPayload]` | Object descriptors for all known objects |
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `branch` | `str` | ✓ | Branch name being pushed |
+| `head_commit_id` | `str` | ✓ | Local branch HEAD commit ID |
+| `commits` | `list[PushCommitPayload]` | ✓ | Delta commits (chronological, oldest first) |
+| `objects` | `list[PushObjectPayload]` | ✓ | Object descriptors for all known objects |
+| `force` | `bool` | optional | Overwrite remote branch on non-fast-forward |
+| `force_with_lease` | `bool` | optional | Overwrite remote only if `expected_remote_head` matches Hub's current HEAD |
+| `expected_remote_head` | `str \| None` | optional | Commit ID we believe the remote HEAD to be (used with `force_with_lease`) |
+| `tags` | `list[PushTagPayload]` | optional | VCS tag refs from `.muse/refs/tags/` |
 
 **Producer:** `_build_push_request()`
 **Consumer:** Hub `/push` endpoint via `MuseHubClient.post()`
+**Note:** Extends `_PushRequestRequired` + `total=False` optional fields.
 
 ---
 
@@ -5185,14 +5208,18 @@ Response from the Hub's `/push` endpoint.
 **Module:** `maestro/muse_cli/hub_client.py`
 
 Payload sent to `POST <remote>/pull`. Tells the Hub which commits and objects
-the client already has so the Hub can compute the minimal delta.
+the client already has so the Hub can compute the minimal delta. Optional flags
+hint at the client's intended post-fetch integration strategy.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `branch` | `str` | Branch to pull |
-| `have_commits` | `list[str]` | Commit IDs already in local DB |
-| `have_objects` | `list[str]` | Object IDs already in local DB |
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `branch` | `str` | ✓ | Branch to pull |
+| `have_commits` | `list[str]` | ✓ | Commit IDs already in local DB |
+| `have_objects` | `list[str]` | ✓ | Object IDs already in local DB |
+| `rebase` | `bool` | optional | Client intends to rebase after fetching |
+| `ff_only` | `bool` | optional | Client will refuse to merge; only fast-forward |
 
+**Note:** Extends `_PullRequestRequired` + `total=False` optional fields.
 **Producer:** `_pull_async()`
 **Consumer:** Hub `/pull` endpoint via `MuseHubClient.post()`
 

--- a/maestro/muse_cli/commands/pull.py
+++ b/maestro/muse_cli/commands/pull.py
@@ -158,7 +158,7 @@ async def _rebase_commits_onto(
 
 
 def _is_ancestor(
-    commits_by_id: Mapping[str, object],
+    commits_by_id: Mapping[str, MuseCliCommit],
     ancestor_id: str,
     descendant_id: str,
 ) -> bool:

--- a/maestro/muse_cli/hub_client.py
+++ b/maestro/muse_cli/hub_client.py
@@ -66,13 +66,45 @@ class PushObjectPayload(TypedDict):
     size_bytes: int
 
 
-class PushRequest(TypedDict):
-    """Payload sent to ``POST /musehub/repos/{repo_id}/push``."""
+class PushTagPayload(TypedDict):
+    """A VCS-style tag ref sent during a push with ``--tags``.
+
+    Represents a lightweight ref stored in ``.muse/refs/tags/<tag_name>``
+    that points to a commit ID.
+    """
+
+    tag_name: str
+    commit_id: str
+
+
+class _PushRequestRequired(TypedDict):
+    """Required fields for every push request."""
 
     branch: str
     head_commit_id: str
     commits: list[PushCommitPayload]
     objects: list[PushObjectPayload]
+
+
+class PushRequest(_PushRequestRequired, total=False):
+    """Payload sent to ``POST /musehub/repos/{repo_id}/push``.
+
+    Optional flags control override behaviour and extra data:
+
+    - ``force``: overwrite remote branch even on non-fast-forward.
+    - ``force_with_lease``: overwrite only if remote HEAD matches
+      ``expected_remote_head``; the Hub must reject if the remote has
+      advanced since we last fetched.
+    - ``expected_remote_head``: the commit ID we believe the remote HEAD to
+      be (required when ``force_with_lease`` is ``True``).
+    - ``tags``: VCS-style tag refs from ``.muse/refs/tags/`` to push alongside
+      the branch commits.
+    """
+
+    force: bool
+    force_with_lease: bool
+    expected_remote_head: str | None
+    tags: list[PushTagPayload]
 
 
 class PushResponse(TypedDict):
@@ -82,12 +114,28 @@ class PushResponse(TypedDict):
     message: str
 
 
-class PullRequest(TypedDict):
-    """Payload sent to ``POST /musehub/repos/{repo_id}/pull``."""
+class _PullRequestRequired(TypedDict):
+    """Required fields for every pull request."""
 
     branch: str
     have_commits: list[str]
     have_objects: list[str]
+
+
+class PullRequest(_PullRequestRequired, total=False):
+    """Payload sent to ``POST /musehub/repos/{repo_id}/pull``.
+
+    Optional flags are informational hints for the Hub (and drive local
+    post-fetch behaviour):
+
+    - ``rebase``: caller intends to rebase local commits onto the fetched
+      remote HEAD rather than merge.
+    - ``ff_only``: caller will refuse to integrate if the result would not be
+      a fast-forward; the Hub may use this to gate the response.
+    """
+
+    rebase: bool
+    ff_only: bool
 
 
 class PullCommitPayload(TypedDict):
@@ -231,6 +279,7 @@ __all__ = [
     "MuseHubClient",
     "PushCommitPayload",
     "PushObjectPayload",
+    "PushTagPayload",
     "PushRequest",
     "PushResponse",
     "PullRequest",


### PR DESCRIPTION
## Summary
Closes #77 — adds `--force`, `--force-with-lease`, `--tags`, `--set-upstream` to `muse push`; adds `--rebase`, `--ff-only` to `muse pull`.

## Root Cause / Motivation
`muse push` and `muse pull` had only minimal functionality. Users could not safely force-push, set upstream tracking, sync tags, rebase on pull, or enforce fast-forward-only pulls — all workflows required for production CI and multi-collaborator music sessions.

## Solution

### Push flags added
- **`--force` / `-f`**: Overwrite remote branch even on non-fast-forward. Sends `force: true` in `PushRequest`.
- **`--force-with-lease`**: Include `force_with_lease: true` and `expected_remote_head` in `PushRequest`. Hub must return HTTP 409 if remote has advanced beyond our last tracking pointer; pull detects the 409 and exits 1 with an instructive retry message.
- **`--tags`**: Enumerate `.muse/refs/tags/` and include `PushTagPayload` list in the push payload.
- **`--set-upstream` / `-u`**: After successful push, write `branch = <branch>` under `[remotes.<name>]` in `.muse/config.toml` via new `set_upstream()` config helper.

### Pull flags added
- **`--ff-only`**: After fetching, advance local branch ref to `remote_head` if `local_head` is an ancestor (fast-forward). Exit 1 with clear message if branches have diverged.
- **`--rebase`**: Fast-forward when remote is strictly ahead. For diverged branches, find merge base and replay local commits above it onto `remote_head` using `compute_commit_tree_id` (deterministic — idempotent). Both `rebase` and `ff_only` are also sent as hint flags in `PullRequest`.

### TypedDict changes
- `PushRequest`: split into `_PushRequestRequired` + `total=False` optional fields (`force`, `force_with_lease`, `expected_remote_head`, `tags`).
- `PullRequest`: split into `_PullRequestRequired` + `total=False` optional fields (`rebase`, `ff_only`).
- New `PushTagPayload` TypedDict: `{tag_name: str, commit_id: str}`.
- New `config.py` helpers: `set_upstream()`, `get_upstream()`.

## Layers Affected
- [x] Muse VCS
- [x] Muse CLI

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (552 files)
- [x] `docker compose exec storpheus mypy .` — not affected
- [x] All 40 tests in `test_push.py` + `test_pull.py` pass
- [x] Docs updated (`muse_vcs.md`, `type_contracts.md`)

## Tests Added
- `test_build_push_request_force_flag` — `--force` sets `force=True` in payload
- `test_build_push_request_force_with_lease` — `--force-with-lease` sets lease fields
- `test_build_push_request_no_force_flags_by_default` — no spurious flags in default push
- `test_build_push_request_tags` — tags included in payload when tag_payloads provided
- `test_collect_tag_refs_empty_when_no_tags_dir` — graceful when `.muse/refs/tags/` absent
- `test_collect_tag_refs_returns_tags_from_dir` — reads tag files correctly
- `test_collect_tag_refs_ignores_empty_files` — skips empty tag files
- `test_push_force_with_lease_rejects_mismatch` — HTTP 409 → exit 1 with instructive message (regression #77)
- `test_push_tags_includes_tags` — `--tags` includes tag refs in push payload (regression #77)
- `test_push_set_upstream_writes_config` — `--set-upstream` writes tracking to config (regression #77)
- `test_push_force_flag_sends_force_in_payload` — `--force` sends `force=True` in payload
- `test_pull_ff_only_fast_forwards_when_remote_ahead` — `--ff-only` advances branch ref (regression #77)
- `test_pull_ff_only_fails_when_not_ff` — `--ff-only` exits 1 when diverged (regression #77)
- `test_pull_rebase_fast_forwards_when_remote_ahead` — `--rebase` fast-forwards when possible (regression #77)
- `test_pull_rebase_sends_rebase_hint_in_request` — `rebase=True` included in PullRequest
- `test_pull_ff_only_sends_ff_only_hint_in_request` — `ff_only=True` included in PullRequest

## Handoff
N/A — no SSE/MCP protocol change.