### PR TITLE
feat(musehub): download and export integration — format selector and split-tracks

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -1140,6 +1140,30 @@ On failure: `success=False` plus `error` (and optionally `message`).
 
 ---
 
+### `ExportResult`
+
+**Path:** `maestro/services/musehub_exporter.py`
+
+`dataclass(frozen=True)` — Fully packaged export artifact returned by `export_repo_at_ref()`.
+Ready for direct streaming to the HTTP client via `Response(content=result.content, ...)`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `content` | `bytes` | Raw bytes of the artifact or ZIP archive |
+| `content_type` | `str` | MIME type for the HTTP `Content-Type` header |
+| `filename` | `str` | Suggested filename for `Content-Disposition: attachment` |
+
+**Companion enum:**
+
+`ExportFormat(str, Enum)` — `midi`, `json`, `musicxml`, `abc`, `wav`, `mp3`.
+
+**Sentinel returns:** `export_repo_at_ref()` returns the string literal `"ref_not_found"` when
+the ref cannot be resolved to any known commit or branch, and `"no_matching_objects"` when
+no stored artifacts match the requested format + section filter. Route handlers convert
+these to HTTP 404.
+
+---
+
 ### `RenderPreviewResult`
 
 **Path:** `maestro/services/muse_render_preview.py`

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -1157,6 +1157,16 @@ Ready for direct streaming to the HTTP client via `Response(content=result.conte
 
 `ExportFormat(str, Enum)` — `midi`, `json`, `musicxml`, `abc`, `wav`, `mp3`.
 
+**Companion TypedDict:**
+
+`ObjectIndexEntry(TypedDict)` — One entry in the JSON export object index (used in `format=json` responses).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `object_id` | `str` | Muse Hub object ID |
+| `path` | `str` | Artifact path within the repo |
+| `size_bytes` | `int` | Stored artifact size in bytes |
+
 **Sentinel returns:** `export_repo_at_ref()` returns the string literal `"ref_not_found"` when
 the ref cannot be resolved to any known commit or branch, and `"no_matching_objects"` when
 no stored artifacts match the requested format + section filter. Route handlers convert

--- a/maestro/services/musehub_exporter.py
+++ b/maestro/services/musehub_exporter.py
@@ -1,0 +1,298 @@
+"""Muse Hub export service — format conversion and ZIP packaging.
+
+Resolves a repo ref (commit ID or branch name) and packages stored artifacts
+into a downloadable payload. The export is deterministic for a given
+repo + ref + format + options combination.
+
+Format support:
+  midi      — returns .mid artifacts directly or ZIPed for split_tracks
+  json      — serialises commit metadata + object index as JSON
+  musicxml  — returns .xml/.musicxml/.mxl artifacts (pass-through)
+  abc       — returns .abc artifacts (pass-through)
+  wav       — returns .wav artifacts (pass-through)
+  mp3       — returns .mp3 artifacts (pass-through)
+
+For split_tracks=True or when multiple artifacts match the requested format,
+all files are bundled into a ZIP archive. Single-artifact exports are returned
+as the raw file with the appropriate MIME type.
+
+Boundary rules:
+  - Must NOT import from maestro.core.* (no intent/pipeline logic here).
+  - Must NOT call external services (no Storpheus, no OpenRouter).
+  - Reads from DB via musehub_repository; reads file bytes directly from disk.
+"""
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import zipfile
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.services import musehub_repository
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+class ExportFormat(str, Enum):
+    """Supported export formats for a Muse Hub repo snapshot.
+
+    midi      — Audio MIDI (.mid); the native Muse format.
+    json      — Commit metadata + object index; machine-readable for agents.
+    musicxml  — MusicXML (.xml/.musicxml/.mxl); notation-app interchange.
+    abc       — ABC notation (.abc); plain-text music representation.
+    wav       — PCM audio (.wav); lossless render.
+    mp3       — Compressed audio (.mp3); delivery format.
+    """
+
+    midi = "midi"
+    json = "json"
+    musicxml = "musicxml"
+    abc = "abc"
+    wav = "wav"
+    mp3 = "mp3"
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    """Fully packaged export artifact ready for streaming to the client.
+
+    content      — Raw bytes of the file or ZIP archive.
+    content_type — MIME type for the HTTP response Content-Type header.
+    filename     — Suggested filename for Content-Disposition: attachment.
+    """
+
+    content: bytes
+    content_type: str
+    filename: str
+
+
+# ---------------------------------------------------------------------------
+# Internal constants
+# ---------------------------------------------------------------------------
+
+# Maps ExportFormat → file extensions whose objects are candidates for that format
+_FORMAT_EXTENSIONS: dict[ExportFormat, tuple[str, ...]] = {
+    ExportFormat.midi: (".mid", ".midi"),
+    ExportFormat.musicxml: (".xml", ".musicxml", ".mxl"),
+    ExportFormat.abc: (".abc",),
+    ExportFormat.wav: (".wav",),
+    ExportFormat.mp3: (".mp3",),
+    # json is handled separately — no on-disk extension match needed
+    ExportFormat.json: (),
+}
+
+_FORMAT_MIME: dict[ExportFormat, str] = {
+    ExportFormat.midi: "audio/midi",
+    ExportFormat.json: "application/json",
+    ExportFormat.musicxml: "application/vnd.recordare.musicxml+xml",
+    ExportFormat.abc: "text/plain; charset=utf-8",
+    ExportFormat.wav: "audio/wav",
+    ExportFormat.mp3: "audio/mpeg",
+}
+
+
+# ---------------------------------------------------------------------------
+# Ref resolution helpers
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_ref(
+    session: AsyncSession,
+    repo_id: str,
+    ref: str,
+) -> str | None:
+    """Resolve a ref string to a commit_id.
+
+    Tries in order:
+    1. Direct commit_id lookup.
+    2. Branch head lookup (ref treated as branch name).
+
+    Returns None if the ref cannot be resolved to any known commit.
+    """
+    commit = await musehub_repository.get_commit(session, repo_id, ref)
+    if commit is not None:
+        return commit.commit_id
+
+    branches = await musehub_repository.list_branches(session, repo_id)
+    for branch in branches:
+        if branch.name == ref and branch.head_commit_id:
+            return branch.head_commit_id
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Section filtering
+# ---------------------------------------------------------------------------
+
+
+def _matches_sections(path: str, sections: list[str] | None) -> bool:
+    """Return True if the artifact path should be included given the section filter.
+
+    When ``sections`` is None or empty, all paths pass. Otherwise, the path
+    must contain at least one section name as a path component or substring.
+    Section names are compared case-insensitively.
+    """
+    if not sections:
+        return True
+    path_lower = path.lower()
+    return any(s.lower() in path_lower for s in sections)
+
+
+# ---------------------------------------------------------------------------
+# Format builders
+# ---------------------------------------------------------------------------
+
+
+def _build_zip(
+    artifacts: list[tuple[str, bytes]],
+) -> bytes:
+    """Bundle a list of (filename, content) pairs into an in-memory ZIP archive."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, data in artifacts:
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _build_json_export(
+    repo_id: str,
+    ref: str,
+    commit_id: str,
+    objects: list[dict[str, object]],
+) -> bytes:
+    """Serialise a commit's metadata and object index to compact JSON bytes.
+
+    The schema is:
+        {
+          "repo_id": str,
+          "ref": str,
+          "commit_id": str,
+          "objects": [{"object_id": str, "path": str, "size_bytes": int}]
+        }
+    """
+    payload: dict[str, object] = {
+        "repo_id": repo_id,
+        "ref": ref,
+        "commit_id": commit_id,
+        "objects": objects,
+    }
+    return json.dumps(payload, indent=2).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def export_repo_at_ref(
+    session: AsyncSession,
+    repo_id: str,
+    ref: str,
+    format: ExportFormat,  # noqa: A002 — shadows built-in intentionally for clarity
+    split_tracks: bool = False,
+    sections: list[str] | None = None,
+) -> ExportResult | Literal["ref_not_found", "no_matching_objects"]:
+    """Package stored artifacts for download at the given commit ref.
+
+    Args:
+        session:       Active async DB session.
+        repo_id:       Target Muse Hub repository ID.
+        ref:           Commit ID or branch name to export from.
+        format:        Output format (ExportFormat enum).
+        split_tracks:  When True, always bundle into a ZIP even for a single artifact.
+        sections:      Optional section name filter; only artifacts whose path
+                       contains a listed section name are included.
+
+    Returns:
+        ExportResult on success.
+        ``"ref_not_found"`` if ref does not resolve to any known commit.
+        ``"no_matching_objects"`` if the format filter yields no candidates.
+
+    The ref is validated against known commits and branches. The actual object
+    content is read from disk (``disk_path``). Objects missing from disk are
+    skipped with a warning rather than causing an error — partial exports are
+    preferable to total failures when only some files are missing.
+    """
+    commit_id = await _resolve_ref(session, repo_id, ref)
+    if commit_id is None:
+        logger.warning("⚠️ Export ref %r not found in repo %s", ref, repo_id)
+        return "ref_not_found"
+
+    repo_objects = await musehub_repository.list_objects(session, repo_id)
+
+    if format is ExportFormat.json:
+        filtered = [o for o in repo_objects if _matches_sections(o.path, sections)]
+        obj_list: list[dict[str, object]] = [
+            {"object_id": o.object_id, "path": o.path, "size_bytes": o.size_bytes}
+            for o in filtered
+        ]
+        content = _build_json_export(repo_id, ref, commit_id, obj_list)
+        filename = f"{repo_id}_{ref[:8]}.json"
+        return ExportResult(
+            content=content,
+            content_type=_FORMAT_MIME[ExportFormat.json],
+            filename=filename,
+        )
+
+    valid_exts = _FORMAT_EXTENSIONS[format]
+    candidates = [
+        o
+        for o in repo_objects
+        if os.path.splitext(o.path)[1].lower() in valid_exts
+        and _matches_sections(o.path, sections)
+    ]
+
+    if not candidates:
+        logger.warning(
+            "⚠️ No %s artifacts found for repo %s at ref %s", format.value, repo_id, ref
+        )
+        return "no_matching_objects"
+
+    artifacts: list[tuple[str, bytes]] = []
+    for obj in candidates:
+        raw_obj = await musehub_repository.get_object_row(session, repo_id, obj.object_id)
+        if raw_obj is None or not os.path.exists(raw_obj.disk_path):
+            logger.warning(
+                "⚠️ Object %s missing from disk (path=%s) — skipping",
+                obj.object_id,
+                getattr(raw_obj, "disk_path", "unknown"),
+            )
+            continue
+        with open(raw_obj.disk_path, "rb") as fh:
+            data = fh.read()
+        artifacts.append((os.path.basename(obj.path), data))
+
+    if not artifacts:
+        return "no_matching_objects"
+
+    short_ref = ref[:8]
+    if len(artifacts) == 1 and not split_tracks:
+        filename_single, file_bytes = artifacts[0]
+        return ExportResult(
+            content=file_bytes,
+            content_type=_FORMAT_MIME[format],
+            filename=filename_single,
+        )
+
+    zip_bytes = _build_zip(artifacts)
+    zip_name = f"{repo_id}_{short_ref}_{format.value}.zip"
+    logger.info(
+        "✅ Export ready: %d artifacts → %s (%d bytes)", len(artifacts), zip_name, len(zip_bytes)
+    )
+    return ExportResult(
+        content=zip_bytes,
+        content_type="application/zip",
+        filename=zip_name,
+    )

--- a/tests/test_musehub_export.py
+++ b/tests/test_musehub_export.py
@@ -1,0 +1,527 @@
+"""Tests for the Muse Hub export endpoint and musehub_exporter service.
+
+Covers every acceptance criterion from issue #243:
+- GET /musehub/repos/{repo_id}/export/{ref}?format=midi returns a .mid file
+- GET /musehub/repos/{repo_id}/export/{ref}?format=json returns valid JSON
+- split_tracks=true bundles artifacts into a ZIP with per-track files
+- sections filter restricts artifacts to matching path substrings
+- Unknown format string returns 422 Unprocessable Entity
+- Unresolvable ref returns 404
+- No matching artifacts for a format returns 404
+
+All tests use the shared fixtures from conftest.py.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import tempfile
+import zipfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.services.musehub_exporter import (
+    ExportFormat,
+    ExportResult,
+    export_repo_at_ref,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MIDI_BYTES = b"MThd\x00\x00\x00\x06\x00\x01\x00\x01\x01\xe0"  # minimal valid MIDI header
+_MP3_BYTES = b"\xff\xfb\x90\x00" + b"\x00" * 60  # minimal MP3 frame marker
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode()
+
+
+async def _create_repo(client: AsyncClient, auth_headers: dict[str, str], name: str = "export-test") -> str:
+    r = await client.post("/api/v1/musehub/repos", json={"name": name}, headers=auth_headers)
+    assert r.status_code == 201
+    repo_id: str = r.json()["repoId"]
+    return repo_id
+
+
+async def _push_with_objects(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    repo_id: str,
+    commit_id: str,
+    objects: list[dict[str, object]],
+    tmp_dir: str,
+) -> None:
+    """Push a commit + objects and patch musehub_sync.settings to use tmp_dir."""
+    with patch("maestro.services.musehub_sync.settings") as mock_cfg:
+        mock_cfg.musehub_objects_dir = tmp_dir
+        r = await client.post(
+            f"/api/v1/musehub/repos/{repo_id}/push",
+            json={
+                "branch": "main",
+                "headCommitId": commit_id,
+                "commits": [
+                    {
+                        "commitId": commit_id,
+                        "parentIds": [],
+                        "message": "test commit",
+                        "timestamp": "2024-01-01T00:00:00Z",
+                    }
+                ],
+                "objects": objects,
+                "force": False,
+            },
+            headers=auth_headers,
+        )
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# test_export_midi — MIDI export returns a .mid file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_export_midi(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """A single MIDI object → direct .mid download with correct MIME type."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _create_repo(client, auth_headers, "midi-export")
+        await _push_with_objects(
+            client,
+            auth_headers,
+            repo_id,
+            commit_id="c-midi-001",
+            objects=[
+                {
+                    "objectId": "sha256:midi001",
+                    "path": "tracks/bass.mid",
+                    "contentB64": _b64(_MIDI_BYTES),
+                }
+            ],
+            tmp_dir=tmp,
+        )
+
+        with patch("maestro.services.musehub_exporter.musehub_repository") as mock_repo:
+            from maestro.models.musehub import CommitResponse, ObjectMetaResponse
+            from datetime import datetime, timezone
+
+            mock_repo.get_commit = AsyncMock(
+                return_value=CommitResponse(
+                    commit_id="c-midi-001",
+                    branch="main",
+                    parent_ids=[],
+                    message="test",
+                    author="alice",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            )
+            mock_repo.list_branches = AsyncMock(return_value=[])
+            meta = ObjectMetaResponse(
+                object_id="sha256:midi001",
+                path="tracks/bass.mid",
+                size_bytes=len(_MIDI_BYTES),
+                created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+            mock_repo.list_objects = AsyncMock(return_value=[meta])
+
+            from maestro.db import musehub_models as db_models
+
+            disk_path = str(Path(tmp) / "sha256_midi001.mid")
+            Path(disk_path).write_bytes(_MIDI_BYTES)
+
+            fake_row = db_models.MusehubObject()
+            fake_row.object_id = "sha256:midi001"
+            fake_row.path = "tracks/bass.mid"
+            fake_row.disk_path = disk_path
+            fake_row.size_bytes = len(_MIDI_BYTES)
+            mock_repo.get_object_row = AsyncMock(return_value=fake_row)
+
+            r = await client.get(
+                f"/api/v1/musehub/repos/{repo_id}/export/c-midi-001?format=midi",
+                headers=auth_headers,
+            )
+
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "audio/midi"
+    assert "bass.mid" in r.headers.get("content-disposition", "")
+    assert r.content == _MIDI_BYTES
+
+
+# ---------------------------------------------------------------------------
+# test_export_json — JSON export returns valid JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_export_json(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """format=json returns a valid JSON document with commit and object metadata."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _create_repo(client, auth_headers, "json-export")
+
+        with patch("maestro.services.musehub_exporter.musehub_repository") as mock_repo:
+            from maestro.models.musehub import CommitResponse, ObjectMetaResponse
+            from datetime import datetime, timezone
+
+            mock_repo.get_commit = AsyncMock(
+                return_value=CommitResponse(
+                    commit_id="c-json-001",
+                    branch="main",
+                    parent_ids=[],
+                    message="json export test",
+                    author="bob",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            )
+            mock_repo.list_branches = AsyncMock(return_value=[])
+            mock_repo.list_objects = AsyncMock(
+                return_value=[
+                    ObjectMetaResponse(
+                        object_id="sha256:obj001",
+                        path="tracks/keys.mid",
+                        size_bytes=100,
+                        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    )
+                ]
+            )
+
+            r = await client.get(
+                f"/api/v1/musehub/repos/{repo_id}/export/c-json-001?format=json",
+                headers=auth_headers,
+            )
+
+    assert r.status_code == 200
+    assert "application/json" in r.headers["content-type"]
+    payload = json.loads(r.content)
+    assert payload["commit_id"] == "c-json-001"
+    assert payload["repo_id"] == repo_id
+    assert len(payload["objects"]) == 1
+    assert payload["objects"][0]["path"] == "tracks/keys.mid"
+
+
+# ---------------------------------------------------------------------------
+# test_export_split_tracks_zip — split_tracks produces a ZIP
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_export_split_tracks_zip(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """split_tracks=true with two MIDI objects produces a ZIP with both files."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _create_repo(client, auth_headers, "zip-export")
+
+        bass_path = str(Path(tmp) / "bass.mid")
+        keys_path = str(Path(tmp) / "keys.mid")
+        Path(bass_path).write_bytes(_MIDI_BYTES)
+        Path(keys_path).write_bytes(_MIDI_BYTES + b"\x00")
+
+        with patch("maestro.services.musehub_exporter.musehub_repository") as mock_repo:
+            from maestro.models.musehub import CommitResponse, ObjectMetaResponse
+            from datetime import datetime, timezone
+            from maestro.db import musehub_models as db_models
+
+            mock_repo.get_commit = AsyncMock(
+                return_value=CommitResponse(
+                    commit_id="c-zip-001",
+                    branch="main",
+                    parent_ids=[],
+                    message="zip test",
+                    author="carol",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            )
+            mock_repo.list_branches = AsyncMock(return_value=[])
+            mock_repo.list_objects = AsyncMock(
+                return_value=[
+                    ObjectMetaResponse(
+                        object_id="sha256:bass",
+                        path="tracks/bass.mid",
+                        size_bytes=len(_MIDI_BYTES),
+                        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    ),
+                    ObjectMetaResponse(
+                        object_id="sha256:keys",
+                        path="tracks/keys.mid",
+                        size_bytes=len(_MIDI_BYTES) + 1,
+                        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    ),
+                ]
+            )
+
+            def _fake_get_object_row(
+                session: object, repo_id: str, object_id: str
+            ) -> db_models.MusehubObject:
+                row = db_models.MusehubObject()
+                row.object_id = object_id
+                if object_id == "sha256:bass":
+                    row.path = "tracks/bass.mid"
+                    row.disk_path = bass_path
+                else:
+                    row.path = "tracks/keys.mid"
+                    row.disk_path = keys_path
+                row.size_bytes = 0
+                return row
+
+            mock_repo.get_object_row = AsyncMock(side_effect=_fake_get_object_row)
+
+            r = await client.get(
+                f"/api/v1/musehub/repos/{repo_id}/export/c-zip-001?format=midi&splitTracks=true",
+                headers=auth_headers,
+            )
+
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/zip"
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    names = zf.namelist()
+    assert "bass.mid" in names
+    assert "keys.mid" in names
+
+
+# ---------------------------------------------------------------------------
+# test_export_section_filter — sections param filters artifacts by path substring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_export_section_filter(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """sections=verse includes only artifacts whose path contains 'verse'."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_id = await _create_repo(client, auth_headers, "section-export")
+
+        verse_path = str(Path(tmp) / "verse_bass.mid")
+        chorus_path = str(Path(tmp) / "chorus_bass.mid")
+        Path(verse_path).write_bytes(_MIDI_BYTES)
+        Path(chorus_path).write_bytes(_MIDI_BYTES + b"\x01")
+
+        with patch("maestro.services.musehub_exporter.musehub_repository") as mock_repo:
+            from maestro.models.musehub import CommitResponse, ObjectMetaResponse
+            from datetime import datetime, timezone
+            from maestro.db import musehub_models as db_models
+
+            mock_repo.get_commit = AsyncMock(
+                return_value=CommitResponse(
+                    commit_id="c-sec-001",
+                    branch="main",
+                    parent_ids=[],
+                    message="section test",
+                    author="dave",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            )
+            mock_repo.list_branches = AsyncMock(return_value=[])
+            mock_repo.list_objects = AsyncMock(
+                return_value=[
+                    ObjectMetaResponse(
+                        object_id="sha256:verse",
+                        path="tracks/verse_bass.mid",
+                        size_bytes=len(_MIDI_BYTES),
+                        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    ),
+                    ObjectMetaResponse(
+                        object_id="sha256:chorus",
+                        path="tracks/chorus_bass.mid",
+                        size_bytes=len(_MIDI_BYTES) + 1,
+                        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    ),
+                ]
+            )
+
+            verse_row = db_models.MusehubObject()
+            verse_row.object_id = "sha256:verse"
+            verse_row.path = "tracks/verse_bass.mid"
+            verse_row.disk_path = verse_path
+            verse_row.size_bytes = len(_MIDI_BYTES)
+            mock_repo.get_object_row = AsyncMock(return_value=verse_row)
+
+            r = await client.get(
+                f"/api/v1/musehub/repos/{repo_id}/export/c-sec-001?format=midi&sections=verse",
+                headers=auth_headers,
+            )
+
+    assert r.status_code == 200
+    assert r.content == _MIDI_BYTES
+    assert "verse_bass.mid" in r.headers.get("content-disposition", "")
+
+
+# ---------------------------------------------------------------------------
+# test_export_unknown_format_422 — invalid format returns 422
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_export_unknown_format_422(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """An unrecognised format query param returns HTTP 422."""
+    repo_id = await _create_repo(client, auth_headers, "bad-format")
+    r = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/export/main?format=flac",
+        headers=auth_headers,
+    )
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# test_export_ref_not_found_404 — unresolvable ref returns 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_export_ref_not_found_404(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """A ref that does not match any commit or branch returns HTTP 404."""
+    repo_id = await _create_repo(client, auth_headers, "missing-ref")
+
+    with patch("maestro.services.musehub_exporter.musehub_repository") as mock_repo:
+        mock_repo.get_commit = AsyncMock(return_value=None)
+        mock_repo.list_branches = AsyncMock(return_value=[])
+
+        r = await client.get(
+            f"/api/v1/musehub/repos/{repo_id}/export/nonexistent-sha?format=midi",
+            headers=auth_headers,
+        )
+
+    assert r.status_code == 404
+    assert "nonexistent-sha" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for export_repo_at_ref service function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_export_service_returns_ref_not_found_sentinel() -> None:
+    """export_repo_at_ref returns 'ref_not_found' when the ref resolves to nothing."""
+    from unittest.mock import MagicMock
+
+    mock_session = MagicMock()
+
+    with patch("maestro.services.musehub_exporter.musehub_repository") as mock_repo:
+        mock_repo.get_commit = AsyncMock(return_value=None)
+        mock_repo.list_branches = AsyncMock(return_value=[])
+
+        result = await export_repo_at_ref(
+            mock_session,
+            repo_id="repo-x",
+            ref="deadbeef",
+            format=ExportFormat.midi,
+        )
+
+    assert result == "ref_not_found"
+
+
+@pytest.mark.anyio
+async def test_export_service_returns_no_matching_objects_sentinel() -> None:
+    """export_repo_at_ref returns 'no_matching_objects' when no objects match the format."""
+    from unittest.mock import MagicMock
+    from datetime import datetime, timezone
+    from maestro.models.musehub import CommitResponse, ObjectMetaResponse
+
+    mock_session = MagicMock()
+
+    with patch("maestro.services.musehub_exporter.musehub_repository") as mock_repo:
+        mock_repo.get_commit = AsyncMock(
+            return_value=CommitResponse(
+                commit_id="abc123",
+                branch="main",
+                parent_ids=[],
+                message="x",
+                author="x",
+                timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+        mock_repo.list_branches = AsyncMock(return_value=[])
+        mock_repo.list_objects = AsyncMock(
+            return_value=[
+                ObjectMetaResponse(
+                    object_id="sha256:img",
+                    path="piano_roll.webp",
+                    size_bytes=512,
+                    created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            ]
+        )
+
+        result = await export_repo_at_ref(
+            mock_session,
+            repo_id="repo-y",
+            ref="abc123",
+            format=ExportFormat.midi,
+        )
+
+    assert result == "no_matching_objects"
+
+
+@pytest.mark.anyio
+async def test_export_service_json_format_no_disk_access() -> None:
+    """format=json returns ExportResult with JSON bytes without reading any disk file."""
+    from unittest.mock import MagicMock
+    from datetime import datetime, timezone
+    from maestro.models.musehub import CommitResponse, ObjectMetaResponse
+
+    mock_session = MagicMock()
+
+    with patch("maestro.services.musehub_exporter.musehub_repository") as mock_repo:
+        mock_repo.get_commit = AsyncMock(
+            return_value=CommitResponse(
+                commit_id="abc999",
+                branch="dev",
+                parent_ids=[],
+                message="json only",
+                author="eve",
+                timestamp=datetime(2024, 3, 1, tzinfo=timezone.utc),
+            )
+        )
+        mock_repo.list_branches = AsyncMock(return_value=[])
+        mock_repo.list_objects = AsyncMock(
+            return_value=[
+                ObjectMetaResponse(
+                    object_id="sha256:mid",
+                    path="track.mid",
+                    size_bytes=200,
+                    created_at=datetime(2024, 3, 1, tzinfo=timezone.utc),
+                )
+            ]
+        )
+
+        result = await export_repo_at_ref(
+            mock_session,
+            repo_id="repo-z",
+            ref="abc999",
+            format=ExportFormat.json,
+        )
+
+    assert isinstance(result, ExportResult)
+    assert result.content_type == "application/json"
+    parsed = json.loads(result.content)
+    assert parsed["commit_id"] == "abc999"
+    assert parsed["repo_id"] == "repo-z"
+    assert len(parsed["objects"]) == 1


### PR DESCRIPTION
## Summary
Closes #243 — adds a unified export endpoint so musicians can download any commit's artifacts in multiple formats with split-tracks support.

## Root Cause / Motivation
Individual artifacts were only downloadable one-at-a-time from the artifact browser. There was no way to export an entire commit snapshot as MIDI with split tracks, or to get a machine-readable JSON index of a commit's objects.

## Solution

### New service: `maestro/services/musehub_exporter.py`
- `ExportFormat(str, Enum)` — `midi`, `json`, `musicxml`, `abc`, `wav`, `mp3`
- `ExportResult(dataclass, frozen=True)` — `content: bytes`, `content_type: str`, `filename: str`
- `export_repo_at_ref()` — resolves ref (commit ID or branch name), filters objects by format + sections, returns `ExportResult` or a sentinel string (`"ref_not_found"` / `"no_matching_objects"`)
- Single artifact → raw file; multiple artifacts or `split_tracks=True` → in-memory ZIP via stdlib `zipfile`
- `format=json` → serialises commit metadata + object index to JSON (no disk read needed)

### New endpoint: `GET /api/v1/musehub/repos/{repo_id}/export/{ref}`
Added to `maestro/api/routes/musehub/objects.py`:
- Query params: `format` (default `midi`), `splitTracks` (default `false`), `sections` (comma-separated)
- Resolves sentinels to HTTP 404; invalid `format` → FastAPI 422 automatically via enum validation
- `Content-Disposition: attachment` with meaningful filename

## Layers Affected
- [x] Muse VCS (new export service + endpoint)

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — 13 pre-existing `import-untyped` errors only, 0 new
- [x] `docker compose exec storpheus mypy .` — clean (no changes to storpheus)
- [x] 9/9 targeted tests pass (`tests/test_musehub_export.py`)
- [x] `docs/reference/api.md` — export endpoint documented
- [x] `docs/reference/type_contracts.md` — `ExportResult` and `ExportFormat` registered

## Tests Added
- `test_export_midi` — single MIDI artifact returns raw `.mid` with correct MIME
- `test_export_json` — JSON export returns valid JSON with commit metadata
- `test_export_split_tracks_zip` — two MIDI artifacts + `splitTracks=true` → ZIP with both files
- `test_export_section_filter` — `sections=verse` includes only matching artifacts
- `test_export_unknown_format_422` — unrecognised format string returns 422
- `test_export_ref_not_found_404` — unresolvable ref returns 404
- `test_export_service_returns_ref_not_found_sentinel` — unit test: service sentinel
- `test_export_service_returns_no_matching_objects_sentinel` — unit test: service sentinel
- `test_export_service_json_format_no_disk_access` — unit test: JSON path skips disk

## Handoff
N/A — no SSE/MCP protocol change. New REST endpoint only.