### PR TITLE
feat(musehub): embeddable player widget and oEmbed endpoint

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1330,8 +1330,45 @@ do **not** require an `Authorization` header — auth is handled client-side via
 | `GET /musehub/ui/{repo_id}/pulls/{pr_id}` | PR detail with Merge button |
 | `GET /musehub/ui/{repo_id}/issues` | Issue list with open/closed/all filter |
 | `GET /musehub/ui/{repo_id}/issues/{number}` | Issue detail with Close button |
+| `GET /musehub/ui/{repo_id}/embed/{ref}` | Embeddable player widget (no auth, iframe-safe) |
 
 **Response:** `200 text/html` for all routes. No JSON is returned.
 
-See [integrate.md — Muse Hub web UI](../guides/integrate.md#muse-hub-web-ui) for
-usage and authentication instructions.
+The embed route additionally sets `X-Frame-Options: ALLOWALL` — required for
+cross-origin `<iframe>` embedding on external sites.
+
+See [integrate.md — Embedding MuseHub Compositions](../guides/integrate.md#embedding-musehub-compositions-on-external-sites) for
+usage and iframe code examples.
+
+### GET /oembed
+
+oEmbed discovery endpoint. Returns JSON metadata (including an `<iframe>` HTML
+snippet) for any MuseHub embed URL. No auth required.
+
+**Query parameters:**
+
+| Name        | Type   | Required | Description                                    |
+|-------------|--------|----------|------------------------------------------------|
+| `url`       | string | yes      | MuseHub embed URL to resolve                   |
+| `maxwidth`  | int    | no       | Maximum iframe width in pixels (default 560)   |
+| `maxheight` | int    | no       | Maximum iframe height in pixels (default 152)  |
+| `format`    | string | no       | Response format; only `json` supported         |
+
+**Response `200`:**
+
+```json
+{
+  "version": "1.0",
+  "type": "rich",
+  "title": "MuseHub Composition abc12345",
+  "provider_name": "Muse Hub",
+  "provider_url": "https://musehub.stori.app",
+  "width": 560,
+  "height": 152,
+  "html": "<iframe ...></iframe>"
+}
+```
+
+**Error responses:**
+- `404` — URL does not match an embed URL pattern.
+- `501` — `format` is not `json`.

--- a/maestro/api/routes/musehub/oembed.py
+++ b/maestro/api/routes/musehub/oembed.py
@@ -1,0 +1,128 @@
+"""oEmbed discovery endpoint for MuseHub embeddable player widgets.
+
+oEmbed is a standard protocol (https://oembed.com/) that lets CMSes and
+blogging platforms auto-embed rich content when a user pastes a URL.  By
+exposing ``GET /oembed?url={embed_url}`` we enable Wordpress, Ghost, and
+any oEmbed-aware platform to automatically convert a MuseHub embed URL
+into an ``<iframe>`` snippet.
+
+Endpoint summary:
+  GET /oembed?url={url}&maxwidth={w}&maxheight={h}
+
+The ``url`` parameter must match the embed URL pattern:
+  /musehub/ui/{repo_id}/embed/{ref}
+
+Returns JSON conforming to the oEmbed rich/video response type
+(https://oembed.com/#section2.3.4):
+
+  {
+    "version":       "1.0",
+    "type":          "rich",
+    "title":         "MuseHub Composition {ref[:8]}",
+    "provider_name": "Muse Hub",
+    "provider_url":  "https://musehub.stori.app",
+    "width":         560,
+    "height":        152,
+    "html":          "<iframe ...></iframe>"
+  }
+
+A 404 is returned for URLs that do not match the expected embed pattern
+so that oEmbed consumers can distinguish supported from unsupported URLs.
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["musehub-oembed"])
+
+_EMBED_URL_PATTERN = re.compile(
+    r"/musehub/ui/(?P<repo_id>[^/]+)/embed/(?P<ref>[^/?#]+)"
+)
+
+_DEFAULT_WIDTH = 560
+_DEFAULT_HEIGHT = 152
+_MAX_WIDTH = 1200
+_MAX_HEIGHT = 400
+
+
+@router.get("/oembed", summary="oEmbed discovery for MuseHub embed URLs")
+async def oembed_endpoint(
+    url: str = Query(..., description="The MuseHub embed URL to resolve"),
+    maxwidth: int = Query(_DEFAULT_WIDTH, ge=100, le=_MAX_WIDTH, description="Maximum iframe width in pixels"),
+    maxheight: int = Query(_DEFAULT_HEIGHT, ge=80, le=_MAX_HEIGHT, description="Maximum iframe height in pixels"),
+    format: str = Query("json", description="Response format — only 'json' is supported"),
+) -> JSONResponse:
+    """Return an oEmbed JSON response for a MuseHub embed URL.
+
+    Why this exists: oEmbed-aware platforms (Wordpress, Ghost, Notion, etc.)
+    call this endpoint automatically when a user pastes a MuseHub embed URL,
+    then inject the returned ``html`` field as an ``<iframe>`` into the page.
+
+    Contract:
+    - ``url`` must contain a path matching ``/musehub/ui/{repo_id}/embed/{ref}``.
+    - Returns 404 if the URL does not match the embed pattern.
+    - Returns 501 if ``format`` is not ``json``.
+    - Width and height are clamped to [100, 1200] and [80, 400] respectively.
+    - The ``html`` field is an ``<iframe>`` pointing to the embed route which
+      sets ``X-Frame-Options: ALLOWALL`` — safe for cross-origin embedding.
+
+    Args:
+        url:       Full or path-only MuseHub embed URL to resolve.
+        maxwidth:  Desired maximum iframe width (default 560px).
+        maxheight: Desired maximum iframe height (default 152px).
+        format:    oEmbed response format — only ``json`` is supported.
+
+    Returns:
+        JSONResponse with oEmbed rich type payload.
+
+    Raises:
+        HTTPException 404: URL does not match a MuseHub embed URL pattern.
+        HTTPException 501: Requested format is not ``json``.
+    """
+    if format.lower() != "json":
+        raise HTTPException(status_code=501, detail="Only JSON format is supported")
+
+    match = _EMBED_URL_PATTERN.search(url)
+    if not match:
+        logger.warning("oEmbed: unrecognised URL pattern — %s", url)
+        raise HTTPException(
+            status_code=404,
+            detail="URL does not match a MuseHub embed URL. "
+            "Expected format: /musehub/ui/{repo_id}/embed/{ref}",
+        )
+
+    repo_id = match.group("repo_id")
+    ref = match.group("ref")
+    short_ref = ref[:8] if len(ref) >= 8 else ref
+
+    width = min(maxwidth, _MAX_WIDTH)
+    height = min(maxheight, _MAX_HEIGHT)
+
+    embed_path = f"/musehub/ui/{repo_id}/embed/{ref}"
+    iframe_html = (
+        f'<iframe src="{embed_path}" '
+        f'width="{width}" height="{height}" '
+        'frameborder="0" allowtransparency="true" '
+        'allow="autoplay" scrolling="no" '
+        f'title="MuseHub Composition {short_ref}">'
+        "</iframe>"
+    )
+
+    payload: dict[str, str | int] = {
+        "version": "1.0",
+        "type": "rich",
+        "title": f"MuseHub Composition {short_ref}",
+        "provider_name": "Muse Hub",
+        "provider_url": "https://musehub.stori.app",
+        "width": width,
+        "height": height,
+        "html": iframe_html,
+    }
+    logger.info("✅ oEmbed resolved — repo=%s ref=%s", repo_id, short_ref)
+    return JSONResponse(content=payload)

--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -10,10 +10,14 @@ Endpoint summary:
   GET /musehub/ui/{repo_id}/pulls/{pr_id}          — PR detail page (with merge button)
   GET /musehub/ui/{repo_id}/issues                 — issue list page
   GET /musehub/ui/{repo_id}/issues/{number}        — issue detail page (with close button)
+  GET /musehub/ui/{repo_id}/embed/{ref}            — embeddable player widget (no auth, iframe-safe)
 
 These routes require NO JWT auth — they return static HTML shells whose
 embedded JavaScript fetches data from the authed JSON API
 (``/api/v1/musehub/...``) using a token stored in ``localStorage``.
+
+The embed route is intentionally designed for cross-origin iframe embedding:
+it sets ``X-Frame-Options: ALLOWALL`` and omits the Sign-out button.
 
 No Jinja2 is required; pages are self-contained HTML strings rendered
 server-side.  No external CDN dependencies.
@@ -22,7 +26,7 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Response
 from fastapi.responses import HTMLResponse
 
 logger = logging.getLogger(__name__)
@@ -749,3 +753,269 @@ async def issue_detail_page(repo_id: str, number: int) -> HTMLResponse:
         body_script=script,
     )
     return HTMLResponse(content=html)
+
+
+# ---------------------------------------------------------------------------
+# Embed CSS (compact dark theme, no chrome)
+# ---------------------------------------------------------------------------
+
+_EMBED_CSS = """
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0d1117; color: #c9d1d9;
+  height: 100vh; display: flex; align-items: center; justify-content: center;
+}
+.player {
+  width: 100%; max-width: 100%; padding: 16px 20px;
+  background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+  display: flex; flex-direction: column; gap: 12px;
+}
+.player-header {
+  display: flex; align-items: center; gap: 12px;
+}
+.logo-mark {
+  font-size: 20px; flex-shrink: 0;
+}
+.track-info { flex: 1; overflow: hidden; }
+.track-title {
+  font-size: 14px; font-weight: 600; color: #e6edf3;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.track-sub {
+  font-size: 11px; color: #8b949e; margin-top: 2px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.controls {
+  display: flex; align-items: center; gap: 10px;
+}
+.play-btn {
+  width: 36px; height: 36px; border-radius: 50%;
+  background: #238636; border: none; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0; font-size: 14px; color: #fff;
+  transition: background 0.15s;
+}
+.play-btn:hover { background: #2ea043; }
+.play-btn:disabled { background: #30363d; cursor: not-allowed; }
+.progress-wrap {
+  flex: 1; display: flex; flex-direction: column; gap: 4px;
+}
+.progress-bar {
+  width: 100%; height: 4px; background: #30363d; border-radius: 2px;
+  cursor: pointer; position: relative; overflow: hidden;
+}
+.progress-fill {
+  height: 100%; width: 0%; background: #58a6ff;
+  border-radius: 2px; transition: width 0.1s linear;
+  pointer-events: none;
+}
+.time-row {
+  display: flex; justify-content: space-between;
+  font-size: 11px; color: #8b949e;
+}
+.footer-link {
+  display: flex; justify-content: flex-end; align-items: center;
+}
+.footer-link a {
+  font-size: 11px; color: #58a6ff; text-decoration: none;
+  display: flex; align-items: center; gap: 4px;
+}
+.footer-link a:hover { text-decoration: underline; }
+.status { font-size: 12px; color: #8b949e; text-align: center; padding: 8px 0; }
+.status.error { color: #f85149; }
+"""
+
+
+def _embed_page(title: str, repo_id: str, ref: str, body_script: str) -> str:
+    """Assemble a compact embed player HTML page.
+
+    Designed for iframe embedding on external sites.  No chrome, no token
+    form — just the player widget.  ``X-Frame-Options`` is set by the
+    route handler, not here, since this function only produces the body.
+    """
+    listen_url = f"/musehub/ui/{repo_id}"
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{title} — Muse Hub</title>
+  <style>{_EMBED_CSS}</style>
+</head>
+<body>
+  <div class="player" id="player">
+    <div class="player-header">
+      <span class="logo-mark">&#127925;</span>
+      <div class="track-info">
+        <div class="track-title" id="track-title">Loading&#8230;</div>
+        <div class="track-sub" id="track-sub">Muse Hub</div>
+      </div>
+    </div>
+    <div class="controls">
+      <button class="play-btn" id="play-btn" disabled title="Play / Pause">&#9654;</button>
+      <div class="progress-wrap">
+        <div class="progress-bar" id="progress-bar">
+          <div class="progress-fill" id="progress-fill"></div>
+        </div>
+        <div class="time-row">
+          <span id="time-cur">0:00</span>
+          <span id="time-dur">0:00</span>
+        </div>
+      </div>
+    </div>
+    <div class="footer-link">
+      <a href="{listen_url}" target="_blank" rel="noopener">
+        &#127925; View on Muse Hub
+      </a>
+    </div>
+  </div>
+  <audio id="audio-el" preload="metadata"></audio>
+  <script>
+    (function() {{
+      const repoId = {repr(repo_id)};
+      const ref    = {repr(ref)};
+      const API    = '/api/v1/musehub';
+
+      const audio      = document.getElementById('audio-el');
+      const playBtn    = document.getElementById('play-btn');
+      const fill       = document.getElementById('progress-fill');
+      const bar        = document.getElementById('progress-bar');
+      const timeCur    = document.getElementById('time-cur');
+      const timeDur    = document.getElementById('time-dur');
+      const trackTitle = document.getElementById('track-title');
+      const trackSub   = document.getElementById('track-sub');
+
+      function fmtTime(s) {{
+        if (!isFinite(s)) return '0:00';
+        const m = Math.floor(s / 60);
+        const sec = Math.floor(s % 60);
+        return m + ':' + (sec < 10 ? '0' : '') + sec;
+      }}
+
+      function setStatus(msg, isError) {{
+        trackTitle.textContent = isError ? msg : (trackTitle.textContent || msg);
+        if (isError) trackTitle.classList.add('error');
+      }}
+
+      audio.addEventListener('timeupdate', function() {{
+        const pct = audio.duration ? (audio.currentTime / audio.duration) * 100 : 0;
+        fill.style.width = pct + '%';
+        timeCur.textContent = fmtTime(audio.currentTime);
+      }});
+
+      audio.addEventListener('durationchange', function() {{
+        timeDur.textContent = fmtTime(audio.duration);
+      }});
+
+      audio.addEventListener('ended', function() {{
+        playBtn.innerHTML = '&#9654;';
+        fill.style.width = '0%';
+        audio.currentTime = 0;
+      }});
+
+      audio.addEventListener('canplay', function() {{
+        playBtn.disabled = false;
+      }});
+
+      audio.addEventListener('error', function() {{
+        setStatus('Audio unavailable', true);
+      }});
+
+      playBtn.addEventListener('click', function() {{
+        if (audio.paused) {{
+          audio.play();
+          playBtn.innerHTML = '&#9646;&#9646;';
+        }} else {{
+          audio.pause();
+          playBtn.innerHTML = '&#9654;';
+        }}
+      }});
+
+      bar.addEventListener('click', function(e) {{
+        if (!audio.duration) return;
+        const rect = bar.getBoundingClientRect();
+        const pct  = (e.clientX - rect.left) / rect.width;
+        audio.currentTime = pct * audio.duration;
+      }});
+
+      async function loadTrack() {{
+        try {{
+          const objRes = await fetch(API + '/repos/' + repoId + '/objects');
+          if (!objRes.ok) throw new Error('objects ' + objRes.status);
+          const objData = await objRes.json();
+          const objects = objData.objects || [];
+
+          const audio_exts = ['mp3', 'ogg', 'wav', 'm4a'];
+          const audioObj = objects.find(function(o) {{
+            const ext = o.path.split('.').pop().toLowerCase();
+            return audio_exts.indexOf(ext) !== -1;
+          }});
+
+          if (!audioObj) {{
+            trackTitle.textContent = 'No audio in this commit';
+            trackSub.textContent = 'ref: ' + ref.substring(0, 8);
+            return;
+          }}
+
+          const name = audioObj.path.split('/').pop();
+          trackTitle.textContent = name;
+          trackSub.textContent = 'ref: ' + ref.substring(0, 8);
+
+          const audioUrl = API + '/repos/' + repoId + '/objects/' + audioObj.objectId + '/content';
+          audio.src = audioUrl;
+          audio.load();
+        }} catch(e) {{
+          setStatus('Could not load track', true);
+          trackSub.textContent = e.message;
+        }}
+      }}
+
+      {body_script}
+
+      loadTrack();
+    }})();
+  </script>
+</body>
+</html>"""
+
+
+@router.get(
+    "/{repo_id}/embed/{ref}",
+    response_class=HTMLResponse,
+    summary="Embeddable MuseHub player widget",
+)
+async def embed_page(repo_id: str, ref: str) -> Response:
+    """Render a compact, iframe-safe audio player for a MuseHub repo commit.
+
+    Why this route exists: external sites (blogs, CMSes) embed MuseHub
+    compositions via ``<iframe src="/musehub/ui/{repo_id}/embed/{ref}">``.
+    The oEmbed endpoint (``GET /oembed``) auto-generates this iframe tag.
+
+    Contract:
+    - No JWT required — public repos can be embedded without auth.
+    - Returns ``X-Frame-Options: ALLOWALL`` so browsers permit cross-origin framing.
+    - ``ref`` is a commit SHA or branch name used to label the track.
+    - Audio is fetched from ``/api/v1/musehub/repos/{repo_id}/objects`` at
+      runtime; the first recognised audio file (mp3/ogg/wav/m4a) is played.
+    - Responsive: works from 300px to full viewport width.
+
+    Args:
+        repo_id: UUID of the MuseHub repository.
+        ref:     Commit SHA or branch name identifying the composition version.
+
+    Returns:
+        HTML response with ``X-Frame-Options: ALLOWALL`` header.
+    """
+    short_ref = ref[:8] if len(ref) >= 8 else ref
+    html = _embed_page(
+        title=f"Player {short_ref}",
+        repo_id=repo_id,
+        ref=ref,
+        body_script="",
+    )
+    return Response(
+        content=html,
+        media_type="text/html",
+        headers={"X-Frame-Options": "ALLOWALL"},
+    )

--- a/maestro/main.py
+++ b/maestro/main.py
@@ -22,6 +22,7 @@ from slowapi.errors import RateLimitExceeded
 from maestro.config import settings
 from maestro.api.routes import maestro, maestro_ui, health, users, conversations, assets, variation, muse, musehub
 from maestro.api.routes.musehub import ui as musehub_ui_routes
+from maestro.api.routes.musehub import oembed as musehub_oembed_routes
 from maestro.api.routes import mcp as mcp_routes
 from maestro.db import init_db, close_db
 from maestro.services.storpheus import get_storpheus_client, close_storpheus_client
@@ -35,8 +36,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         response = await call_next(request)
         
-        # Prevent clickjacking
-        response.headers["X-Frame-Options"] = "DENY"
+        # Prevent clickjacking. Embed routes set ALLOWALL explicitly;
+        # only apply the DENY default when no value has been set by the handler.
+        if "X-Frame-Options" not in response.headers:
+            response.headers["X-Frame-Options"] = "DENY"
         
         # Prevent MIME type sniffing
         response.headers["X-Content-Type-Options"] = "nosniff"
@@ -161,6 +164,7 @@ app.include_router(assets.router, prefix="/api/v1", tags=["assets"])
 app.include_router(muse.router, prefix="/api/v1", tags=["muse"])
 app.include_router(musehub.router, prefix="/api/v1", tags=["musehub"])
 app.include_router(musehub_ui_routes.router, tags=["musehub-ui"])
+app.include_router(musehub_oembed_routes.router, tags=["musehub-oembed"])
 app.include_router(mcp_routes.router, prefix="/api/v1/mcp", tags=["mcp"])
 
 from maestro.protocol.endpoints import router as protocol_router

--- a/tests/test_musehub_oembed.py
+++ b/tests/test_musehub_oembed.py
@@ -1,0 +1,112 @@
+"""Tests for the MuseHub oEmbed discovery endpoint.
+
+Covers acceptance criteria from issue #244:
+- test_oembed_endpoint          — GET /oembed returns valid JSON with HTML embed code
+- test_oembed_unknown_url_404   — Invalid / unrecognised URL returns 404
+- test_oembed_iframe_content    — Returned HTML is an <iframe> pointing to embed route
+- test_oembed_respects_maxwidth — maxwidth parameter is reflected in returned iframe width
+- test_oembed_xml_format_501    — Non-JSON format returns 501
+
+The /oembed endpoint requires no auth — oEmbed consumers (CMSes, blog platforms)
+call it without user credentials to discover embed metadata.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.anyio
+async def test_oembed_endpoint(client: AsyncClient) -> None:
+    """GET /oembed with a valid embed URL returns 200 JSON with oEmbed fields."""
+    repo_id = "aaaabbbb-cccc-dddd-eeee-ffff00001111"
+    ref = "abc1234567890"
+    embed_url = f"/musehub/ui/{repo_id}/embed/{ref}"
+
+    response = await client.get(f"/oembed?url={embed_url}")
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+
+    data = response.json()
+    assert data["version"] == "1.0"
+    assert data["type"] == "rich"
+    assert "title" in data
+    assert data["provider_name"] == "Muse Hub"
+    assert "html" in data
+    assert isinstance(data["width"], int)
+    assert isinstance(data["height"], int)
+
+
+@pytest.mark.anyio
+async def test_oembed_unknown_url_404(client: AsyncClient) -> None:
+    """GET /oembed with a URL that doesn't match an embed pattern returns 404."""
+    response = await client.get("/oembed?url=https://example.com/not-musehub")
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_oembed_iframe_content(client: AsyncClient) -> None:
+    """The HTML field returned by /oembed is an <iframe> pointing to the embed route."""
+    repo_id = "11112222-3333-4444-5555-666677778888"
+    ref = "deadbeef1234"
+    embed_url = f"/musehub/ui/{repo_id}/embed/{ref}"
+
+    response = await client.get(f"/oembed?url={embed_url}")
+    assert response.status_code == 200
+
+    html = response.json()["html"]
+    assert "<iframe" in html
+    assert f"/musehub/ui/{repo_id}/embed/{ref}" in html
+    assert "</iframe>" in html
+
+
+@pytest.mark.anyio
+async def test_oembed_respects_maxwidth(client: AsyncClient) -> None:
+    """maxwidth query parameter is reflected as the iframe width attribute."""
+    repo_id = "aaaabbbb-1111-2222-3333-ccccddddeeee"
+    ref = "cafebabe"
+    embed_url = f"/musehub/ui/{repo_id}/embed/{ref}"
+
+    response = await client.get(f"/oembed?url={embed_url}&maxwidth=400")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["width"] == 400
+    assert 'width="400"' in data["html"]
+
+
+@pytest.mark.anyio
+async def test_oembed_xml_format_501(client: AsyncClient) -> None:
+    """Requesting XML format returns 501 Not Implemented."""
+    repo_id = "aaaabbbb-cccc-dddd-eeee-000011112222"
+    ref = "feedface"
+    embed_url = f"/musehub/ui/{repo_id}/embed/{ref}"
+
+    response = await client.get(f"/oembed?url={embed_url}&format=xml")
+    assert response.status_code == 501
+
+
+@pytest.mark.anyio
+async def test_oembed_no_auth_required(client: AsyncClient) -> None:
+    """oEmbed endpoint must not require a JWT — CMS platforms call it unauthenticated."""
+    repo_id = "bbbbcccc-dddd-eeee-ffff-000011112222"
+    ref = "aabbccdd"
+    embed_url = f"/musehub/ui/{repo_id}/embed/{ref}"
+
+    response = await client.get(f"/oembed?url={embed_url}")
+    assert response.status_code != 401
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_oembed_title_contains_short_ref(client: AsyncClient) -> None:
+    """oEmbed title includes the first 8 characters of the ref for human readability."""
+    repo_id = "ccccdddd-eeee-ffff-0000-111122223333"
+    ref = "1234567890abcdef"
+    embed_url = f"/musehub/ui/{repo_id}/embed/{ref}"
+
+    response = await client.get(f"/oembed?url={embed_url}")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert ref[:8] in data["title"]

--- a/tests/test_musehub_ui.py
+++ b/tests/test_musehub_ui.py
@@ -6,6 +6,12 @@ Covers the minimum acceptance criteria from issue #43:
 - test_ui_pr_list_page_returns_200     — PR list page renders without error
 - test_ui_issue_list_page_returns_200  — Issue list page renders without error
 
+Covers acceptance criteria from issue #244 (embed player):
+- test_embed_page_renders              — GET /musehub/ui/{repo_id}/embed/{ref} returns 200
+- test_embed_no_auth_required          — Public embed accessible without JWT
+- test_embed_page_x_frame_options      — Response sets X-Frame-Options: ALLOWALL
+- test_embed_page_contains_player_ui   — Player elements present in embed HTML
+
 UI routes require no JWT auth (they return HTML shells whose JS handles auth).
 The HTML content tests assert structural markers present in every rendered page.
 """
@@ -236,3 +242,65 @@ async def test_get_object_content_404_for_unknown_object(
         headers=auth_headers,
     )
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Embed player route tests (issue #244)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_embed_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{repo_id}/embed/{ref} returns 200 HTML."""
+    repo_id = await _make_repo(db_session)
+    ref = "abc1234567890abcdef"
+    response = await client.get(f"/musehub/ui/{repo_id}/embed/{ref}")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_embed_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Embed page must be accessible without an Authorization header (public embedding)."""
+    repo_id = await _make_repo(db_session)
+    ref = "deadbeef1234"
+    response = await client.get(f"/musehub/ui/{repo_id}/embed/{ref}")
+    assert response.status_code != 401
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_embed_page_x_frame_options(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Embed page must set X-Frame-Options: ALLOWALL to permit cross-origin framing."""
+    repo_id = await _make_repo(db_session)
+    ref = "cafebabe1234"
+    response = await client.get(f"/musehub/ui/{repo_id}/embed/{ref}")
+    assert response.status_code == 200
+    assert response.headers.get("x-frame-options") == "ALLOWALL"
+
+
+@pytest.mark.anyio
+async def test_embed_page_contains_player_ui(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Embed page HTML must contain player elements: play button, progress bar, and Muse Hub link."""
+    repo_id = await _make_repo(db_session)
+    ref = "feedface0123456789ab"
+    response = await client.get(f"/musehub/ui/{repo_id}/embed/{ref}")
+    assert response.status_code == 200
+    body = response.text
+    assert "play-btn" in body
+    assert "progress-bar" in body
+    assert "View on Muse Hub" in body
+    assert "audio" in body
+    assert repo_id in body


### PR DESCRIPTION
## Summary
Closes #244 — adds an iframe-safe embeddable audio player for MuseHub compositions and an oEmbed discovery endpoint so CMSes can auto-embed tracks.

## Root Cause / Motivation
MuseHub compositions had no way to be shared on external sites (blogs, social media, websites). Users could only share a link to the full repo browser.

## Solution

### New endpoint: `GET /musehub/ui/{repo_id}/embed/{ref}`
- Compact dark-theme audio player with play/pause, progress bar (clickable seek), track title, elapsed/total time, and "View on Muse Hub" link.
- No auth required — publicly accessible for any repo.
- Sets `X-Frame-Options: ALLOWALL` so browsers allow cross-origin `<iframe>` embedding.
- `SecurityHeadersMiddleware` updated to only set the `DENY` default when the route handler has not already provided a value.
- Audio loaded at runtime from `/api/v1/musehub/repos/{repo_id}/objects`; first mp3/ogg/wav/m4a file played.
- Responsive: scales from 300 px to full viewport width.

### New endpoint: `GET /oembed`
- Conforms to the [oEmbed standard](https://oembed.com/) (`type: rich`).
- Returns JSON with `html` field containing an `<iframe>` pointing to the embed route.
- Supports `maxwidth`, `maxheight` (clamped), and `format` (only `json`).
- Returns `404` for unrecognised URLs, `501` for XML format requests.
- Registered directly on the FastAPI app (no auth, no prefix).

## Layers Affected
- [x] MuseHub UI routes (`maestro/api/routes/musehub/ui.py`)
- [x] New module: `maestro/api/routes/musehub/oembed.py`
- [x] `maestro/main.py` — router registration + security middleware fix

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — 5 new/modified files clean; pre-existing 3rd-party stub warnings unchanged
- [x] `docker compose exec storpheus mypy .` — clean (no changes to storpheus)
- [x] 23 targeted tests pass (0 failures, 0 warnings)
- [x] Docs updated: `docs/guides/integrate.md` + `docs/reference/api.md`

## Tests Added
- `test_embed_page_renders` — `GET /musehub/ui/{repo_id}/embed/{ref}` returns 200 HTML
- `test_embed_no_auth_required` — embed accessible without JWT (no 401)
- `test_embed_page_x_frame_options` — response sets `X-Frame-Options: ALLOWALL`
- `test_embed_page_contains_player_ui` — play button, progress bar, Muse Hub link present
- `test_oembed_endpoint` — returns valid oEmbed JSON with all required fields
- `test_oembed_unknown_url_404` — unrecognised URL returns 404
- `test_oembed_iframe_content` — HTML field contains `<iframe>` pointing to embed URL
- `test_oembed_respects_maxwidth` — `maxwidth` reflected in iframe width attribute
- `test_oembed_xml_format_501` — `format=xml` returns 501
- `test_oembed_no_auth_required` — oEmbed accessible without JWT
- `test_oembed_title_contains_short_ref` — title includes first 8 chars of ref

## Handoff
N/A — no SSE protocol, MCP tool schema, or DAW adapter changes. This is a presentation-layer addition to the MuseHub UI routes.