### PR TITLE
feat: context viewer — human-readable view of the AI musical context document

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -1431,6 +1431,29 @@ maestro/
 | GET | `/api/v1/musehub/repos/{id}` | Get repo metadata |
 | GET | `/api/v1/musehub/repos/{id}/branches` | List branches |
 | GET | `/api/v1/musehub/repos/{id}/commits` | List commits (newest first) |
+| GET | `/api/v1/musehub/repos/{id}/context/{ref}` | Musical context document for a commit (JSON) |
+
+#### Context Viewer
+
+The context viewer exposes what the AI agent sees when generating music for a given commit.
+
+**API endpoint:** `GET /api/v1/musehub/repos/{repo_id}/context/{ref}` — requires JWT auth.
+Returns a `MuseHubContextResponse` document with:
+- `musical_state` — active tracks derived from stored artifact paths; musical dimensions (key, tempo, etc.) are `null` until Storpheus MIDI analysis is integrated.
+- `history` — up to 5 ancestor commits (newest-first), built by walking `parent_ids`.
+- `missing_elements` — list of dimensions the agent cannot determine from stored data.
+- `suggestions` — composer-facing hints about what to work on next.
+
+**UI page:** `GET /musehub/ui/{repo_id}/context/{ref}` — no auth required (JS shell handles auth).
+Renders the context document in structured HTML with:
+- "What the Agent Sees" explainer at the top
+- Collapsible sections for Musical State, History, Missing Elements, and Suggestions
+- Raw JSON panel with a Copy-to-Clipboard button for pasting context into agent prompts
+- Breadcrumb navigation back to the repo page
+
+**Service:** `maestro/services/musehub_repository.py::get_context_for_commit()` — read-only, deterministic.
+
+**Agent use case:** A musician debugging why the AI generated something unexpected can load the context page for that commit and see exactly what musical knowledge the agent had. The copy button lets them paste the raw JSON into a new agent conversation for direct inspection or override.
 
 #### Issues
 

--- a/docs/guides/integrate.md
+++ b/docs/guides/integrate.md
@@ -84,6 +84,25 @@ separate frontend required.
 | Pull request detail (+ Merge button) | `GET /musehub/ui/{repo_id}/pulls/{pr_id}` |
 | Issue list | `GET /musehub/ui/{repo_id}/issues` |
 | Issue detail (+ Close button) | `GET /musehub/ui/{repo_id}/issues/{number}` |
+| **AI context viewer** | `GET /musehub/ui/{repo_id}/context/{ref}` |
+
+### AI context viewer
+
+The context viewer shows exactly what the AI agent sees when generating music for a given commit. Navigate to:
+
+```
+/musehub/ui/{repo_id}/context/{commit_id}
+```
+
+The page renders a structured document with:
+- **"What the Agent Sees"** — explainer banner summarising the agent's musical knowledge at this commit
+- **Musical State** — active tracks (derived from stored artifact paths) plus any available musical dimensions (key, tempo, time signature, form, emotion)
+- **History Summary** — the target commit and up to 5 ancestor commits, newest-first
+- **Missing Elements** — dimensions the agent cannot determine from stored data (e.g. key, tempo until Storpheus MIDI analysis is wired)
+- **Suggestions** — composer-facing hints for what to develop next
+- **Raw JSON** — the full `MuseHubContextResponse` with a **Copy JSON** button for pasting directly into an agent conversation
+
+**For agents:** The JSON API endpoint is `GET /api/v1/musehub/repos/{repo_id}/context/{ref}` (requires `Authorization: Bearer <token>`). It returns a `MuseHubContextResponse` with the same structure as the UI. Agents consuming this endpoint get the same musical context that the in-app generation pipeline uses.
 
 ### Authentication in the browser
 

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5846,6 +5846,63 @@ Wrapper returned by `GET /api/v1/musehub/repos/{repo_id}/objects`.
 **Producer:** `objects.list_objects` route handler
 **Consumer:** Muse Hub web UI; any agent inspecting which artifacts are available for a repo
 
+### `MuseHubContextCommitInfo`
+
+Minimal commit metadata nested inside `MuseHubContextResponse`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | Full 64-char commit hash |
+| `message` | `str` | Commit message |
+| `author` | `str` | Commit author (from push payload) |
+| `branch` | `str` | Branch the commit belongs to |
+| `timestamp` | `datetime` | UTC timestamp of the commit |
+
+### `MuseHubContextHistoryEntry`
+
+One ancestor commit in the evolutionary history section of `MuseHubContextResponse`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | Full 64-char commit hash |
+| `message` | `str` | Commit message |
+| `author` | `str` | Commit author |
+| `timestamp` | `datetime` | UTC commit timestamp |
+| `active_tracks` | `list[str]` | Track names derived from repo objects at that point |
+
+### `MuseHubContextMusicalState`
+
+Musical state at the target commit, derived from stored artifact paths.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `active_tracks` | `list[str]` | Track names inferred from music file extensions in stored objects |
+| `key` | `str \| None` | Musical key — `null` until Storpheus MIDI analysis is integrated |
+| `mode` | `str \| None` | Modal quality (major/minor/dorian/…) — `null` until Storpheus integrated |
+| `tempo_bpm` | `int \| None` | Tempo in BPM — `null` until Storpheus integrated |
+| `time_signature` | `str \| None` | Time signature (e.g. `"4/4"`) — `null` until Storpheus integrated |
+| `form` | `str \| None` | Song form label — `null` until Storpheus integrated |
+| `emotion` | `str \| None` | Emotional quality — `null` until Storpheus integrated |
+
+### `MuseHubContextResponse`
+
+Complete musical context document for a MuseHub commit. The MuseHub equivalent of `MuseContextResult`,
+built from the remote repo's commit graph and stored objects rather than the local `.muse` filesystem.
+Returned by `GET /api/v1/musehub/repos/{repo_id}/context/{ref}`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo_id` | `str` | Hub repo identifier |
+| `current_branch` | `str` | Branch name for the target commit |
+| `head_commit` | `MuseHubContextCommitInfo` | Metadata for the resolved commit (ref) |
+| `musical_state` | `MuseHubContextMusicalState` | Active tracks and musical dimensions |
+| `history` | `list[MuseHubContextHistoryEntry]` | Up to 5 ancestor commits, newest-first |
+| `missing_elements` | `list[str]` | Dimensions that could not be determined from stored data |
+| `suggestions` | `dict[str, str]` | Composer-facing hints about what to work on next |
+
+**Producer:** `musehub_repository.get_context_for_commit()` → `repos.get_context` route handler
+**Consumer:** Muse Hub web UI context page (`/musehub/ui/{repo_id}/context/{ref}`); AI agents calling the JSON endpoint directly to obtain the same context the generation pipeline uses.
+
 ---
 
 ## Muse Bisect Types

--- a/maestro/api/routes/musehub/repos.py
+++ b/maestro/api/routes/musehub/repos.py
@@ -23,6 +23,7 @@ from maestro.models.musehub import (
     BranchListResponse,
     CommitListResponse,
     CreateRepoRequest,
+    MuseHubContextResponse,
     RepoResponse,
 )
 from maestro.services import musehub_repository
@@ -112,3 +113,35 @@ async def list_commits(
         db, repo_id, branch=branch, limit=limit
     )
     return CommitListResponse(commits=commits, total=total)
+
+
+@router.get(
+    "/repos/{repo_id}/context/{ref}",
+    response_model=MuseHubContextResponse,
+    summary="Get musical context document for a commit",
+)
+async def get_context(
+    repo_id: str,
+    ref: str,
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> MuseHubContextResponse:
+    """Return a structured musical context document for the given commit ref.
+
+    The context document is the same information the AI agent receives when
+    generating music for this repo at this commit — making it human-inspectable
+    for debugging and transparency.
+
+    Raises 404 if either the repo or the commit does not exist.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    context = await musehub_repository.get_context_for_commit(db, repo_id, ref)
+    if context is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Commit {ref!r} not found in repo",
+        )
+    return context

--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -669,6 +669,220 @@ async def issue_list_page(repo_id: str) -> HTMLResponse:
 
 
 @router.get(
+    "/{repo_id}/context/{ref}",
+    response_class=HTMLResponse,
+    summary="Muse Hub context viewer page",
+)
+async def context_page(repo_id: str, ref: str) -> HTMLResponse:
+    """Render the AI context viewer for a given commit ref.
+
+    Fetches ``GET /api/v1/musehub/repos/{repo_id}/context/{ref}`` and renders
+    the MuseHubContextResponse as a structured human-readable document.
+
+    Sections:
+    - "What the agent sees" explainer
+    - Musical State (active tracks + available musical dimensions)
+    - History Summary (recent ancestor commits)
+    - Missing Elements (dimensions not yet available)
+    - Suggestions (what to compose next)
+    - Raw JSON toggle for debugging
+    - Copy-to-clipboard button for sharing with agents
+    """
+    script = f"""
+      const repoId = {repr(repo_id)};
+      const ref    = {repr(ref)};
+      const base   = '/musehub/ui/' + repoId;
+
+      function escHtml(s) {{
+        if (s === null || s === undefined) return '—';
+        return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+      }}
+
+      function copyJson() {{
+        const text = document.getElementById('raw-json').textContent;
+        navigator.clipboard.writeText(text).then(() => {{
+          const btn = document.getElementById('copy-btn');
+          btn.textContent = 'Copied!';
+          setTimeout(() => {{ btn.textContent = 'Copy JSON'; }}, 2000);
+        }});
+      }}
+
+      function toggleSection(id) {{
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.style.display = el.style.display === 'none' ? '' : 'none';
+        const btn = document.querySelector('[data-target="' + id + '"]');
+        if (btn) btn.textContent = el.style.display === 'none' ? '▶ Show' : '▼ Hide';
+      }}
+
+      async function load() {{
+        try {{
+          const ctx = await apiFetch('/repos/' + repoId + '/context/' + ref);
+
+          const tracks = (ctx.musicalState.activeTracks || []);
+          const trackList = tracks.length > 0
+            ? tracks.map(t => '<span class="label">' + escHtml(t) + '</span>').join(' ')
+            : '<em style="color:#8b949e">No music files found in repo yet.</em>';
+
+          function dimRow(label, val) {{
+            return val !== null && val !== undefined
+              ? '<div class="meta-item"><span class="meta-label">' + label + '</span>'
+                + '<span class="meta-value">' + escHtml(val) + '</span></div>'
+              : '';
+          }}
+
+          const musicalDims = [
+            dimRow('Key', ctx.musicalState.key),
+            dimRow('Mode', ctx.musicalState.mode),
+            dimRow('Tempo (BPM)', ctx.musicalState.tempoBpm),
+            dimRow('Time Signature', ctx.musicalState.timeSignature),
+            dimRow('Form', ctx.musicalState.form),
+            dimRow('Emotion', ctx.musicalState.emotion),
+          ].filter(Boolean).join('');
+
+          const histEntries = (ctx.history || []);
+          const histRows = histEntries.length > 0
+            ? histEntries.map(h => `
+                <div class="commit-row">
+                  <a class="commit-sha" href="${{base}}/commits/${{h.commitId}}">${{shortSha(h.commitId)}}</a>
+                  <span class="commit-msg">${{escHtml(h.message)}}</span>
+                  <span class="commit-meta">${{escHtml(h.author)}} &bull; ${{fmtDate(h.timestamp)}}</span>
+                </div>`).join('')
+            : '<p class="loading">No ancestor commits.</p>';
+
+          const missing = (ctx.missingElements || []);
+          const missingList = missing.length > 0
+            ? '<ul style="padding-left:20px;font-size:14px">' + missing.map(m => '<li>' + escHtml(m) + '</li>').join('') + '</ul>'
+            : '<p style="color:#3fb950;font-size:14px">All musical dimensions are available.</p>';
+
+          const suggestions = ctx.suggestions || {{}};
+          const suggKeys = Object.keys(suggestions);
+          const suggList = suggKeys.length > 0
+            ? suggKeys.map(k => '<div style="margin-bottom:8px"><strong style="color:#e6edf3">' + escHtml(k) + ':</strong> ' + escHtml(suggestions[k]) + '</div>').join('')
+            : '<p class="loading">No suggestions available.</p>';
+
+          const rawJson = JSON.stringify(ctx, null, 2);
+
+          document.getElementById('content').innerHTML = `
+            <div style="margin-bottom:12px">
+              <a href="${{base}}">&larr; Back to repo</a>
+            </div>
+
+            <div class="card" style="border-color:#1f6feb">
+              <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px">
+                <span style="font-size:20px">&#127925;</span>
+                <h1 style="margin:0;font-size:18px">What the Agent Sees</h1>
+              </div>
+              <p style="font-size:14px;color:#8b949e;margin-bottom:0">
+                This is the musical context document that the AI agent receives
+                when generating music for this repo at commit
+                <code style="font-size:12px;background:#0d1117;padding:2px 6px;border-radius:4px">${{shortSha(ref)}}</code>.
+                Every composition decision — key, tempo, arrangement, what to add next —
+                is guided by this document.
+              </p>
+            </div>
+
+            <div class="card">
+              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+                <h2 style="margin:0">&#127925; Musical State</h2>
+                <button class="btn btn-secondary" style="font-size:12px"
+                        data-target="musical-state-body" onclick="toggleSection('musical-state-body')">&#9660; Hide</button>
+              </div>
+              <div id="musical-state-body">
+                <div style="margin-bottom:10px">
+                  <span class="meta-label">Active Tracks</span>
+                  <div style="margin-top:4px">${{trackList}}</div>
+                </div>
+                ${{musicalDims ? '<div class="meta-row" style="margin-top:12px">' + musicalDims + '</div>' : '<p style="font-size:13px;color:#8b949e">Musical dimensions (key, tempo, etc.) require MIDI analysis — not yet available.</p>'}}
+              </div>
+            </div>
+
+            <div class="card">
+              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+                <h2 style="margin:0">&#128337; History Summary</h2>
+                <button class="btn btn-secondary" style="font-size:12px"
+                        data-target="history-body" onclick="toggleSection('history-body')">&#9660; Hide</button>
+              </div>
+              <div id="history-body">
+                <div class="meta-row" style="margin-bottom:12px">
+                  <div class="meta-item">
+                    <span class="meta-label">Commit</span>
+                    <span class="meta-value" style="font-family:monospace">${{shortSha(ctx.headCommit.commitId)}}</span>
+                  </div>
+                  <div class="meta-item">
+                    <span class="meta-label">Branch</span>
+                    <span class="meta-value">${{escHtml(ctx.currentBranch)}}</span>
+                  </div>
+                  <div class="meta-item">
+                    <span class="meta-label">Author</span>
+                    <span class="meta-value">${{escHtml(ctx.headCommit.author)}}</span>
+                  </div>
+                  <div class="meta-item">
+                    <span class="meta-label">Date</span>
+                    <span class="meta-value">${{fmtDate(ctx.headCommit.timestamp)}}</span>
+                  </div>
+                </div>
+                <pre style="margin-bottom:12px">${{escHtml(ctx.headCommit.message)}}</pre>
+                <h2 style="font-size:14px;margin-bottom:8px">Ancestors (${{histEntries.length}})</h2>
+                ${{histRows}}
+              </div>
+            </div>
+
+            <div class="card">
+              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+                <h2 style="margin:0">&#9888;&#65039; Missing Elements</h2>
+                <button class="btn btn-secondary" style="font-size:12px"
+                        data-target="missing-body" onclick="toggleSection('missing-body')">&#9660; Hide</button>
+              </div>
+              <div id="missing-body">
+                ${{missingList}}
+              </div>
+            </div>
+
+            <div class="card" style="border-color:#238636">
+              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+                <h2 style="margin:0">&#127775; Suggestions</h2>
+                <button class="btn btn-secondary" style="font-size:12px"
+                        data-target="suggestions-body" onclick="toggleSection('suggestions-body')">&#9660; Hide</button>
+              </div>
+              <div id="suggestions-body">
+                ${{suggList}}
+              </div>
+            </div>
+
+            <div class="card">
+              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+                <h2 style="margin:0">&#128196; Raw JSON</h2>
+                <div style="display:flex;gap:8px">
+                  <button id="copy-btn" class="btn btn-secondary" style="font-size:12px" onclick="copyJson()">Copy JSON</button>
+                  <button class="btn btn-secondary" style="font-size:12px"
+                          data-target="raw-json-body" onclick="toggleSection('raw-json-body')">&#9660; Hide</button>
+                </div>
+              </div>
+              <div id="raw-json-body">
+                <pre id="raw-json">${{escHtml(rawJson)}}</pre>
+              </div>
+            </div>`;
+        }} catch(e) {{
+          if (e.message !== 'auth')
+            document.getElementById('content').innerHTML = '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+        }}
+      }}
+
+      load();
+    """
+    html = _page(
+        title=f"Context {ref[:8]}",
+        breadcrumb=(
+            f'<a href="/musehub/ui/{repo_id}">{repo_id[:8]}</a> / '
+            f"context / {ref[:8]}"
+        ),
+        body_script=script,
+    )
+    return HTMLResponse(content=html)
+
+
+@router.get(
     "/{repo_id}/issues/{number}",
     response_class=HTMLResponse,
     summary="Muse Hub issue detail page",

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -240,3 +240,76 @@ class ObjectMetaListResponse(CamelModel):
     """List of artifact metadata for a repo."""
 
     objects: list[ObjectMetaResponse]
+
+
+# ── Context models ────────────────────────────────────────────────────────────
+
+
+class MuseHubContextCommitInfo(CamelModel):
+    """Minimal commit metadata included in a MuseHub context document."""
+
+    commit_id: str
+    message: str
+    author: str
+    branch: str
+    timestamp: datetime
+
+
+class MuseHubContextHistoryEntry(CamelModel):
+    """A single ancestor commit in the evolutionary history of the composition.
+
+    History is built by walking parent_ids from the target commit.
+    Entries are returned newest-first and limited to the last 5 ancestors.
+    """
+
+    commit_id: str
+    message: str
+    author: str
+    timestamp: datetime
+    active_tracks: list[str]
+
+
+class MuseHubContextMusicalState(CamelModel):
+    """Musical state at the target commit, derived from stored artifact paths.
+
+    ``active_tracks`` is populated from object paths in the repo.
+    All analytical fields (key, tempo, etc.) are None until Storpheus MIDI
+    analysis is integrated — agents should treat None as "unknown."
+    """
+
+    active_tracks: list[str]
+    key: str | None = None
+    mode: str | None = None
+    tempo_bpm: int | None = None
+    time_signature: str | None = None
+    form: str | None = None
+    emotion: str | None = None
+
+
+class MuseHubContextResponse(CamelModel):
+    """Human-readable and agent-consumable musical context document for a commit.
+
+    Returned by ``GET /api/v1/musehub/repos/{repo_id}/context/{ref}``.
+
+    This is the MuseHub equivalent of ``MuseContextResult`` — built from
+    the remote repo's commit graph and stored objects rather than the local
+    ``.muse`` filesystem.  The structure deliberately mirrors ``MuseContextResult``
+    so that agents consuming either source see the same schema.
+
+    Fields:
+        repo_id:        The hub repo identifier.
+        current_branch: Branch name for the target commit.
+        head_commit:    Metadata for the resolved commit (ref).
+        musical_state:  Active tracks and any available musical dimensions.
+        history:        Up to 5 ancestor commits, newest-first.
+        missing_elements: Dimensions that could not be determined from stored data.
+        suggestions:    Composer-facing hints about what to work on next.
+    """
+
+    repo_id: str
+    current_branch: str
+    head_commit: MuseHubContextCommitInfo
+    musical_state: MuseHubContextMusicalState
+    history: list[MuseHubContextHistoryEntry]
+    missing_elements: list[str]
+    suggestions: dict[str, str]

--- a/maestro/services/musehub_repository.py
+++ b/maestro/services/musehub_repository.py
@@ -20,6 +20,10 @@ from maestro.db import musehub_models as db
 from maestro.models.musehub import (
     BranchResponse,
     CommitResponse,
+    MuseHubContextCommitInfo,
+    MuseHubContextHistoryEntry,
+    MuseHubContextMusicalState,
+    MuseHubContextResponse,
     ObjectMetaResponse,
     RepoResponse,
 )
@@ -179,3 +183,165 @@ async def list_commits(
     rows_stmt = base.order_by(desc(db.MusehubCommit.timestamp)).limit(limit)
     rows = (await session.execute(rows_stmt)).scalars().all()
     return [_to_commit_response(r) for r in rows], total
+
+
+# ---------------------------------------------------------------------------
+# Context document builder
+# ---------------------------------------------------------------------------
+
+_MUSIC_FILE_EXTENSIONS = frozenset(
+    {".mid", ".midi", ".mp3", ".wav", ".aiff", ".aif", ".flac"}
+)
+
+_CONTEXT_HISTORY_DEPTH = 5
+
+
+def _extract_track_names_from_objects(objects: list[db.MusehubObject]) -> list[str]:
+    """Derive human-readable track names from stored object paths.
+
+    Files with recognised music extensions whose stems do not look like raw
+    SHA-256 hashes are treated as track names.  The stem is lowercased and
+    de-duplicated, matching the convention in ``muse_context._extract_track_names``.
+    """
+    import pathlib
+
+    tracks: list[str] = []
+    for obj in objects:
+        p = pathlib.PurePosixPath(obj.path)
+        if p.suffix.lower() in _MUSIC_FILE_EXTENSIONS:
+            stem = p.stem.lower()
+            if len(stem) == 64 and all(c in "0123456789abcdef" for c in stem):
+                continue
+            tracks.append(stem)
+    return sorted(set(tracks))
+
+
+async def _get_commit_by_id(
+    session: AsyncSession, repo_id: str, commit_id: str
+) -> db.MusehubCommit | None:
+    """Fetch a raw MusehubCommit ORM row by (repo_id, commit_id)."""
+    stmt = select(db.MusehubCommit).where(
+        db.MusehubCommit.repo_id == repo_id,
+        db.MusehubCommit.commit_id == commit_id,
+    )
+    return (await session.execute(stmt)).scalars().first()
+
+
+async def _build_hub_history(
+    session: AsyncSession,
+    repo_id: str,
+    start_commit: db.MusehubCommit,
+    objects: list[db.MusehubObject],
+    depth: int,
+) -> list[MuseHubContextHistoryEntry]:
+    """Walk the parent chain, returning up to *depth* ancestor entries.
+
+    The *start_commit* (the context target) is NOT included — it is surfaced
+    separately as ``head_commit`` in the result.  Entries are newest-first.
+    The object list is reused across entries since we have no per-commit object
+    index at this layer; active tracks reflect the overall repo's artifact set.
+    """
+    entries: list[MuseHubContextHistoryEntry] = []
+    parent_ids: list[str] = list(start_commit.parent_ids or [])
+
+    while parent_ids and len(entries) < depth:
+        parent_id = parent_ids[0]
+        commit = await _get_commit_by_id(session, repo_id, parent_id)
+        if commit is None:
+            logger.warning("⚠️ Hub history chain broken at %s", parent_id[:8])
+            break
+        entries.append(
+            MuseHubContextHistoryEntry(
+                commit_id=commit.commit_id,
+                message=commit.message,
+                author=commit.author,
+                timestamp=commit.timestamp,
+                active_tracks=_extract_track_names_from_objects(objects),
+            )
+        )
+        parent_ids = list(commit.parent_ids or [])
+
+    return entries
+
+
+async def get_context_for_commit(
+    session: AsyncSession,
+    repo_id: str,
+    ref: str,
+) -> MuseHubContextResponse | None:
+    """Build a musical context document for a MuseHub commit.
+
+    Traverses the commit's parent chain (up to 5 ancestors) and derives active
+    tracks from the repo's stored objects.  Musical dimensions (key, tempo,
+    etc.) are always None until Storpheus MIDI analysis is integrated.
+
+    Args:
+        session:  Open async DB session. Read-only — no writes performed.
+        repo_id:  Hub repo identifier.
+        ref:      Target commit ID.  Must belong to this repo.
+
+    Returns:
+        ``MuseHubContextResponse`` ready for JSON serialisation, or None if the
+        commit does not exist in this repo.
+
+    The output is deterministic: for the same ``repo_id`` + ``ref``, the result
+    is always identical, making it safe to cache.
+    """
+    commit = await _get_commit_by_id(session, repo_id, ref)
+    if commit is None:
+        return None
+
+    objects = await list_objects(session, repo_id)
+    raw_objects_stmt = select(db.MusehubObject).where(
+        db.MusehubObject.repo_id == repo_id
+    )
+    raw_objects = (await session.execute(raw_objects_stmt)).scalars().all()
+
+    active_tracks = _extract_track_names_from_objects(list(raw_objects))
+
+    head_commit_info = MuseHubContextCommitInfo(
+        commit_id=commit.commit_id,
+        message=commit.message,
+        author=commit.author,
+        branch=commit.branch,
+        timestamp=commit.timestamp,
+    )
+
+    musical_state = MuseHubContextMusicalState(active_tracks=active_tracks)
+
+    history = await _build_hub_history(
+        session, repo_id, commit, list(raw_objects), _CONTEXT_HISTORY_DEPTH
+    )
+
+    missing: list[str] = []
+    if not active_tracks:
+        missing.append("no music files found in repo")
+    for dim in ("key", "tempo_bpm", "time_signature", "form", "emotion"):
+        missing.append(dim)
+
+    suggestions: dict[str, str] = {}
+    if not active_tracks:
+        suggestions["first_track"] = (
+            "Push your first MIDI or audio file to populate the musical state."
+        )
+    else:
+        suggestions["next_section"] = (
+            f"Current tracks: {', '.join(active_tracks)}. "
+            "Consider adding harmonic or melodic variation to develop the composition."
+        )
+
+    logger.info(
+        "✅ Muse Hub context built for repo %s commit %s (tracks=%d)",
+        repo_id[:8],
+        ref[:8],
+        len(active_tracks),
+    )
+    return MuseHubContextResponse(
+        repo_id=repo_id,
+        current_branch=commit.branch,
+        head_commit=head_commit_info,
+        musical_state=musical_state,
+        history=history,
+        missing_elements=missing,
+        suggestions=suggestions,
+    )

--- a/maestro/services/musehub_repository.py
+++ b/maestro/services/musehub_repository.py
@@ -291,7 +291,6 @@ async def get_context_for_commit(
     if commit is None:
         return None
 
-    objects = await list_objects(session, repo_id)
     raw_objects_stmt = select(db.MusehubObject).where(
         db.MusehubObject.repo_id == repo_id
     )

--- a/tests/test_musehub_ui.py
+++ b/tests/test_musehub_ui.py
@@ -1,21 +1,27 @@
 """Tests for Muse Hub web UI endpoints.
 
-Covers the minimum acceptance criteria from issue #43:
+Covers the minimum acceptance criteria from issue #43 and issue #232:
 - test_ui_repo_page_returns_200        — GET /musehub/ui/{repo_id} returns HTML
 - test_ui_commit_page_shows_artifact_links — commit page HTML mentions img/download
 - test_ui_pr_list_page_returns_200     — PR list page renders without error
 - test_ui_issue_list_page_returns_200  — Issue list page renders without error
+- test_context_page_renders            — context viewer page returns 200 HTML
+- test_context_json_response           — JSON returns MuseHubContextResponse structure
+- test_context_includes_musical_state  — response includes active_tracks field
+- test_context_unknown_ref_404         — nonexistent ref returns 404
 
 UI routes require no JWT auth (they return HTML shells whose JS handles auth).
 The HTML content tests assert structural markers present in every rendered page.
 """
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from maestro.db.musehub_models import MusehubRepo
+from maestro.db.musehub_models import MusehubCommit, MusehubRepo
 
 
 # ---------------------------------------------------------------------------
@@ -236,3 +242,152 @@ async def test_get_object_content_404_for_unknown_object(
         headers=auth_headers,
     )
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Context viewer tests (issue #232)
+# ---------------------------------------------------------------------------
+
+_FIXED_COMMIT_ID = "aabbccdd" * 8  # 64-char hex string
+
+
+async def _make_repo_with_commit(db_session: AsyncSession) -> tuple[str, str]:
+    """Seed a repo with one commit and return (repo_id, commit_id)."""
+    repo = MusehubRepo(
+        name="jazz-context-test",
+        visibility="private",
+        owner_user_id="test-owner",
+    )
+    db_session.add(repo)
+    await db_session.flush()
+    await db_session.refresh(repo)
+    repo_id = str(repo.repo_id)
+
+    commit = MusehubCommit(
+        commit_id=_FIXED_COMMIT_ID,
+        repo_id=repo_id,
+        branch="main",
+        parent_ids=[],
+        message="Add bass and drums",
+        author="test-musician",
+        timestamp=datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    db_session.add(commit)
+    await db_session.commit()
+    return repo_id, _FIXED_COMMIT_ID
+
+
+@pytest.mark.anyio
+async def test_context_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{repo_id}/context/{ref} returns 200 HTML without auth."""
+    repo_id, commit_id = await _make_repo_with_commit(db_session)
+    response = await client.get(f"/musehub/ui/{repo_id}/context/{commit_id}")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "Muse Hub" in body
+    assert "What the Agent Sees" in body
+    assert commit_id[:8] in body
+
+
+@pytest.mark.anyio
+async def test_context_json_response(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /api/v1/musehub/repos/{repo_id}/context/{ref} returns MuseHubContextResponse."""
+    repo_id, commit_id = await _make_repo_with_commit(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context/{commit_id}",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["repoId"] == repo_id
+    assert body["currentBranch"] == "main"
+    assert "headCommit" in body
+    assert body["headCommit"]["commitId"] == commit_id
+    assert body["headCommit"]["author"] == "test-musician"
+    assert "musicalState" in body
+    assert "history" in body
+    assert "missingElements" in body
+    assert "suggestions" in body
+
+
+@pytest.mark.anyio
+async def test_context_includes_musical_state(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Context response includes musicalState with an activeTracks field."""
+    repo_id, commit_id = await _make_repo_with_commit(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context/{commit_id}",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    musical_state = response.json()["musicalState"]
+    assert "activeTracks" in musical_state
+    assert isinstance(musical_state["activeTracks"], list)
+    # Dimensions requiring MIDI analysis are None at this stage
+    assert musical_state["key"] is None
+    assert musical_state["tempoBpm"] is None
+
+
+@pytest.mark.anyio
+async def test_context_unknown_ref_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /api/v1/musehub/repos/{repo_id}/context/{ref} returns 404 for unknown ref."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context/deadbeef" + "0" * 56,
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_context_unknown_repo_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /api/v1/musehub/repos/{unknown}/context/{ref} returns 404 for unknown repo."""
+    response = await client.get(
+        "/api/v1/musehub/repos/ghost-repo/context/deadbeef" + "0" * 56,
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_context_requires_auth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /api/v1/musehub/repos/{repo_id}/context/{ref} returns 401 without auth."""
+    repo_id = await _make_repo(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/context/deadbeef" + "0" * 56,
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_context_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The context UI page must be accessible without a JWT (HTML shell handles auth)."""
+    repo_id, commit_id = await _make_repo_with_commit(db_session)
+    response = await client.get(f"/musehub/ui/{repo_id}/context/{commit_id}")
+    assert response.status_code != 401
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
Closes #232 — adds a human-readable context viewer for the AI musical context document.

## Root Cause / Motivation
The `muse context` command generates a comprehensive musical context document that AI agents use for composition decisions. Humans had no way to see what the agent sees — no UI, no human-readable presentation. This creates a black box: musicians cannot verify or guide the agent's musical knowledge.

## Solution

### New JSON endpoint
`GET /api/v1/musehub/repos/{repo_id}/context/{ref}` — requires JWT auth.  
Returns `MuseHubContextResponse` built from the repo's commit graph and stored object paths.

### New UI page
`GET /musehub/ui/{repo_id}/context/{ref}` — no auth required (JS shell handles auth).  
Renders the context document with:
- **"What the Agent Sees"** explainer banner
- **Musical State** — active tracks + available dimensions (key, tempo, etc. are `null` until Storpheus MIDI analysis is integrated)
- **History Summary** — target commit + up to 5 ancestor commits, newest-first
- **Missing Elements** — dimensions unavailable from stored data
- **Suggestions** — composer-facing hints
- **Raw JSON panel** with Copy-to-Clipboard for pasting into agent prompts
- Collapsible sections for all panels

### New types
- `MuseHubContextCommitInfo` — commit metadata for the head commit
- `MuseHubContextHistoryEntry` — one ancestor commit entry
- `MuseHubContextMusicalState` — active tracks + musical dimensions
- `MuseHubContextResponse` — complete context document (mirrors `MuseContextResult` schema)

### New service function
`musehub_repository.get_context_for_commit()` — read-only, deterministic, walks parent chain.

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (13 pre-existing untyped-import warnings, none in new code)
- [x] `docker compose exec storpheus mypy .` — clean
- [x] All 19 tests in `tests/test_musehub_ui.py` pass
- [x] All 14 tests in `tests/test_musehub_repos.py` pass (no regressions)
- [x] Docs updated: `muse_vcs.md`, `integrate.md`, `type_contracts.md`

## Tests Added
- `test_context_page_renders` — HTML page returns 200 without auth
- `test_context_json_response` — JSON returns full MuseHubContextResponse structure
- `test_context_includes_musical_state` — activeTracks field present, MIDI dims are null
- `test_context_unknown_ref_404` — nonexistent commit ref returns 404
- `test_context_unknown_repo_404` — nonexistent repo returns 404
- `test_context_requires_auth` — JSON endpoint returns 401 without JWT
- `test_context_page_no_auth_required` — UI page accessible without JWT

## Handoff
N/A — no SSE/MCP protocol change. The new JSON endpoint is a read-only addition to the MuseHub API. No Swift frontend changes required.