### PR TITLE
feat: agent context endpoint — single URL returning complete musical context for AI composition

### DIFF
--- a/docs/guides/integrate.md
+++ b/docs/guides/integrate.md
@@ -364,3 +364,67 @@ Start with (1); then (2) if you want to demo inside Cursor; then (3) when the ap
 1. **Confirm from Cursor** – In chat, list tools and call one (e.g. `stori_generate_drums` or, with a DAW connected, `stori_read_project`).
 2. **Wire WebSockets on the front end** – Stori app connects to `wss://<host>/api/v1/mcp/daw?token=<jwt>`, handles `tool_call` messages, runs the action in the DAW, and sends `tool_response` with `request_id` and `result`.
 3. **Test track icon/color from Cursor** – With the DAW connected over WebSocket, ask Cursor to change a track’s icon or color. Use `stori_set_track_icon` (e.g. `icon`: `pianokeys`, `guitars`, `music.note`) or `stori_set_track_color` (e.g. `color`: `blue`, `green`). The backend forwards these to the DAW; the app must implement the handlers and respond with `tool_response`.
+
+---
+
+## Agent Context — Starting a Composition Session
+
+The agent context endpoint is the canonical first call an AI agent makes when starting
+a composition session. It returns a complete musical briefing in a single HTTP request.
+
+### Usage
+
+```bash
+# Standard depth (default — fits in ~8K tokens)
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://hub.stori.app/api/v1/musehub/repos/<repo-id>/context"
+
+# Brief depth for tight context windows (~2K tokens)
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://hub.stori.app/api/v1/musehub/repos/<repo-id>/context?depth=brief"
+
+# Target a specific branch
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://hub.stori.app/api/v1/musehub/repos/<repo-id>/context?ref=main"
+
+# YAML format (human-readable, useful in agent logs)
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://hub.stori.app/api/v1/musehub/repos/<repo-id>/context?format=yaml"
+```
+
+### What agents receive
+
+The response contains seven sections:
+
+| Section | Description | Notes |
+|---------|-------------|-------|
+| `musicalState` | Key, tempo, time signature, active tracks | Optional fields `null` until Storpheus MIDI integration |
+| `history` | Recent commits (newest first) | 3 / 10 / 50 entries at brief / standard / verbose |
+| `analysis` | Per-dimension highlights (harmony, groove, etc.) | All `null` at MVP |
+| `activePrs` | Open pull requests | Bodies included at `standard` and `verbose` depth |
+| `openIssues` | Open issues | Bodies included at `verbose` depth only |
+| `suggestions` | Actionable next steps | Heuristic at MVP; LLM-powered in future |
+
+### Depth selection guide
+
+| Goal | Depth | Approximate size |
+|------|-------|-----------------|
+| Fit in a 2K-token budget (GPT-4o-mini tools) | `brief` | ≤ 2K tokens |
+| Full briefing for a new session | `standard` | ≤ 8K tokens |
+| Full audit / detailed analysis | `verbose` | Uncapped |
+
+### Python example
+
+```python
+import httpx
+
+async def get_context(repo_id: str, token: str, depth: str = "standard") -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"https://hub.stori.app/api/v1/musehub/repos/{repo_id}/context",
+            headers={"Authorization": f"Bearer {token}"},
+            params={"depth": depth},
+        )
+        response.raise_for_status()
+        return response.json()
+```

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5904,3 +5904,122 @@ if state is not None and state.conflict_paths:
 **Related helpers:**
 - `apply_resolution(root, rel_path, object_id)` — copies an object from the local store to `muse-work/`; used by `--theirs` resolution and `--abort`.
 - `is_conflict_resolved(merge_state, rel_path)` — returns `True` if `rel_path` is not in `conflict_paths`.
+
+---
+
+## Agent Context Models (`maestro/models/musehub_context.py`)
+
+### ContextDepth
+
+**Location:** `maestro/models/musehub_context.py`
+**Kind:** `str` Enum
+
+Controls how much data the agent context endpoint returns.
+
+| Value | Token budget | History entries | PR bodies | Issue bodies |
+|-------|-------------|-----------------|-----------|--------------|
+| `brief` | ~2K | ≤ 3 | No | No |
+| `standard` | ~8K | ≤ 10 | Yes | No |
+| `verbose` | Uncapped | ≤ 50 | Yes | Yes |
+
+### ContextFormat
+
+**Location:** `maestro/models/musehub_context.py`
+**Kind:** `str` Enum
+
+Wire format for the context response: `json` or `yaml`.
+
+### MusicalStateContext
+
+**Location:** `maestro/models/musehub_context.py`
+**Kind:** Pydantic `CamelModel`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `active_tracks` | `list[str]` | Yes (default: `[]`) | Track names from the snapshot manifest |
+| `key` | `str \| None` | No | Detected key (e.g. `"F# minor"`) |
+| `mode` | `str \| None` | No | Detected mode (e.g. `"dorian"`) |
+| `tempo_bpm` | `int \| None` | No | Tempo in beats per minute |
+| `time_signature` | `str \| None` | No | Time signature (e.g. `"4/4"`) |
+| `form` | `str \| None` | No | Detected form (e.g. `"AABA"`) |
+| `emotion` | `str \| None` | No | Emotional character |
+
+**Note:** All optional fields are `None` until Storpheus MIDI analysis is integrated. Agents must handle `None` gracefully.
+
+### HistoryEntryContext
+
+**Location:** `maestro/models/musehub_context.py`
+**Kind:** Pydantic `CamelModel`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `commit_id` | `str` | Yes | Commit UUID |
+| `message` | `str` | Yes | Commit message |
+| `author` | `str` | Yes | Author identifier |
+| `timestamp` | `str` | Yes | ISO-8601 UTC timestamp |
+| `active_tracks` | `list[str]` | Yes (default: `[]`) | Track names at this commit |
+
+### AnalysisSummaryContext
+
+**Location:** `maestro/models/musehub_context.py`
+**Kind:** Pydantic `CamelModel`
+
+Per-dimension analysis highlights. All fields are `None` until Storpheus integration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key_finding` | `str \| None` | Key and mode summary |
+| `chord_progression` | `list[str] \| None` | Detected chord sequence |
+| `groove_score` | `float \| None` | Groove quality `[0.0, 1.0]` |
+| `emotion` | `str \| None` | Emotional character |
+| `harmonic_tension` | `str \| None` | `"low"`, `"medium"`, or `"high"` |
+| `melodic_contour` | `str \| None` | Contour description |
+
+### ActivePRContext
+
+**Location:** `maestro/models/musehub_context.py`
+**Kind:** Pydantic `CamelModel`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pr_id` | `str` | PR UUID |
+| `title` | `str` | PR title |
+| `from_branch` | `str` | Source branch |
+| `to_branch` | `str` | Target branch |
+| `state` | `str` | Always `"open"` in context |
+| `body` | `str` | PR description (empty at `brief` depth) |
+
+### OpenIssueContext
+
+**Location:** `maestro/models/musehub_context.py`
+**Kind:** Pydantic `CamelModel`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `issue_id` | `str` | Issue UUID |
+| `number` | `int` | Per-repo sequential number |
+| `title` | `str` | Issue title |
+| `labels` | `list[str]` | Label strings |
+| `body` | `str` | Issue body (only at `verbose` depth; empty otherwise) |
+
+### AgentContextResponse
+
+**Location:** `maestro/models/musehub_context.py`
+**Kind:** Pydantic `CamelModel`
+
+Top-level response from `GET /musehub/repos/{repo_id}/context`. Self-contained: an agent receiving only this document has everything it needs to compose coherent music.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo_id` | `str` | Repo UUID |
+| `ref` | `str` | Resolved branch name or commit ID |
+| `depth` | `str` | Depth level used |
+| `musical_state` | `MusicalStateContext` | Current musical state |
+| `history` | `list[HistoryEntryContext]` | Recent commits (head excluded) |
+| `analysis` | `AnalysisSummaryContext` | Per-dimension highlights |
+| `active_prs` | `list[ActivePRContext]` | Open PRs |
+| `open_issues` | `list[OpenIssueContext]` | Open issues |
+| `suggestions` | `list[str]` | Actionable composition suggestions |
+
+**Produced by:** `maestro.services.musehub_context.build_agent_context()`
+**Consumed by:** AI composition agents at session start; MCP context tool (planned)

--- a/maestro/core/prompts/structured.py
+++ b/maestro/core/prompts/structured.py
@@ -60,7 +60,7 @@ def structured_prompt_context(parsed: "MaestroPrompt") -> str:
     Used by the EDITING LLM, which needs the creative brief to generate
     correct note data, voicings, dynamics, etc.
     """
-    import yaml as _yaml  # local to avoid circular at module import time
+    import yaml as _yaml  # type: ignore[import-untyped]  # PyYAML ships no py.typed marker
 
     lines = _structured_routing_lines(parsed)
 

--- a/maestro/models/musehub_context.py
+++ b/maestro/models/musehub_context.py
@@ -1,0 +1,153 @@
+"""Pydantic v2 request/response models for the agent context endpoint.
+
+The context endpoint (GET /musehub/repos/{repo_id}/context) is the canonical
+agent entry point for composition sessions.  These models define the wire
+format that agents receive when they ask: "what do I need to know to start
+composing in this project?"
+
+Depth levels control how much data is returned:
+- ``brief``    — fits in ~2 K tokens; musical state + 3 history entries
+- ``standard`` — fits in ~8 K tokens; full state + 10 history + analysis
+- ``verbose``  — uncapped; all history, full issue/PR bodies, full analysis
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Annotated
+
+from pydantic import Field
+
+from maestro.models.base import CamelModel
+
+
+class ContextDepth(str, Enum):
+    """Depth level controlling how much data the context endpoint returns."""
+
+    brief = "brief"
+    standard = "standard"
+    verbose = "verbose"
+
+
+class ContextFormat(str, Enum):
+    """Wire format for the context response."""
+
+    json = "json"
+    yaml = "yaml"
+
+
+# ---------------------------------------------------------------------------
+# Sub-sections of the context response
+# ---------------------------------------------------------------------------
+
+
+class MusicalStateContext(CamelModel):
+    """Current musical state of the project at the resolved ref.
+
+    All optional fields require Storpheus MIDI analysis and are None until
+    that integration is complete. Agents must handle None gracefully.
+    """
+
+    active_tracks: list[str] = Field(
+        default_factory=list,
+        description="Track names derived from the snapshot manifest",
+    )
+    key: Annotated[str | None, Field(description="Detected key (e.g. 'F# minor')")] = None
+    mode: Annotated[str | None, Field(description="Detected mode (e.g. 'dorian')")] = None
+    tempo_bpm: Annotated[int | None, Field(description="Tempo in beats per minute")] = None
+    time_signature: Annotated[str | None, Field(description="Time signature (e.g. '4/4')")] = None
+    form: Annotated[str | None, Field(description="Detected form (e.g. 'AABA', 'verse-chorus')")] = None
+    emotion: Annotated[str | None, Field(description="Emotional character (e.g. 'melancholic')")] = None
+
+
+class HistoryEntryContext(CamelModel):
+    """A single commit entry in the composition history."""
+
+    commit_id: str
+    message: str
+    author: str
+    timestamp: str = Field(description="ISO-8601 UTC timestamp")
+    active_tracks: list[str] = Field(default_factory=list)
+
+
+class AnalysisSummaryContext(CamelModel):
+    """Per-dimension analysis highlights for the current state.
+
+    All fields are None until Storpheus MIDI analysis integration is complete.
+    Agents should treat None as "unknown" and compose without relying on these.
+    """
+
+    key_finding: Annotated[
+        str | None, Field(description="Key and mode detection summary")
+    ] = None
+    chord_progression: Annotated[
+        list[str] | None,
+        Field(description="Detected chord progression (e.g. ['Cm', 'Ab', 'Eb', 'Bb'])"),
+    ] = None
+    groove_score: Annotated[
+        float | None, Field(description="Groove quality score [0.0, 1.0]")
+    ] = None
+    emotion: Annotated[str | None, Field(description="Emotional character")] = None
+    harmonic_tension: Annotated[
+        str | None,
+        Field(description="Harmonic tension assessment ('low', 'medium', 'high')"),
+    ] = None
+    melodic_contour: Annotated[
+        str | None, Field(description="Melodic contour description")
+    ] = None
+
+
+class ActivePRContext(CamelModel):
+    """An open pull request that may inform composition decisions."""
+
+    pr_id: str
+    title: str
+    from_branch: str
+    to_branch: str
+    state: str
+    body: str = Field(
+        default="",
+        description="PR description; included at standard/verbose depth only",
+    )
+
+
+class OpenIssueContext(CamelModel):
+    """An open issue that may describe desired compositional changes."""
+
+    issue_id: str
+    number: int
+    title: str
+    labels: list[str] = Field(default_factory=list)
+    body: str = Field(
+        default="",
+        description="Issue body; included at verbose depth only",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Top-level context response
+# ---------------------------------------------------------------------------
+
+
+class AgentContextResponse(CamelModel):
+    """Complete agent context document for one project ref.
+
+    This is the top-level response from GET /musehub/repos/{repo_id}/context.
+    It is self-contained: an agent receiving only this document has everything
+    it needs to generate structurally and stylistically coherent music.
+
+    ``depth`` controls how much data is returned; ``format`` is echoed from
+    the request so agents can validate they received what they asked for.
+    """
+
+    repo_id: str
+    ref: str = Field(description="The resolved branch name or commit ID")
+    depth: str = Field(description="Depth level used to build this response")
+    musical_state: MusicalStateContext
+    history: list[HistoryEntryContext] = Field(default_factory=list)
+    analysis: AnalysisSummaryContext
+    active_prs: list[ActivePRContext] = Field(default_factory=list)
+    open_issues: list[OpenIssueContext] = Field(default_factory=list)
+    suggestions: list[str] = Field(
+        default_factory=list,
+        description="AI-generated suggestions for next compositional actions",
+    )

--- a/maestro/muse_cli/commands/context.py
+++ b/maestro/muse_cli/commands/context.py
@@ -102,7 +102,7 @@ async def _context_async(
 
     if fmt == OutputFormat.yaml:
         try:
-            import yaml
+            import yaml  # type: ignore[import-untyped]  # PyYAML ships no py.typed marker
 
             typer.echo(yaml.dump(data, sort_keys=False, allow_unicode=True))
         except ImportError:

--- a/maestro/prompts/parser.py
+++ b/maestro/prompts/parser.py
@@ -40,7 +40,7 @@ from maestro.prompts.base import (
 from maestro.prompts.errors import InvalidMaestroPrompt, UnsupportedPromptHeader
 from maestro.prompts.maestro import MaestroPrompt
 
-import yaml
+import yaml  # type: ignore[import-untyped]  # PyYAML ships no py.typed marker
 
 logger = logging.getLogger(__name__)
 

--- a/maestro/services/musehub_context.py
+++ b/maestro/services/musehub_context.py
@@ -1,0 +1,355 @@
+"""Muse Hub agent context aggregation service.
+
+This is the canonical read-path for AI composition agents.  ``build_agent_context``
+aggregates musical state, commit history, analysis highlights, open PRs, and open
+issues for a given repo ref into a single ``AgentContextResponse``.
+
+Design notes
+------------
+- **Read-only**: this service never writes to the DB.
+- **Deterministic**: for the same repo_id + resolved ref, the output is always
+  identical, making it safe to cache.
+- **Depth-aware**: ``brief`` returns minimal data for tight context windows;
+  ``standard`` returns a full briefing; ``verbose`` adds all bodies/history.
+- **Analysis stubs**: per-dimension analysis (key, groove, harmony) is currently
+  None — these require Storpheus MIDI integration. The schema is fully defined so
+  agents can handle None gracefully today and receive populated values once that
+  integration lands.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db import musehub_models as db_models
+from maestro.models.musehub_context import (
+    ActivePRContext,
+    AgentContextResponse,
+    AnalysisSummaryContext,
+    ContextDepth,
+    HistoryEntryContext,
+    MusicalStateContext,
+    OpenIssueContext,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Depth configuration
+# ---------------------------------------------------------------------------
+
+_HISTORY_LIMIT: dict[str, int] = {
+    ContextDepth.brief: 3,
+    ContextDepth.standard: 10,
+    ContextDepth.verbose: 50,
+}
+
+_INCLUDE_PR_BODY: dict[str, bool] = {
+    ContextDepth.brief: False,
+    ContextDepth.standard: True,
+    ContextDepth.verbose: True,
+}
+
+_INCLUDE_ISSUE_BODY: dict[str, bool] = {
+    ContextDepth.brief: False,
+    ContextDepth.standard: False,
+    ContextDepth.verbose: True,
+}
+
+_MUSIC_FILE_EXTENSIONS = frozenset(
+    {".mid", ".midi", ".mp3", ".wav", ".aiff", ".aif", ".flac"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc_iso(dt: datetime) -> str:
+    """Return a UTC ISO-8601 string from a datetime (naive or aware)."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()
+
+
+def _extract_tracks_from_snapshot(snapshot: db_models.MusehubObject | None) -> list[str]:
+    """Not applicable in MuseHub context — snapshots are binary objects.
+
+    Track names in the MuseHub context come from commit message heuristics and
+    branch-level metadata.  This stub returns an empty list until commit-level
+    manifest tracking is added to MusehubCommit.
+    """
+    return []
+
+
+async def _resolve_ref_to_commit(
+    session: AsyncSession,
+    repo_id: str,
+    ref: str,
+) -> db_models.MusehubCommit | None:
+    """Resolve a ref (branch name or commit ID) to a MusehubCommit row.
+
+    Resolution order:
+    1. If ``ref`` matches a branch name → return its head commit.
+    2. If ``ref`` matches a commit ID (exact) → return that commit.
+    3. Return None if neither matches.
+    """
+    # Try branch lookup first (most common case)
+    branch_stmt = select(db_models.MusehubBranch).where(
+        db_models.MusehubBranch.repo_id == repo_id,
+        db_models.MusehubBranch.name == ref,
+    )
+    branch = (await session.execute(branch_stmt)).scalars().first()
+    if branch is not None and branch.head_commit_id is not None:
+        commit = await session.get(db_models.MusehubCommit, branch.head_commit_id)
+        return commit
+
+    # Fall back to direct commit ID lookup
+    commit_stmt = select(db_models.MusehubCommit).where(
+        db_models.MusehubCommit.repo_id == repo_id,
+        db_models.MusehubCommit.commit_id == ref,
+    )
+    return (await session.execute(commit_stmt)).scalars().first()
+
+
+async def _get_latest_commit(
+    session: AsyncSession,
+    repo_id: str,
+) -> db_models.MusehubCommit | None:
+    """Return the most-recent commit for any branch in the repo, or None."""
+    stmt = (
+        select(db_models.MusehubCommit)
+        .where(db_models.MusehubCommit.repo_id == repo_id)
+        .order_by(desc(db_models.MusehubCommit.timestamp))
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalars().first()
+
+
+async def _build_history(
+    session: AsyncSession,
+    repo_id: str,
+    head_commit: db_models.MusehubCommit,
+    limit: int,
+) -> list[HistoryEntryContext]:
+    """Return up to *limit* recent commits for the repo (newest-first).
+
+    The head commit itself is excluded — it is surfaced as the current ref.
+    We query by repo and timestamp rather than walking parent links, because
+    MusehubCommit parent_ids are a JSONB list and graph traversal would
+    require N+1 queries.  Timestamp ordering is an approximation; in practice
+    it matches the commit graph order for sequential workflows.
+    """
+    stmt = (
+        select(db_models.MusehubCommit)
+        .where(
+            db_models.MusehubCommit.repo_id == repo_id,
+            db_models.MusehubCommit.commit_id != head_commit.commit_id,
+        )
+        .order_by(desc(db_models.MusehubCommit.timestamp))
+        .limit(limit)
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+    return [
+        HistoryEntryContext(
+            commit_id=row.commit_id,
+            message=row.message,
+            author=row.author,
+            timestamp=_utc_iso(row.timestamp),
+            active_tracks=[],
+        )
+        for row in rows
+    ]
+
+
+async def _get_open_prs(
+    session: AsyncSession,
+    repo_id: str,
+    include_body: bool,
+) -> list[ActivePRContext]:
+    """Return all open pull requests for the repo."""
+    stmt = (
+        select(db_models.MusehubPullRequest)
+        .where(
+            db_models.MusehubPullRequest.repo_id == repo_id,
+            db_models.MusehubPullRequest.state == "open",
+        )
+        .order_by(db_models.MusehubPullRequest.created_at)
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+    return [
+        ActivePRContext(
+            pr_id=row.pr_id,
+            title=row.title,
+            from_branch=row.from_branch,
+            to_branch=row.to_branch,
+            state=row.state,
+            body=row.body if include_body else "",
+        )
+        for row in rows
+    ]
+
+
+async def _get_open_issues(
+    session: AsyncSession,
+    repo_id: str,
+    include_body: bool,
+) -> list[OpenIssueContext]:
+    """Return all open issues for the repo, ordered by number."""
+    stmt = (
+        select(db_models.MusehubIssue)
+        .where(
+            db_models.MusehubIssue.repo_id == repo_id,
+            db_models.MusehubIssue.state == "open",
+        )
+        .order_by(db_models.MusehubIssue.number)
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+    return [
+        OpenIssueContext(
+            issue_id=row.issue_id,
+            number=row.number,
+            title=row.title,
+            labels=list(row.labels or []),
+            body=row.body if include_body else "",
+        )
+        for row in rows
+    ]
+
+
+def _generate_suggestions(
+    musical_state: MusicalStateContext,
+    open_issues: list[OpenIssueContext],
+    active_prs: list[ActivePRContext],
+    depth: ContextDepth,
+) -> list[str]:
+    """Generate heuristic composition suggestions based on current context.
+
+    This is a deterministic, rule-based function until LLM-powered suggestions
+    are integrated. Suggestions are derived from:
+    - Missing musical dimensions (no tempo, no key, etc.)
+    - Open issues that describe compositional problems
+    - Open PRs that are waiting for review
+
+    At ``brief`` depth, only 1–2 suggestions are returned.
+    """
+    suggestions: list[str] = []
+
+    if musical_state.tempo_bpm is None:
+        suggestions.append(
+            "Set a project tempo: no BPM detected. Run `muse tempo set <bpm>` to anchor the grid."
+        )
+    if musical_state.key is None:
+        suggestions.append(
+            "Declare a key center: no key detected. Run `muse key set <key>` to enable harmonic analysis."
+        )
+    if not musical_state.active_tracks:
+        suggestions.append(
+            "Add tracks: no audio or MIDI files found in the latest commit. Push a commit with track files."
+        )
+    if open_issues:
+        issue = open_issues[0]
+        suggestions.append(
+            f"Address open issue #{issue.number}: '{issue.title}'. "
+            "This may describe a compositional problem to fix before the next section."
+        )
+    if active_prs:
+        pr = active_prs[0]
+        suggestions.append(
+            f"Review PR '{pr.title}' ({pr.from_branch} → {pr.to_branch}). "
+            "Merge or close it before branching for the next section."
+        )
+
+    if depth == ContextDepth.brief:
+        return suggestions[:2]
+    if depth == ContextDepth.standard:
+        return suggestions[:4]
+    return suggestions
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def build_agent_context(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    ref: str = "HEAD",
+    depth: ContextDepth = ContextDepth.standard,
+) -> AgentContextResponse | None:
+    """Build a complete agent context document for a MuseHub repo at a given ref.
+
+    Returns None if the repo does not exist or has no commits.
+
+    Args:
+        session:  Open async DB session. Read-only — no writes performed.
+        repo_id:  The MuseHub repo UUID.
+        ref:      Branch name or commit ID. Defaults to HEAD (latest commit).
+        depth:    Controls how much data is returned:
+                  - ``brief``    — minimal context (~2 K tokens)
+                  - ``standard`` — full briefing (~8 K tokens)
+                  - ``verbose``  — uncapped (all history, full bodies)
+
+    Returns:
+        ``AgentContextResponse`` if repo + ref are valid, ``None`` if repo
+        is not found or has no commits. The caller should surface None as HTTP 404.
+    """
+    repo = await session.get(db_models.MusehubRepo, repo_id)
+    if repo is None:
+        return None
+
+    # Resolve ref → commit
+    if ref == "HEAD":
+        head_commit = await _get_latest_commit(session, repo_id)
+    else:
+        head_commit = await _resolve_ref_to_commit(session, repo_id, ref)
+
+    if head_commit is None:
+        logger.warning("⚠️ No commit found for repo %s ref %s", repo_id, ref)
+        return None
+
+    resolved_ref = ref if ref != "HEAD" else head_commit.branch
+
+    history_limit = _HISTORY_LIMIT[depth]
+    include_pr_body = _INCLUDE_PR_BODY[depth]
+    include_issue_body = _INCLUDE_ISSUE_BODY[depth]
+
+    # Gather all sections concurrently would require asyncio.gather; we keep
+    # sequential awaits for readability — this is a read-heavy, low-latency path.
+    history = await _build_history(session, repo_id, head_commit, history_limit)
+    active_prs = await _get_open_prs(session, repo_id, include_pr_body)
+    open_issues = await _get_open_issues(session, repo_id, include_issue_body)
+
+    musical_state = MusicalStateContext(active_tracks=[])
+
+    analysis = AnalysisSummaryContext()
+
+    suggestions = _generate_suggestions(musical_state, open_issues, active_prs, depth)
+
+    logger.info(
+        "✅ Agent context built for repo %s ref %s (depth=%s, history=%d, prs=%d, issues=%d)",
+        repo_id,
+        resolved_ref,
+        depth,
+        len(history),
+        len(active_prs),
+        len(open_issues),
+    )
+
+    return AgentContextResponse(
+        repo_id=repo_id,
+        ref=resolved_ref,
+        depth=depth,
+        musical_state=musical_state,
+        history=history,
+        analysis=analysis,
+        active_prs=active_prs,
+        open_issues=open_issues,
+        suggestions=suggestions,
+    )

--- a/tests/test_musehub_context.py
+++ b/tests/test_musehub_context.py
@@ -20,7 +20,7 @@ All tests use fixtures from conftest.py.
 from __future__ import annotations
 
 import pytest
-import yaml
+import yaml  # type: ignore[import-untyped]  # PyYAML ships no py.typed marker
 from datetime import datetime, timezone
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/tests/test_musehub_context.py
+++ b/tests/test_musehub_context.py
@@ -1,0 +1,570 @@
+"""Tests for the agent context endpoint (GET /musehub/repos/{repo_id}/context).
+
+Covers every acceptance criterion from issue #249:
+- GET /musehub/repos/{repo_id}/context returns all required sections
+- Musical state section is present (active_tracks, key, tempo, etc.)
+- History section includes recent commits
+- Active PRs section lists open PRs
+- Open issues section lists open issues
+- Suggestions section is present
+- ?depth=brief returns minimal context
+- ?depth=standard returns moderate context
+- ?depth=verbose returns full context
+- ?format=yaml returns valid YAML
+- Unknown repo returns 404
+- Missing ref returns 404
+- Endpoint requires JWT auth
+
+All tests use fixtures from conftest.py.
+"""
+from __future__ import annotations
+
+import pytest
+import yaml
+from datetime import datetime, timezone
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import (
+    MusehubBranch,
+    MusehubCommit,
+    MusehubIssue,
+    MusehubPullRequest,
+    MusehubRepo,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+async def _create_repo(client: AsyncClient, auth_headers: dict[str, str], name: str = "neo-soul") -> str:
+    """Create a repo via the API and return its repo_id."""
+    response = await client.post(
+        "/api/v1/musehub/repos",
+        json={"name": name},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    repo_id: str = response.json()["repoId"]
+    return repo_id
+
+
+async def _seed_repo_with_commits(
+    db: AsyncSession,
+    repo_id: str,
+    branch_name: str = "main",
+    num_commits: int = 3,
+) -> tuple[str, list[str]]:
+    """Seed a repo with a branch and commits. Returns (branch_id, list_of_commit_ids)."""
+    commit_ids: list[str] = []
+    parent_id: str | None = None
+    ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    import uuid
+    from datetime import timedelta
+
+    for i in range(num_commits):
+        commit_id = str(uuid.uuid4()).replace("-", "")
+        commit = MusehubCommit(
+            commit_id=commit_id,
+            repo_id=repo_id,
+            branch=branch_name,
+            parent_ids=[parent_id] if parent_id else [],
+            message=f"Add layer {i + 1} — bass groove refinement",
+            author="session-agent",
+            timestamp=ts + timedelta(hours=i),
+        )
+        db.add(commit)
+        commit_ids.append(commit_id)
+        parent_id = commit_id
+
+    branch = MusehubBranch(
+        repo_id=repo_id,
+        name=branch_name,
+        head_commit_id=commit_ids[-1],
+    )
+    db.add(branch)
+    await db.flush()
+
+    return branch_name, commit_ids
+
+
+# ---------------------------------------------------------------------------
+# test_context_endpoint_returns_all_sections
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_endpoint_returns_all_sections(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/repos/{repo_id}/context returns all required top-level sections."""
+    repo_id = await _create_repo(client, auth_headers)
+    await _seed_repo_with_commits(db_session, repo_id)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+
+    assert "repoId" in body
+    assert "ref" in body
+    assert "depth" in body
+    assert "musicalState" in body
+    assert "history" in body
+    assert "analysis" in body
+    assert "activePrs" in body
+    assert "openIssues" in body
+    assert "suggestions" in body
+
+    assert body["repoId"] == repo_id
+    assert body["depth"] == "standard"
+
+
+# ---------------------------------------------------------------------------
+# test_context_includes_musical_state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_includes_musical_state(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """Musical state section contains expected fields (key, tempo, etc. may be None at MVP)."""
+    repo_id = await _create_repo(client, auth_headers)
+    await _seed_repo_with_commits(db_session, repo_id)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    state = response.json()["musicalState"]
+
+    assert "activeTracks" in state
+    assert isinstance(state["activeTracks"], list)
+    # Optional fields present (None until Storpheus integration)
+    assert "key" in state
+    assert "tempoBpm" in state
+    assert "timeSignature" in state
+    assert "form" in state
+    assert "emotion" in state
+
+
+# ---------------------------------------------------------------------------
+# test_context_includes_history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_includes_history(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """History section includes recent commits (excluding the head commit)."""
+    repo_id = await _create_repo(client, auth_headers)
+    _, commit_ids = await _seed_repo_with_commits(db_session, repo_id, num_commits=5)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    history = response.json()["history"]
+
+    assert isinstance(history, list)
+    # 5 commits seeded → head excluded → at most 4 in history at standard depth
+    assert len(history) <= 10
+    assert len(history) >= 1
+
+    entry = history[0]
+    assert "commitId" in entry
+    assert "message" in entry
+    assert "author" in entry
+    assert "timestamp" in entry
+    assert "activeTracks" in entry
+
+
+# ---------------------------------------------------------------------------
+# test_context_includes_active_prs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_includes_active_prs(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """Active PRs section lists open pull requests for the repo."""
+    repo_id = await _create_repo(client, auth_headers)
+    await _seed_repo_with_commits(db_session, repo_id, branch_name="main")
+
+    import uuid
+    from datetime import timedelta
+
+    feature_branch = MusehubBranch(
+        repo_id=repo_id,
+        name="feat/tritone-subs",
+        head_commit_id=str(uuid.uuid4()).replace("-", ""),
+    )
+    db_session.add(feature_branch)
+    await db_session.flush()
+
+    pr = MusehubPullRequest(
+        repo_id=repo_id,
+        title="Add tritone substitution in bridge",
+        body="Resolves the harmonic monotony in bars 24-28.",
+        state="open",
+        from_branch="feat/tritone-subs",
+        to_branch="main",
+    )
+    db_session.add(pr)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    prs = response.json()["activePrs"]
+
+    assert isinstance(prs, list)
+    assert len(prs) == 1
+    assert prs[0]["title"] == "Add tritone substitution in bridge"
+    assert prs[0]["state"] == "open"
+    assert "prId" in prs[0]
+    assert "fromBranch" in prs[0]
+    assert "toBranch" in prs[0]
+
+
+# ---------------------------------------------------------------------------
+# test_context_brief_depth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_brief_depth(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """?depth=brief returns minimal context — at most 3 history entries and 2 suggestions."""
+    repo_id = await _create_repo(client, auth_headers)
+    await _seed_repo_with_commits(db_session, repo_id, num_commits=8)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context?depth=brief",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["depth"] == "brief"
+    assert len(body["history"]) <= 3
+    assert len(body["suggestions"]) <= 2
+
+
+# ---------------------------------------------------------------------------
+# test_context_standard_depth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_standard_depth(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """?depth=standard (default) returns at most 10 history entries."""
+    repo_id = await _create_repo(client, auth_headers)
+    await _seed_repo_with_commits(db_session, repo_id, num_commits=15)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context?depth=standard",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["depth"] == "standard"
+    assert len(body["history"]) <= 10
+
+
+# ---------------------------------------------------------------------------
+# test_context_verbose_depth_includes_issue_bodies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_verbose_depth_includes_issue_bodies(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """?depth=verbose includes full issue bodies; brief/standard do not."""
+    repo_id = await _create_repo(client, auth_headers)
+    await _seed_repo_with_commits(db_session, repo_id)
+
+    import uuid
+
+    issue = MusehubIssue(
+        repo_id=repo_id,
+        number=1,
+        title="Add more harmonic tension",
+        body="Consider a tritone substitution in bar 24 to create tension before the resolution.",
+        state="open",
+        labels=["harmonic", "composition"],
+    )
+    db_session.add(issue)
+    await db_session.commit()
+
+    # brief: body should be empty string
+    brief_resp = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context?depth=brief",
+        headers=auth_headers,
+    )
+    assert brief_resp.status_code == 200
+    brief_issues = brief_resp.json()["openIssues"]
+    assert len(brief_issues) == 1
+    assert brief_issues[0]["body"] == ""
+
+    # verbose: body should be included
+    verbose_resp = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context?depth=verbose",
+        headers=auth_headers,
+    )
+    assert verbose_resp.status_code == 200
+    verbose_issues = verbose_resp.json()["openIssues"]
+    assert len(verbose_issues) == 1
+    assert "tritone substitution" in verbose_issues[0]["body"]
+
+
+# ---------------------------------------------------------------------------
+# test_context_yaml_format
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_yaml_format(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """?format=yaml returns valid YAML with the same structure as JSON."""
+    repo_id = await _create_repo(client, auth_headers)
+    await _seed_repo_with_commits(db_session, repo_id)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context?format=yaml",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert "yaml" in response.headers["content-type"]
+
+    parsed = yaml.safe_load(response.text)
+    assert isinstance(parsed, dict)
+    assert "repoId" in parsed
+    assert "musicalState" in parsed
+    assert "history" in parsed
+    assert "analysis" in parsed
+
+
+# ---------------------------------------------------------------------------
+# test_context_unknown_repo_404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_unknown_repo_404(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /musehub/repos/{unknown_id}/context returns 404 for a non-existent repo."""
+    response = await client.get(
+        "/api/v1/musehub/repos/nonexistent-repo-id/context",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# test_context_ref_not_found_404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_ref_not_found_404(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """GET .../context?ref=nonexistent returns 404 when the ref has no commits."""
+    repo_id = await _create_repo(client, auth_headers)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context?ref=nonexistent-branch",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# test_context_requires_auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_requires_auth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/repos/{repo_id}/context returns 401 without a Bearer token."""
+    response = await client.get(
+        "/api/v1/musehub/repos/any-repo-id/context",
+    )
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# test_context_default_ref_resolves_to_latest_commit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_default_ref_resolves_to_latest_commit(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """?ref=HEAD (default) resolves to the latest commit and returns a valid ref in response."""
+    repo_id = await _create_repo(client, auth_headers)
+    await _seed_repo_with_commits(db_session, repo_id, branch_name="main")
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+
+    # ref should resolve to a branch name or commit id (not literally "HEAD")
+    assert body["ref"] != ""
+
+
+# ---------------------------------------------------------------------------
+# test_context_branch_ref_resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_branch_ref_resolution(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """?ref=<branch_name> resolves the branch head commit."""
+    repo_id = await _create_repo(client, auth_headers)
+    await _seed_repo_with_commits(db_session, repo_id, branch_name="main")
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context?ref=main",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ref"] == "main"
+
+
+# ---------------------------------------------------------------------------
+# test_context_suggestions_generated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_suggestions_generated(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """Suggestions are generated and returned as a list of strings."""
+    repo_id = await _create_repo(client, auth_headers)
+    await _seed_repo_with_commits(db_session, repo_id)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    suggestions = response.json()["suggestions"]
+
+    assert isinstance(suggestions, list)
+    assert all(isinstance(s, str) for s in suggestions)
+    # At least one suggestion since no key/tempo detected (stubs)
+    assert len(suggestions) >= 1
+
+
+# ---------------------------------------------------------------------------
+# test_context_open_issues_excluded_when_closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_context_open_issues_excluded_when_closed(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """Closed issues do not appear in the open_issues section."""
+    repo_id = await _create_repo(client, auth_headers)
+    await _seed_repo_with_commits(db_session, repo_id)
+
+    closed_issue = MusehubIssue(
+        repo_id=repo_id,
+        number=1,
+        title="Closed: fix the bridge",
+        body="Already fixed.",
+        state="closed",
+        labels=[],
+    )
+    open_issue = MusehubIssue(
+        repo_id=repo_id,
+        number=2,
+        title="Add swing feel to verse",
+        body="",
+        state="open",
+        labels=["groove"],
+    )
+    db_session.add(closed_issue)
+    db_session.add(open_issue)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    issues = response.json()["openIssues"]
+
+    assert len(issues) == 1
+    assert issues[0]["title"] == "Add swing feel to verse"
+    assert issues[0]["number"] == 2


### PR DESCRIPTION
## Summary

Closes #249 — adds `GET /musehub/repos/{repo_id}/context`, the canonical agent entry point for composition sessions. One call returns a complete musical briefing: state, history, analysis, open PRs, open issues, and actionable suggestions.

## Root Cause / Motivation

Agents starting a composition session had no single endpoint to bootstrap from. They would need to make 4+ separate calls (commits, PRs, issues, state) and stitch the results together manually. This endpoint provides a self-contained document optimised for agent consumption with depth control for different context window sizes.

## Solution

Three new modules following the existing MuseHub layer pattern:

- **`maestro/models/musehub_context.py`** — Pydantic response models: `AgentContextResponse`, `MusicalStateContext`, `HistoryEntryContext`, `AnalysisSummaryContext`, `ActivePRContext`, `OpenIssueContext`, `ContextDepth` enum, `ContextFormat` enum. Uses `Annotated[T | None, Field(...)] = None` pattern for mypy strict compliance without the pydantic plugin.
- **`maestro/services/musehub_context.py`** — `build_agent_context()`: read-only, deterministic aggregation service. Resolves `ref` (branch name → head commit, or direct commit ID), fetches history, open PRs, open issues, and generates heuristic suggestions. Musical state and analysis fields are `None` at MVP pending Storpheus MIDI integration.
- **`maestro/api/routes/musehub/repos.py`** — New `GET /repos/{repo_id}/context` endpoint with `?ref`, `?depth`, and `?format` query params. Returns JSON or YAML via `Response` (not `response_model`) to support both content types cleanly.

**Depth control:**
| Depth | History | PR bodies | Issue bodies | Token budget |
|-------|---------|-----------|--------------|-------------|
| `brief` | ≤ 3 | No | No | ~2K |
| `standard` | ≤ 10 | Yes | No | ~8K |
| `verbose` | ≤ 50 | Yes | Yes | Uncapped |

Also fixed pre-existing mypy yaml `import-untyped` errors in `parser.py`, `structured.py`, and `muse_cli/commands/context.py` (added `# type: ignore[import-untyped]` with explanation). These errors existed but were masked by pyproject.toml not loading in worktree context.

## Layers Affected

- [x] Muse VCS (MuseHub read path)
- [ ] Intent Engine
- [ ] Pipeline
- [ ] Maestro Handlers
- [ ] Agent Teams
- [ ] Storpheus Client
- [ ] MCP
- [ ] DAW Adapter
- [ ] Auth / Budget
- [ ] RAG
- [ ] Variation
- [ ] SSE Protocol

## Verification

- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (no new errors introduced; 10 pre-existing errors from mido/boto3/gradio_client remain, all in override scope)
- [x] All 15 new tests pass: `pytest tests/test_musehub_context.py -v`
- [x] `docs/reference/api.md` — full endpoint docs with response schema
- [x] `docs/reference/type_contracts.md` — all 8 new named types registered
- [x] `docs/guides/integrate.md` — agent context consumption guide with depth table and Python example

## Tests Added

- `test_context_endpoint_returns_all_sections` — all top-level fields present
- `test_context_includes_musical_state` — musical state fields present (may be None)
- `test_context_includes_history` — history entries with correct shape
- `test_context_includes_active_prs` — open PRs listed correctly
- `test_context_brief_depth` — ≤ 3 history entries, ≤ 2 suggestions at brief
- `test_context_standard_depth` — ≤ 10 history entries at standard
- `test_context_verbose_depth_includes_issue_bodies` — verbose includes bodies; brief does not
- `test_context_yaml_format` — YAML response is valid and has correct structure
- `test_context_unknown_repo_404` — non-existent repo returns 404
- `test_context_ref_not_found_404` — non-existent ref returns 404
- `test_context_requires_auth` — 401 without token
- `test_context_default_ref_resolves_to_latest_commit` — HEAD resolves correctly
- `test_context_branch_ref_resolution` — branch name resolves to its head
- `test_context_suggestions_generated` — suggestions are a list of strings
- `test_context_open_issues_excluded_when_closed` — closed issues excluded

## Handoff

N/A — no SSE or MCP protocol change. New endpoint is additive.