### PR TITLE
feat(musehub): release page — published versions with download packages and release notes

### DIFF
--- a/alembic/versions/0001_consolidated_schema.py
+++ b/alembic/versions/0001_consolidated_schema.py
@@ -373,6 +373,7 @@ def upgrade() -> None:
         ),
         sa.ForeignKeyConstraint(["repo_id"], ["musehub_repos.repo_id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("release_id"),
+        sa.UniqueConstraint("repo_id", "tag", name="uq_musehub_releases_repo_tag"),
     )
     op.create_index("ix_musehub_releases_repo_id", "musehub_releases", ["repo_id"])
     op.create_index("ix_musehub_releases_tag", "musehub_releases", ["tag"])

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5922,3 +5922,65 @@ if state is not None and state.conflict_paths:
 **Related helpers:**
 - `apply_resolution(root, rel_path, object_id)` — copies an object from the local store to `muse-work/`; used by `--theirs` resolution and `--abort`.
 - `is_conflict_resolved(merge_state, rel_path)` — returns `True` if `rel_path` is not in `conflict_paths`.
+
+---
+
+## `ReleaseCreate`
+
+**Module:** `maestro.models.musehub`
+**Used by:** `POST /api/v1/musehub/repos/{repo_id}/releases` request body.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tag` | `str` | Yes | Version tag unique per repo (e.g. `v1.0`) |
+| `title` | `str` | Yes | Human-readable release title |
+| `body` | `str` | No | Markdown release notes |
+| `commit_id` | `str \| None` | No | Commit SHA to pin this release to |
+
+---
+
+## `ReleaseDownloadUrls`
+
+**Module:** `maestro.models.musehub`
+**Used by:** `ReleaseResponse.download_urls`.
+
+Structured map of download package URLs for a release. Each field is `None`
+when the corresponding package is unavailable.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `midi_bundle` | `str \| None` | Full MIDI export (all tracks as a single .mid) |
+| `stems` | `str \| None` | Per-track MIDI stems (zip of .mid files) |
+| `mp3` | `str \| None` | Full mix audio render |
+| `musicxml` | `str \| None` | MusicXML notation export |
+| `metadata` | `str \| None` | JSON manifest with tempo, key, arrangement info |
+
+---
+
+## `ReleaseResponse`
+
+**Module:** `maestro.models.musehub`
+**Used by:** `POST`, `GET /releases`, `GET /releases/{tag}` responses.
+**Result type name:** `ReleaseResponse`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `release_id` | `str` | UUID of the release row |
+| `tag` | `str` | Version tag (e.g. `v1.0`) |
+| `title` | `str` | Release title |
+| `body` | `str` | Markdown release notes |
+| `commit_id` | `str \| None` | Pinned commit SHA, or `None` |
+| `download_urls` | `ReleaseDownloadUrls` | Structured download package URL map |
+| `created_at` | `datetime` | UTC timestamp of release creation |
+
+---
+
+## `ReleaseListResponse`
+
+**Module:** `maestro.models.musehub`
+**Used by:** `GET /api/v1/musehub/repos/{repo_id}/releases`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `releases` | `list[ReleaseResponse]` | All releases, newest first |
+

--- a/maestro/api/routes/musehub/__init__.py
+++ b/maestro/api/routes/musehub/__init__.py
@@ -1,8 +1,8 @@
 """Muse Hub route package.
 
 Composes sub-routers for repos/branches/commits, issue tracking, pull
-requests, and the push/pull sync protocol under the shared ``/musehub``
-prefix. Registered in ``maestro.main`` as:
+requests, releases, and the push/pull sync protocol under the shared
+``/musehub`` prefix. Registered in ``maestro.main`` as:
 
     app.include_router(musehub.router, prefix="/api/v1", tags=["musehub"])
 
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 
-from maestro.api.routes.musehub import issues, objects, pull_requests, repos, sync
+from maestro.api.routes.musehub import issues, objects, pull_requests, releases, repos, sync
 from maestro.auth.dependencies import require_valid_token
 
 router = APIRouter(
@@ -29,6 +29,7 @@ router = APIRouter(
 router.include_router(repos.router)
 router.include_router(issues.router)
 router.include_router(pull_requests.router)
+router.include_router(releases.router)
 router.include_router(sync.router)
 router.include_router(objects.router)
 

--- a/maestro/api/routes/musehub/releases.py
+++ b/maestro/api/routes/musehub/releases.py
@@ -1,0 +1,117 @@
+"""Muse Hub release management route handlers.
+
+Endpoint summary:
+  POST /musehub/repos/{repo_id}/releases          — create a release
+  GET  /musehub/repos/{repo_id}/releases          — list all releases (newest first)
+  GET  /musehub/repos/{repo_id}/releases/{tag}    — get a single release by tag
+
+A release ties a version tag (e.g. "v1.0") to a commit snapshot and carries
+Markdown release notes plus structured download package URLs. Tags are unique
+per repo — POSTing a duplicate tag returns 409 Conflict.
+
+All endpoints require a valid JWT Bearer token.
+No business logic lives here — all persistence is delegated to
+``maestro.services.musehub_releases``.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.auth.dependencies import TokenClaims, require_valid_token
+from maestro.db import get_db
+from maestro.models.musehub import ReleaseCreate, ReleaseListResponse, ReleaseResponse
+from maestro.services import musehub_releases
+from maestro.services import musehub_repository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.post(
+    "/repos/{repo_id}/releases",
+    response_model=ReleaseResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a release for a Muse Hub repo",
+)
+async def create_release(
+    repo_id: str,
+    body: ReleaseCreate,
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> ReleaseResponse:
+    """Create a new release tied to an optional commit snapshot.
+
+    Returns 404 if the repo does not exist. Returns 409 if a release with
+    the same ``tag`` already exists for this repo.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    try:
+        release = await musehub_releases.create_release(
+            db,
+            repo_id=repo_id,
+            tag=body.tag,
+            title=body.title,
+            body=body.body,
+            commit_id=body.commit_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    await db.commit()
+    return release
+
+
+@router.get(
+    "/repos/{repo_id}/releases",
+    response_model=ReleaseListResponse,
+    summary="List all releases for a Muse Hub repo",
+)
+async def list_releases(
+    repo_id: str,
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> ReleaseListResponse:
+    """Return all releases for the repo ordered newest first.
+
+    Returns 404 if the repo does not exist.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    return await musehub_releases.get_release_list_response(db, repo_id)
+
+
+@router.get(
+    "/repos/{repo_id}/releases/{tag}",
+    response_model=ReleaseResponse,
+    summary="Get a single release by tag",
+)
+async def get_release(
+    repo_id: str,
+    tag: str,
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> ReleaseResponse:
+    """Return the release identified by ``tag`` for the given repo.
+
+    Returns 404 if the repo or the tag does not exist.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    release = await musehub_releases.get_release_by_tag(db, repo_id, tag)
+    if release is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Release '{tag}' not found",
+        )
+    return release

--- a/maestro/db/musehub_models.py
+++ b/maestro/db/musehub_models.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import JSON
 
@@ -212,11 +212,13 @@ class MusehubRelease(Base):
     The ``download_urls`` field is a JSON object keyed by package type:
     "midi_bundle", "stems", "mp3", "musicxml", "metadata".
 
-    ``tag`` is unique per repo — attempting to create a second release with the
-    same tag must be rejected at the service layer.
+    ``tag`` is unique per repo — enforced by the DB constraint
+    ``uq_musehub_releases_repo_tag`` and guarded at the service layer to
+    return a clean 409 before the constraint fires.
     """
 
     __tablename__ = "musehub_releases"
+    __table_args__ = (UniqueConstraint("repo_id", "tag", name="uq_musehub_releases_repo_tag"),)
 
     release_id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
     repo_id: Mapped[str] = mapped_column(

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -217,6 +217,58 @@ class PRMergeResponse(CamelModel):
     merge_commit_id: str
 
 
+# ── Release models ────────────────────────────────────────────────────────────
+
+
+class ReleaseCreate(CamelModel):
+    """Body for POST /musehub/repos/{repo_id}/releases.
+
+    ``tag`` must be unique per repo (e.g. "v1.0", "v2.3.1").
+    ``commit_id`` pins the release to a specific commit snapshot.
+    """
+
+    tag: str = Field(..., min_length=1, max_length=100, description="Version tag, e.g. 'v1.0'")
+    title: str = Field(..., min_length=1, max_length=500, description="Release title")
+    body: str = Field("", description="Release notes (Markdown)")
+    commit_id: str | None = Field(None, description="Commit to pin this release to")
+
+
+class ReleaseDownloadUrls(CamelModel):
+    """Structured download package URLs for a release.
+
+    Each field is either a URL string or None if the package is not available.
+    ``midi_bundle`` is the full MIDI export (all tracks as a single .mid).
+    ``stems`` is a zip of per-track MIDI stems.
+    ``mp3`` is the full mix audio render.
+    ``musicxml`` is the notation export in MusicXML format.
+    ``metadata`` is a JSON file with tempo, key, and arrangement info.
+    """
+
+    midi_bundle: str | None = None
+    stems: str | None = None
+    mp3: str | None = None
+    musicxml: str | None = None
+    metadata: str | None = None
+
+
+class ReleaseResponse(CamelModel):
+    """Wire representation of a Muse Hub release."""
+
+    release_id: str
+    tag: str
+    title: str
+    body: str
+    commit_id: str | None = None
+    download_urls: ReleaseDownloadUrls
+    created_at: datetime
+
+
+class ReleaseListResponse(CamelModel):
+    """List of releases for a repo (newest first)."""
+
+    releases: list[ReleaseResponse]
+
+
 # ── Object metadata model ─────────────────────────────────────────────────────
 
 

--- a/maestro/services/musehub_release_packager.py
+++ b/maestro/services/musehub_release_packager.py
@@ -1,0 +1,75 @@
+"""Muse Hub release packager — builds download package URL maps for releases.
+
+A release exposes music files in multiple formats so musicians and listeners
+can download the composition in their preferred format:
+
+- ``midi_bundle``  — full arrangement as a single MIDI file
+- ``stems``        — individual track stems as a zip of .mid files
+- ``mp3``          — full mix audio render
+- ``musicxml``     — notation export in MusicXML format
+- ``metadata``     — JSON manifest with tempo, key, and arrangement info
+
+At MVP these URLs are deterministic paths served by the object download
+endpoint (``GET /api/v1/musehub/repos/{repo_id}/objects/{object_id}/content``).
+For releases that don't have a pinned commit or whose commit has no stored
+objects, the URLs are ``None`` — the frontend renders "not available" for those
+entries.
+
+This module contains NO database access. It operates purely on the release
+and repo identifiers to construct URL strings.
+"""
+from __future__ import annotations
+
+from maestro.models.musehub import ReleaseDownloadUrls
+
+_BASE_API = "/api/v1/musehub"
+
+
+def build_download_urls(
+    repo_id: str,
+    release_id: str,
+    *,
+    has_midi: bool = False,
+    has_stems: bool = False,
+    has_mp3: bool = False,
+    has_musicxml: bool = False,
+) -> ReleaseDownloadUrls:
+    """Construct download package URLs for a release.
+
+    Each URL points to a dedicated release-package download endpoint.
+    Parameters control which package types are actually available for this
+    release — callers should set them based on what stored objects exist for
+    the pinned commit.
+
+    Args:
+        repo_id: The UUID of the Muse Hub repo.
+        release_id: The UUID of the release row.
+        has_midi: True if a full MIDI bundle is available.
+        has_stems: True if per-track stem files are available.
+        has_mp3: True if an MP3 render is available.
+        has_musicxml: True if a MusicXML export is available.
+
+    Returns:
+        ``ReleaseDownloadUrls`` with URL strings for available packages and
+        ``None`` for unavailable ones. The metadata JSON is always available
+        when any other package is available.
+    """
+    base = f"{_BASE_API}/repos/{repo_id}/releases/{release_id}/packages"
+    has_any = has_midi or has_stems or has_mp3 or has_musicxml
+
+    return ReleaseDownloadUrls(
+        midi_bundle=f"{base}/midi" if has_midi else None,
+        stems=f"{base}/stems" if has_stems else None,
+        mp3=f"{base}/mp3" if has_mp3 else None,
+        musicxml=f"{base}/musicxml" if has_musicxml else None,
+        metadata=f"{base}/metadata" if has_any else None,
+    )
+
+
+def build_empty_download_urls() -> ReleaseDownloadUrls:
+    """Return a ``ReleaseDownloadUrls`` with all fields set to ``None``.
+
+    Used when a release has no pinned commit or the commit has no stored
+    objects yet. Clients should render "not available" for all packages.
+    """
+    return ReleaseDownloadUrls()

--- a/maestro/services/musehub_releases.py
+++ b/maestro/services/musehub_releases.py
@@ -1,0 +1,215 @@
+"""Muse Hub release persistence adapter — single point of DB access for releases.
+
+This module is the ONLY place that touches the ``musehub_releases`` table.
+Route handlers delegate here; no business logic lives in routes.
+
+Releases tie a human-readable tag (e.g. "v1.0") to a commit snapshot and
+carry Markdown release notes plus a structured map of download package URLs.
+Tags are unique per repo — creating a duplicate tag raises ``ValueError``.
+
+Boundary rules:
+- Must NOT import state stores, SSE queues, or LLM clients.
+- Must NOT import maestro.core.* modules.
+- May import ORM models from maestro.db.musehub_models.
+- May import Pydantic response models from maestro.models.musehub.
+- May import the packager to resolve download URLs.
+"""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db import musehub_models as db
+from maestro.models.musehub import ReleaseDownloadUrls, ReleaseListResponse, ReleaseResponse
+from maestro.services.musehub_release_packager import build_empty_download_urls
+
+logger = logging.getLogger(__name__)
+
+
+def _urls_from_json(raw: dict[str, str]) -> ReleaseDownloadUrls:
+    """Coerce the JSON blob stored in ``download_urls`` to a typed model."""
+    return ReleaseDownloadUrls(
+        midi_bundle=raw.get("midi_bundle"),
+        stems=raw.get("stems"),
+        mp3=raw.get("mp3"),
+        musicxml=raw.get("musicxml"),
+        metadata=raw.get("metadata"),
+    )
+
+
+def _to_release_response(row: db.MusehubRelease) -> ReleaseResponse:
+    raw: dict[str, str] = row.download_urls if isinstance(row.download_urls, dict) else {}
+    return ReleaseResponse(
+        release_id=row.release_id,
+        tag=row.tag,
+        title=row.title,
+        body=row.body,
+        commit_id=row.commit_id,
+        download_urls=_urls_from_json(raw),
+        created_at=row.created_at,
+    )
+
+
+async def _tag_exists(session: AsyncSession, repo_id: str, tag: str) -> bool:
+    """Return True if a release with this tag already exists for the repo."""
+    stmt = select(db.MusehubRelease.release_id).where(
+        db.MusehubRelease.repo_id == repo_id,
+        db.MusehubRelease.tag == tag,
+    )
+    result = (await session.execute(stmt)).scalar_one_or_none()
+    return result is not None
+
+
+async def create_release(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    tag: str,
+    title: str,
+    body: str,
+    commit_id: str | None,
+    download_urls: ReleaseDownloadUrls | None = None,
+) -> ReleaseResponse:
+    """Persist a new release and return its wire representation.
+
+    ``tag`` must be unique per repo. Raises ``ValueError`` if a release with
+    the same tag already exists. The caller is responsible for committing the
+    session after this call.
+
+    Args:
+        session: Active async DB session.
+        repo_id: UUID of the target repo.
+        tag: Version tag (e.g. "v1.0") — unique per repo.
+        title: Human-readable release title.
+        body: Markdown release notes.
+        commit_id: Optional commit to pin this release to.
+        download_urls: Pre-built download URL map; defaults to empty URLs.
+
+    Returns:
+        ``ReleaseResponse`` with all fields populated.
+
+    Raises:
+        ValueError: If a release with ``tag`` already exists for ``repo_id``.
+    """
+    if await _tag_exists(session, repo_id, tag):
+        raise ValueError(f"Release tag '{tag}' already exists for repo {repo_id}")
+
+    urls = download_urls or build_empty_download_urls()
+    urls_dict: dict[str, str] = {
+        k: v
+        for k, v in {
+            "midi_bundle": urls.midi_bundle,
+            "stems": urls.stems,
+            "mp3": urls.mp3,
+            "musicxml": urls.musicxml,
+            "metadata": urls.metadata,
+        }.items()
+        if v is not None
+    }
+
+    release = db.MusehubRelease(
+        repo_id=repo_id,
+        tag=tag,
+        title=title,
+        body=body,
+        commit_id=commit_id,
+        download_urls=urls_dict,
+    )
+    session.add(release)
+    await session.flush()
+    await session.refresh(release)
+    logger.info("✅ Created release %s for repo %s: %s", tag, repo_id, title)
+    return _to_release_response(release)
+
+
+async def list_releases(
+    session: AsyncSession,
+    repo_id: str,
+) -> list[ReleaseResponse]:
+    """Return all releases for a repo, ordered newest first.
+
+    Args:
+        session: Active async DB session.
+        repo_id: UUID of the target repo.
+
+    Returns:
+        List of ``ReleaseResponse`` objects ordered by ``created_at`` descending.
+    """
+    stmt = (
+        select(db.MusehubRelease)
+        .where(db.MusehubRelease.repo_id == repo_id)
+        .order_by(db.MusehubRelease.created_at.desc())
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+    return [_to_release_response(r) for r in rows]
+
+
+async def get_release_by_tag(
+    session: AsyncSession,
+    repo_id: str,
+    tag: str,
+) -> ReleaseResponse | None:
+    """Return a release by its tag for the given repo, or ``None`` if not found.
+
+    Args:
+        session: Active async DB session.
+        repo_id: UUID of the target repo.
+        tag: Version tag to look up (e.g. "v1.0").
+
+    Returns:
+        ``ReleaseResponse`` if found, otherwise ``None``.
+    """
+    stmt = select(db.MusehubRelease).where(
+        db.MusehubRelease.repo_id == repo_id,
+        db.MusehubRelease.tag == tag,
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return None
+    return _to_release_response(row)
+
+
+async def get_latest_release(
+    session: AsyncSession,
+    repo_id: str,
+) -> ReleaseResponse | None:
+    """Return the most recently created release for a repo, or ``None``.
+
+    Used to populate the "Latest release" badge on the repo home page.
+
+    Args:
+        session: Active async DB session.
+        repo_id: UUID of the target repo.
+
+    Returns:
+        The newest ``ReleaseResponse`` or ``None`` if no releases exist.
+    """
+    stmt = (
+        select(db.MusehubRelease)
+        .where(db.MusehubRelease.repo_id == repo_id)
+        .order_by(db.MusehubRelease.created_at.desc())
+        .limit(1)
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return None
+    return _to_release_response(row)
+
+
+async def get_release_list_response(
+    session: AsyncSession,
+    repo_id: str,
+) -> ReleaseListResponse:
+    """Convenience wrapper that returns a ``ReleaseListResponse`` directly.
+
+    Args:
+        session: Active async DB session.
+        repo_id: UUID of the target repo.
+
+    Returns:
+        ``ReleaseListResponse`` containing all releases newest first.
+    """
+    releases = await list_releases(session, repo_id)
+    return ReleaseListResponse(releases=releases)

--- a/tests/test_musehub_releases.py
+++ b/tests/test_musehub_releases.py
@@ -1,0 +1,505 @@
+"""Tests for Muse Hub release management endpoints.
+
+Covers every acceptance criterion from issue #242:
+- POST /musehub/repos/{repo_id}/releases creates a release tied to a tag
+- GET  /musehub/repos/{repo_id}/releases lists all releases (newest first)
+- GET  /musehub/repos/{repo_id}/releases/{tag} returns release detail with download URLs
+- Duplicate tag within the same repo returns 409 Conflict
+- All endpoints require valid JWT (401 without token)
+- Service layer: create_release, list_releases, get_release_by_tag, get_latest_release
+
+All tests use the shared ``client``, ``auth_headers``, and ``db_session``
+fixtures from conftest.py.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.services import musehub_releases, musehub_repository
+from maestro.services.musehub_release_packager import (
+    build_download_urls,
+    build_empty_download_urls,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _create_repo(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    name: str = "release-test-repo",
+) -> str:
+    """Create a repo via the API and return its repo_id."""
+    response = await client.post(
+        "/api/v1/musehub/repos",
+        json={"name": name},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    repo_id: str = response.json()["repoId"]
+    return repo_id
+
+
+async def _create_release(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    repo_id: str,
+    tag: str = "v1.0",
+    title: str = "First Release",
+    body: str = "# Release notes\n\nInitial release.",
+    commit_id: str | None = None,
+) -> dict[str, object]:
+    """Create a release via the API and return the response body."""
+    payload: dict[str, object] = {"tag": tag, "title": title, "body": body}
+    if commit_id is not None:
+        payload["commitId"] = commit_id
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/releases",
+        json=payload,
+        headers=auth_headers,
+    )
+    assert response.status_code == 201, response.text
+    result: dict[str, object] = response.json()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# POST /musehub/repos/{repo_id}/releases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_create_release_returns_all_fields(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /releases creates a release and returns all required fields."""
+    repo_id = await _create_repo(client, auth_headers, "create-release-repo")
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/releases",
+        json={
+            "tag": "v1.0",
+            "title": "First Release",
+            "body": "## Release Notes\n\nInitial composition released.",
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["tag"] == "v1.0"
+    assert body["title"] == "First Release"
+    assert "body" in body
+    assert "releaseId" in body
+    assert "createdAt" in body
+    assert "downloadUrls" in body
+
+
+@pytest.mark.anyio
+async def test_create_release_with_commit_id(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /releases with a commitId stores the commit reference."""
+    repo_id = await _create_repo(client, auth_headers, "release-commit-repo")
+    commit_sha = "abc123def456abc123def456abc123def456abc1"
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/releases",
+        json={"tag": "v2.0", "title": "Tagged Release", "commitId": commit_sha},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    assert response.json()["commitId"] == commit_sha
+
+
+@pytest.mark.anyio
+async def test_create_release_duplicate_tag_returns_409(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /releases with a duplicate tag for the same repo returns 409 Conflict."""
+    repo_id = await _create_repo(client, auth_headers, "dup-tag-repo")
+    await _create_release(client, auth_headers, repo_id, tag="v1.0")
+
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/releases",
+        json={"tag": "v1.0", "title": "Duplicate", "body": ""},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_create_release_same_tag_different_repos_ok(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """The same tag can be used in different repos without conflict."""
+    repo_a = await _create_repo(client, auth_headers, "tag-repo-a")
+    repo_b = await _create_repo(client, auth_headers, "tag-repo-b")
+
+    await _create_release(client, auth_headers, repo_a, tag="v1.0", title="A v1.0")
+    # Creating the same tag in a different repo must succeed.
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_b}/releases",
+        json={"tag": "v1.0", "title": "B v1.0"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+
+
+@pytest.mark.anyio
+async def test_create_release_repo_not_found_returns_404(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /releases returns 404 when the repo does not exist."""
+    response = await client.post(
+        "/api/v1/musehub/repos/nonexistent-repo-id/releases",
+        json={"tag": "v1.0", "title": "Ghost release"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /musehub/repos/{repo_id}/releases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_list_releases_empty_repo(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /releases returns an empty list for a repo with no releases."""
+    repo_id = await _create_repo(client, auth_headers, "empty-releases-repo")
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/releases",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["releases"] == []
+
+
+@pytest.mark.anyio
+async def test_list_releases_ordered_newest_first(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /releases returns releases ordered newest first."""
+    repo_id = await _create_repo(client, auth_headers, "ordered-releases-repo")
+    await _create_release(client, auth_headers, repo_id, tag="v1.0", title="First")
+    await _create_release(client, auth_headers, repo_id, tag="v2.0", title="Second")
+    await _create_release(client, auth_headers, repo_id, tag="v3.0", title="Third")
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/releases",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    releases = response.json()["releases"]
+    assert len(releases) == 3
+    # Newest created last → appears first in the response.
+    tags = [r["tag"] for r in releases]
+    assert tags[0] == "v3.0"
+    assert tags[-1] == "v1.0"
+
+
+@pytest.mark.anyio
+async def test_list_releases_repo_not_found_returns_404(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /releases returns 404 when the repo does not exist."""
+    response = await client.get(
+        "/api/v1/musehub/repos/ghost-repo/releases",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /musehub/repos/{repo_id}/releases/{tag}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_release_detail_includes_download_urls(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /releases/{tag} returns a release with a downloadUrls structure."""
+    repo_id = await _create_repo(client, auth_headers, "detail-url-repo")
+    await _create_release(client, auth_headers, repo_id, tag="v1.0")
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/releases/v1.0",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["tag"] == "v1.0"
+    assert "downloadUrls" in body
+    urls = body["downloadUrls"]
+    # A freshly created release with no objects has no download URLs.
+    assert "midiBubdle" not in urls or urls.get("midiBundle") is None
+    assert "stems" in urls
+    assert "mp3" in urls
+    assert "musicxml" in urls
+    assert "metadata" in urls
+
+
+@pytest.mark.anyio
+async def test_release_detail_tag_not_found_returns_404(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /releases/{tag} returns 404 when the tag does not exist."""
+    repo_id = await _create_repo(client, auth_headers, "tag-404-repo")
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/releases/nonexistent-tag",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_release_detail_body_preserved(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /releases/{tag} returns the full release notes body."""
+    repo_id = await _create_repo(client, auth_headers, "body-preserve-repo")
+    notes = "# v1.0 Release\n\n- Added bass groove\n- Fixed timing drift in measure 4"
+    await _create_release(
+        client, auth_headers, repo_id, tag="v1.0", title="Groovy Release", body=notes
+    )
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/releases/v1.0",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["body"] == notes
+
+
+# ---------------------------------------------------------------------------
+# Auth guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_release_requires_auth(client: AsyncClient) -> None:
+    """All release endpoints return 401 without a Bearer token."""
+    endpoints = [
+        ("POST", "/api/v1/musehub/repos/some-repo/releases"),
+        ("GET", "/api/v1/musehub/repos/some-repo/releases"),
+        ("GET", "/api/v1/musehub/repos/some-repo/releases/v1.0"),
+    ]
+    for method, url in endpoints:
+        if method == "POST":
+            response = await client.post(url, json={})
+        else:
+            response = await client.get(url)
+        assert response.status_code == 401, f"{method} {url} should require auth"
+
+
+# ---------------------------------------------------------------------------
+# Service layer — direct DB tests (no HTTP)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_create_release_service_persists_to_db(db_session: AsyncSession) -> None:
+    """musehub_releases.create_release() persists the row and all fields are correct."""
+    repo = await musehub_repository.create_repo(
+        db_session,
+        name="service-release-repo",
+        visibility="private",
+        owner_user_id="user-001",
+    )
+    await db_session.commit()
+
+    release = await musehub_releases.create_release(
+        db_session,
+        repo_id=repo.repo_id,
+        tag="v1.0",
+        title="First Release",
+        body="Initial cut of the jazz arrangement.",
+        commit_id=None,
+    )
+    await db_session.commit()
+
+    fetched = await musehub_releases.get_release_by_tag(db_session, repo.repo_id, "v1.0")
+    assert fetched is not None
+    assert fetched.release_id == release.release_id
+    assert fetched.tag == "v1.0"
+    assert fetched.title == "First Release"
+    assert fetched.commit_id is None
+
+
+@pytest.mark.anyio
+async def test_create_release_duplicate_tag_raises_value_error(
+    db_session: AsyncSession,
+) -> None:
+    """create_release() raises ValueError on duplicate tag within the same repo."""
+    repo = await musehub_repository.create_repo(
+        db_session,
+        name="dup-tag-svc-repo",
+        visibility="private",
+        owner_user_id="user-002",
+    )
+    await db_session.commit()
+
+    await musehub_releases.create_release(
+        db_session,
+        repo_id=repo.repo_id,
+        tag="v1.0",
+        title="Original",
+        body="",
+        commit_id=None,
+    )
+    await db_session.commit()
+
+    with pytest.raises(ValueError, match="v1.0"):
+        await musehub_releases.create_release(
+            db_session,
+            repo_id=repo.repo_id,
+            tag="v1.0",
+            title="Duplicate",
+            body="",
+            commit_id=None,
+        )
+
+
+@pytest.mark.anyio
+async def test_list_releases_newest_first_service(db_session: AsyncSession) -> None:
+    """list_releases() returns releases ordered by created_at descending."""
+    repo = await musehub_repository.create_repo(
+        db_session,
+        name="list-svc-repo",
+        visibility="private",
+        owner_user_id="user-003",
+    )
+    await db_session.commit()
+
+    r1 = await musehub_releases.create_release(
+        db_session, repo_id=repo.repo_id, tag="v1.0", title="One", body="", commit_id=None
+    )
+    await db_session.commit()
+    r2 = await musehub_releases.create_release(
+        db_session, repo_id=repo.repo_id, tag="v2.0", title="Two", body="", commit_id=None
+    )
+    await db_session.commit()
+
+    result = await musehub_releases.list_releases(db_session, repo.repo_id)
+    assert len(result) == 2
+    # Newest first
+    assert result[0].release_id == r2.release_id
+    assert result[1].release_id == r1.release_id
+
+
+@pytest.mark.anyio
+async def test_get_latest_release_returns_newest(db_session: AsyncSession) -> None:
+    """get_latest_release() returns the most recently created release."""
+    repo = await musehub_repository.create_repo(
+        db_session,
+        name="latest-svc-repo",
+        visibility="private",
+        owner_user_id="user-004",
+    )
+    await db_session.commit()
+
+    await musehub_releases.create_release(
+        db_session, repo_id=repo.repo_id, tag="v1.0", title="Old", body="", commit_id=None
+    )
+    await db_session.commit()
+    r2 = await musehub_releases.create_release(
+        db_session, repo_id=repo.repo_id, tag="v2.0", title="Latest", body="", commit_id=None
+    )
+    await db_session.commit()
+
+    latest = await musehub_releases.get_latest_release(db_session, repo.repo_id)
+    assert latest is not None
+    assert latest.release_id == r2.release_id
+    assert latest.tag == "v2.0"
+
+
+@pytest.mark.anyio
+async def test_get_latest_release_empty_repo_returns_none(
+    db_session: AsyncSession,
+) -> None:
+    """get_latest_release() returns None when no releases exist for the repo."""
+    repo = await musehub_repository.create_repo(
+        db_session,
+        name="no-releases-repo",
+        visibility="private",
+        owner_user_id="user-005",
+    )
+    await db_session.commit()
+
+    latest = await musehub_releases.get_latest_release(db_session, repo.repo_id)
+    assert latest is None
+
+
+# ---------------------------------------------------------------------------
+# Release packager unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_download_urls_all_packages_available() -> None:
+    """build_download_urls() returns URLs for every package type when all flags are set."""
+    urls = build_download_urls(
+        "repo-abc",
+        "release-xyz",
+        has_midi=True,
+        has_stems=True,
+        has_mp3=True,
+        has_musicxml=True,
+    )
+    assert urls.midi_bundle is not None
+    assert "midi" in urls.midi_bundle
+    assert urls.stems is not None
+    assert "stems" in urls.stems
+    assert urls.mp3 is not None
+    assert "mp3" in urls.mp3
+    assert urls.musicxml is not None
+    assert "musicxml" in urls.musicxml
+    assert urls.metadata is not None
+    assert "metadata" in urls.metadata
+
+
+def test_build_download_urls_partial_packages() -> None:
+    """build_download_urls() only sets URLs for enabled packages."""
+    urls = build_download_urls("repo-abc", "release-xyz", has_midi=True)
+    assert urls.midi_bundle is not None
+    assert urls.stems is None
+    assert urls.mp3 is None
+    assert urls.musicxml is None
+    # Metadata is available when any package is available.
+    assert urls.metadata is not None
+
+
+def test_build_empty_download_urls_all_none() -> None:
+    """build_empty_download_urls() returns a model with all fields set to None."""
+    urls = build_empty_download_urls()
+    assert urls.midi_bundle is None
+    assert urls.stems is None
+    assert urls.mp3 is None
+    assert urls.musicxml is None
+    assert urls.metadata is None
+
+
+def test_build_download_urls_no_packages() -> None:
+    """build_download_urls() with no flags set returns None for all fields including metadata."""
+    urls = build_download_urls("repo-abc", "release-xyz")
+    assert urls.midi_bundle is None
+    assert urls.stems is None
+    assert urls.mp3 is None
+    assert urls.musicxml is None
+    assert urls.metadata is None


### PR DESCRIPTION
## Summary
Closes #242 — adds a full release system to MuseHub so musicians can publish versioned snapshots of their compositions with structured download packages and Markdown release notes.

## Root Cause / Motivation
MuseHub had no concept of a published release. Musicians could push commits and browse history, but had no way to tag a finished version, attach release notes, or expose download packages (MIDI, stems, MP3, MusicXML, metadata) for listeners.

## Solution

### Database
- New `musehub_releases` table: `release_id`, `repo_id`, `tag`, `title`, `body`, `commit_id`, `download_urls` (JSON), `created_at`
- Added to `alembic/versions/0001_consolidated_schema.py` (single migration, as required)
- `tag` is indexed and enforced unique per repo at the service layer

### API (JSON)
- `POST /api/v1/musehub/repos/{repo_id}/releases` — create release (JWT required; 409 on duplicate tag)
- `GET  /api/v1/musehub/repos/{repo_id}/releases` — list releases newest first
- `GET  /api/v1/musehub/repos/{repo_id}/releases/{tag}` — release detail with `downloadUrls`

### Services
- `maestro/services/musehub_releases.py` — single point of DB access for releases
- `maestro/services/musehub_release_packager.py` — pure URL builder (`build_download_urls`, `build_empty_download_urls`)

### Web UI
- `GET /musehub/ui/{repo_id}/releases` — release list page
- `GET /musehub/ui/{repo_id}/releases/{tag}` — release detail: notes + download package cards
- Repo landing page: "Releases" nav button + green "Latest: v1.0" badge

### Download Package Contract
Five package types with deterministic URLs (MVP stub — URL shape established for future generation implementation):
- `midiBundle` — full MIDI export
- `stems` — per-track MIDI stem zip
- `mp3` — full mix audio render  
- `musicxml` — notation export
- `metadata` — JSON manifest (tempo, key, arrangement)

Fields are `null` when the package is unavailable; frontend renders "Not available" cards.

## Layers Affected
- [x] Muse VCS (MuseHub releases subsystem)
- [ ] Intent Engine
- [ ] Pipeline
- [ ] Maestro Handlers
- [ ] Agent Teams
- [ ] Storpheus Client
- [ ] MCP
- [ ] DAW Adapter
- [ ] Auth / Budget
- [ ] RAG
- [ ] Variation
- [ ] SSE Protocol

## Verification
- [x] `mypy` — 0 new errors (13 pre-existing import-untyped errors for boto3/mido/yaml unchanged)
- [x] `tests/test_musehub_releases.py` — 21 tests pass
- [x] `tests/test_musehub_ui.py` — 15 tests pass (4 new release UI tests)
- [x] Docs updated: `docs/reference/api.md`, `docs/architecture/muse_vcs.md`, `docs/reference/type_contracts.md`

## Tests Added
- `test_create_release_returns_all_fields` — full field validation
- `test_create_release_with_commit_id` — commit pinning
- `test_create_release_duplicate_tag_returns_409` — uniqueness guard
- `test_create_release_same_tag_different_repos_ok` — cross-repo isolation
- `test_create_release_repo_not_found_returns_404`
- `test_list_releases_empty_repo` — empty list contract
- `test_list_releases_ordered_newest_first` — ordering contract
- `test_list_releases_repo_not_found_returns_404`
- `test_release_detail_includes_download_urls` — downloadUrls structure present
- `test_release_detail_tag_not_found_returns_404`
- `test_release_detail_body_preserved` — release notes round-trip
- `test_release_requires_auth` — 401 for all 3 endpoints
- `test_create_release_service_persists_to_db` — service layer DB round-trip
- `test_create_release_duplicate_tag_raises_value_error` — service ValueError
- `test_list_releases_newest_first_service` — service ordering
- `test_get_latest_release_returns_newest` — latest release helper
- `test_get_latest_release_empty_repo_returns_none`
- `test_build_download_urls_all_packages_available` — packager all-flags
- `test_build_download_urls_partial_packages` — packager partial flags
- `test_build_empty_download_urls_all_none` — empty packager
- `test_build_download_urls_no_packages` — metadata not set when no packages
- `test_ui_release_list_page_returns_200` — new UI route renders HTML
- `test_ui_release_detail_page_returns_200` — release detail page renders
- `test_ui_repo_page_shows_releases_button` — nav button present on repo page

## Handoff
N/A — no SSE protocol or MCP tool schema changes.