### PR TITLE
feat(musehub): raw file endpoint — direct download with correct MIME types for scripted access

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -1418,7 +1418,9 @@ maestro/
     ├── repos.py                          — Repo/branch/commit route handlers
     ├── issues.py                         — Issue tracking route handlers
     ├── pull_requests.py                  — Pull request route handlers
-    └── sync.py                           — Push/pull sync route handlers
+    ├── sync.py                           — Push/pull sync route handlers
+    ├── objects.py                        — Artifact list + content-by-object-id endpoints (auth required)
+    └── raw.py                            — Raw file download by path (public repos: no auth)
 ```
 
 ### Endpoints
@@ -1457,7 +1459,34 @@ maestro/
 | POST | `/api/v1/musehub/repos/{id}/push` | Upload commits and objects (fast-forward enforced) |
 | POST | `/api/v1/musehub/repos/{id}/pull` | Fetch missing commits and objects |
 
-All endpoints require `Authorization: Bearer <token>`. See [api.md](../reference/api.md#muse-hub-api) for full field docs.
+#### Raw File Download
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/musehub/repos/{id}/raw/{ref}/{path}` | Download file by path with correct MIME type |
+
+The raw endpoint is designed for `curl`, `wget`, and scripted pipelines. It
+serves files with `Accept-Ranges: bytes` so audio clients can perform range
+requests for partial playback.
+
+**Auth:** No token required for **public** repos. Private repos return 401
+without a valid Bearer token.
+
+```bash
+# Public repo — no auth needed
+curl https://musehub.stori.com/api/v1/musehub/repos/<repo_id>/raw/main/tracks/bass.mid \
+  -o bass.mid
+
+# Private repo — Bearer token required
+curl -H "Authorization: Bearer <token>" \
+  https://musehub.stori.com/api/v1/musehub/repos/<repo_id>/raw/main/mix/final.mp3 \
+  -o final.mp3
+```
+
+See [api.md](../reference/api.md#get-apiv1musehub-reposrepo_idrawrefpath) for the
+full MIME type table and error reference.
+
+All other endpoints require `Authorization: Bearer <token>`. See [api.md](../reference/api.md#muse-hub-api) for full field docs.
 
 ### Issue Workflow
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1316,6 +1316,66 @@ others → `application/octet-stream`).
 
 ---
 
+### GET /api/v1/musehub/repos/{repo_id}/raw/{ref}/{path}
+
+Direct file download by human-readable path and ref (branch/tag), analogous to
+GitHub's `raw.githubusercontent.com` URLs. Designed for `curl`, `wget`, and
+scripted pipelines.
+
+**Auth:** No token required for **public** repos. Private repos require
+`Authorization: Bearer <token>` and return 401 otherwise.
+
+**Path parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `repo_id` | UUID of the target Muse Hub repo |
+| `ref` | Branch or tag name (e.g. `main`). Accepted for URL semantics; current implementation serves the most-recently-pushed object at `path`. |
+| `path` | Relative file path inside the repo (e.g. `tracks/bass.mid`). Supports nested paths. |
+
+**Response headers:**
+
+| Header | Value |
+|--------|-------|
+| `Content-Type` | MIME type derived from file extension (see table below) |
+| `Content-Disposition` | `attachment; filename="<basename>"` |
+| `Accept-Ranges` | `bytes` — range requests are supported |
+
+**MIME type resolution:**
+
+| Extension | Content-Type |
+|-----------|-------------|
+| `.mid`, `.midi` | `audio/midi` |
+| `.mp3` | `audio/mpeg` |
+| `.wav` | `audio/wav` |
+| `.json` | `application/json` |
+| `.webp` | `image/webp` |
+| `.xml` | `application/xml` |
+| `.abc` | `text/vnd.abc` |
+| Others | `application/octet-stream` |
+
+**Range request example:**
+
+```bash
+curl -H "Range: bytes=0-1023" \
+  https://musehub.stori.com/api/v1/musehub/repos/<repo_id>/raw/main/tracks/bass.mid
+# → 206 Partial Content with first 1 KB
+```
+
+**Full download example:**
+
+```bash
+curl https://musehub.stori.com/api/v1/musehub/repos/<repo_id>/raw/main/tracks/bass.mid \
+  -o bass.mid
+```
+
+**Errors:**
+- **401** — private repo accessed without a valid Bearer token
+- **404** — repo not found, or no object exists at the given path
+- **410** — object metadata exists in DB but the file was removed from disk
+
+---
+
 ## Muse Hub Web UI
 
 The following routes serve HTML pages for browser-based repo navigation. They

--- a/maestro/api/routes/musehub/raw.py
+++ b/maestro/api/routes/musehub/raw.py
@@ -1,0 +1,183 @@
+"""Muse Hub raw file endpoint — direct file download with correct MIME types.
+
+Endpoint:
+  GET /musehub/repos/{repo_id}/raw/{ref}/{path}
+
+Serves artifact bytes from disk with:
+- Correct Content-Type for .mid, .mp3, .wav, .json, .webp, .xml, .abc, and more
+- Content-Disposition header with the original filename
+- Accept-Ranges / 206 Partial Content for streaming audio playback
+- No auth required for public repos; JWT required for private repos
+
+This endpoint is intentionally **not** added to the auth-protected musehub
+router (``maestro.api.routes.musehub.__init__``) so that public-repo files
+can be fetched without a Bearer token — matching GitHub's raw.githubusercontent
+semantics. The privacy check is enforced inside the handler itself.
+"""
+from __future__ import annotations
+
+import logging
+import mimetypes
+import os
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import FileResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.auth.tokens import AccessCodeError, validate_access_code
+from maestro.db import get_db
+from maestro.services import musehub_repository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["musehub-raw"])
+
+# ---------------------------------------------------------------------------
+# MIME type registry
+# ---------------------------------------------------------------------------
+
+_MIME_MAP: dict[str, str] = {
+    ".mid": "audio/midi",
+    ".midi": "audio/midi",
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".json": "application/json",
+    ".webp": "image/webp",
+    ".xml": "application/xml",
+    ".abc": "text/vnd.abc",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".ogg": "audio/ogg",
+}
+
+# HTTPBearer with auto_error=False so we get None instead of 401
+# when no Authorization header is present — allows public-repo access.
+_optional_bearer = HTTPBearer(auto_error=False)
+
+
+def _resolve_mime(path: str) -> str:
+    """Resolve MIME type from file extension; fall back to octet-stream.
+
+    Prefers the hand-curated ``_MIME_MAP`` over the system mimetypes database
+    so that audio/midi is always returned for .mid files regardless of OS
+    configuration.
+    """
+    ext = os.path.splitext(path)[1].lower()
+    if ext in _MIME_MAP:
+        return _MIME_MAP[ext]
+    guessed, _ = mimetypes.guess_type(path)
+    return guessed or "application/octet-stream"
+
+
+# ---------------------------------------------------------------------------
+# Route handler
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/musehub/repos/{repo_id}/raw/{ref}/{path:path}",
+    summary="Download a raw file from a Muse Hub repo",
+    response_class=FileResponse,
+)
+async def raw_file(
+    repo_id: str,
+    ref: str,
+    path: str,
+    db: AsyncSession = Depends(get_db),
+    credentials: HTTPAuthorizationCredentials | None = Depends(_optional_bearer),
+) -> FileResponse:
+    """Serve raw artifact bytes from a Muse Hub repo at the given ref and path.
+
+    Auth rules:
+    - Public repos: no token required. Anyone can ``curl`` or ``wget`` files.
+    - Private repos: a valid Bearer JWT is required; returns 401 otherwise.
+
+    The ``ref`` parameter mirrors Git branch/tag semantics (e.g. ``main``).
+    It is accepted to support human-readable URLs and future ref-based
+    filtering, but the current implementation serves the most-recently-pushed
+    object at ``path`` regardless of ref — consistent with MVP scope.
+
+    Args:
+        repo_id: UUID of the target Muse Hub repo.
+        ref: Branch or tag name, e.g. ``main``. Accepted but not yet
+            used for filtering (future: return the object at that branch HEAD).
+        path: Relative file path inside the repo, e.g. ``tracks/bass.mid``.
+
+    Returns:
+        FileResponse with:
+        - Correct Content-Type derived from the file extension.
+        - Content-Disposition: attachment with the filename.
+        - Accept-Ranges: bytes (range requests supported via Starlette).
+
+    Raises:
+        HTTPException 401: Private repo accessed without a valid JWT.
+        HTTPException 404: Repo not found, or no object at the given path.
+        HTTPException 410: Object metadata exists but the file is missing from disk.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    if repo.visibility != "public":
+        _require_token(credentials)
+
+    obj = await musehub_repository.get_object_by_path(db, repo_id, path)
+    if obj is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No object at path '{path}' in ref '{ref}'",
+        )
+
+    if not os.path.exists(obj.disk_path):
+        logger.warning(
+            "⚠️ Object at path '%s' exists in DB but missing from disk: %s",
+            path,
+            obj.disk_path,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail="Object file has been removed from storage",
+        )
+
+    filename = os.path.basename(obj.path)
+    media_type = _resolve_mime(obj.path)
+    logger.debug("✅ Serving raw file '%s' (%s) from repo %s", path, media_type, repo_id[:8])
+    return FileResponse(
+        obj.disk_path,
+        media_type=media_type,
+        filename=filename,
+        headers={"Accept-Ranges": "bytes"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal auth helper
+# ---------------------------------------------------------------------------
+
+
+def _require_token(credentials: HTTPAuthorizationCredentials | None) -> None:
+    """Raise 401 if credentials are absent or the JWT is invalid/expired.
+
+    Private repos gate behind the same JWT validation as the rest of the
+    musehub API.  This helper is intentionally narrow: it validates the token
+    but does NOT check revocation (that would require a DB round-trip on
+    every raw download for private repos — acceptable as a future hardening
+    step once revocation is indexed by hash).
+    """
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="This repo is private. Provide a Bearer token to access raw files.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    try:
+        validate_access_code(credentials.credentials)
+    except AccessCodeError as exc:
+        logger.warning("⚠️ Invalid token on private raw download: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired access token.",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc

--- a/maestro/main.py
+++ b/maestro/main.py
@@ -22,6 +22,7 @@ from slowapi.errors import RateLimitExceeded
 from maestro.config import settings
 from maestro.api.routes import maestro, maestro_ui, health, users, conversations, assets, variation, muse, musehub
 from maestro.api.routes.musehub import ui as musehub_ui_routes
+from maestro.api.routes.musehub import raw as musehub_raw_routes
 from maestro.api.routes import mcp as mcp_routes
 from maestro.db import init_db, close_db
 from maestro.services.storpheus import get_storpheus_client, close_storpheus_client
@@ -161,6 +162,7 @@ app.include_router(assets.router, prefix="/api/v1", tags=["assets"])
 app.include_router(muse.router, prefix="/api/v1", tags=["muse"])
 app.include_router(musehub.router, prefix="/api/v1", tags=["musehub"])
 app.include_router(musehub_ui_routes.router, tags=["musehub-ui"])
+app.include_router(musehub_raw_routes.router, prefix="/api/v1", tags=["musehub-raw"])
 app.include_router(mcp_routes.router, prefix="/api/v1/mcp", tags=["mcp"])
 
 from maestro.protocol.endpoints import router as protocol_router

--- a/tests/test_musehub_raw.py
+++ b/tests/test_musehub_raw.py
@@ -1,0 +1,346 @@
+"""Tests for the Muse Hub raw file download endpoint.
+
+Covers every acceptance criterion from issue #245:
+- test_raw_midi_correct_mime       — .mid served with audio/midi
+- test_raw_mp3_correct_mime        — .mp3 served with audio/mpeg
+- test_raw_wav_correct_mime        — .wav served with audio/wav
+- test_raw_json_correct_mime       — .json served with application/json
+- test_raw_webp_correct_mime       — .webp served with image/webp
+- test_raw_xml_correct_mime        — .xml served with application/xml
+- test_raw_404_unknown_path        — nonexistent path returns 404
+- test_raw_404_unknown_repo        — nonexistent repo_id returns 404
+- test_raw_public_no_auth          — public repo accessible without JWT
+- test_raw_private_requires_auth   — private repo returns 401 without JWT
+- test_raw_private_with_auth       — private repo accessible with valid JWT
+- test_raw_range_request           — Range request returns 206 with partial content
+- test_raw_content_disposition     — Content-Disposition header carries filename
+- test_raw_accept_ranges_header    — Accept-Ranges: bytes is present in response
+
+The endpoint under test:
+  GET /api/v1/musehub/repos/{repo_id}/raw/{ref}/{path:path}
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import MusehubObject, MusehubRepo
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _make_repo(db: AsyncSession, *, visibility: str = "public") -> str:
+    """Seed a minimal Muse Hub repo and return its repo_id."""
+    repo = MusehubRepo(
+        name="test-beats",
+        visibility=visibility,
+        owner_user_id="test-owner",
+    )
+    db.add(repo)
+    await db.commit()
+    await db.refresh(repo)
+    return str(repo.repo_id)
+
+
+async def _make_object(
+    db: AsyncSession,
+    repo_id: str,
+    *,
+    path: str,
+    content: bytes = b"FAKE_CONTENT",
+    tmp_dir: str,
+) -> str:
+    """Write content to a temp file, seed an object row, return the object_id."""
+    filename = os.path.basename(path)
+    disk_path = os.path.join(tmp_dir, filename)
+    with open(disk_path, "wb") as fh:
+        fh.write(content)
+
+    obj = MusehubObject(
+        object_id=f"sha256:test-{filename}",
+        repo_id=repo_id,
+        path=path,
+        size_bytes=len(content),
+        disk_path=disk_path,
+    )
+    db.add(obj)
+    await db.commit()
+    return str(obj.object_id)
+
+
+# ---------------------------------------------------------------------------
+# MIME type tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_raw_midi_correct_mime(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """.mid file is served with Content-Type: audio/midi."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _make_repo(db_session, visibility="public")
+        await _make_object(db_session, repo_id, path="tracks/bass.mid", tmp_dir=tmp)
+
+        resp = await client.get(f"/api/v1/musehub/repos/{repo_id}/raw/main/tracks/bass.mid")
+
+    assert resp.status_code == 200
+    assert "audio/midi" in resp.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_raw_mp3_correct_mime(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """.mp3 file is served with Content-Type: audio/mpeg."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _make_repo(db_session, visibility="public")
+        await _make_object(db_session, repo_id, path="mix/final.mp3", tmp_dir=tmp)
+
+        resp = await client.get(f"/api/v1/musehub/repos/{repo_id}/raw/main/mix/final.mp3")
+
+    assert resp.status_code == 200
+    assert "audio/mpeg" in resp.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_raw_wav_correct_mime(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """.wav file is served with Content-Type: audio/wav."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _make_repo(db_session, visibility="public")
+        await _make_object(db_session, repo_id, path="stems/drums.wav", tmp_dir=tmp)
+
+        resp = await client.get(f"/api/v1/musehub/repos/{repo_id}/raw/main/stems/drums.wav")
+
+    assert resp.status_code == 200
+    assert "audio/wav" in resp.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_raw_json_correct_mime(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """.json file is served with Content-Type: application/json."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _make_repo(db_session, visibility="public")
+        await _make_object(
+            db_session,
+            repo_id,
+            path="metadata/track.json",
+            content=b'{"bpm": 120}',
+            tmp_dir=tmp,
+        )
+
+        resp = await client.get(
+            f"/api/v1/musehub/repos/{repo_id}/raw/main/metadata/track.json"
+        )
+
+    assert resp.status_code == 200
+    assert "application/json" in resp.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_raw_webp_correct_mime(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """.webp file is served with Content-Type: image/webp."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _make_repo(db_session, visibility="public")
+        await _make_object(db_session, repo_id, path="previews/piano_roll.webp", tmp_dir=tmp)
+
+        resp = await client.get(
+            f"/api/v1/musehub/repos/{repo_id}/raw/main/previews/piano_roll.webp"
+        )
+
+    assert resp.status_code == 200
+    assert "image/webp" in resp.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_raw_xml_correct_mime(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """.xml file is served with Content-Type: application/xml."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _make_repo(db_session, visibility="public")
+        await _make_object(
+            db_session,
+            repo_id,
+            path="scores/piece.xml",
+            content=b"<score></score>",
+            tmp_dir=tmp,
+        )
+
+        resp = await client.get(f"/api/v1/musehub/repos/{repo_id}/raw/main/scores/piece.xml")
+
+    assert resp.status_code == 200
+    assert "application/xml" in resp.headers["content-type"]
+
+
+# ---------------------------------------------------------------------------
+# 404 / error cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_raw_404_unknown_path(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Path that has no matching object returns 404."""
+    repo_id = await _make_repo(db_session, visibility="public")
+    resp = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/raw/main/does/not/exist.mid"
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_raw_404_unknown_repo(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Nonexistent repo_id returns 404 immediately."""
+    resp = await client.get(
+        "/api/v1/musehub/repos/nonexistent-repo-uuid/raw/main/track.mid"
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Auth tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_raw_public_no_auth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Public repo files are accessible without any Authorization header."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _make_repo(db_session, visibility="public")
+        await _make_object(db_session, repo_id, path="tracks/open.mid", tmp_dir=tmp)
+
+        resp = await client.get(
+            f"/api/v1/musehub/repos/{repo_id}/raw/main/tracks/open.mid"
+        )
+
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_raw_private_requires_auth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Private repo raw download without a JWT returns 401."""
+    repo_id = await _make_repo(db_session, visibility="private")
+    resp = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/raw/main/tracks/secret.mid"
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_raw_private_with_auth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Private repo raw download WITH a valid JWT returns 200."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _make_repo(db_session, visibility="private")
+        await _make_object(db_session, repo_id, path="tracks/secret.mid", tmp_dir=tmp)
+
+        resp = await client.get(
+            f"/api/v1/musehub/repos/{repo_id}/raw/main/tracks/secret.mid",
+            headers={"Authorization": auth_headers["Authorization"]},
+        )
+
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Header correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_raw_content_disposition(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Response carries a Content-Disposition header with the original filename."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _make_repo(db_session, visibility="public")
+        await _make_object(
+            db_session, repo_id, path="tracks/groove_42.mid", tmp_dir=tmp
+        )
+
+        resp = await client.get(
+            f"/api/v1/musehub/repos/{repo_id}/raw/main/tracks/groove_42.mid"
+        )
+
+    assert resp.status_code == 200
+    cd = resp.headers.get("content-disposition", "")
+    assert "groove_42.mid" in cd
+
+
+@pytest.mark.anyio
+async def test_raw_accept_ranges_header(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Response includes Accept-Ranges: bytes so Range requests are signalled."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _make_repo(db_session, visibility="public")
+        await _make_object(db_session, repo_id, path="mix/audio.mp3", tmp_dir=tmp)
+
+        resp = await client.get(
+            f"/api/v1/musehub/repos/{repo_id}/raw/main/mix/audio.mp3"
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers.get("accept-ranges") == "bytes"
+
+
+@pytest.mark.anyio
+async def test_raw_range_request(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Range request returns 206 Partial Content with the requested byte slice."""
+    content = b"HELLO_WORLD_AUDIO_DATA_BYTES_HERE"
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _make_repo(db_session, visibility="public")
+        await _make_object(
+            db_session,
+            repo_id,
+            path="mix/partial.mp3",
+            content=content,
+            tmp_dir=tmp,
+        )
+
+        resp = await client.get(
+            f"/api/v1/musehub/repos/{repo_id}/raw/main/mix/partial.mp3",
+            headers={"Range": "bytes=0-4"},
+        )
+
+    assert resp.status_code == 206
+    assert resp.content == content[:5]


### PR DESCRIPTION
## Summary
Closes #245 — adds a raw file download endpoint to Muse Hub so that `curl`, `wget`, and
scripted pipelines can fetch any repo artifact directly by path with correct MIME types.

## Root Cause / Motivation
The existing object download endpoint (`/objects/{object_id}/content`) requires knowing the
content-addressed `object_id` UUID — unusable in scripts. No human-readable path-based
download existed. Public repos had no unauthenticated access path at all.

## Solution

### New endpoint
`GET /api/v1/musehub/repos/{repo_id}/raw/{ref}/{path:path}`

- **Auth:** No token for public repos; Bearer JWT required for private repos (returns 401)
- **MIME resolution:** Hand-curated map covers `.mid → audio/midi`, `.mp3 → audio/mpeg`,
  `.wav → audio/wav`, `.json → application/json`, `.webp → image/webp`, `.xml → application/xml`,
  `.abc → text/vnd.abc`; falls back to system mimetypes then `application/octet-stream`
- **Content-Disposition:** `attachment; filename="<basename>"` on every response
- **Range requests:** `Accept-Ranges: bytes` header; Starlette's `FileResponse` handles
  `Range:` headers natively → 206 Partial Content for audio streaming

### New files
- `maestro/api/routes/musehub/raw.py` — endpoint handler + optional auth logic
- `tests/test_musehub_raw.py` — 14 tests (all passing)

### Modified files
- `maestro/services/musehub_repository.py` — adds `get_object_by_path()` (path → newest object)
- `maestro/main.py` — registers the raw router outside the auth-protected musehub router
- `docs/reference/api.md` — full endpoint spec with MIME table and curl examples
- `docs/architecture/muse_vcs.md` — module map update, endpoint table, curl examples

## Layers Affected
- [x] Muse VCS (musehub objects service — read path only)
- [ ] Intent Engine
- [ ] Pipeline
- [ ] Maestro Handlers
- [ ] Agent Teams
- [ ] Storpheus Client
- [ ] MCP
- [ ] DAW Adapter
- [ ] Auth / Budget
- [ ] RAG
- [ ] Variation
- [ ] SSE Protocol

## Verification
- [x] `docker compose exec maestro mypy` — clean (0 errors)
- [x] `pytest tests/test_musehub_raw.py -v` — 14/14 passed
- [x] Affected docs updated (api.md + muse_vcs.md)

## Tests Added
- `test_raw_midi_correct_mime` — `.mid` → `audio/midi`
- `test_raw_mp3_correct_mime` — `.mp3` → `audio/mpeg`
- `test_raw_wav_correct_mime` — `.wav` → `audio/wav`
- `test_raw_json_correct_mime` — `.json` → `application/json`
- `test_raw_webp_correct_mime` — `.webp` → `image/webp`
- `test_raw_xml_correct_mime` — `.xml` → `application/xml`
- `test_raw_404_unknown_path` — nonexistent path returns 404
- `test_raw_404_unknown_repo` — nonexistent repo_id returns 404
- `test_raw_public_no_auth` — public repo accessible without JWT
- `test_raw_private_requires_auth` — private repo returns 401 without JWT
- `test_raw_private_with_auth` — private repo accessible with valid JWT
- `test_raw_content_disposition` — Content-Disposition contains filename
- `test_raw_accept_ranges_header` — Accept-Ranges: bytes present
- `test_raw_range_request` — Range header returns 206 with correct byte slice

## Handoff
N/A — no SSE protocol change. New endpoint only.