### PR TITLE
feat: credits page — dynamic attribution aggregation like album liner notes

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -1410,20 +1410,22 @@ maestro/
 ├── db/musehub_models.py                  — SQLAlchemy ORM models
 ├── models/musehub.py                     — Pydantic v2 request/response models
 ├── services/musehub_repository.py        — Async DB queries for repos/branches/commits
+├── services/musehub_credits.py           — Credits aggregation from commit history
 ├── services/musehub_issues.py            — Async DB queries for issues (single point of DB access)
 ├── services/musehub_pull_requests.py     — Async DB queries for PRs (single point of DB access)
 ├── services/musehub_sync.py              — Push/pull sync protocol (ingest_push, compute_pull_delta)
 └── api/routes/musehub/
     ├── __init__.py                       — Composes sub-routers under /musehub prefix
-    ├── repos.py                          — Repo/branch/commit route handlers
+    ├── repos.py                          — Repo/branch/commit/credits route handlers
     ├── issues.py                         — Issue tracking route handlers
     ├── pull_requests.py                  — Pull request route handlers
-    └── sync.py                           — Push/pull sync route handlers
+    ├── sync.py                           — Push/pull sync route handlers
+    └── ui.py                             — Browser UI pages (HTML, no auth — JS handles it)
 ```
 
 ### Endpoints
 
-#### Repos, Branches, Commits
+#### Repos, Branches, Commits, Credits
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -1431,6 +1433,37 @@ maestro/
 | GET | `/api/v1/musehub/repos/{id}` | Get repo metadata |
 | GET | `/api/v1/musehub/repos/{id}/branches` | List branches |
 | GET | `/api/v1/musehub/repos/{id}/commits` | List commits (newest first) |
+| GET | `/api/v1/musehub/repos/{id}/credits` | Aggregated contributor credits (`?sort=count\|recency\|alpha`) |
+
+#### Credits Page
+
+`GET /api/v1/musehub/repos/{repo_id}/credits` returns a `CreditsResponse` — the full contributor roll aggregated from commit history, analogous to dynamic album liner notes.
+
+**Sort options:**
+
+| `sort` value | Ordering |
+|---|---|
+| `count` (default) | Most prolific contributor first |
+| `recency` | Most recently active contributor first |
+| `alpha` | Alphabetical by author name |
+
+**Result type:** `CreditsResponse` — fields: `repo_id`, `contributors` (list of `ContributorCredits`), `sort`, `total_contributors`.
+
+**`ContributorCredits` fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `author` | `str` | Contributor name (from commit `author` field) |
+| `session_count` | `int` | Number of commits attributed to this author |
+| `contribution_types` | `list[str]` | Inferred roles: composer, arranger, producer, performer, mixer, editor, lyricist, sound designer |
+| `first_active` | `datetime` | Timestamp of earliest commit |
+| `last_active` | `datetime` | Timestamp of most recent commit |
+
+**Contribution type inference:** Roles are inferred from commit message keywords using `_ROLE_KEYWORDS` in `musehub_credits.py`. No role matched → falls back to `["contributor"]`. The list evolves as musicians describe their work more richly in commit messages.
+
+**Machine-readable credits:** The UI page (`GET /musehub/ui/{repo_id}/credits`) injects a `<script type="application/ld+json">` block using schema.org `MusicComposition` vocabulary for embeddable, machine-readable attribution.
+
+**Agent use case:** An AI agent generating release notes or liner notes calls `GET /api/v1/musehub/repos/{id}/credits?sort=count` to enumerate all contributors and their roles, then formats the result as attribution text. The JSON-LD block is ready for schema.org consumers (streaming platforms, metadata aggregators).
 
 #### Issues
 

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5846,6 +5846,39 @@ Wrapper returned by `GET /api/v1/musehub/repos/{repo_id}/objects`.
 **Producer:** `objects.list_objects` route handler
 **Consumer:** Muse Hub web UI; any agent inspecting which artifacts are available for a repo
 
+### `ContributorCredits`
+
+Defined in `maestro/models/musehub.py`.
+
+One contributor record aggregated from all commits attributed to a single author.  Part of `CreditsResponse`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `author` | `str` | Author name (from commit record) |
+| `session_count` | `int` | Total commits by this author in the repo |
+| `contribution_types` | `list[str]` | Inferred roles (composer, arranger, producer, etc.) |
+| `first_active` | `datetime` | Timestamp of earliest commit |
+| `last_active` | `datetime` | Timestamp of most recent commit |
+
+**Producer:** `musehub_credits.aggregate_credits()` → `repos.get_credits` route handler
+**Consumer:** Muse Hub credits page UI; any agent generating liner notes or attribution summaries
+
+### `CreditsResponse`
+
+Defined in `maestro/models/musehub.py`.
+
+Full contributor roll for a Muse Hub repo.  Returned by `GET /api/v1/musehub/repos/{repo_id}/credits`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo_id` | `str` | Target repo ID |
+| `contributors` | `list[ContributorCredits]` | All contributors, sorted per `sort` |
+| `sort` | `str` | Echoed sort order (`count`, `recency`, or `alpha`) |
+| `total_contributors` | `int` | Total number of distinct contributors |
+
+**Producer:** `musehub_credits.aggregate_credits()` → `repos.get_credits` route handler
+**Consumer:** Muse Hub credits page UI; AI agents generating liner notes, release attribution, or schema.org `MusicComposition` JSON-LD
+
 ---
 
 ## Muse Bisect Types

--- a/maestro/api/routes/musehub/repos.py
+++ b/maestro/api/routes/musehub/repos.py
@@ -1,14 +1,15 @@
-"""Muse Hub repo, branch, and commit route handlers.
+"""Muse Hub repo, branch, commit, and credits route handlers.
 
 Endpoint summary:
   POST /musehub/repos                        — create a new remote repo
   GET  /musehub/repos/{repo_id}              — get repo metadata
   GET  /musehub/repos/{repo_id}/branches     — list all branches
   GET  /musehub/repos/{repo_id}/commits      — list commits (newest first)
+  GET  /musehub/repos/{repo_id}/credits      — aggregated contributor credits
 
 All endpoints require a valid JWT Bearer token.
 No business logic lives here — all persistence is delegated to
-maestro.services.musehub_repository.
+maestro.services.musehub_repository and maestro.services.musehub_credits.
 """
 from __future__ import annotations
 
@@ -23,9 +24,10 @@ from maestro.models.musehub import (
     BranchListResponse,
     CommitListResponse,
     CreateRepoRequest,
+    CreditsResponse,
     RepoResponse,
 )
-from maestro.services import musehub_repository
+from maestro.services import musehub_credits, musehub_repository
 
 logger = logging.getLogger(__name__)
 
@@ -112,3 +114,38 @@ async def list_commits(
         db, repo_id, branch=branch, limit=limit
     )
     return CommitListResponse(commits=commits, total=total)
+
+
+@router.get(
+    "/repos/{repo_id}/credits",
+    response_model=CreditsResponse,
+    summary="Get aggregated contributor credits for a repo",
+)
+async def get_credits(
+    repo_id: str,
+    sort: str = Query(
+        "count",
+        pattern="^(count|recency|alpha)$",
+        description="Sort order: 'count' (most prolific), 'recency' (most recent), 'alpha' (A–Z)",
+    ),
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> CreditsResponse:
+    """Return dynamic contributor credits aggregated from all commits in a repo.
+
+    Analogous to album liner notes: every contributor is listed with their
+    session count, inferred contribution types (composer, arranger, producer,
+    etc.), and activity window (first and last commit timestamps).
+
+    Content negotiation: when the request ``Accept`` header includes
+    ``application/ld+json``, clients should request the ``/credits`` endpoint
+    directly — the JSON body is schema.org-compatible and can be wrapped in
+    JSON-LD by the consumer.  This endpoint always returns ``application/json``.
+
+    Returns 404 if the repo does not exist.
+    Returns an empty ``contributors`` list when no commits have been pushed yet.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+    return await musehub_credits.aggregate_credits(db, repo_id, sort=sort)

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -217,6 +217,38 @@ class PRMergeResponse(CamelModel):
     merge_commit_id: str
 
 
+# ── Credits models ────────────────────────────────────────────────────────────
+
+
+class ContributorCredits(CamelModel):
+    """Wire representation of a single contributor's credit record.
+
+    Aggregated from commit history — one record per unique author string.
+    Contribution types are inferred from commit message keywords so that an
+    agent or a human can understand each collaborator's role at a glance.
+    """
+
+    author: str
+    session_count: int
+    contribution_types: list[str]
+    first_active: datetime
+    last_active: datetime
+
+
+class CreditsResponse(CamelModel):
+    """Wire representation of the full credits roll for a repo.
+
+    Returned by ``GET /api/v1/musehub/repos/{repo_id}/credits``.
+    The ``sort`` field echoes back the sort order applied to the list.
+    An empty ``contributors`` list means no commits have been pushed yet.
+    """
+
+    repo_id: str
+    contributors: list[ContributorCredits]
+    sort: str
+    total_contributors: int
+
+
 # ── Object metadata model ─────────────────────────────────────────────────────
 
 

--- a/maestro/services/musehub_credits.py
+++ b/maestro/services/musehub_credits.py
@@ -1,0 +1,148 @@
+"""Credits aggregation service for Muse Hub repos.
+
+Aggregates contributor information from commit history — think dynamic album
+liner notes that update as the composition evolves.  Every pushed commit
+contributes an author name, a timestamp, and a message whose keywords are
+used to infer contribution types (composer, arranger, producer, etc.).
+
+Design decisions:
+- Pure DB read — no mutations, no side effects.
+- Contribution types are inferred from commit message keywords, not stored
+  explicitly, so they evolve as musicians describe their work more richly.
+- Sort options mirror what a label credit page would offer: by contribution
+  count (most prolific first), by recency (most recently active first), and
+  alphabetical (predictable scanning order).
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db import musehub_models as db
+from maestro.models.musehub import ContributorCredits, CreditsResponse
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Role inference keyword map
+# Keys are contribution-type labels; values are substrings to search for in
+# the lower-cased commit message.  Order matters: first match wins per token.
+# ---------------------------------------------------------------------------
+
+_ROLE_KEYWORDS: dict[str, list[str]] = {
+    "composer": ["compos", "wrote", "writing", "melody", "theme", "motif"],
+    "arranger": ["arrang", "orchestrat", "voicing", "reharmoni"],
+    "producer": ["produc", "session", "master", "mix session", "track layout"],
+    "performer": ["perform", "record", "played", "guitar", "piano", "bass", "drum"],
+    "mixer": ["mix", "blend", "balance", "eq ", "equaliz", "compressor"],
+    "editor": ["edit", "cut", "splice", "trim", "clip"],
+    "lyricist": ["lyric", "word", "verse", "chorus", "hook", "lyric"],
+    "sound designer": ["synth", "sound design", "patch", "preset", "timbre"],
+}
+
+
+def _infer_roles(message: str) -> list[str]:
+    """Return contribution type labels detected from a commit message.
+
+    Uses a simple keyword scan — sufficient for MVP.  If no keywords match,
+    falls back to ``["contributor"]`` so every commit always carries a role.
+    """
+    lower = message.lower()
+    found: list[str] = []
+    for role, keywords in _ROLE_KEYWORDS.items():
+        if any(kw in lower for kw in keywords):
+            found.append(role)
+    return found if found else ["contributor"]
+
+
+def _sort_contributors(
+    contributors: list[ContributorCredits], sort: str
+) -> list[ContributorCredits]:
+    """Apply the requested sort order to the contributor list.
+
+    Supported values:
+    - ``"count"``      — most prolific contributor first (default)
+    - ``"recency"``    — most recently active contributor first
+    - ``"alpha"``      — alphabetical by author name
+    """
+    if sort == "recency":
+        return sorted(contributors, key=lambda c: c.last_active, reverse=True)
+    if sort == "alpha":
+        return sorted(contributors, key=lambda c: c.author.lower())
+    # Default: sort by session count descending, then alpha for ties
+    return sorted(contributors, key=lambda c: (-c.session_count, c.author.lower()))
+
+
+async def aggregate_credits(
+    session: AsyncSession,
+    repo_id: str,
+    *,
+    sort: str = "count",
+) -> CreditsResponse:
+    """Aggregate contributors across all commits in a repo.
+
+    Reads every commit for the repo (no limit — credits need completeness,
+    not pagination).  Groups by author string, counts sessions, infers roles
+    from commit messages, and records activity timestamps.
+
+    Args:
+        session: Active async DB session.
+        repo_id: Target repo ID.
+        sort: Sort order for the contributor list — ``"count"`` (default),
+              ``"recency"``, or ``"alpha"``.
+
+    Returns:
+        ``CreditsResponse`` with a complete contributor list and echoed sort.
+    """
+    stmt = (
+        select(db.MusehubCommit)
+        .where(db.MusehubCommit.repo_id == repo_id)
+        .order_by(db.MusehubCommit.timestamp)
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+
+    # Per-author accumulators
+    counts: dict[str, int] = defaultdict(int)
+    roles_sets: dict[str, set[str]] = defaultdict(set)
+    first_active: dict[str, datetime] = {}
+    last_active: dict[str, datetime] = {}
+
+    for row in rows:
+        author = row.author
+        counts[author] += 1
+        for role in _infer_roles(row.message):
+            roles_sets[author].add(role)
+        ts = row.timestamp
+        if author not in first_active or ts < first_active[author]:
+            first_active[author] = ts
+        if author not in last_active or ts > last_active[author]:
+            last_active[author] = ts
+
+    contributors = [
+        ContributorCredits(
+            author=author,
+            session_count=counts[author],
+            contribution_types=sorted(roles_sets[author]),
+            first_active=first_active[author],
+            last_active=last_active[author],
+        )
+        for author in counts
+    ]
+
+    sorted_contributors = _sort_contributors(contributors, sort)
+    logger.debug(
+        "✅ Credits aggregated for repo %s: %d contributor(s), sort=%s",
+        repo_id,
+        len(sorted_contributors),
+        sort,
+    )
+    return CreditsResponse(
+        repo_id=repo_id,
+        contributors=sorted_contributors,
+        sort=sort,
+        total_contributors=len(sorted_contributors),
+    )

--- a/tests/test_musehub_repos.py
+++ b/tests/test_musehub_repos.py
@@ -1,4 +1,4 @@
-"""Tests for Muse Hub repo, branch, and commit endpoints.
+"""Tests for Muse Hub repo, branch, commit, and credits endpoints.
 
 Covers every acceptance criterion from issue #39:
 - POST /musehub/repos returns 201 with correct fields
@@ -7,16 +7,26 @@ Covers every acceptance criterion from issue #39:
 - GET /musehub/repos/{repo_id}/branches returns empty list on new repo
 - GET /musehub/repos/{repo_id}/commits returns newest first, respects ?limit
 
+Covers issue #241 (credits aggregation):
+- test_credits_aggregation             — contributors aggregated from session commits
+- test_credits_sorted_by_count         — default sort is most prolific first
+- test_credits_sorted_by_recency       — recency sort puts most recent first
+- test_credits_sorted_by_alpha         — alpha sort is lexicographic by author name
+- test_credits_404_for_unknown_repo    — credits returns 404 for non-existent repo
+- test_credits_requires_auth           — credits JSON endpoint requires JWT
+
 All tests use the shared ``client`` and ``auth_headers`` fixtures from conftest.py.
 """
 from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from maestro.db.musehub_models import MusehubCommit, MusehubRepo
-from maestro.services import musehub_repository
+from maestro.services import musehub_credits, musehub_repository
 
 
 # ---------------------------------------------------------------------------
@@ -315,3 +325,221 @@ async def test_list_branches_returns_empty_for_new_repo(db_session: AsyncSession
     await db_session.commit()
     branches = await musehub_repository.list_branches(db_session, repo.repo_id)
     assert branches == []
+
+
+# ---------------------------------------------------------------------------
+# Credits endpoint tests (issue #241)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_credits_repo(db_session: AsyncSession) -> str:
+    """Create a repo with commits from two distinct authors and return repo_id."""
+    repo = MusehubRepo(name="liner-notes", visibility="public", owner_user_id="producer-1")
+    db_session.add(repo)
+    await db_session.flush()
+    repo_id = str(repo.repo_id)
+
+    now = datetime.now(tz=timezone.utc)
+    commits = [
+        MusehubCommit(
+            commit_id="c001",
+            repo_id=repo_id,
+            branch="main",
+            parent_ids=[],
+            message="compose intro melody and theme",
+            author="Alice",
+            timestamp=now - timedelta(days=10),
+        ),
+        MusehubCommit(
+            commit_id="c002",
+            repo_id=repo_id,
+            branch="main",
+            parent_ids=["c001"],
+            message="arrang strings for verse",
+            author="Bob",
+            timestamp=now - timedelta(days=5),
+        ),
+        MusehubCommit(
+            commit_id="c003",
+            repo_id=repo_id,
+            branch="main",
+            parent_ids=["c002"],
+            message="mix and master final session",
+            author="Alice",
+            timestamp=now - timedelta(days=1),
+        ),
+    ]
+    db_session.add_all(commits)
+    await db_session.commit()
+    return repo_id
+
+
+@pytest.mark.anyio
+async def test_credits_aggregation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /api/v1/musehub/repos/{repo_id}/credits aggregates contributors from commits."""
+    repo_id = await _seed_credits_repo(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/credits",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["totalContributors"] == 2
+    authors = {c["author"] for c in body["contributors"]}
+    assert "Alice" in authors
+    assert "Bob" in authors
+
+
+@pytest.mark.anyio
+async def test_credits_sorted_by_count(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Default sort (count) puts the most prolific contributor first."""
+    repo_id = await _seed_credits_repo(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/credits?sort=count",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    contributors = body["contributors"]
+    assert contributors[0]["author"] == "Alice"
+    assert contributors[0]["sessionCount"] == 2
+    assert contributors[1]["author"] == "Bob"
+    assert contributors[1]["sessionCount"] == 1
+
+
+@pytest.mark.anyio
+async def test_credits_sorted_by_recency(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """sort=recency puts the most recently active contributor first."""
+    repo_id = await _seed_credits_repo(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/credits?sort=recency",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    contributors = response.json()["contributors"]
+    # Alice has a commit 1 day ago; Bob's last was 5 days ago
+    assert contributors[0]["author"] == "Alice"
+
+
+@pytest.mark.anyio
+async def test_credits_sorted_by_alpha(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """sort=alpha returns contributors in alphabetical order."""
+    repo_id = await _seed_credits_repo(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/credits?sort=alpha",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    contributors = response.json()["contributors"]
+    authors = [c["author"] for c in contributors]
+    assert authors == sorted(authors, key=str.lower)
+
+
+@pytest.mark.anyio
+async def test_credits_contribution_types_inferred(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Contribution types are inferred from commit messages."""
+    repo_id = await _seed_credits_repo(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/credits",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    contributors = response.json()["contributors"]
+    alice = next(c for c in contributors if c["author"] == "Alice")
+    # Alice's commits mention "compose" and "mix"
+    types = set(alice["contributionTypes"])
+    assert "composer" in types or "mixer" in types
+
+
+@pytest.mark.anyio
+async def test_credits_404_for_unknown_repo(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /api/v1/musehub/repos/{unknown}/credits returns 404."""
+    response = await client.get(
+        "/api/v1/musehub/repos/does-not-exist/credits",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_credits_requires_auth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /api/v1/musehub/repos/{repo_id}/credits returns 401 without JWT."""
+    repo = MusehubRepo(name="auth-test-repo", visibility="private", owner_user_id="u1")
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    response = await client.get(f"/api/v1/musehub/repos/{repo.repo_id}/credits")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_credits_invalid_sort_param(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /api/v1/musehub/repos/{repo_id}/credits with invalid sort returns 422."""
+    repo = MusehubRepo(name="sort-test", visibility="private", owner_user_id="u1")
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo.repo_id}/credits?sort=invalid",
+        headers=auth_headers,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_credits_aggregation_service_direct(db_session: AsyncSession) -> None:
+    """musehub_credits.aggregate_credits() returns correct data without HTTP layer."""
+    repo = MusehubRepo(name="direct-test", visibility="private", owner_user_id="u1")
+    db_session.add(repo)
+    await db_session.flush()
+    repo_id = str(repo.repo_id)
+
+    now = datetime.now(tz=timezone.utc)
+    db_session.add(
+        MusehubCommit(
+            commit_id="svc-001",
+            repo_id=repo_id,
+            branch="main",
+            parent_ids=[],
+            message="produce and mix the drop",
+            author="Charlie",
+            timestamp=now,
+        )
+    )
+    await db_session.commit()
+
+    result = await musehub_credits.aggregate_credits(db_session, repo_id)
+    assert result.total_contributors == 1
+    assert result.contributors[0].author == "Charlie"
+    assert result.contributors[0].session_count == 1
+    assert len(result.contributors[0].contribution_types) >= 1

--- a/tests/test_musehub_ui.py
+++ b/tests/test_musehub_ui.py
@@ -6,6 +6,12 @@ Covers the minimum acceptance criteria from issue #43:
 - test_ui_pr_list_page_returns_200     — PR list page renders without error
 - test_ui_issue_list_page_returns_200  — Issue list page renders without error
 
+Covers issue #241 (credits page):
+- test_credits_page_renders            — GET /musehub/ui/{repo_id}/credits returns 200 HTML
+- test_credits_json_response           — GET /api/v1/musehub/repos/{repo_id}/credits returns JSON
+- test_credits_empty_state             — empty state message when no commits exist
+- test_credits_no_auth_required        — credits UI page is accessible without JWT
+
 UI routes require no JWT auth (they return HTML shells whose JS handles auth).
 The HTML content tests assert structural markers present in every rendered page.
 """
@@ -236,3 +242,120 @@ async def test_get_object_content_404_for_unknown_object(
         headers=auth_headers,
     )
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Credits UI page tests (issue #241)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_credits_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{repo_id}/credits returns 200 HTML without requiring a JWT."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(f"/musehub/ui/{repo_id}/credits")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "Muse Hub" in body
+    assert "Credits" in body
+    assert repo_id[:8] in body
+
+
+@pytest.mark.anyio
+async def test_credits_page_contains_json_ld_injection(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Credits page embeds JSON-LD injection logic for machine-readable attribution."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(f"/musehub/ui/{repo_id}/credits")
+    assert response.status_code == 200
+    body = response.text
+    assert "application/ld+json" in body
+    assert "schema.org" in body
+    assert "MusicComposition" in body
+
+
+@pytest.mark.anyio
+async def test_credits_page_contains_sort_options(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Credits page includes sort dropdown with count, recency, and alpha options."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(f"/musehub/ui/{repo_id}/credits")
+    assert response.status_code == 200
+    body = response.text
+    assert "Most prolific" in body
+    assert "Most recent" in body
+    assert "A" in body  # "A – Z" option
+
+
+@pytest.mark.anyio
+async def test_credits_empty_state_message_in_page(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Credits page JS includes empty-state message for repos with no sessions."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(f"/musehub/ui/{repo_id}/credits")
+    assert response.status_code == 200
+    body = response.text
+    assert "muse session start" in body
+
+
+@pytest.mark.anyio
+async def test_credits_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Credits UI page must be accessible without an Authorization header (HTML shell)."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(f"/musehub/ui/{repo_id}/credits")
+    assert response.status_code == 200
+    assert response.status_code != 401
+
+
+@pytest.mark.anyio
+async def test_credits_json_response(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /api/v1/musehub/repos/{repo_id}/credits returns JSON with required fields."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/credits",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "repoId" in body
+    assert "contributors" in body
+    assert "sort" in body
+    assert "totalContributors" in body
+    assert body["repoId"] == repo_id
+    assert isinstance(body["contributors"], list)
+    assert body["sort"] == "count"
+
+
+@pytest.mark.anyio
+async def test_credits_empty_state_json(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Repo with no commits returns empty contributors list and totalContributors=0."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/credits",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["contributors"] == []
+    assert body["totalContributors"] == 0


### PR DESCRIPTION
## Summary
Closes #241 — Adds a dynamic credits page to Muse Hub that aggregates contributor attribution from commit history, like album liner notes that update as the composition evolves.

## Root Cause / Motivation
No attribution page existed for Muse Hub repos. Project leads had no way to see who contributed what across sessions, making it hard to credit collaborators correctly at release time.

## Solution
- **`maestro/services/musehub_credits.py`** — `aggregate_credits()` groups all commits in a repo by author, counts sessions, infers contribution types from commit message keywords (`_ROLE_KEYWORDS` maps roles like composer/arranger/producer/mixer/performer to message substrings), and tracks first/last activity timestamps. Pure DB read, no side effects.
- **`maestro/models/musehub.py`** — `ContributorCredits` and `CreditsResponse` Pydantic v2 response models registered as typed named entities.
- **`maestro/api/routes/musehub/repos.py`** — `GET /api/v1/musehub/repos/{repo_id}/credits?sort=count|recency|alpha` endpoint. Returns 404 for unknown repos, 422 for invalid sort values.
- **`maestro/api/routes/musehub/ui.py`** — `GET /musehub/ui/{repo_id}/credits` HTML page with contributor list, sort dropdown, empty-state message (`"No sessions recorded yet. Start a session with muse session start."`), and `<script type="application/ld+json">` injection for machine-readable schema.org `MusicComposition` attribution. Credits link added to repo landing page.

## Layers Affected
- [x] Muse VCS
- [ ] Intent Engine
- [ ] Pipeline
- [ ] Maestro Handlers
- [ ] Agent Teams
- [ ] Storpheus Client
- [ ] MCP
- [ ] DAW Adapter
- [ ] Auth / Budget
- [ ] RAG
- [ ] Variation
- [ ] SSE Protocol

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (pre-existing untyped third-party stubs only)
- [x] `docker compose exec storpheus mypy .` — N/A (no Storpheus changes)
- [x] 42 tests pass (`test_musehub_ui.py` + `test_musehub_repos.py`) — zero failures, zero warnings
- [x] Affected docs updated (muse_vcs.md + type_contracts.md)

## Tests Added
- `test_credits_page_renders` — credits page returns 200 HTML (UI)
- `test_credits_page_contains_json_ld_injection` — JSON-LD schema.org block present
- `test_credits_page_contains_sort_options` — sort dropdown options present
- `test_credits_empty_state_message_in_page` — empty state JS message present
- `test_credits_no_auth_required` — UI page accessible without JWT
- `test_credits_json_response` — JSON endpoint returns all required fields
- `test_credits_empty_state_json` — empty contributors list for new repo
- `test_credits_aggregation` — contributors correctly aggregated from commits
- `test_credits_sorted_by_count` — most prolific contributor first
- `test_credits_sorted_by_recency` — most recently active contributor first
- `test_credits_sorted_by_alpha` — alphabetical order
- `test_credits_contribution_types_inferred` — roles inferred from commit messages
- `test_credits_404_for_unknown_repo` — 404 for non-existent repo
- `test_credits_requires_auth` — 401 without JWT
- `test_credits_invalid_sort_param` — 422 for invalid sort value
- `test_credits_aggregation_service_direct` — service layer tested without HTTP

## Handoff
N/A — no protocol change. Credits page is a read-only Muse Hub feature, no SSE events or MCP tool schema changes.