### PR TITLE
feat(musehub): divergence visualization — radar chart and side-by-side comparison between branches

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -1063,6 +1063,48 @@ On failure: `success=False` plus `error` (and optionally `message`).
 
 ---
 
+#### `MuseHubDimensionDivergence`
+
+**Path:** `maestro/services/musehub_divergence.py`
+
+`dataclass(frozen=True)` — Divergence score for a single musical dimension in a Muse Hub repo comparison.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dimension` | `str` | Dimension name: `"melodic"`, `"harmonic"`, `"rhythmic"`, `"structural"`, or `"dynamic"` |
+| `level` | `MuseHubDivergenceLevel` | Qualitative label: `NONE` / `LOW` / `MED` / `HIGH` |
+| `score` | `float` | Normalised Jaccard divergence in [0.0, 1.0] |
+| `description` | `str` | Human-readable divergence summary |
+| `branch_a_commits` | `int` | Number of commits touching this dimension on branch A |
+| `branch_b_commits` | `int` | Number of commits touching this dimension on branch B |
+
+#### `MuseHubDivergenceResult`
+
+**Path:** `maestro/services/musehub_divergence.py`
+
+`dataclass(frozen=True)` — Full musical divergence report between two Muse Hub branches.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo_id` | `str` | Muse Hub repository ID |
+| `branch_a` | `str` | Name of the first branch |
+| `branch_b` | `str` | Name of the second branch |
+| `common_ancestor` | `str \| None` | Merge-base commit ID; `None` if histories are disjoint |
+| `dimensions` | `tuple[MuseHubDimensionDivergence, ...]` | Five per-dimension results |
+| `overall_score` | `float` | Mean of all per-dimension scores in [0.0, 1.0] |
+
+**Where used:**
+
+| Module | Usage |
+|--------|-------|
+| `maestro/services/musehub_divergence.py` | `compute_hub_divergence` return type |
+| `maestro/api/routes/musehub/repos.py` | `get_divergence` endpoint — serialized to `DivergenceResponse` |
+| `tests/test_musehub_repos.py` | Divergence endpoint tests |
+
+**Wire format:** Serialized as `DivergenceResponse` (camelCase) via `maestro/models/musehub.py`.
+
+---
+
 ### `ExpressivenessResult`
 
 **Path:** `maestro/services/expressiveness.py`

--- a/maestro/api/routes/musehub/repos.py
+++ b/maestro/api/routes/musehub/repos.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 
-import yaml  # type: ignore[import-untyped]  # PyYAML ships no py.typed marker
+import yaml
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -30,7 +30,6 @@ from maestro.models.musehub import (
     RepoResponse,
 )
 from maestro.models.musehub_context import (
-    AgentContextResponse,
     ContextDepth,
     ContextFormat,
 )

--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -669,6 +669,237 @@ async def issue_list_page(repo_id: str) -> HTMLResponse:
 
 
 @router.get(
+    "/{repo_id}/divergence",
+    response_class=HTMLResponse,
+    summary="Muse Hub divergence visualization page",
+)
+async def divergence_page(repo_id: str) -> HTMLResponse:
+    """Render the divergence visualization page: radar chart + dimension detail panels.
+
+    Fetches ``GET /api/v1/musehub/repos/{repo_id}/divergence?branch_a=...&branch_b=...``
+    for the raw data, then renders:
+    - A five-axis radar chart (melodic/harmonic/rhythmic/structural/dynamic)
+    - Level labels (NONE/LOW/MED/HIGH) per dimension
+    - Overall divergence score as a percentage
+    - Per-dimension detail panels (click to expand)
+
+    Auth is handled client-side via localStorage JWT.  No Jinja2 required.
+    """
+    script = f"""
+      const repoId = {repr(repo_id)};
+      const apiBase = '/api/v1/musehub/repos/' + repoId;
+      const uiBase  = '/musehub/ui/' + repoId;
+
+      function escHtml(s) {{
+        if (!s) return '';
+        return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+      }}
+
+      const DIMENSIONS = ['melodic','harmonic','rhythmic','structural','dynamic'];
+      const LEVEL_COLOR = {{ NONE:'#1f6feb', LOW:'#388bfd', MED:'#f0883e', HIGH:'#f85149' }};
+      const LEVEL_BG    = {{ NONE:'#0d2942', LOW:'#102a4c', MED:'#341a00', HIGH:'#3d0000' }};
+      const AXIS_LABELS = {{
+        melodic:'Melodic', harmonic:'Harmonic', rhythmic:'Rhythmic',
+        structural:'Structural', dynamic:'Dynamic'
+      }};
+
+      function levelBadge(level) {{
+        const color = LEVEL_COLOR[level] || '#8b949e';
+        return `<span style="display:inline-block;padding:1px 7px;border-radius:10px;
+          font-size:11px;font-weight:700;color:#fff;background:${{color}}">${{level}}</span>`;
+      }}
+
+      function radarSvg(dims) {{
+        const cx = 180, cy = 180, r = 140;
+        const n = dims.length;
+        const pts = dims.map((d, i) => {{
+          const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+          const sr = d.score * r;
+          return {{ x: cx + sr * Math.cos(angle), y: cy + sr * Math.sin(angle) }};
+        }});
+        const bgPts = DIMENSIONS.map((_, i) => {{
+          const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+          return `${{cx + r * Math.cos(angle)}},${{cy + r * Math.sin(angle)}}`;
+        }}).join(' ');
+        const scorePoly = pts.map(p => `${{p.x}},${{p.y}}`).join(' ');
+
+        const axisLines = DIMENSIONS.map((_, i) => {{
+          const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+          const ex = cx + r * Math.cos(angle), ey = cy + r * Math.sin(angle);
+          return `<line x1="${{cx}}" y1="${{cy}}" x2="${{ex}}" y2="${{ey}}"
+            stroke="#30363d" stroke-width="1"/>`;
+        }}).join('');
+
+        const gridLines = [0.25, 0.5, 0.75, 1.0].map(frac => {{
+          const gPts = DIMENSIONS.map((_, i) => {{
+            const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+            return `${{cx + frac * r * Math.cos(angle)}},${{cy + frac * r * Math.sin(angle)}}`;
+          }}).join(' ');
+          return `<polygon points="${{gPts}}" fill="none" stroke="#21262d" stroke-width="1"/>`;
+        }}).join('');
+
+        const labels = dims.map((d, i) => {{
+          const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+          const lx = cx + (r + 22) * Math.cos(angle);
+          const ly = cy + (r + 22) * Math.sin(angle);
+          const color = LEVEL_COLOR[d.level] || '#8b949e';
+          return `<text x="${{lx}}" y="${{ly + 4}}" text-anchor="middle"
+            font-size="12" fill="${{color}}" font-family="system-ui">${{AXIS_LABELS[d.dimension]}}</text>`;
+        }}).join('');
+
+        const dots = pts.map((p, i) => {{
+          const color = LEVEL_COLOR[dims[i].level] || '#58a6ff';
+          return `<circle cx="${{p.x}}" cy="${{p.y}}" r="4" fill="${{color}}" stroke="#0d1117" stroke-width="2"/>`;
+        }}).join('');
+
+        return `<svg viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg"
+            style="width:100%;max-width:360px;display:block;margin:0 auto">
+          ${{gridLines}}${{axisLines}}
+          <polygon points="${{bgPts}}" fill="rgba(88,166,255,0.04)" stroke="#30363d" stroke-width="1"/>
+          <polygon points="${{scorePoly}}" fill="rgba(248,81,73,0.18)" stroke="#f85149" stroke-width="2"/>
+          ${{labels}}${{dots}}
+        </svg>`;
+      }}
+
+      function dimensionPanel(d, expanded) {{
+        const bg = LEVEL_BG[d.level] || '#161b22';
+        const id = 'dim-' + d.dimension;
+        const detail = expanded ? `
+          <div style="margin-top:10px;font-size:13px;color:#8b949e">
+            <div>${{escHtml(d.description)}}</div>
+            <div style="margin-top:6px;display:flex;gap:16px">
+              <span>Branch A: <b style="color:#e6edf3">${{d.branchACommits}} commit(s)</b></span>
+              <span>Branch B: <b style="color:#e6edf3">${{d.branchBCommits}} commit(s)</b></span>
+            </div>
+          </div>` : '';
+        const pct = Math.round(d.score * 100);
+        return `<div id="${{id}}" class="card" style="background:${{bg}};cursor:pointer;margin-bottom:8px"
+            onclick="toggleDim('${{d.dimension}}')">
+          <div style="display:flex;align-items:center;gap:12px">
+            <span style="font-size:14px;color:#e6edf3;font-weight:600;min-width:90px">
+              ${{AXIS_LABELS[d.dimension]}}</span>
+            ${{levelBadge(d.level)}}
+            <div style="flex:1;height:6px;background:#21262d;border-radius:3px;overflow:hidden">
+              <div style="height:100%;width:${{pct}}%;background:${{LEVEL_COLOR[d.level] || '#58a6ff'}};
+                border-radius:3px;transition:width .3s"></div>
+            </div>
+            <span style="font-size:13px;color:#8b949e;white-space:nowrap">${{pct}}%</span>
+          </div>
+          ${{detail}}
+        </div>`;
+      }}
+
+      const _expanded = {{}};
+      function toggleDim(dim) {{
+        _expanded[dim] = !_expanded[dim];
+        renderDims(window._lastDims || []);
+      }}
+
+      function renderDims(dims) {{
+        window._lastDims = dims;
+        document.getElementById('dim-panels').innerHTML =
+          dims.map(d => dimensionPanel(d, !!_expanded[d.dimension])).join('');
+      }}
+
+      const params = new URLSearchParams(location.search);
+      let _branchA = params.get('branch_a') || '';
+      let _branchB = params.get('branch_b') || '';
+
+      async function loadBranches() {{
+        try {{
+          const data = await apiFetch('/repos/' + repoId + '/branches');
+          return (data.branches || []).map(b => b.name);
+        }} catch(e) {{ return []; }}
+      }}
+
+      async function loadDivergence(bA, bB) {{
+        if (!bA || !bB) {{
+          document.getElementById('radar-area').innerHTML =
+            '<p class="loading">Select two branches to compare.</p>';
+          document.getElementById('dim-panels').innerHTML = '';
+          document.getElementById('overall-area').innerHTML = '';
+          return;
+        }}
+        document.getElementById('radar-area').innerHTML = '<p class="loading">Computing&#8230;</p>';
+        try {{
+          const d = await apiFetch('/repos/' + repoId + '/divergence?branch_a=' +
+            encodeURIComponent(bA) + '&branch_b=' + encodeURIComponent(bB));
+          const pct = Math.round((d.overallScore || 0) * 100);
+          document.getElementById('radar-area').innerHTML = radarSvg(d.dimensions || []);
+          document.getElementById('overall-area').innerHTML = `
+            <div style="text-align:center;margin:12px 0">
+              <div style="font-size:32px;font-weight:700;color:#e6edf3">${{pct}}%</div>
+              <div style="font-size:12px;color:#8b949e;margin-top:2px">overall divergence</div>
+              ${{d.commonAncestor ? `<div style="font-size:11px;color:#8b949e;margin-top:4px;font-family:monospace">
+                base: ${{d.commonAncestor.substring(0,8)}}</div>` : ''}}
+            </div>`;
+          renderDims(d.dimensions || []);
+        }} catch(e) {{
+          if (e.message !== 'auth')
+            document.getElementById('radar-area').innerHTML =
+              '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+        }}
+      }}
+
+      async function load() {{
+        const branches = await loadBranches();
+        const opts = branches.map(b =>
+          '<option value="' + escHtml(b) + '">' + escHtml(b) + '</option>').join('');
+
+        document.getElementById('content').innerHTML = `
+          <div style="margin-bottom:12px">
+            <a href="${{uiBase}}">&larr; Back to repo</a>
+          </div>
+          <div class="card">
+            <h1 style="margin-bottom:12px">Divergence Visualization</h1>
+            <div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:16px">
+              <div>
+                <div class="meta-label" style="font-size:11px;color:#8b949e;margin-bottom:4px">BRANCH A</div>
+                <select id="sel-a" onchange="onBranchChange()">
+                  <option value="">Select branch&#8230;</option>${{opts}}
+                </select>
+              </div>
+              <div style="display:flex;align-items:flex-end;padding-bottom:4px;font-size:18px;color:#8b949e">
+                vs
+              </div>
+              <div>
+                <div class="meta-label" style="font-size:11px;color:#8b949e;margin-bottom:4px">BRANCH B</div>
+                <select id="sel-b" onchange="onBranchChange()">
+                  <option value="">Select branch&#8230;</option>${{opts}}
+                </select>
+              </div>
+            </div>
+            <div id="radar-area"><p class="loading">Select two branches to compare.</p></div>
+            <div id="overall-area"></div>
+          </div>
+          <div id="dim-panels"></div>`;
+
+        if (_branchA) document.getElementById('sel-a').value = _branchA;
+        if (_branchB) document.getElementById('sel-b').value = _branchB;
+        if (_branchA && _branchB) loadDivergence(_branchA, _branchB);
+      }}
+
+      function onBranchChange() {{
+        _branchA = document.getElementById('sel-a').value;
+        _branchB = document.getElementById('sel-b').value;
+        const url = new URL(location.href);
+        url.searchParams.set('branch_a', _branchA);
+        url.searchParams.set('branch_b', _branchB);
+        history.replaceState(null,'',url.toString());
+        loadDivergence(_branchA, _branchB);
+      }}
+
+      load();
+    """
+    html = _page(
+        title="Divergence",
+        breadcrumb=f'<a href="/musehub/ui/{repo_id}">{repo_id[:8]}</a> / divergence',
+        body_script=script,
+    )
+    return HTMLResponse(content=html)
+
+
+@router.get(
     "/{repo_id}/issues/{number}",
     response_class=HTMLResponse,
     summary="Muse Hub issue detail page",

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -240,3 +240,41 @@ class ObjectMetaListResponse(CamelModel):
     """List of artifact metadata for a repo."""
 
     objects: list[ObjectMetaResponse]
+
+
+# ── Divergence visualization models ───────────────────────────────────────────
+
+
+class DivergenceDimensionResponse(CamelModel):
+    """Wire representation of divergence scores for a single musical dimension.
+
+    Mirrors :class:`maestro.services.musehub_divergence.MuseHubDimensionDivergence`
+    for JSON serialization.  AI agents consume this to decide which dimension
+    of a branch needs creative attention before merging.
+    """
+
+    dimension: str
+    level: str
+    score: float
+    description: str
+    branch_a_commits: int
+    branch_b_commits: int
+
+
+class DivergenceResponse(CamelModel):
+    """Full musical divergence report between two Muse Hub branches.
+
+    Returned by ``GET /musehub/repos/{repo_id}/divergence``.  Contains five
+    per-dimension scores (melodic, harmonic, rhythmic, structural, dynamic)
+    and an overall score computed as the mean of those five scores.
+
+    The ``overall_score`` is in [0.0, 1.0]; multiply by 100 for a percentage.
+    A score of 0.0 means identical, 1.0 means completely diverged.
+    """
+
+    repo_id: str
+    branch_a: str
+    branch_b: str
+    common_ancestor: str | None
+    dimensions: list[DivergenceDimensionResponse]
+    overall_score: float

--- a/maestro/services/musehub_divergence.py
+++ b/maestro/services/musehub_divergence.py
@@ -1,0 +1,411 @@
+"""Muse Hub Divergence Engine — musical divergence between two remote branches.
+
+Computes per-dimension divergence scores by comparing the commit history on
+two branches since their common ancestor (merge base), using commit message
+keyword classification to determine which musical dimensions each commit
+touches.
+
+Dimensions analysed
+-------------------
+- ``melodic``    — melody, lead, solo, vocal, tune, note, pitch, riff, arpeggio
+- ``harmonic``   — chord, harmony, key, scale, progression, voicing
+- ``rhythmic``   — beat, drum, rhythm, groove, percussion, swing, tempo, bpm
+- ``structural`` — structure, form, section, bridge, chorus, verse, intro, outro
+- ``dynamic``    — mix, master, volume, level, dynamics, eq, compressor, reverb
+
+Score formula (per dimension)
+------------------------------
+Given the sets of commit messages classified to dimension D on branch A
+(``a_dim``) and branch B (``b_dim``) since the merge base:
+
+    score = |symmetric_difference(a_dim, b_dim)| / |union(a_dim, b_dim)|
+
+Score 0.0 = both branches changed exactly the same things in this dimension.
+Score 1.0 = no overlap — completely diverged.
+
+Boundary rules
+--------------
+- Must NOT import StateStore, executor, MCP tools, or handlers.
+- May import ``maestro.db.musehub_models``.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from maestro.db.musehub_models import MusehubCommit
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ALL_DIMENSIONS: tuple[str, ...] = (
+    "melodic",
+    "harmonic",
+    "rhythmic",
+    "structural",
+    "dynamic",
+)
+
+#: Keyword patterns used to classify commit messages into musical dimensions.
+_DIMENSION_PATTERNS: dict[str, tuple[str, ...]] = {
+    "melodic": ("melody", "lead", "solo", "vocal", "tune", "note", "pitch", "riff", "arpeggio"),
+    "harmonic": ("chord", "harmony", "harmonic", "key", "scale", "progression", "voicing"),
+    "rhythmic": ("beat", "drum", "rhythm", "groove", "perc", "swing", "tempo", "bpm", "quantize"),
+    "structural": (
+        "struct",
+        "form",
+        "section",
+        "bridge",
+        "chorus",
+        "verse",
+        "intro",
+        "outro",
+        "arrangement",
+        "transition",
+    ),
+    "dynamic": ("mix", "master", "volume", "level", "dynamic", "eq", "compress", "reverb", "fx"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+class MuseHubDivergenceLevel(str, Enum):
+    """Qualitative label for a per-dimension or overall divergence score.
+
+    Thresholds mirror the CLI divergence engine for consistency.
+
+    - ``NONE`` — score < 0.15
+    - ``LOW``  — 0.15 ≤ score < 0.40
+    - ``MED``  — 0.40 ≤ score < 0.70
+    - ``HIGH`` — score ≥ 0.70
+    """
+
+    NONE = "NONE"
+    LOW = "LOW"
+    MED = "MED"
+    HIGH = "HIGH"
+
+
+@dataclass(frozen=True)
+class MuseHubDimensionDivergence:
+    """Divergence score and description for a single musical dimension.
+
+    Attributes:
+        dimension:        Dimension name (e.g. ``"melodic"``).
+        level:            Qualitative divergence level label.
+        score:            Normalised divergence score in [0.0, 1.0].
+        description:      Human-readable divergence summary.
+        branch_a_commits: Number of commits in this dimension on branch A.
+        branch_b_commits: Number of commits in this dimension on branch B.
+    """
+
+    dimension: str
+    level: MuseHubDivergenceLevel
+    score: float
+    description: str
+    branch_a_commits: int
+    branch_b_commits: int
+
+
+@dataclass(frozen=True)
+class MuseHubDivergenceResult:
+    """Full musical divergence report between two Muse Hub branches.
+
+    Attributes:
+        repo_id:         Repository ID.
+        branch_a:        Name of the first branch.
+        branch_b:        Name of the second branch.
+        common_ancestor: Commit ID of the merge base, or ``None`` if disjoint.
+        dimensions:      Per-dimension divergence results (always 5 entries).
+        overall_score:   Mean of all per-dimension scores in [0.0, 1.0].
+    """
+
+    repo_id: str
+    branch_a: str
+    branch_b: str
+    common_ancestor: str | None
+    dimensions: tuple[MuseHubDimensionDivergence, ...]
+    overall_score: float
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def classify_message(message: str) -> set[str]:
+    """Return the set of musical dimensions this commit message touches.
+
+    Matching is case-insensitive and keyword-based.  A single message may map
+    to multiple dimensions (e.g. "add jazzy chord melody" → melodic + harmonic).
+
+    Args:
+        message: Commit message text.
+
+    Returns:
+        Set of dimension names that the message matches.  Empty if unclassified.
+    """
+    lower = message.lower()
+    return {
+        dim
+        for dim, patterns in _DIMENSION_PATTERNS.items()
+        if any(pat in lower for pat in patterns)
+    }
+
+
+def score_to_level(score: float) -> MuseHubDivergenceLevel:
+    """Map a numeric divergence score to a qualitative level label.
+
+    Args:
+        score: Normalised score in [0.0, 1.0].
+
+    Returns:
+        The appropriate :class:`MuseHubDivergenceLevel` enum member.
+    """
+    if score < 0.15:
+        return MuseHubDivergenceLevel.NONE
+    if score < 0.40:
+        return MuseHubDivergenceLevel.LOW
+    if score < 0.70:
+        return MuseHubDivergenceLevel.MED
+    return MuseHubDivergenceLevel.HIGH
+
+
+def compute_hub_dimension_divergence(
+    dimension: str,
+    a_commit_ids: set[str],
+    b_commit_ids: set[str],
+    a_messages: dict[str, str],
+    b_messages: dict[str, str],
+) -> MuseHubDimensionDivergence:
+    """Compute divergence for a single musical dimension across two commit sets.
+
+    Score = ``|symmetric_diff| / |union|`` over commit IDs classified into
+    *dimension*:
+
+    - 0.0 → both branches touched exactly the same commits in this dimension.
+    - 1.0 → no overlap — completely diverged.
+
+    Args:
+        dimension:     Dimension name (one of :data:`ALL_DIMENSIONS`).
+        a_commit_ids:  Commit IDs for branch A since the merge base.
+        b_commit_ids:  Commit IDs for branch B since the merge base.
+        a_messages:    Mapping of commit_id → message for branch A.
+        b_messages:    Mapping of commit_id → message for branch B.
+
+    Returns:
+        A :class:`MuseHubDimensionDivergence` with score, level, and summary.
+    """
+
+    def _filter_by_dim(ids: set[str], messages: dict[str, str]) -> set[str]:
+        return {cid for cid in ids if dimension in classify_message(messages.get(cid, ""))}
+
+    a_dim = _filter_by_dim(a_commit_ids, a_messages)
+    b_dim = _filter_by_dim(b_commit_ids, b_messages)
+
+    union = a_dim | b_dim
+    sym_diff = a_dim.symmetric_difference(b_dim)
+    total = len(union)
+
+    if total == 0:
+        score = 0.0
+        desc = f"No {dimension} changes on either branch."
+    else:
+        score = len(sym_diff) / total
+        if score < 0.15:
+            desc = f"Both branches made similar {dimension} changes."
+        elif score < 0.40:
+            desc = f"Minor {dimension} divergence — mostly aligned."
+        elif score < 0.70:
+            desc = f"Moderate {dimension} divergence — different directions."
+        else:
+            desc = f"High {dimension} divergence — branches took different creative paths."
+
+    level = score_to_level(score)
+    return MuseHubDimensionDivergence(
+        dimension=dimension,
+        level=level,
+        score=round(score, 4),
+        description=desc,
+        branch_a_commits=len(a_dim),
+        branch_b_commits=len(b_dim),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Async DB helpers
+# ---------------------------------------------------------------------------
+
+
+async def get_branch_commits(
+    session: AsyncSession,
+    repo_id: str,
+    branch: str,
+) -> list[MusehubCommit]:
+    """Return all commits on *branch* for *repo_id*, newest first.
+
+    Args:
+        session:  Open async DB session.
+        repo_id:  Repository identifier.
+        branch:   Branch name.
+
+    Returns:
+        List of :class:`MusehubCommit` objects ordered by timestamp descending.
+    """
+    result = await session.execute(
+        select(MusehubCommit)
+        .where(
+            MusehubCommit.repo_id == repo_id,
+            MusehubCommit.branch == branch,
+        )
+        .order_by(MusehubCommit.timestamp.desc())
+    )
+    return list(result.scalars().all())
+
+
+def find_common_ancestor(
+    a_commits: list[MusehubCommit],
+    b_commits: list[MusehubCommit],
+) -> str | None:
+    """Find the most recent common ancestor commit ID between two branch histories.
+
+    Uses a simple BFS walk through parent_ids starting from each branch's HEAD,
+    returning the first commit ID seen on both branches.
+
+    Args:
+        a_commits: All commits on branch A (newest first).
+        b_commits: All commits on branch B (newest first).
+
+    Returns:
+        The commit ID of the most recent common ancestor, or ``None`` if the
+        two histories are completely disjoint.
+    """
+    a_ids = {c.commit_id for c in a_commits}
+    b_ids = {c.commit_id for c in b_commits}
+    common = a_ids & b_ids
+    if not common:
+        return None
+    all_a = {c.commit_id: c for c in a_commits}
+    all_b = {c.commit_id: c for c in b_commits}
+    all_commits = {**all_a, **all_b}
+    a_ancestry: set[str] = set()
+    frontier = list(a_ids)
+    while frontier:
+        cid = frontier.pop()
+        if cid in a_ancestry:
+            continue
+        a_ancestry.add(cid)
+        commit = all_commits.get(cid)
+        if commit:
+            frontier.extend(commit.parent_ids)
+    for commit in sorted(b_commits, key=lambda c: c.timestamp, reverse=True):
+        if commit.commit_id in a_ancestry:
+            return commit.commit_id
+    return None
+
+
+def get_commits_since(
+    all_commits: list[MusehubCommit],
+    base_commit_id: str | None,
+) -> list[MusehubCommit]:
+    """Filter commits to only those introduced after *base_commit_id*.
+
+    When *base_commit_id* is ``None``, all commits are returned (disjoint
+    histories — no common ancestor).
+
+    Args:
+        all_commits:    All commits for a branch (newest first).
+        base_commit_id: Common ancestor commit ID to exclude, or ``None``.
+
+    Returns:
+        Commits introduced after the base, in newest-first order.
+    """
+    if base_commit_id is None:
+        return all_commits
+    return [c for c in all_commits if c.commit_id != base_commit_id]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def compute_hub_divergence(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    branch_a: str,
+    branch_b: str,
+) -> MuseHubDivergenceResult:
+    """Compute musical divergence between two Muse Hub branches.
+
+    Finds the common ancestor, collects each branch's commits since that point,
+    classifies commit messages into musical dimensions, and computes a
+    per-dimension Jaccard divergence score.
+
+    Args:
+        session:  Open async DB session.
+        repo_id:  Repository ID.
+        branch_a: Name of the first branch.
+        branch_b: Name of the second branch.
+
+    Returns:
+        A :class:`MuseHubDivergenceResult` with per-dimension scores and the
+        resolved common ancestor commit ID.
+
+    Raises:
+        ValueError: If *branch_a* or *branch_b* has no commits in *repo_id*.
+    """
+    a_all = await get_branch_commits(session, repo_id, branch_a)
+    if not a_all:
+        raise ValueError(f"Branch '{branch_a}' has no commits in repo '{repo_id}'.")
+    b_all = await get_branch_commits(session, repo_id, branch_b)
+    if not b_all:
+        raise ValueError(f"Branch '{branch_b}' has no commits in repo '{repo_id}'.")
+
+    common_ancestor = find_common_ancestor(a_all, b_all)
+
+    logger.info(
+        "✅ musehub divergence: %r vs %r, base=%s",
+        branch_a,
+        branch_b,
+        common_ancestor[:8] if common_ancestor else "none",
+    )
+
+    a_since = get_commits_since(a_all, common_ancestor)
+    b_since = get_commits_since(b_all, common_ancestor)
+
+    a_ids = {c.commit_id for c in a_since}
+    b_ids = {c.commit_id for c in b_since}
+    a_msgs = {c.commit_id: c.message for c in a_since}
+    b_msgs = {c.commit_id: c.message for c in b_since}
+
+    dimensions = tuple(
+        compute_hub_dimension_divergence(dim, a_ids, b_ids, a_msgs, b_msgs)
+        for dim in ALL_DIMENSIONS
+    )
+
+    overall = (
+        round(sum(d.score for d in dimensions) / len(dimensions), 4)
+        if dimensions
+        else 0.0
+    )
+
+    return MuseHubDivergenceResult(
+        repo_id=repo_id,
+        branch_a=branch_a,
+        branch_b=branch_b,
+        common_ancestor=common_ancestor,
+        dimensions=dimensions,
+        overall_score=overall,
+    )

--- a/tests/test_musehub_repos.py
+++ b/tests/test_musehub_repos.py
@@ -315,3 +315,214 @@ async def test_list_branches_returns_empty_for_new_repo(db_session: AsyncSession
     await db_session.commit()
     branches = await musehub_repository.list_branches(db_session, repo.repo_id)
     assert branches == []
+
+
+# ---------------------------------------------------------------------------
+# GET /musehub/repos/{repo_id}/divergence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_divergence_endpoint_returns_five_dimensions(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """GET /divergence returns five dimension scores with level labels."""
+    from datetime import datetime, timezone, timedelta
+
+    create = await client.post(
+        "/api/v1/musehub/repos",
+        json={"name": "divergence-test-repo"},
+        headers=auth_headers,
+    )
+    assert create.status_code == 201
+    repo_id = create.json()["repoId"]
+
+    now = datetime.now(tz=timezone.utc)
+    db_session.add(
+        MusehubCommit(
+            commit_id="aaa-melody",
+            repo_id=repo_id,
+            branch="main",
+            parent_ids=[],
+            message="add lead melody line",
+            author="alice",
+            timestamp=now - timedelta(hours=2),
+        )
+    )
+    db_session.add(
+        MusehubCommit(
+            commit_id="bbb-chord",
+            repo_id=repo_id,
+            branch="feature",
+            parent_ids=[],
+            message="update chord progression",
+            author="bob",
+            timestamp=now - timedelta(hours=1),
+        )
+    )
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/divergence?branch_a=main&branch_b=feature",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "dimensions" in body
+    assert len(body["dimensions"]) == 5
+
+    dim_names = {d["dimension"] for d in body["dimensions"]}
+    assert dim_names == {"melodic", "harmonic", "rhythmic", "structural", "dynamic"}
+
+    for dim in body["dimensions"]:
+        assert "level" in dim
+        assert dim["level"] in {"NONE", "LOW", "MED", "HIGH"}
+        assert "score" in dim
+        assert 0.0 <= dim["score"] <= 1.0
+
+
+@pytest.mark.anyio
+async def test_divergence_overall_score_is_mean_of_dimensions(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """Overall divergence score equals the mean of all five dimension scores."""
+    from datetime import datetime, timezone, timedelta
+
+    create = await client.post(
+        "/api/v1/musehub/repos",
+        json={"name": "divergence-mean-repo"},
+        headers=auth_headers,
+    )
+    repo_id = create.json()["repoId"]
+
+    now = datetime.now(tz=timezone.utc)
+    db_session.add(
+        MusehubCommit(
+            commit_id="c1-beat",
+            repo_id=repo_id,
+            branch="alpha",
+            parent_ids=[],
+            message="rework drum beat groove",
+            author="producer-a",
+            timestamp=now - timedelta(hours=3),
+        )
+    )
+    db_session.add(
+        MusehubCommit(
+            commit_id="c2-mix",
+            repo_id=repo_id,
+            branch="beta",
+            parent_ids=[],
+            message="fix master volume level",
+            author="producer-b",
+            timestamp=now - timedelta(hours=2),
+        )
+    )
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/divergence?branch_a=alpha&branch_b=beta",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+
+    dims = body["dimensions"]
+    computed_mean = round(sum(d["score"] for d in dims) / len(dims), 4)
+    assert abs(body["overallScore"] - computed_mean) < 1e-6
+
+
+@pytest.mark.anyio
+async def test_divergence_json_response_structure(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """JSON response has all required top-level fields and camelCase keys."""
+    from datetime import datetime, timezone, timedelta
+
+    create = await client.post(
+        "/api/v1/musehub/repos",
+        json={"name": "divergence-struct-repo"},
+        headers=auth_headers,
+    )
+    repo_id = create.json()["repoId"]
+
+    now = datetime.now(tz=timezone.utc)
+    for i, (branch, msg) in enumerate(
+        [("main", "add melody riff"), ("dev", "update chorus section")]
+    ):
+        db_session.add(
+            MusehubCommit(
+                commit_id=f"struct-{i}",
+                repo_id=repo_id,
+                branch=branch,
+                parent_ids=[],
+                message=msg,
+                author="test",
+                timestamp=now + timedelta(seconds=i),
+            )
+        )
+    await db_session.commit()
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/divergence?branch_a=main&branch_b=dev",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["repoId"] == repo_id
+    assert body["branchA"] == "main"
+    assert body["branchB"] == "dev"
+    assert "commonAncestor" in body
+    assert "overallScore" in body
+    assert isinstance(body["overallScore"], float)
+    assert isinstance(body["dimensions"], list)
+    assert len(body["dimensions"]) == 5
+
+    for dim in body["dimensions"]:
+        assert "dimension" in dim
+        assert "level" in dim
+        assert "score" in dim
+        assert "description" in dim
+        assert "branchACommits" in dim
+        assert "branchBCommits" in dim
+
+
+@pytest.mark.anyio
+async def test_divergence_endpoint_returns_404_for_unknown_repo(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /divergence returns 404 for an unknown repo."""
+    response = await client.get(
+        "/api/v1/musehub/repos/no-such-repo/divergence?branch_a=a&branch_b=b",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_divergence_endpoint_returns_422_for_empty_branch(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """GET /divergence returns 422 when a branch has no commits."""
+    create = await client.post(
+        "/api/v1/musehub/repos",
+        json={"name": "empty-branch-repo"},
+        headers=auth_headers,
+    )
+    repo_id = create.json()["repoId"]
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/divergence?branch_a=ghost&branch_b=also-ghost",
+        headers=auth_headers,
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
Closes #231 — adds a five-dimension musical divergence endpoint and browser UI to Muse Hub, enabling producers to visualize how two branches have diverged before merging.

## Root Cause / Motivation
Branch divergence data was only accessible via the `muse divergence` CLI command. Producers using the Muse Hub web interface had no way to compare branches visually, forcing them to rely on CLI output or guess at merge consequences.

## Solution

### New service — `maestro/services/musehub_divergence.py`
- Computes Jaccard divergence per musical dimension by classifying commit messages via keyword matching (melodic/harmonic/rhythmic/structural/dynamic)
- Finds common ancestor using parent_ids traversal across both branch histories
- Returns typed `MuseHubDivergenceResult` with five `MuseHubDimensionDivergence` entries

### API endpoint — `GET /api/v1/musehub/repos/{repo_id}/divergence`
- Query params: `branch_a`, `branch_b`
- Returns `DivergenceResponse` (camelCase JSON) with five dimension scores, levels (NONE/LOW/MED/HIGH), overall score (mean), and common ancestor
- 404 if repo not found; 422 if a branch has no commits

### Browser UI — `GET /musehub/ui/{repo_id}/divergence`
- SVG radar chart with five axes, colour-coded by divergence level
- Overall percentage display with merge-base commit SHA
- Per-dimension progress bars + level badges
- Click-to-expand detail panels showing commit counts per branch
- Branch selector dropdowns with URL state sync (`?branch_a=...&branch_b=...`)

### New Pydantic models — `maestro/models/musehub.py`
- `DivergenceDimensionResponse` — per-dimension wire format
- `DivergenceResponse` — full report wire format

### Docs
- `docs/architecture/muse_vcs.md` — Divergence Visualization section with API contract, score formula, UI description, AI agent use case; updated module map and endpoint table
- `docs/reference/type_contracts.md` — `MuseHubDimensionDivergence` and `MuseHubDivergenceResult` entries

## Layers Affected
- [x] Muse VCS (new service: musehub_divergence.py)
- [x] Muse Hub routes (repos.py, ui.py)

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (pre-existing third-party stub warnings only, no new errors)
- [x] `docker compose exec storpheus mypy .` — N/A (no storpheus changes)
- [x] All 19 tests in `tests/test_musehub_repos.py` pass, zero warnings
- [x] Docs updated in same commit as code

## Tests Added
- `test_divergence_endpoint_returns_five_dimensions` — endpoint returns exactly 5 dimensions with valid level labels and scores
- `test_divergence_overall_score_is_mean_of_dimensions` — overall score equals arithmetic mean of dimension scores
- `test_divergence_json_response_structure` — all required camelCase JSON fields present
- `test_divergence_endpoint_returns_404_for_unknown_repo` — 404 on missing repo
- `test_divergence_endpoint_returns_422_for_empty_branch` — 422 when a branch has no commits

## Handoff
N/A — no SSE/MCP protocol change. API is a new GET endpoint with no impact on existing Swift frontend flows.