### PR TITLE
feat(musehub): cross-repo search — global search across all public repos with result grouping

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -6264,3 +6264,116 @@ registration index matches the filesystem.
 **Implementation:** `maestro/muse_cli/commands/worktree.py` — `prune_worktrees(root)`.
 
 ---
+
+## Muse Hub — Cross-Repo Global Search
+
+### Overview
+
+Global search lets musicians and AI agents search commit messages across **all
+public Muse Hub repos** in a single query.  It is the cross-repo counterpart of
+the per-repo `muse find` command.
+
+Only `visibility='public'` repos are searched — private repos are excluded at
+the persistence layer and are never enumerated regardless of caller identity.
+
+### API
+
+```
+GET /api/v1/musehub/search?q={query}&mode={mode}&page={page}&page_size={page_size}
+Authorization: Bearer <jwt>
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `q` | string (required) | — | Search query (1–500 chars) |
+| `mode` | `keyword` \| `pattern` | `keyword` | Matching strategy (see below) |
+| `page` | int ≥ 1 | 1 | Repo-group page number |
+| `page_size` | int 1–50 | 10 | Repo-groups per page |
+
+**Search modes:**
+
+- **keyword** — whitespace-split OR-match of each term against commit messages
+  and repo names (case-insensitive, uses `lower()` + `LIKE %term%`).
+- **pattern** — raw SQL `LIKE` pattern applied to commit messages only.  Use
+  `%` as wildcard (e.g. `q=%minor%`).
+
+### Response shape
+
+Returns `GlobalSearchResult` (JSON, camelCase):
+
+```json
+{
+  "query": "jazz groove",
+  "mode": "keyword",
+  "totalReposSearched": 42,
+  "page": 1,
+  "pageSize": 10,
+  "groups": [
+    {
+      "repoId": "uuid",
+      "repoName": "jazz-lab",
+      "repoOwner": "alice",
+      "repoVisibility": "public",
+      "totalMatches": 3,
+      "matches": [
+        {
+          "commitId": "abc123",
+          "message": "jazz groove — walking bass variant",
+          "author": "alice",
+          "branch": "main",
+          "timestamp": "2026-02-27T12:00:00Z",
+          "repoId": "uuid",
+          "repoName": "jazz-lab",
+          "repoOwner": "alice",
+          "repoVisibility": "public",
+          "audioObjectId": "sha256:abc..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+Results are **grouped by repo**.  Each group contains up to 20 matching commits
+(newest-first).  `totalMatches` reflects the actual count before the 20-commit
+cap.  Pagination (`page` / `page_size`) controls how many repo-groups appear
+per response.
+
+`audioObjectId` is populated when the repo has at least one `.mp3`, `.ogg`, or
+`.wav` artifact — the first one alphabetically by path is chosen.  Consumers
+can use this to render `<audio>` preview players without a separate API call.
+
+### Browser UI
+
+```
+GET /musehub/ui/search?q={query}&mode={mode}
+```
+
+Returns a static HTML shell (no JWT required).  The page pre-fills the search
+form from URL params, submits to the JSON API via localStorage JWT, and renders
+grouped results with audio previews and pagination.
+
+### Implementation
+
+| Layer | File | What it does |
+|-------|------|-------------|
+| Pydantic models | `maestro/models/musehub.py` | `GlobalSearchCommitMatch`, `GlobalSearchRepoGroup`, `GlobalSearchResult` |
+| Service | `maestro/services/musehub_repository.py` | `global_search()` — public-only filter, keyword/pattern predicate, group assembly, audio preview resolution |
+| Route | `maestro/api/routes/musehub/search.py` | `GET /musehub/search` — validates params, delegates to service |
+| UI | `maestro/api/routes/musehub/ui.py` | `global_search_page()` — static HTML shell at `/musehub/ui/search` |
+
+### Agent use case
+
+An AI composition agent searching for reference material can call:
+
+```
+GET /api/v1/musehub/search?q=F%23+minor+walking+bass&mode=keyword&page_size=5
+```
+
+The grouped response lets the agent scan commit messages by repo context,
+identify matching repos by name and owner, and immediately fetch audio previews
+via `audioObjectId` without additional round-trips.
+
+---

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5958,3 +5958,54 @@ if state is not None and state.conflict_paths:
 **Related helpers:**
 - `apply_resolution(root, rel_path, object_id)` — copies an object from the local store to `muse-work/`; used by `--theirs` resolution and `--abort`.
 - `is_conflict_resolved(merge_state, rel_path)` — returns `True` if `rel_path` is not in `conflict_paths`.
+
+
+---
+
+## Muse Hub — Cross-Repo Search Types (`maestro/models/musehub.py`)
+
+### `GlobalSearchCommitMatch`
+
+Pydantic model (`CamelModel`) representing a single commit that matched a
+cross-repo search query.  Returned inside `GlobalSearchRepoGroup.matches`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | Commit SHA |
+| `message` | `str` | Commit message |
+| `author` | `str` | Author identifier |
+| `branch` | `str` | Branch the commit lives on |
+| `timestamp` | `datetime` | Commit timestamp (UTC) |
+| `repo_id` | `str` | Owning repo UUID |
+| `repo_name` | `str` | Human-readable repo name |
+| `repo_owner` | `str` | Owner user ID |
+| `repo_visibility` | `str` | Always `"public"` (private repos are excluded) |
+| `audio_object_id` | `str \| None` | First `.mp3`/`.ogg`/`.wav` object ID in the repo, if any |
+
+### `GlobalSearchRepoGroup`
+
+Pydantic model grouping all matching commits for a single public repo.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo_id` | `str` | Repo UUID |
+| `repo_name` | `str` | Human-readable repo name |
+| `repo_owner` | `str` | Owner user ID |
+| `repo_visibility` | `str` | Always `"public"` |
+| `matches` | `list[GlobalSearchCommitMatch]` | Up to 20 matching commits, newest-first |
+| `total_matches` | `int` | Actual match count before the 20-commit cap |
+
+### `GlobalSearchResult`
+
+Top-level response model for `GET /api/v1/musehub/search`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `query` | `str` | Original query string |
+| `mode` | `str` | `"keyword"` or `"pattern"` |
+| `groups` | `list[GlobalSearchRepoGroup]` | One entry per matching public repo (paginated) |
+| `total_repos_searched` | `int` | Count of public repos scanned (not just repos with matches) |
+| `page` | `int` | Current page number (1-based) |
+| `page_size` | `int` | Repo-groups per page |
+
+**Service function:** `musehub_repository.global_search(session, *, query, mode, page, page_size)`

--- a/maestro/api/routes/musehub/__init__.py
+++ b/maestro/api/routes/musehub/__init__.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 
-from maestro.api.routes.musehub import issues, objects, pull_requests, repos, sync
+from maestro.api.routes.musehub import issues, objects, pull_requests, repos, search, sync
 from maestro.auth.dependencies import require_valid_token
 
 router = APIRouter(
@@ -31,5 +31,6 @@ router.include_router(issues.router)
 router.include_router(pull_requests.router)
 router.include_router(sync.router)
 router.include_router(objects.router)
+router.include_router(search.router)
 
 __all__ = ["router"]

--- a/maestro/api/routes/musehub/search.py
+++ b/maestro/api/routes/musehub/search.py
@@ -1,0 +1,84 @@
+"""Muse Hub cross-repo search route handlers.
+
+Endpoint summary:
+  GET /musehub/search?q={query}&mode={mode}&page={page}&page_size={page_size}
+    — search commit messages across all public repos, results grouped by repo.
+
+The search endpoint requires a valid JWT Bearer token so unauthenticated
+callers cannot enumerate commit messages from public repos without identity.
+
+Content negotiation:
+  Accept: application/json  (default) — returns GlobalSearchResult JSON.
+  The UI page at GET /musehub/ui/search serves the browser-readable shell.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.auth.dependencies import TokenClaims, require_valid_token
+from maestro.db import get_db
+from maestro.models.musehub import GlobalSearchResult
+from maestro.services import musehub_repository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_VALID_MODES = frozenset({"keyword", "pattern"})
+
+
+@router.get(
+    "/search",
+    response_model=GlobalSearchResult,
+    summary="Global cross-repo search across all public Muse Hub repos",
+)
+async def global_search(
+    q: str = Query(..., min_length=1, max_length=500, description="Search query string"),
+    mode: str = Query("keyword", description="Search mode: 'keyword' or 'pattern'"),
+    page: int = Query(1, ge=1, description="1-based page number for repo-group pagination"),
+    page_size: int = Query(10, ge=1, le=50, description="Number of repo groups per page"),
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> GlobalSearchResult:
+    """Search commit messages across all public Muse Hub repos.
+
+    Results are grouped by repo — each group contains up to 20 matching
+    commits ordered newest-first with repo-level metadata (name, owner).
+
+    Only ``visibility='public'`` repos are searched.  Private repos are
+    excluded at the persistence layer regardless of caller identity.
+
+    Pagination applies to repo-groups: ``page=1&page_size=10`` returns the
+    first 10 repos that had at least one match.
+
+    Supported search modes:
+    - ``keyword``: OR-match whitespace-split terms against commit messages and
+      repo names (case-insensitive).
+    - ``pattern``: raw SQL LIKE pattern applied to commit messages only.
+      Use ``%`` as wildcard (e.g. ``q=%minor%``).
+
+    Content negotiation: this endpoint always returns JSON.  The companion
+    HTML page at ``GET /musehub/ui/search`` renders the browser UI shell.
+    """
+    effective_mode = mode if mode in _VALID_MODES else "keyword"
+    if effective_mode != mode:
+        logger.warning("⚠️ Unknown search mode %r — falling back to 'keyword'", mode)
+
+    result = await musehub_repository.global_search(
+        db,
+        query=q,
+        mode=effective_mode,
+        page=page,
+        page_size=page_size,
+    )
+    logger.info(
+        "✅ Global search q=%r mode=%s page=%d → %d repo groups",
+        q,
+        effective_mode,
+        page,
+        len(result.groups),
+    )
+    return result

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -245,17 +245,6 @@ class ObjectMetaListResponse(CamelModel):
 # ── Cross-repo search models ───────────────────────────────────────────────────
 
 
-class SearchMode(str):
-    """Valid cross-repo search mode identifiers.
-
-    keyword   — full-text match against commit messages and repo names.
-    pattern   — SQL LIKE pattern applied to commit messages.
-    """
-
-    KEYWORD = "keyword"
-    PATTERN = "pattern"
-
-
 class GlobalSearchCommitMatch(CamelModel):
     """A single commit that matched the search query in a cross-repo search.
 

--- a/tests/test_musehub_search.py
+++ b/tests/test_musehub_search.py
@@ -1,0 +1,356 @@
+"""Tests for Muse Hub cross-repo global search.
+
+Covers acceptance criteria from issue #236:
+- test_global_search_page_renders          — GET /musehub/ui/search returns 200 HTML
+- test_global_search_results_grouped       — JSON results are grouped by repo
+- test_global_search_public_only           — private repos are excluded
+- test_global_search_json                  — JSON content-type returned
+- test_global_search_empty_query_handled   — graceful response for empty result set
+- test_global_search_requires_auth         — 401 without JWT
+- test_global_search_keyword_mode          — keyword mode matches across message terms
+- test_global_search_pattern_mode          — pattern mode uses SQL LIKE
+- test_global_search_pagination            — page/page_size params respected
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import MusehubCommit, MusehubRepo
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_repo(
+    db_session: AsyncSession,
+    *,
+    name: str = "test-repo",
+    visibility: str = "public",
+    owner: str = "test-owner",
+) -> str:
+    """Seed a repo and return its repo_id."""
+    repo = MusehubRepo(name=name, visibility=visibility, owner_user_id=owner)
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    return str(repo.repo_id)
+
+
+async def _make_commit(
+    db_session: AsyncSession,
+    repo_id: str,
+    *,
+    commit_id: str,
+    message: str,
+    author: str = "alice",
+    branch: str = "main",
+) -> None:
+    """Seed a commit attached to the given repo."""
+    from datetime import datetime, timezone
+
+    commit = MusehubCommit(
+        commit_id=commit_id,
+        repo_id=repo_id,
+        branch=branch,
+        parent_ids=[],
+        message=message,
+        author=author,
+        timestamp=datetime.now(tz=timezone.utc),
+    )
+    db_session.add(commit)
+    await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# UI page test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_global_search_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/search returns 200 HTML with a search form (no auth required)."""
+    response = await client.get("/musehub/ui/search")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "Global Search" in body
+    assert "Muse Hub" in body
+    assert "q-input" in body
+    assert "mode-sel" in body
+
+
+@pytest.mark.anyio
+async def test_global_search_page_pre_fills_query(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/search?q=jazz pre-fills the search form with 'jazz'."""
+    response = await client.get("/musehub/ui/search?q=jazz&mode=keyword")
+    assert response.status_code == 200
+    body = response.text
+    assert "jazz" in body
+
+
+# ---------------------------------------------------------------------------
+# JSON API tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_global_search_requires_auth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /api/v1/musehub/search returns 401 without a JWT."""
+    response = await client.get("/api/v1/musehub/search?q=jazz")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_global_search_json(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /api/v1/musehub/search returns JSON with correct content-type."""
+    response = await client.get(
+        "/api/v1/musehub/search?q=jazz",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+    data = response.json()
+    assert "groups" in data
+    assert "query" in data
+    assert data["query"] == "jazz"
+
+
+@pytest.mark.anyio
+async def test_global_search_public_only(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Private repos must not appear in global search results."""
+    public_id = await _make_repo(db_session, name="public-beats", visibility="public")
+    private_id = await _make_repo(db_session, name="secret-beats", visibility="private")
+
+    await _make_commit(
+        db_session, public_id, commit_id="pub001abc", message="jazz groove session"
+    )
+    await _make_commit(
+        db_session, private_id, commit_id="priv001abc", message="jazz private session"
+    )
+
+    response = await client.get(
+        "/api/v1/musehub/search?q=jazz",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    repo_ids_in_results = {g["repoId"] for g in data["groups"]}
+    assert public_id in repo_ids_in_results
+    assert private_id not in repo_ids_in_results
+
+
+@pytest.mark.anyio
+async def test_global_search_results_grouped(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Results are grouped by repo — each group has repoId, repoName, matches list."""
+    repo_a = await _make_repo(db_session, name="repo-alpha", visibility="public")
+    repo_b = await _make_repo(db_session, name="repo-beta", visibility="public")
+
+    await _make_commit(
+        db_session, repo_a, commit_id="a001abc123", message="bossa nova rhythm"
+    )
+    await _make_commit(
+        db_session, repo_a, commit_id="a002abc123", message="bossa nova variation"
+    )
+    await _make_commit(
+        db_session, repo_b, commit_id="b001abc123", message="bossa nova groove"
+    )
+
+    response = await client.get(
+        "/api/v1/musehub/search?q=bossa+nova",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    groups = data["groups"]
+
+    # Both repos should appear
+    group_repo_ids = {g["repoId"] for g in groups}
+    assert repo_a in group_repo_ids
+    assert repo_b in group_repo_ids
+
+    # Each group has the required fields
+    for group in groups:
+        assert "repoId" in group
+        assert "repoName" in group
+        assert "repoOwner" in group
+        assert "repoVisibility" in group
+        assert "matches" in group
+        assert "totalMatches" in group
+        assert isinstance(group["matches"], list)
+
+    # repo_a has 2 matches
+    group_a = next(g for g in groups if g["repoId"] == repo_a)
+    assert group_a["totalMatches"] == 2
+    assert len(group_a["matches"]) == 2
+
+
+@pytest.mark.anyio
+async def test_global_search_empty_query_handled(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """A query that matches nothing returns empty groups and valid pagination metadata."""
+    await _make_repo(db_session, name="silent-repo", visibility="public")
+
+    response = await client.get(
+        "/api/v1/musehub/search?q=zyxqwvutsr_no_match",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["groups"] == []
+    assert data["page"] == 1
+    assert "totalReposSearched" in data
+
+
+@pytest.mark.anyio
+async def test_global_search_keyword_mode(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Keyword mode matches any term in the query (OR logic, case-insensitive)."""
+    repo_id = await _make_repo(db_session, name="jazz-lab", visibility="public")
+    await _make_commit(
+        db_session, repo_id, commit_id="kw001abcde", message="Blues Shuffle in E"
+    )
+    await _make_commit(
+        db_session, repo_id, commit_id="kw002abcde", message="Jazz Waltz Trio"
+    )
+
+    response = await client.get(
+        "/api/v1/musehub/search?q=blues&mode=keyword",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    group = next((g for g in data["groups"] if g["repoId"] == repo_id), None)
+    assert group is not None
+    messages = [m["message"] for m in group["matches"]]
+    assert any("Blues" in msg for msg in messages)
+
+
+@pytest.mark.anyio
+async def test_global_search_pattern_mode(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Pattern mode applies a raw SQL LIKE pattern to commit messages."""
+    repo_id = await _make_repo(db_session, name="pattern-lab", visibility="public")
+    await _make_commit(
+        db_session, repo_id, commit_id="pt001abcde", message="minor pentatonic run"
+    )
+    await _make_commit(
+        db_session, repo_id, commit_id="pt002abcde", message="major scale exercise"
+    )
+
+    response = await client.get(
+        "/api/v1/musehub/search?q=%25minor%25&mode=pattern",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    group = next((g for g in data["groups"] if g["repoId"] == repo_id), None)
+    assert group is not None
+    assert group["totalMatches"] == 1
+    assert "minor" in group["matches"][0]["message"]
+
+
+@pytest.mark.anyio
+async def test_global_search_pagination(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """page and page_size parameters control repo-group pagination."""
+    # Create 3 public repos each with a matching commit
+    ids = []
+    for i in range(3):
+        rid = await _make_repo(
+            db_session, name=f"paged-repo-{i}", visibility="public", owner=f"owner-{i}"
+        )
+        ids.append(rid)
+        await _make_commit(
+            db_session, rid, commit_id=f"pg{i:03d}abcde", message="paginate funk groove"
+        )
+
+    # page_size=2 → first page returns at most 2 groups
+    response = await client.get(
+        "/api/v1/musehub/search?q=paginate&page=1&page_size=2",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["groups"]) <= 2
+    assert data["page"] == 1
+    assert data["pageSize"] == 2
+
+    # page=2 returns the remaining group(s)
+    response2 = await client.get(
+        "/api/v1/musehub/search?q=paginate&page=2&page_size=2",
+        headers=auth_headers,
+    )
+    assert response2.status_code == 200
+    data2 = response2.json()
+    assert data2["page"] == 2
+
+
+@pytest.mark.anyio
+async def test_global_search_match_contains_required_fields(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Each match entry contains commitId, message, author, branch, timestamp, repoId."""
+    repo_id = await _make_repo(db_session, name="fields-check", visibility="public")
+    await _make_commit(
+        db_session,
+        repo_id,
+        commit_id="fc001abcde",
+        message="swing feel experiment",
+        author="charlie",
+        branch="main",
+    )
+
+    response = await client.get(
+        "/api/v1/musehub/search?q=swing",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    group = next((g for g in data["groups"] if g["repoId"] == repo_id), None)
+    assert group is not None
+    match = group["matches"][0]
+    assert match["commitId"] == "fc001abcde"
+    assert match["message"] == "swing feel experiment"
+    assert match["author"] == "charlie"
+    assert match["branch"] == "main"
+    assert "timestamp" in match
+    assert match["repoId"] == repo_id

--- a/tests/test_musehub_ui.py
+++ b/tests/test_musehub_ui.py
@@ -183,6 +183,31 @@ async def test_ui_pages_include_token_form(
 
 
 @pytest.mark.anyio
+async def test_global_search_ui_page_returns_200(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/search returns 200 HTML (no auth required — HTML shell)."""
+    response = await client.get("/musehub/ui/search")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "Global Search" in body
+    assert "Muse Hub" in body
+
+
+@pytest.mark.anyio
+async def test_global_search_ui_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/search must not return 401 — it is a static HTML shell."""
+    response = await client.get("/musehub/ui/search")
+    assert response.status_code != 401
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
 async def test_list_objects_returns_empty_for_new_repo(
     client: AsyncClient,
     db_session: AsyncSession,


### PR DESCRIPTION
## Summary
Closes #236 — adds global cross-repo search across all public Muse Hub repos, with results grouped by repo and audio preview support.

## Root Cause / Motivation
No global search existed across Muse Hub. Musicians and AI agents could only search within individual repos, making it impossible to find compositions by key, tempo, or genre across the entire ecosystem.

## Solution

### New endpoint
`GET /api/v1/musehub/search?q={query}&mode={mode}&page={page}&page_size={page_size}`
- Searches commit messages across all `visibility='public'` repos (private repos excluded at persistence layer)
- Two search modes: **keyword** (OR-match whitespace-split terms against message + repo name, case-insensitive) and **pattern** (raw SQL LIKE on commit messages)
- Results grouped by repo — each group contains up to 20 matching commits, newest-first
- Repo metadata in each group: `repoId`, `repoName`, `repoOwner`, `repoVisibility`
- Audio preview: `audioObjectId` set to the first `.mp3`/`.ogg`/`.wav` artifact in the repo
- Pagination by repo-group via `page` / `page_size`

### Browser UI
`GET /musehub/ui/search` — static HTML shell (no JWT required); JS fetches from the JSON API via localStorage JWT; pre-fills form from URL params for shareability.

### Files changed
- `maestro/models/musehub.py` — added `GlobalSearchCommitMatch`, `GlobalSearchRepoGroup`, `GlobalSearchResult`
- `maestro/services/musehub_repository.py` — added `global_search()` service function
- `maestro/api/routes/musehub/search.py` — new route `GET /musehub/search`
- `maestro/api/routes/musehub/ui.py` — added `global_search_page()` at `GET /musehub/ui/search`
- `maestro/api/routes/musehub/__init__.py` — registered `search.router`
- `docs/architecture/muse_vcs.md` — documented cross-repo search
- `docs/reference/type_contracts.md` — registered three new named result types

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (12 source files, no issues)
- [x] `docker compose exec storpheus mypy .` — pre-existing (not affected by this change)
- [x] 25 tests pass (11 new in `test_musehub_search.py` + 2 new in `test_musehub_ui.py` + 12 pre-existing)
- [x] Zero warnings in test output
- [x] Docs updated in same commit

## Tests Added
- `test_global_search_page_renders` — UI page returns 200 HTML
- `test_global_search_page_pre_fills_query` — URL params pre-fill the form
- `test_global_search_requires_auth` — 401 without JWT
- `test_global_search_json` — JSON content-type and correct structure
- `test_global_search_public_only` — private repos excluded from results
- `test_global_search_results_grouped` — results grouped by repo with all required fields
- `test_global_search_empty_query_handled` — graceful empty result
- `test_global_search_keyword_mode` — keyword mode OR-matches terms
- `test_global_search_pattern_mode` — pattern mode uses LIKE
- `test_global_search_pagination` — page/page_size params respected
- `test_global_search_match_contains_required_fields` — all match fields present
- `test_global_search_ui_page_returns_200` — HTML shell check (in test_musehub_ui.py)
- `test_global_search_ui_page_no_auth_required` — UI page accessible without JWT

## Handoff
N/A — no SSE protocol or MCP tool schema changes. API-only addition.