### PR TITLE
feat(musehub): in-repo search — musical property, natural language, keyword, and pattern search

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -1408,17 +1408,20 @@ The Muse Hub is a lightweight GitHub-equivalent that lives inside the Maestro Fa
 ```
 maestro/
 ├── db/musehub_models.py                  — SQLAlchemy ORM models
-├── models/musehub.py                     — Pydantic v2 request/response models
+├── models/musehub.py                     — Pydantic v2 request/response models (incl. SearchCommitMatch, SearchResponse)
 ├── services/musehub_repository.py        — Async DB queries for repos/branches/commits
 ├── services/musehub_issues.py            — Async DB queries for issues (single point of DB access)
 ├── services/musehub_pull_requests.py     — Async DB queries for PRs (single point of DB access)
+├── services/musehub_search.py            — In-repo search service (property / ask / keyword / pattern)
 ├── services/musehub_sync.py              — Push/pull sync protocol (ingest_push, compute_pull_delta)
 └── api/routes/musehub/
     ├── __init__.py                       — Composes sub-routers under /musehub prefix
     ├── repos.py                          — Repo/branch/commit route handlers
     ├── issues.py                         — Issue tracking route handlers
     ├── pull_requests.py                  — Pull request route handlers
-    └── sync.py                           — Push/pull sync route handlers
+    ├── search.py                         — In-repo search route handler
+    ├── sync.py                           — Push/pull sync route handlers
+    └── ui.py                             — HTML UI pages (incl. /search page with mode tabs)
 ```
 
 ### Endpoints
@@ -1449,6 +1452,44 @@ maestro/
 | GET | `/api/v1/musehub/repos/{id}/pull-requests` | List PRs (`?state=open\|merged\|closed\|all`) |
 | GET | `/api/v1/musehub/repos/{id}/pull-requests/{pr_id}` | Get a single PR by ID |
 | POST | `/api/v1/musehub/repos/{id}/pull-requests/{pr_id}/merge` | Merge an open PR |
+
+#### In-Repo Search
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/musehub/repos/{id}/search` | Search commits by mode (property / ask / keyword / pattern) |
+| GET | `/musehub/ui/{id}/search` | HTML search page with four mode tabs (no auth required) |
+
+**Search query parameters:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `mode` | string | `property` \| `ask` \| `keyword` \| `pattern` (default: `keyword`) |
+| `q` | string | Query string — interpreted differently per mode |
+| `harmony` | string | [property mode] Harmony filter (e.g. `key=Eb` or `key=C-Eb` range) |
+| `rhythm` | string | [property mode] Rhythm filter (e.g. `tempo=120-130`) |
+| `melody` | string | [property mode] Melody filter |
+| `structure` | string | [property mode] Structure filter |
+| `dynamic` | string | [property mode] Dynamics filter |
+| `emotion` | string | [property mode] Emotion filter |
+| `since` | ISO datetime | Only include commits on or after this datetime |
+| `until` | ISO datetime | Only include commits on or before this datetime |
+| `limit` | int | Max results (1–200, default 20) |
+
+**Result type:** `SearchResponse` — fields: `mode`, `query`, `matches`, `totalScanned`, `limit`.
+Each match is a `SearchCommitMatch` with: `commitId`, `branch`, `message`, `author`, `timestamp`, `score`, `matchSource`.
+
+**Search modes explained:**
+
+- **`property`** — delegates to `muse_find.search_commits()`. All non-empty property filters are ANDed. Accepts `key=low-high` range syntax for numeric properties. Score is always 1.0 (exact filter match). `matchSource = "property"`.
+
+- **`ask`** — natural-language query. Stop-words are stripped from `q`; remaining tokens are scored against each commit message using the overlap coefficient (`|Q ∩ M| / |Q|`). Commits with zero overlap are excluded. This is a keyword-matching stub; LLM-powered answer generation is a planned enhancement.
+
+- **`keyword`** — raw keyword overlap scoring. Tokenises `q` and each commit message; scores by `|Q ∩ M| / |Q|`. Commits with zero overlap excluded. Useful for precise term search.
+
+- **`pattern`** — case-insensitive substring match of `q` against commit messages (primary) and branch names (secondary). Score is always 1.0. `matchSource` is `"message"` or `"branch"`.
+
+**Agent use case:** AI music composition agents can call the search endpoint to locate commits by musical property (e.g. find all commits with `harmony=Fm`) before applying `muse checkout`, `muse diff`, or `muse replay` to reconstruct or compare those versions.
 
 #### Sync Protocol
 

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5846,6 +5846,42 @@ Wrapper returned by `GET /api/v1/musehub/repos/{repo_id}/objects`.
 **Producer:** `objects.list_objects` route handler
 **Consumer:** Muse Hub web UI; any agent inspecting which artifacts are available for a repo
 
+### `SearchCommitMatch`
+
+A single commit returned by any of the four in-repo search modes.
+
+Defined in `maestro/models/musehub.py`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commitId` | `str` | Full commit SHA |
+| `branch` | `str` | Branch the commit belongs to |
+| `message` | `str` | Commit message |
+| `author` | `str` | Commit author |
+| `timestamp` | `datetime` | When the commit was created |
+| `score` | `float` | Match score 0–1; always 1.0 for property/pattern modes |
+| `matchSource` | `str` | Where the match was found: `"message"`, `"branch"`, or `"property"` |
+
+**Producer:** `musehub_search.search_by_*` → `search.search_repo` route handler
+**Consumer:** Muse Hub search page UI; AI agents using search to locate commits before checkout/diff
+
+### `SearchResponse`
+
+Envelope returned by `GET /api/v1/musehub/repos/{repo_id}/search`.
+
+Defined in `maestro/models/musehub.py`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mode` | `str` | Echoed search mode: `property` \| `ask` \| `keyword` \| `pattern` |
+| `query` | `str` | Echoed query string (property mode uses filter summary) |
+| `matches` | `list[SearchCommitMatch]` | Ordered matches (score desc, then recency desc) |
+| `totalScanned` | `int` | Total commits examined before limit was applied |
+| `limit` | `int` | The limit cap that was applied |
+
+**Producer:** `search.search_repo` route handler
+**Consumer:** Muse Hub search page (renders result rows); AI agents finding commits by musical property
+
 ---
 
 ## Muse Bisect Types

--- a/maestro/api/routes/musehub/__init__.py
+++ b/maestro/api/routes/musehub/__init__.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 
-from maestro.api.routes.musehub import issues, objects, pull_requests, repos, sync
+from maestro.api.routes.musehub import issues, objects, pull_requests, repos, search, sync
 from maestro.auth.dependencies import require_valid_token
 
 router = APIRouter(
@@ -31,5 +31,6 @@ router.include_router(issues.router)
 router.include_router(pull_requests.router)
 router.include_router(sync.router)
 router.include_router(objects.router)
+router.include_router(search.router)
 
 __all__ = ["router"]

--- a/maestro/api/routes/musehub/search.py
+++ b/maestro/api/routes/musehub/search.py
@@ -1,0 +1,137 @@
+"""Muse Hub in-repo search route handlers.
+
+Endpoint summary:
+  GET /api/v1/musehub/repos/{repo_id}/search — search commits by mode
+
+Search modes (``?mode=`` query parameter):
+  ``property``  — filter by musical properties (harmony, rhythm, melody, etc.)
+  ``ask``       — natural-language query (keyword extraction + overlap scoring)
+  ``keyword``   — keyword/phrase overlap scored search
+  ``pattern``   — substring pattern match against message and branch name
+
+All modes accept optional ``since`` / ``until`` date-range filters and a
+``limit`` cap (default 20, max 200).  All modes return the same JSON shape
+(:class:`~maestro.models.musehub.SearchResponse`) so the UI can use a
+single result renderer.
+
+Content negotiation: this endpoint always returns JSON. The HTML search page
+at ``GET /musehub/ui/{repo_id}/search`` fetches this endpoint client-side.
+
+Authentication: JWT Bearer token required (inherited from musehub router).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.auth.dependencies import TokenClaims, require_valid_token
+from maestro.db import get_db
+from maestro.models.musehub import SearchResponse
+from maestro.services import musehub_repository, musehub_search
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_VALID_MODES = frozenset({"property", "ask", "keyword", "pattern"})
+
+
+@router.get(
+    "/repos/{repo_id}/search",
+    response_model=SearchResponse,
+    summary="Search Muse repo commits",
+)
+async def search_repo(
+    repo_id: str,
+    q: str = Query("", description="Search query — interpreted by the selected mode"),
+    mode: str = Query("keyword", description="Search mode: property | ask | keyword | pattern"),
+    harmony: str | None = Query(None, description="[property mode] Harmony filter"),
+    rhythm: str | None = Query(None, description="[property mode] Rhythm filter"),
+    melody: str | None = Query(None, description="[property mode] Melody filter"),
+    structure: str | None = Query(None, description="[property mode] Structure filter"),
+    dynamic: str | None = Query(None, description="[property mode] Dynamics filter"),
+    emotion: str | None = Query(None, description="[property mode] Emotion filter"),
+    since: datetime | None = Query(None, description="Only include commits on or after this ISO datetime"),
+    until: datetime | None = Query(None, description="Only include commits on or before this ISO datetime"),
+    limit: int = Query(20, ge=1, le=200, description="Maximum results to return"),
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> SearchResponse:
+    """Search commit history using one of four musical search modes.
+
+    The ``mode`` parameter selects the search algorithm:
+
+    - **property** — filter commits by musical properties using AND logic.
+      Supply any of ``harmony``, ``rhythm``, ``melody``, ``structure``,
+      ``dynamic``, ``emotion`` query params.  Accepts ``key=low-high`` range
+      syntax (e.g. ``rhythm=tempo=120-130``).
+
+    - **ask** — treat ``q`` as a natural-language question.  Stop-words are
+      stripped; remaining keywords are scored by overlap coefficient.
+
+    - **keyword** — score commits by keyword overlap against ``q``.
+      Useful for exact term search (e.g. ``q=Fmin_jazz_bassline``).
+
+    - **pattern** — case-insensitive substring match of ``q`` against commit
+      messages and branch names.  No scoring; matched rows returned newest-first.
+
+    Returns 404 if the repo does not exist.  Returns an empty ``matches`` list
+    when no commits satisfy the criteria (not a 404).
+    """
+    if mode not in _VALID_MODES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Invalid mode '{mode}'. Must be one of: {sorted(_VALID_MODES)}",
+        )
+
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    if mode == "property":
+        return await musehub_search.search_by_property(
+            db,
+            repo_id=repo_id,
+            harmony=harmony,
+            rhythm=rhythm,
+            melody=melody,
+            structure=structure,
+            dynamic=dynamic,
+            emotion=emotion,
+            since=since,
+            until=until,
+            limit=limit,
+        )
+
+    if mode == "ask":
+        return await musehub_search.search_by_ask(
+            db,
+            repo_id=repo_id,
+            question=q,
+            since=since,
+            until=until,
+            limit=limit,
+        )
+
+    if mode == "keyword":
+        return await musehub_search.search_by_keyword(
+            db,
+            repo_id=repo_id,
+            keyword=q,
+            since=since,
+            until=until,
+            limit=limit,
+        )
+
+    # mode == "pattern"
+    return await musehub_search.search_by_pattern(
+        db,
+        repo_id=repo_id,
+        pattern=q,
+        since=since,
+        until=until,
+        limit=limit,
+    )

--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -10,6 +10,7 @@ Endpoint summary:
   GET /musehub/ui/{repo_id}/pulls/{pr_id}          — PR detail page (with merge button)
   GET /musehub/ui/{repo_id}/issues                 — issue list page
   GET /musehub/ui/{repo_id}/issues/{number}        — issue detail page (with close button)
+  GET /musehub/ui/{repo_id}/search                 — in-repo search page (four modes)
 
 These routes require NO JWT auth — they return static HTML shells whose
 embedded JavaScript fetches data from the authed JSON API
@@ -273,6 +274,7 @@ async def repo_page(repo_id: str) -> HTMLResponse:
               <div style="display:flex;gap:12px;margin-bottom:16px;flex-wrap:wrap">
                 <a href="${{base}}/pulls" class="btn btn-secondary">Pull Requests</a>
                 <a href="${{base}}/issues" class="btn btn-secondary">Issues</a>
+                <a href="${{base}}/search" class="btn btn-secondary">&#128269; Search</a>
               </div>
               <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">
                 <select id="branch-sel" onchange="load(this.value)">
@@ -746,6 +748,243 @@ async def issue_detail_page(repo_id: str, number: int) -> HTMLResponse:
             f'<a href="/musehub/ui/{repo_id}">{repo_id[:8]}</a> / '
             f'<a href="/musehub/ui/{repo_id}/issues">issues</a> / #{number}'
         ),
+        body_script=script,
+    )
+    return HTMLResponse(content=html)
+
+
+@router.get(
+    "/{repo_id}/search",
+    response_class=HTMLResponse,
+    summary="Muse Hub in-repo search page",
+)
+async def search_page(repo_id: str) -> HTMLResponse:
+    """Render the in-repo search page with four mode tabs.
+
+    Modes map to the JSON API at ``GET /api/v1/musehub/repos/{repo_id}/search``:
+    - Musical Properties (``mode=property``) — filter by harmony/rhythm/melody/etc.
+    - Natural Language (``mode=ask``) — free-text question over commit history.
+    - Keyword (``mode=keyword``) — keyword overlap scored search.
+    - Pattern (``mode=pattern``) — substring match against messages and branches.
+
+    Results render as commit rows with SHA, message, author, timestamp, and an
+    audio preview link for any ``mp3``/``wav``/``ogg`` artifact on that commit.
+    Authentication is handled client-side via localStorage JWT.
+    """
+    script = f"""
+      const repoId = {repr(repo_id)};
+      const base   = '/musehub/ui/' + repoId;
+      const apiBase = '/api/v1/musehub/repos/' + repoId;
+
+      function escHtml(s) {{
+        if (!s) return '';
+        return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+      }}
+
+      // ── State ──────────────────────────────────────────────────────────────
+      let currentMode = 'keyword';
+
+      function setMode(mode) {{
+        currentMode = mode;
+        document.querySelectorAll('.tab-btn').forEach(b => {{
+          b.classList.toggle('tab-active', b.dataset.mode === mode);
+        }});
+        document.querySelectorAll('.mode-panel').forEach(p => {{
+          p.style.display = p.dataset.mode === mode ? 'block' : 'none';
+        }});
+      }}
+
+      // ── Result rendering ───────────────────────────────────────────────────
+      function renderResults(data) {{
+        const matches = data.matches || [];
+        const header = `<p style="color:#8b949e;font-size:13px;margin-bottom:12px">
+          Mode: <strong>${{escHtml(data.mode)}}</strong> &bull;
+          Query: <em>${{escHtml(data.query || '(all)')}}</em> &bull;
+          ${{matches.length}} result(s) &bull; ${{data.totalScanned}} commits scanned
+        </p>`;
+
+        if (matches.length === 0) {{
+          document.getElementById('results').innerHTML = header +
+            '<p class="loading">No matching commits found.</p>';
+          return;
+        }}
+
+        const rows = matches.map(m => `
+          <div class="commit-row">
+            <a class="commit-sha" href="${{base}}/commits/${{m.commitId}}">${{shortSha(m.commitId)}}</a>
+            <div class="commit-msg" style="flex:1">
+              <a href="${{base}}/commits/${{m.commitId}}">${{escHtml(m.message)}}</a>
+              <div style="font-size:12px;color:#8b949e;margin-top:2px">
+                ${{escHtml(m.author)}} &bull; ${{fmtDate(m.timestamp)}}
+                &bull; branch: ${{escHtml(m.branch)}}
+                ${{m.score < 1.0 ? '&bull; score: ' + m.score.toFixed(3) : ''}}
+                <a href="${{base}}/commits/${{m.commitId}}"
+                   class="btn btn-secondary"
+                   style="font-size:11px;padding:2px 8px;margin-left:8px">
+                  &#9654; Preview
+                </a>
+              </div>
+            </div>
+          </div>`).join('');
+
+        document.getElementById('results').innerHTML = header +
+          '<div class="card">' + rows + '</div>';
+      }}
+
+      // ── Search dispatch ────────────────────────────────────────────────────
+      async function runSearch() {{
+        document.getElementById('results').innerHTML = '<p class="loading">Searching&#8230;</p>';
+        try {{
+          let url = apiBase + '/search?mode=' + encodeURIComponent(currentMode);
+          const limit = document.getElementById('inp-limit').value || 20;
+          const since = document.getElementById('inp-since').value;
+          const until = document.getElementById('inp-until').value;
+          url += '&limit=' + encodeURIComponent(limit);
+          if (since) url += '&since=' + encodeURIComponent(since + 'T00:00:00Z');
+          if (until) url += '&until=' + encodeURIComponent(until + 'T23:59:59Z');
+
+          if (currentMode === 'property') {{
+            const fields = ['harmony','rhythm','melody','structure','dynamic','emotion'];
+            fields.forEach(f => {{
+              const v = document.getElementById('prop-' + f).value.trim();
+              if (v) url += '&' + f + '=' + encodeURIComponent(v);
+            }});
+          }} else {{
+            const q = document.getElementById('inp-q-' + currentMode).value.trim();
+            if (q) url += '&q=' + encodeURIComponent(q);
+          }}
+
+          const data = await apiFetch(url.replace(apiBase, ''));
+          renderResults(data);
+        }} catch(e) {{
+          if (e.message !== 'auth')
+            document.getElementById('results').innerHTML =
+              '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+        }}
+      }}
+
+      // ── Page bootstrap ─────────────────────────────────────────────────────
+      document.getElementById('content').innerHTML = `
+        <div style="margin-bottom:12px">
+          <a href="${{base}}">&larr; Back to repo</a>
+        </div>
+        <div class="card">
+          <h1 style="margin-bottom:16px">&#128269; Search Commits</h1>
+
+          <!-- Mode tabs -->
+          <div style="display:flex;gap:8px;margin-bottom:20px;flex-wrap:wrap">
+            <button class="btn tab-btn tab-active" data-mode="keyword"
+                    onclick="setMode('keyword')">Keyword</button>
+            <button class="btn tab-btn" data-mode="ask"
+                    onclick="setMode('ask')">Natural Language</button>
+            <button class="btn tab-btn" data-mode="pattern"
+                    onclick="setMode('pattern')">Pattern</button>
+            <button class="btn tab-btn" data-mode="property"
+                    onclick="setMode('property')">Musical Properties</button>
+          </div>
+
+          <!-- Shared date range + limit -->
+          <div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:16px;align-items:flex-end">
+            <div class="meta-item">
+              <span class="meta-label">Since</span>
+              <input id="inp-since" type="date" style="background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:6px;padding:6px 10px;font-size:14px" />
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Until</span>
+              <input id="inp-until" type="date" style="background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:6px;padding:6px 10px;font-size:14px" />
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Limit</span>
+              <input id="inp-limit" type="number" value="20" min="1" max="200"
+                     style="width:80px;background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:6px;padding:6px 10px;font-size:14px" />
+            </div>
+          </div>
+
+          <!-- Keyword panel -->
+          <div class="mode-panel" data-mode="keyword">
+            <div style="display:flex;gap:8px">
+              <input id="inp-q-keyword" type="text" placeholder="e.g. dark jazz bassline"
+                     style="flex:1;background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:6px;padding:8px;font-size:14px"
+                     onkeydown="if(event.key==='Enter')runSearch()" />
+              <button class="btn btn-primary" onclick="runSearch()">Search</button>
+            </div>
+            <p style="font-size:12px;color:#8b949e;margin-top:6px">
+              Scores commits by keyword overlap. Higher score = better match.
+            </p>
+          </div>
+
+          <!-- Natural Language panel -->
+          <div class="mode-panel" data-mode="ask" style="display:none">
+            <div style="display:flex;gap:8px">
+              <input id="inp-q-ask" type="text" placeholder="e.g. when did I change to F# minor?"
+                     style="flex:1;background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:6px;padding:8px;font-size:14px"
+                     onkeydown="if(event.key==='Enter')runSearch()" />
+              <button class="btn btn-primary" onclick="runSearch()">Ask</button>
+            </div>
+            <p style="font-size:12px;color:#8b949e;margin-top:6px">
+              Keyword extraction from your question. Full LLM-powered search is a planned enhancement.
+            </p>
+          </div>
+
+          <!-- Pattern panel -->
+          <div class="mode-panel" data-mode="pattern" style="display:none">
+            <div style="display:flex;gap:8px">
+              <input id="inp-q-pattern" type="text" placeholder="e.g. Cm7 or feature/hip-hop"
+                     style="flex:1;background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:6px;padding:8px;font-size:14px"
+                     onkeydown="if(event.key==='Enter')runSearch()" />
+              <button class="btn btn-primary" onclick="runSearch()">Search</button>
+            </div>
+            <p style="font-size:12px;color:#8b949e;margin-top:6px">
+              Case-insensitive substring match against commit messages and branch names.
+            </p>
+          </div>
+
+          <!-- Musical Properties panel -->
+          <div class="mode-panel" data-mode="property" style="display:none">
+            <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:12px;margin-bottom:12px">
+              ${{['harmony','rhythm','melody','structure','dynamic','emotion'].map(f => `
+                <div class="meta-item">
+                  <span class="meta-label">${{f}}</span>
+                  <input id="prop-${{f}}" type="text" placeholder="e.g. ${{f==='harmony'?'key=Eb':f==='rhythm'?'tempo=120-130':f}}"
+                         style="background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:6px;padding:6px 10px;font-size:13px;width:100%" />
+                </div>`).join('')}}
+            </div>
+            <button class="btn btn-primary" onclick="runSearch()">Filter</button>
+            <p style="font-size:12px;color:#8b949e;margin-top:6px">
+              All non-empty fields are combined with AND logic.
+              Range syntax: <code>tempo=120-130</code>.
+            </p>
+          </div>
+        </div>
+
+        <!-- Results area -->
+        <div id="results"><p class="loading" style="display:none"></p></div>
+      `;
+
+      // Apply tab styles after DOM is written.
+      document.querySelectorAll('.tab-btn').forEach(b => {{
+        b.style.background = '#21262d';
+        b.style.color = '#c9d1d9';
+        b.style.border = '1px solid #30363d';
+      }});
+
+      function applyTabActive() {{
+        document.querySelectorAll('.tab-btn').forEach(b => {{
+          const active = b.dataset.mode === currentMode;
+          b.style.background = active ? '#1f6feb' : '#21262d';
+          b.style.color = active ? '#fff' : '#c9d1d9';
+        }});
+      }}
+
+      document.querySelectorAll('.tab-btn').forEach(b => {{
+        b.addEventListener('click', applyTabActive);
+      }});
+
+      applyTabActive();
+    """
+    html = _page(
+        title="Search",
+        breadcrumb=f'<a href="/musehub/ui/{repo_id}">{repo_id[:8]}</a> / search',
         body_script=script,
     )
     return HTMLResponse(content=html)

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -240,3 +240,38 @@ class ObjectMetaListResponse(CamelModel):
     """List of artifact metadata for a repo."""
 
     objects: list[ObjectMetaResponse]
+
+
+# ── In-repo search models ─────────────────────────────────────────────────────
+
+
+class SearchCommitMatch(CamelModel):
+    """A single commit returned by a search query.
+
+    Carries enough metadata to render a result row and launch an audio preview.
+    The ``score`` field is populated by keyword/recall modes (0–1 overlap ratio);
+    property and grep modes always return 1.0.
+    """
+
+    commit_id: str
+    branch: str
+    message: str
+    author: str
+    timestamp: datetime
+    score: float = Field(1.0, ge=0.0, le=1.0, description="Match score (0–1); always 1.0 for exact-match modes")
+    match_source: str = Field("message", description="Where the match was found: 'message', 'branch', or 'property'")
+
+
+class SearchResponse(CamelModel):
+    """Response envelope for all four in-repo search modes.
+
+    ``mode`` echoes back the requested search mode so clients can render
+    mode-appropriate headers.  ``total_scanned`` is the number of commits
+    examined before limit was applied; useful for indicating search depth.
+    """
+
+    mode: str
+    query: str
+    matches: list[SearchCommitMatch]
+    total_scanned: int
+    limit: int

--- a/maestro/services/musehub_search.py
+++ b/maestro/services/musehub_search.py
@@ -1,0 +1,376 @@
+"""Muse Hub in-repo search service.
+
+Provides four search modes over a repo's commit history, all operating on the
+shared ``muse_cli_commits`` table and scoped to a single ``repo_id``.
+
+Modes and their underlying algorithms:
+- ``property``  — musical property filter (delegates to :mod:`maestro.services.muse_find`)
+- ``ask``       — natural-language query; keyword extraction + overlap scoring
+- ``keyword``   — raw keyword/phrase overlap (normalised overlap coefficient)
+- ``pattern``   — substring pattern match against message and branch name
+
+All four modes return :class:`~maestro.models.musehub.SearchResponse` so the
+UI can render results with a single shared commit-row template regardless of mode.
+
+Date-range filtering (``since`` / ``until``) is applied at the SQL layer for
+efficiency before any Python-level scoring.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+
+from sqlalchemy import and_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from maestro.models.musehub import SearchCommitMatch, SearchResponse
+from maestro.muse_cli.models import MuseCliCommit
+from maestro.services import muse_find
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LIMIT = 20
+_TOKEN_RE = re.compile(r"[a-zA-Z0-9]+")
+
+# Stop-words stripped during NL ask-mode keyword extraction.
+_STOP_WORDS = frozenset({
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "shall", "can", "need", "dare", "ought",
+    "i", "my", "me", "we", "our", "you", "your", "he", "she", "it",
+    "they", "their", "them", "what", "when", "where", "who", "which",
+    "how", "why", "in", "on", "at", "to", "of", "for", "and", "or",
+    "but", "not", "with", "from", "by", "about", "into", "through",
+    "did", "make", "made", "last", "any", "all", "that", "this",
+})
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _tokenize(text: str) -> set[str]:
+    """Return a set of lowercase word tokens from *text*."""
+    return {m.group().lower() for m in _TOKEN_RE.finditer(text)}
+
+
+def _overlap_score(query_tokens: set[str], message: str) -> float:
+    """Normalised overlap coefficient: |Q ∩ M| / |Q|.
+
+    Returns 1.0 when every query token appears in the message, 0.0 when
+    none do.  Returns 0.0 for an empty query set to avoid division by zero.
+    """
+    if not query_tokens:
+        return 0.0
+    message_tokens = _tokenize(message)
+    return len(query_tokens & message_tokens) / len(query_tokens)
+
+
+async def _fetch_candidates(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    since: datetime | None,
+    until: datetime | None,
+    limit_multiplier: int = 10,
+    cap: int = 5000,
+) -> tuple[list[MuseCliCommit], int]:
+    """Fetch candidate commits from DB with optional date range filter.
+
+    Returns ``(rows, total_scanned)`` where ``total_scanned`` is the raw DB count
+    before any Python-level filtering.  We over-fetch (up to ``cap``) and let
+    callers apply their own ranking/limit so the SQL stays simple and fast.
+    """
+    stmt = select(MuseCliCommit).where(MuseCliCommit.repo_id == repo_id)
+
+    conditions = []
+    if since is not None:
+        conditions.append(MuseCliCommit.committed_at >= since)
+    if until is not None:
+        conditions.append(MuseCliCommit.committed_at <= until)
+    if conditions:
+        stmt = stmt.where(and_(*conditions))
+
+    stmt = stmt.order_by(MuseCliCommit.committed_at.desc()).limit(cap)
+
+    result = await session.execute(stmt)
+    rows = list(result.scalars().all())
+    return rows, len(rows)
+
+
+def _commit_to_match(
+    commit: MuseCliCommit,
+    *,
+    score: float = 1.0,
+    match_source: str = "message",
+) -> SearchCommitMatch:
+    """Convert a DB row to the wire-format :class:`SearchCommitMatch`."""
+    return SearchCommitMatch(
+        commit_id=commit.commit_id,
+        branch=commit.branch,
+        message=commit.message,
+        author=commit.author,
+        timestamp=commit.committed_at,
+        score=round(score, 4),
+        match_source=match_source,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Search modes
+# ---------------------------------------------------------------------------
+
+
+async def search_by_property(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    harmony: str | None = None,
+    rhythm: str | None = None,
+    melody: str | None = None,
+    structure: str | None = None,
+    dynamic: str | None = None,
+    emotion: str | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = _DEFAULT_LIMIT,
+) -> SearchResponse:
+    """Musical property filter — delegates to :func:`muse_find.search_commits`.
+
+    Each non-None property is ANDed together; accepts both plain-text and
+    ``key=low-high`` range expressions (e.g. ``tempo=120-130``).
+
+    Args:
+        session: Async SQLAlchemy session.
+        repo_id: Repo to search.
+        harmony: Harmony property filter string.
+        rhythm: Rhythm property filter string.
+        melody: Melody property filter string.
+        structure: Structure property filter string.
+        dynamic: Dynamics property filter string.
+        emotion: Emotion property filter string.
+        since: Earliest committed_at to include (inclusive).
+        until: Latest committed_at to include (inclusive).
+        limit: Maximum results to return.
+
+    Returns:
+        :class:`~maestro.models.musehub.SearchResponse` with mode="property".
+    """
+    query = muse_find.MuseFindQuery(
+        harmony=harmony,
+        rhythm=rhythm,
+        melody=melody,
+        structure=structure,
+        dynamic=dynamic,
+        emotion=emotion,
+        since=since,
+        until=until,
+        limit=limit,
+    )
+    results = await muse_find.search_commits(session, repo_id, query)
+
+    # Build a human-readable summary of the active filters for the query echo.
+    active_filters = {
+        k: v for k, v in {
+            "harmony": harmony,
+            "rhythm": rhythm,
+            "melody": melody,
+            "structure": structure,
+            "dynamic": dynamic,
+            "emotion": emotion,
+        }.items() if v is not None
+    }
+    query_echo = " AND ".join(f"{k}={v}" for k, v in active_filters.items()) or "(all commits)"
+
+    matches = [
+        SearchCommitMatch(
+            commit_id=m.commit_id,
+            branch=m.branch,
+            message=m.message,
+            author=m.author,
+            timestamp=m.committed_at,
+            score=1.0,
+            match_source="property",
+        )
+        for m in results.matches
+    ]
+
+    logger.info("✅ musehub search property: %d matches (repo=%s)", len(matches), repo_id[:8])
+    return SearchResponse(
+        mode="property",
+        query=query_echo,
+        matches=matches,
+        total_scanned=results.total_scanned,
+        limit=limit,
+    )
+
+
+async def search_by_ask(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    question: str,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = _DEFAULT_LIMIT,
+) -> SearchResponse:
+    """Natural-language query — keyword extraction + overlap scoring.
+
+    Strips stop-words from the question to produce a focused keyword set,
+    then ranks commits by overlap coefficient.  Commits with zero overlap
+    are excluded.  Returns at most ``limit`` results ordered by score desc.
+
+    This is a stub implementation; LLM-powered answer generation is a planned
+    enhancement that will replace the keyword scoring step.
+
+    Args:
+        session: Async SQLAlchemy session.
+        repo_id: Repo to search.
+        question: Natural-language question string.
+        since: Earliest committed_at (inclusive).
+        until: Latest committed_at (inclusive).
+        limit: Maximum results to return.
+
+    Returns:
+        :class:`~maestro.models.musehub.SearchResponse` with mode="ask".
+    """
+    rows, total_scanned = await _fetch_candidates(
+        session, repo_id=repo_id, since=since, until=until
+    )
+
+    # Extract meaningful keywords after stop-word removal.
+    tokens_raw = re.split(r"[\s\W]+", question.lower())
+    keywords: set[str] = {t for t in tokens_raw if t and t not in _STOP_WORDS and len(t) > 1}
+
+    scored: list[tuple[float, MuseCliCommit]] = []
+    for commit in rows:
+        if keywords:
+            score = _overlap_score(keywords, commit.message)
+        else:
+            # No useful tokens → include all commits with neutral score.
+            score = 1.0
+        if score > 0.0:
+            scored.append((score, commit))
+
+    scored.sort(key=lambda x: (x[0], x[1].committed_at.timestamp()), reverse=True)
+    top = scored[:limit]
+
+    matches = [_commit_to_match(c, score=s, match_source="message") for s, c in top]
+
+    logger.info("✅ musehub search ask: %d matches (repo=%s)", len(matches), repo_id[:8])
+    return SearchResponse(
+        mode="ask",
+        query=question,
+        matches=matches,
+        total_scanned=total_scanned,
+        limit=limit,
+    )
+
+
+async def search_by_keyword(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    keyword: str,
+    threshold: float = 0.0,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = _DEFAULT_LIMIT,
+) -> SearchResponse:
+    """Keyword search — overlap coefficient over commit messages.
+
+    Tokenises both *keyword* and each commit message, then scores using the
+    overlap coefficient.  Commits below *threshold* are excluded.
+
+    Args:
+        session: Async SQLAlchemy session.
+        repo_id: Repo to search.
+        keyword: Keyword or phrase to search for.
+        threshold: Minimum overlap score [0, 1] to include a commit (default 0 = any match).
+        since: Earliest committed_at (inclusive).
+        until: Latest committed_at (inclusive).
+        limit: Maximum results to return.
+
+    Returns:
+        :class:`~maestro.models.musehub.SearchResponse` with mode="keyword".
+    """
+    rows, total_scanned = await _fetch_candidates(
+        session, repo_id=repo_id, since=since, until=until
+    )
+
+    query_tokens = _tokenize(keyword)
+    scored: list[tuple[float, MuseCliCommit]] = []
+    for commit in rows:
+        score = _overlap_score(query_tokens, commit.message)
+        if score >= threshold and score > 0.0:
+            scored.append((score, commit))
+
+    scored.sort(key=lambda x: (x[0], x[1].committed_at.timestamp()), reverse=True)
+    top = scored[:limit]
+
+    matches = [_commit_to_match(c, score=s, match_source="message") for s, c in top]
+
+    logger.info("✅ musehub search keyword: %d matches (repo=%s)", len(matches), repo_id[:8])
+    return SearchResponse(
+        mode="keyword",
+        query=keyword,
+        matches=matches,
+        total_scanned=total_scanned,
+        limit=limit,
+    )
+
+
+async def search_by_pattern(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    pattern: str,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = _DEFAULT_LIMIT,
+) -> SearchResponse:
+    """Pattern search — case-insensitive substring match against message and branch.
+
+    Matches commits where *pattern* appears anywhere in the commit message or
+    the branch name.  Prioritises message matches over branch-name matches in
+    the result ordering.
+
+    Args:
+        session: Async SQLAlchemy session.
+        repo_id: Repo to search.
+        pattern: Substring pattern to search for.
+        since: Earliest committed_at (inclusive).
+        until: Latest committed_at (inclusive).
+        limit: Maximum results to return.
+
+    Returns:
+        :class:`~maestro.models.musehub.SearchResponse` with mode="pattern".
+    """
+    rows, total_scanned = await _fetch_candidates(
+        session, repo_id=repo_id, since=since, until=until
+    )
+
+    pat = pattern.lower()
+    message_matches: list[SearchCommitMatch] = []
+    branch_matches: list[SearchCommitMatch] = []
+
+    for commit in rows:
+        if pat in commit.message.lower():
+            message_matches.append(_commit_to_match(commit, match_source="message"))
+        elif pat in commit.branch.lower():
+            branch_matches.append(_commit_to_match(commit, match_source="branch"))
+
+    # Message matches come first, then branch matches.
+    all_matches = (message_matches + branch_matches)[:limit]
+
+    logger.info("✅ musehub search pattern: %d matches (repo=%s)", len(all_matches), repo_id[:8])
+    return SearchResponse(
+        mode="pattern",
+        query=pattern,
+        matches=all_matches,
+        total_scanned=total_scanned,
+        limit=limit,
+    )

--- a/maestro/services/musehub_search.py
+++ b/maestro/services/musehub_search.py
@@ -75,7 +75,6 @@ async def _fetch_candidates(
     repo_id: str,
     since: datetime | None,
     until: datetime | None,
-    limit_multiplier: int = 10,
     cap: int = 5000,
 ) -> tuple[list[MuseCliCommit], int]:
     """Fetch candidate commits from DB with optional date range filter.

--- a/tests/test_musehub_search.py
+++ b/tests/test_musehub_search.py
@@ -1,0 +1,464 @@
+"""Tests for Muse Hub in-repo search — issue #235.
+
+Acceptance criteria verified:
+- test_search_page_renders              — GET /musehub/ui/{repo_id}/search → 200 HTML
+- test_search_keyword_mode              — keyword search returns matching commits
+- test_search_keyword_empty_query       — empty keyword query returns empty matches
+- test_search_musical_property          — musical property filter works
+- test_search_natural_language          — ask mode returns matching commits
+- test_search_pattern_message           — pattern matches commit message
+- test_search_pattern_branch            — pattern matches branch name
+- test_search_json_response             — JSON search endpoint returns SearchResponse shape
+- test_search_date_range_since          — since filter excludes old commits
+- test_search_date_range_until          — until filter excludes future commits
+- test_search_invalid_mode              — invalid mode returns 422
+- test_search_unknown_repo              — unknown repo_id returns 404
+- test_search_requires_auth             — unauthenticated request returns 401
+- test_search_limit_respected           — limit caps result count
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import MusehubRepo
+from maestro.muse_cli.models import MuseCliCommit, MuseCliSnapshot
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_repo(db: AsyncSession) -> str:
+    """Seed a minimal MuseHub repo; return repo_id."""
+    repo = MusehubRepo(
+        name="search-test-repo",
+        visibility="private",
+        owner_user_id="test-owner",
+    )
+    db.add(repo)
+    await db.commit()
+    await db.refresh(repo)
+    return str(repo.repo_id)
+
+
+async def _make_snapshot(db: AsyncSession, snapshot_id: str) -> None:
+    """Seed a minimal snapshot so FK constraint on commits is satisfied."""
+    snap = MuseCliSnapshot(snapshot_id=snapshot_id, manifest={})
+    db.add(snap)
+    await db.flush()
+
+
+async def _make_commit(
+    db: AsyncSession,
+    *,
+    repo_id: str,
+    message: str,
+    branch: str = "main",
+    author: str = "test-author",
+    committed_at: datetime | None = None,
+) -> MuseCliCommit:
+    """Seed a single commit for search tests."""
+    snap_id = "snap-" + str(uuid.uuid4()).replace("-", "")[:16]
+    await _make_snapshot(db, snap_id)
+    commit = MuseCliCommit(
+        commit_id=str(uuid.uuid4()).replace("-", ""),
+        repo_id=repo_id,
+        branch=branch,
+        snapshot_id=snap_id,
+        message=message,
+        author=author,
+        committed_at=committed_at or datetime.now(timezone.utc),
+    )
+    db.add(commit)
+    await db.flush()
+    return commit
+
+
+# ---------------------------------------------------------------------------
+# UI page test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_search_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{repo_id}/search returns 200 HTML with mode tabs."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(f"/musehub/ui/{repo_id}/search")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "Muse Hub" in body
+    assert "Search Commits" in body
+    # All four mode tab labels must be present
+    assert "Keyword" in body
+    assert "Natural Language" in body
+    assert "Pattern" in body
+    assert "Musical Properties" in body
+    # Date range inputs
+    assert "inp-since" in body
+    assert "inp-until" in body
+
+
+@pytest.mark.anyio
+async def test_search_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Search UI page is accessible without a JWT (HTML shell, JS handles auth)."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(f"/musehub/ui/{repo_id}/search")
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# JSON search API — authentication
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_search_requires_auth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /api/v1/musehub/repos/{repo_id}/search returns 401 without a token."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(f"/api/v1/musehub/repos/{repo_id}/search?mode=keyword&q=jazz")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_search_unknown_repo(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /api/v1/musehub/repos/{unknown}/search returns 404."""
+    response = await client.get(
+        "/api/v1/musehub/repos/does-not-exist/search?mode=keyword&q=test",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_search_invalid_mode(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET search with an unknown mode returns 422."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/search?mode=badmode&q=x",
+        headers=auth_headers,
+    )
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# JSON search API — keyword mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_search_keyword_mode(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Keyword search returns commits whose messages overlap with the query."""
+    repo_id = await _make_repo(db_session)
+    await db_session.commit()
+
+    await _make_commit(db_session, repo_id=repo_id, message="dark jazz bassline in Dm")
+    await _make_commit(db_session, repo_id=repo_id, message="classical piano intro section")
+    await _make_commit(db_session, repo_id=repo_id, message="hip hop drum fill pattern")
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/search?mode=keyword&q=jazz+bassline",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "keyword"
+    assert data["query"] == "jazz bassline"
+    # The jazz bassline commit must match; the others may or may not
+    assert any("jazz" in m["message"].lower() for m in data["matches"])
+
+
+@pytest.mark.anyio
+async def test_search_keyword_empty_query(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Empty keyword query returns empty matches (no tokens → no overlap)."""
+    repo_id = await _make_repo(db_session)
+    await db_session.commit()
+    await _make_commit(db_session, repo_id=repo_id, message="some commit")
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/search?mode=keyword&q=",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "keyword"
+    assert data["matches"] == []
+
+
+@pytest.mark.anyio
+async def test_search_json_response(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Search response has the expected SearchResponse JSON shape."""
+    repo_id = await _make_repo(db_session)
+    await db_session.commit()
+    await _make_commit(db_session, repo_id=repo_id, message="piano chord progression F Bb Eb")
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/search?mode=keyword&q=piano",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    # Verify top-level envelope fields
+    assert "mode" in data
+    assert "query" in data
+    assert "matches" in data
+    assert "totalScanned" in data
+    assert "limit" in data
+
+    # Verify commit-match field shape
+    if data["matches"]:
+        m = data["matches"][0]
+        assert "commitId" in m
+        assert "branch" in m
+        assert "message" in m
+        assert "author" in m
+        assert "timestamp" in m
+        assert "score" in m
+        assert "matchSource" in m
+
+
+# ---------------------------------------------------------------------------
+# JSON search API — musical property mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_search_musical_property(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Property mode filters commits containing the harmony string."""
+    repo_id = await _make_repo(db_session)
+    await db_session.commit()
+
+    await _make_commit(db_session, repo_id=repo_id, message="add harmony=Eb bridge section")
+    await _make_commit(db_session, repo_id=repo_id, message="drum groove tweak no harmony")
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/search?mode=property&harmony=Eb",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "property"
+    assert len(data["matches"]) >= 1
+    assert all("Eb" in m["message"] for m in data["matches"])
+
+
+# ---------------------------------------------------------------------------
+# JSON search API — natural language (ask) mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_search_natural_language(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Ask mode extracts keywords and returns relevant commits."""
+    repo_id = await _make_repo(db_session)
+    await db_session.commit()
+
+    await _make_commit(db_session, repo_id=repo_id, message="switched tempo to 140bpm for drop")
+    await _make_commit(db_session, repo_id=repo_id, message="piano melody in minor key")
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/search?mode=ask&q=what+tempo+changes+did+I+make",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "ask"
+    # The tempo commit should match; keywords extracted: "tempo", "changes"
+    assert any("tempo" in m["message"].lower() for m in data["matches"])
+
+
+# ---------------------------------------------------------------------------
+# JSON search API — pattern mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_search_pattern_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Pattern mode matches substring in commit message."""
+    repo_id = await _make_repo(db_session)
+    await db_session.commit()
+
+    await _make_commit(db_session, repo_id=repo_id, message="add Cm7 chord voicing in bridge")
+    await _make_commit(db_session, repo_id=repo_id, message="fix timing on verse drums")
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/search?mode=pattern&q=Cm7",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "pattern"
+    assert len(data["matches"]) == 1
+    assert "Cm7" in data["matches"][0]["message"]
+    assert data["matches"][0]["matchSource"] == "message"
+
+
+@pytest.mark.anyio
+async def test_search_pattern_branch(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Pattern mode matches substring in branch name when message doesn't match."""
+    repo_id = await _make_repo(db_session)
+    await db_session.commit()
+
+    await _make_commit(
+        db_session,
+        repo_id=repo_id,
+        message="rough cut",
+        branch="feature/hip-hop-session",
+    )
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/search?mode=pattern&q=hip-hop",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mode"] == "pattern"
+    assert len(data["matches"]) == 1
+    assert data["matches"][0]["matchSource"] == "branch"
+
+
+# ---------------------------------------------------------------------------
+# JSON search API — date range filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_search_date_range_since(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """since filter excludes commits committed before the given datetime."""
+    repo_id = await _make_repo(db_session)
+    await db_session.commit()
+
+    old_ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    new_ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    await _make_commit(db_session, repo_id=repo_id, message="old jazz commit", committed_at=old_ts)
+    await _make_commit(db_session, repo_id=repo_id, message="new jazz commit", committed_at=new_ts)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/search?mode=keyword&q=jazz&since=2025-06-01T00:00:00Z",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert all(m["message"] != "old jazz commit" for m in data["matches"])
+    assert any(m["message"] == "new jazz commit" for m in data["matches"])
+
+
+@pytest.mark.anyio
+async def test_search_date_range_until(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """until filter excludes commits committed after the given datetime."""
+    repo_id = await _make_repo(db_session)
+    await db_session.commit()
+
+    old_ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    new_ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    await _make_commit(db_session, repo_id=repo_id, message="old piano commit", committed_at=old_ts)
+    await _make_commit(db_session, repo_id=repo_id, message="new piano commit", committed_at=new_ts)
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/search?mode=keyword&q=piano&until=2025-06-01T00:00:00Z",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert any(m["message"] == "old piano commit" for m in data["matches"])
+    assert all(m["message"] != "new piano commit" for m in data["matches"])
+
+
+# ---------------------------------------------------------------------------
+# JSON search API — limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_search_limit_respected(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """The limit parameter caps the number of results returned."""
+    repo_id = await _make_repo(db_session)
+    await db_session.commit()
+
+    for i in range(10):
+        await _make_commit(db_session, repo_id=repo_id, message=f"bass groove iteration {i}")
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/search?mode=keyword&q=bass&limit=3",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["matches"]) <= 3
+    assert data["limit"] == 3


### PR DESCRIPTION
## Summary
Closes #235 — adds a full in-repo search interface to Muse Hub, exposing all four Muse search modes through a web UI and JSON API.

## Root Cause / Motivation
Muse Hub had no search capability. Musicians needed to fall back to the CLI (`muse find`, `muse ask`, `muse recall`, `muse grep`) even for simple queries like "when did I switch to F# minor?". This adds a first-class web search experience.

## Solution

### New files
- **`maestro/services/musehub_search.py`** — Service layer with four search functions (property / ask / keyword / pattern), all operating on `muse_cli_commits` scoped by `repo_id`. Delegates `property` mode to the existing `muse_find.search_commits()`.
- **`maestro/api/routes/musehub/search.py`** — `GET /api/v1/musehub/repos/{repo_id}/search` endpoint. Mode-dispatches to the search service. Returns `SearchResponse` JSON.
- **`tests/test_musehub_search.py`** — 15 tests covering all four modes, date-range filters, auth, 404, 422, limit capping.

### Updated files
- **`maestro/models/musehub.py`** — Added `SearchCommitMatch` and `SearchResponse` Pydantic models.
- **`maestro/api/routes/musehub/__init__.py`** — Wired `search.router`.
- **`maestro/api/routes/musehub/ui.py`** — Added `search_page()` at `GET /musehub/ui/{repo_id}/search` with four mode tabs (Keyword, Natural Language, Pattern, Musical Properties), date range inputs, and a live results renderer with audio preview links. Also added a Search nav link to the repo page.
- **`docs/architecture/muse_vcs.md`** — In-repo search section with endpoint table, parameter table, mode explanations, and agent use case.
- **`docs/reference/type_contracts.md`** — Registered `SearchCommitMatch` and `SearchResponse`.

### Search modes
| Mode | Algorithm | Score |
|------|-----------|-------|
| `property` | AND-combined musical property filters; delegates to `muse_find` | 1.0 |
| `ask` | Stop-word stripped keyword extraction + overlap coefficient | 0–1 |
| `keyword` | Overlap coefficient `\|Q ∩ M\| / \|Q\|` | 0–1 |
| `pattern` | Case-insensitive substring match (message → branch) | 1.0 |

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (pre-existing untyped-import errors only)
- [x] `pytest tests/test_musehub_search.py` — 15 passed, 0 warnings
- [x] `pytest tests/test_musehub_ui.py` — 12 passed, 0 warnings
- [x] Docs updated in same commit

## Tests Added
- `test_search_page_renders` — HTML page 200 with all four mode tabs
- `test_search_page_no_auth_required` — UI page accessible without JWT
- `test_search_requires_auth` — API returns 401 without token
- `test_search_unknown_repo` — returns 404
- `test_search_invalid_mode` — returns 422
- `test_search_keyword_mode` — keyword overlap returns matching commits
- `test_search_keyword_empty_query` — empty query → empty matches
- `test_search_json_response` — full SearchResponse shape verified
- `test_search_musical_property` — harmony filter returns property matches
- `test_search_natural_language` — ask mode extracts keywords, finds commits
- `test_search_pattern_message` — pattern matches commit message
- `test_search_pattern_branch` — pattern matches branch name
- `test_search_date_range_since` — since filter excludes old commits
- `test_search_date_range_until` — until filter excludes future commits
- `test_search_limit_respected` — limit caps result count

## Handoff
N/A — no SSE protocol or MCP tool schema changes.