### PR TITLE
feat(musehub): MCP tools for MuseHub browsing — agents browse repos, read files, and query analysis via MCP

### DIFF
--- a/docs/guides/integrate.md
+++ b/docs/guides/integrate.md
@@ -274,6 +274,36 @@ Tool list and parameters: see [api.md](../reference/api.md#tools).
 
 ---
 
+### MuseHub browsing tools (`musehub_*`)
+
+Seven server-side MCP tools let AI agents browse MuseHub repositories, inspect commit history, read artifact metadata, and query musical context — all without a connected DAW. They are always executed server-side and never forwarded to the Stori app.
+
+| Tool | Purpose | Required args |
+|------|---------|---------------|
+| `musehub_browse_repo` | Overview: metadata, branches, 10 most-recent commits | `repo_id` |
+| `musehub_list_branches` | All branches with head commit IDs | `repo_id` |
+| `musehub_list_commits` | Paginated commits, newest first | `repo_id` (opt: `branch`, `limit`) |
+| `musehub_read_file` | Artifact metadata (path, size, MIME type) | `repo_id`, `object_id` |
+| `musehub_get_analysis` | Structured analysis — `overview`, `commits`, or `objects` dimension | `repo_id` (opt: `dimension`) |
+| `musehub_search` | Substring search by file path or commit message | `repo_id`, `query` (opt: `mode`) |
+| `musehub_get_context` | Full AI context document — the primary agent entry point | `repo_id` |
+
+**Recommended agent workflow:**
+
+```
+1. musehub_get_context(repo_id=...)   → orient the agent; get the full picture
+2. musehub_list_commits(...)          → inspect recent commit history
+3. musehub_search(query="bass", ...)  → find specific artifacts
+4. musehub_read_file(object_id=...)   → read artifact metadata
+5. musehub_get_analysis(dimension="objects")  → artifact inventory by type
+```
+
+**Error codes:** All tools return structured errors with `error_code` values: `not_found` (repo or object missing), `invalid_dimension` (bad analysis dimension), `invalid_mode` (bad search mode). The MCP server surfaces these as `is_error=True` responses; `invalid_dimension` and `invalid_mode` additionally set `bad_request=True`.
+
+**Musical analysis note:** The `musical_analysis` fields (key, tempo, time_signature) in `musehub_get_analysis` and `musehub_get_context` are `null` until Storpheus MIDI analysis integration is complete. Agents should handle `null` gracefully.
+
+---
+
 ### MCP MVP: prove it works
 
 You already have: HTTP endpoints (list/call with Bearer), stdio server (`maestro.mcp.stdio_server`), WebSocket for DAW, and server-side generation tools (e.g. `stori_generate_drums`) that run without a connected DAW. To **prove the MCP idea** end-to-end:

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -924,6 +924,37 @@ Full diff of two arrangement matrices.  Built by `build_arrangement_diff()`.
 
 ## Services
 
+### MuseHub MCP Executor
+
+**Path:** `maestro/services/musehub_mcp_executor.py`
+
+#### `MusehubToolResult`
+
+`dataclass(frozen=True)` — Result of executing a single `musehub_*` MCP tool. This is the
+contract between the executor functions and the MCP server's routing layer.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `ok` | `bool` | yes | `True` on success, `False` on failure |
+| `data` | `dict[str, JSONValue]` | no | JSON-serialisable payload on success; empty dict on failure |
+| `error_code` | `MusehubErrorCode \| None` | no | Error kind on failure; `None` on success |
+| `error_message` | `str \| None` | no | Human-readable error message; `None` on success |
+
+**`MusehubErrorCode`** — `Literal["not_found", "invalid_dimension", "invalid_mode", "db_unavailable"]`
+
+| Code | When |
+|------|------|
+| `not_found` | Repo or object does not exist |
+| `invalid_dimension` | Unrecognised analysis dimension (valid: `overview`, `commits`, `objects`) |
+| `invalid_mode` | Unrecognised search mode (valid: `path`, `commit`) |
+| `db_unavailable` | DB session factory not initialised (startup race) |
+
+**Agent use case:** The MCP server calls executor functions and pattern-matches on `result.ok`
+and `result.error_code` to build the `MCPContentBlock` response. On success, `result.data`
+is JSON-serialised directly into the content block text.
+
+---
+
 ### Assets
 
 **Path:** `maestro/services/assets.py`

--- a/maestro/mcp/tools/__init__.py
+++ b/maestro/mcp/tools/__init__.py
@@ -1,14 +1,22 @@
-"""MCP tool access — delegates to the Stori DAW adapter's tool registry.
+"""MCP tool access — combined registry for DAW tools and MuseHub browsing tools.
 
-MCP transport code imports tool definitions from here.  The canonical
-definitions live in ``app.daw.stori.tool_registry``.
+DAW tool definitions (``stori_*``) come from ``maestro.daw.stori.tool_registry``.
+MuseHub browsing tools (``musehub_*``) are defined here and are always
+server-side (never forwarded to the DAW).
+
+``MCP_TOOLS``         — full combined list (DAW + MuseHub), used by the MCP server.
+``SERVER_SIDE_TOOLS`` — names of all server-side tools (generation + musehub).
+``DAW_TOOLS``         — names of all DAW-forwarded tools.
+``TOOL_CATEGORIES``   — maps every tool name to its category string.
+``MUSEHUB_TOOL_NAMES``— set of ``musehub_*`` tool names for routing.
 """
 from __future__ import annotations
 
+from maestro.contracts.mcp_types import MCPToolDef
 from maestro.daw.stori.tool_registry import (
-    MCP_TOOLS,
-    TOOL_CATEGORIES,
-    SERVER_SIDE_TOOLS,
+    MCP_TOOLS as _DAW_MCP_TOOLS,
+    TOOL_CATEGORIES as _DAW_TOOL_CATEGORIES,
+    SERVER_SIDE_TOOLS as _DAW_SERVER_SIDE_TOOLS,
     DAW_TOOLS,
 )
 from maestro.daw.stori.tools.project import PROJECT_TOOLS
@@ -21,6 +29,19 @@ from maestro.daw.stori.tools.midi_control import MIDI_CONTROL_TOOLS
 from maestro.daw.stori.tools.generation import GENERATION_TOOLS
 from maestro.daw.stori.tools.playback import PLAYBACK_TOOLS
 from maestro.daw.stori.tools.ui import UI_TOOLS
+from maestro.mcp.tools.musehub import MUSEHUB_TOOLS, MUSEHUB_TOOL_NAMES
+
+# Combined tool list: DAW tools first, then MuseHub browsing tools.
+MCP_TOOLS: list[MCPToolDef] = _DAW_MCP_TOOLS + MUSEHUB_TOOLS
+
+# MuseHub tools are always server-side — merge with the DAW server-side set.
+SERVER_SIDE_TOOLS: set[str] = _DAW_SERVER_SIDE_TOOLS | MUSEHUB_TOOL_NAMES
+
+# Category map: DAW categories + musehub category for all MuseHub tools.
+TOOL_CATEGORIES: dict[str, str] = {
+    **_DAW_TOOL_CATEGORIES,
+    **{name: "musehub" for name in MUSEHUB_TOOL_NAMES},
+}
 
 __all__ = [
     "PROJECT_TOOLS",
@@ -33,6 +54,8 @@ __all__ = [
     "GENERATION_TOOLS",
     "PLAYBACK_TOOLS",
     "UI_TOOLS",
+    "MUSEHUB_TOOLS",
+    "MUSEHUB_TOOL_NAMES",
     "MCP_TOOLS",
     "TOOL_CATEGORIES",
     "SERVER_SIDE_TOOLS",

--- a/maestro/mcp/tools/musehub.py
+++ b/maestro/mcp/tools/musehub.py
@@ -1,0 +1,197 @@
+"""MuseHub MCP tool definitions — server-side browsing tools for AI agents.
+
+These tools allow Cursor/Claude and other MCP clients to explore MuseHub
+repositories, inspect commit history, read artifact metadata, query musical
+analysis, and search — all without requiring a connected DAW.
+
+Every tool in this module is ``server_side: True``.  The MCP server routes
+them to ``musehub_mcp_executor`` rather than forwarding them to the DAW.
+
+Naming convention: ``musehub_<verb>_<noun>`` — distinct from DAW tools
+which use the ``stori_`` prefix.
+"""
+from __future__ import annotations
+
+from maestro.contracts.mcp_types import MCPToolDef
+
+
+MUSEHUB_TOOLS: list[MCPToolDef] = [
+    {
+        "name": "musehub_browse_repo",
+        "server_side": True,
+        "description": (
+            "Get an overview of a MuseHub repository: metadata, branches, and recent commits. "
+            "Use this to orient yourself before reading files or analysing commit history. "
+            "Example: musehub_browse_repo(repo_id='a3f2-...')."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo_id": {
+                    "type": "string",
+                    "description": "UUID of the MuseHub repository (e.g. 'a3f2-...').",
+                },
+            },
+            "required": ["repo_id"],
+        },
+    },
+    {
+        "name": "musehub_list_branches",
+        "server_side": True,
+        "description": (
+            "List all branches in a MuseHub repository with their head commit IDs. "
+            "Call before musehub_list_commits to identify the target branch ref. "
+            "Example: musehub_list_branches(repo_id='a3f2-...')."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo_id": {
+                    "type": "string",
+                    "description": "UUID of the MuseHub repository.",
+                },
+            },
+            "required": ["repo_id"],
+        },
+    },
+    {
+        "name": "musehub_list_commits",
+        "server_side": True,
+        "description": (
+            "List commits on a MuseHub repository (newest first). "
+            "Optionally filter by branch name and cap the result count. "
+            "Example: musehub_list_commits(repo_id='a3f2-...', branch='main', limit=10)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo_id": {
+                    "type": "string",
+                    "description": "UUID of the MuseHub repository.",
+                },
+                "branch": {
+                    "type": "string",
+                    "description": "Branch name filter (e.g. 'main'). Omit to list across all branches.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum commits to return (default: 20, max: 100).",
+                    "default": 20,
+                    "minimum": 1,
+                    "maximum": 100,
+                },
+            },
+            "required": ["repo_id"],
+        },
+    },
+    {
+        "name": "musehub_read_file",
+        "server_side": True,
+        "description": (
+            "Read the metadata for a stored artifact (MIDI, MP3, WebP piano roll) "
+            "in a MuseHub repo. Returns path, size_bytes, mime_type, and object_id. "
+            "Binary content is not returned — discover object IDs via musehub_browse_repo first. "
+            "Example: musehub_read_file(repo_id='a3f2-...', object_id='sha256:abc...')."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo_id": {
+                    "type": "string",
+                    "description": "UUID of the MuseHub repository.",
+                },
+                "object_id": {
+                    "type": "string",
+                    "description": "Content-addressed object ID (e.g. 'sha256:abc...').",
+                },
+            },
+            "required": ["repo_id", "object_id"],
+        },
+    },
+    {
+        "name": "musehub_get_analysis",
+        "server_side": True,
+        "description": (
+            "Get structured analysis for a MuseHub repository. "
+            "Dimensions: 'overview' returns repo stats + branch/commit/object counts; "
+            "'commits' returns commit activity summary (authors, message samples); "
+            "'objects' returns artifact inventory grouped by MIME type. "
+            "MIDI audio analysis requires Storpheus integration (not yet available — "
+            "dimension fields for key/tempo will be None until integrated). "
+            "Example: musehub_get_analysis(repo_id='a3f2-...', dimension='overview')."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo_id": {
+                    "type": "string",
+                    "description": "UUID of the MuseHub repository.",
+                },
+                "dimension": {
+                    "type": "string",
+                    "description": "Analysis dimension: 'overview', 'commits', or 'objects'.",
+                    "enum": ["overview", "commits", "objects"],
+                    "default": "overview",
+                },
+            },
+            "required": ["repo_id"],
+        },
+    },
+    {
+        "name": "musehub_search",
+        "server_side": True,
+        "description": (
+            "Search within a MuseHub repository by substring query. "
+            "Mode 'path' matches artifact file paths (e.g. 'tracks/jazz'); "
+            "mode 'commit' searches commit messages (e.g. 'add bass'). "
+            "Returns matching items with their metadata. "
+            "Example: musehub_search(repo_id='a3f2-...', query='bass', mode='path')."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo_id": {
+                    "type": "string",
+                    "description": "UUID of the MuseHub repository to search within.",
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Substring query string (case-insensitive).",
+                },
+                "mode": {
+                    "type": "string",
+                    "description": "Search mode: 'path' searches object paths; 'commit' searches commit messages.",
+                    "enum": ["path", "commit"],
+                    "default": "path",
+                },
+            },
+            "required": ["repo_id", "query"],
+        },
+    },
+    {
+        "name": "musehub_get_context",
+        "server_side": True,
+        "description": (
+            "Get the full AI context document for a MuseHub repository. "
+            "This is the primary read-side interface for music generation agents: it returns "
+            "a structured summary of the repo's musical state — branches, recent commits, "
+            "artifact inventory, and repo metadata — in a single call. "
+            "Feed this document to the agent before generating new music to ensure "
+            "harmonic and structural coherence with existing work. "
+            "Example: musehub_get_context(repo_id='a3f2-...')."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo_id": {
+                    "type": "string",
+                    "description": "UUID of the MuseHub repository.",
+                },
+            },
+            "required": ["repo_id"],
+        },
+    },
+]
+
+MUSEHUB_TOOL_NAMES: set[str] = {t["name"] for t in MUSEHUB_TOOLS}
+"""Set of all musehub_* tool names — used by the MCP server to route calls."""

--- a/maestro/services/musehub_mcp_executor.py
+++ b/maestro/services/musehub_mcp_executor.py
@@ -172,9 +172,6 @@ async def execute_list_branches(repo_id: str) -> MusehubToolResult:
         ``MusehubToolResult`` with ``data.branches`` as a list of branch
         dicts, or ``error_code="not_found"`` if the repo does not exist.
     """
-    from maestro.db.database import AsyncSessionLocal
-    from maestro.services import musehub_repository
-
     async with AsyncSessionLocal() as session:
         repo = await musehub_repository.get_repo(session, repo_id)
         if repo is None:
@@ -216,9 +213,6 @@ async def execute_list_commits(
         ``MusehubToolResult`` with ``data.commits`` and ``data.total``,
         or ``error_code="not_found"`` if the repo does not exist.
     """
-    from maestro.db.database import AsyncSessionLocal
-    from maestro.services import musehub_repository
-
     limit = max(1, min(limit, 100))
 
     async with AsyncSessionLocal() as session:
@@ -275,9 +269,6 @@ async def execute_read_file(repo_id: str, object_id: str) -> MusehubToolResult:
         ``MusehubToolResult`` with file metadata, or ``error_code="not_found"``
         if the repo or object does not exist.
     """
-    from maestro.db.database import AsyncSessionLocal
-    from maestro.services import musehub_repository
-
     async with AsyncSessionLocal() as session:
         repo = await musehub_repository.get_repo(session, repo_id)
         if repo is None:
@@ -331,9 +322,6 @@ async def execute_get_analysis(
     Returns:
         ``MusehubToolResult`` with analysis data, or an error code on failure.
     """
-    from maestro.db.database import AsyncSessionLocal
-    from maestro.services import musehub_repository
-
     valid_dimensions = {"overview", "commits", "objects"}
     if dimension not in valid_dimensions:
         return MusehubToolResult(
@@ -451,9 +439,6 @@ async def execute_search(
     Returns:
         ``MusehubToolResult`` with ``data.results`` list, or an error on failure.
     """
-    from maestro.db.database import AsyncSessionLocal
-    from maestro.services import musehub_repository
-
     valid_modes = {"path", "commit"}
     if mode not in valid_modes:
         return MusehubToolResult(
@@ -535,9 +520,6 @@ async def execute_get_context(repo_id: str) -> MusehubToolResult:
         ``MusehubToolResult`` with ``data.context`` (the full context doc),
         or ``error_code="not_found"`` if the repo does not exist.
     """
-    from maestro.db.database import AsyncSessionLocal
-    from maestro.services import musehub_repository
-
     async with AsyncSessionLocal() as session:
         repo = await musehub_repository.get_repo(session, repo_id)
         if repo is None:

--- a/maestro/services/musehub_mcp_executor.py
+++ b/maestro/services/musehub_mcp_executor.py
@@ -1,0 +1,610 @@
+"""MuseHub MCP tool executor — server-side logic for all musehub_* MCP tools.
+
+This module is the execution backend for MuseHub browsing tools exposed via
+MCP.  Each public function opens its own DB session via ``AsyncSessionLocal``,
+delegates to ``musehub_repository`` for persistence access, and returns a
+typed ``MusehubToolResult``.
+
+Design contract
+---------------
+- All functions are async and return ``MusehubToolResult`` on both success
+  and failure (no exceptions propagate to the MCP server).
+- ``MusehubToolResult.ok`` distinguishes success from failure.
+- ``MusehubToolResult.error_code`` is one of: ``"not_found"``,
+  ``"invalid_dimension"``, ``"invalid_mode"``, ``"db_unavailable"``.
+- Callers (``MaestroMCPServer._execute_musehub_tool``) pattern-match on
+  these codes to build appropriate ``MCPContentBlock`` responses.
+- This module must NOT import MCP protocol types — it is pure service layer.
+
+``AsyncSessionLocal`` is imported at module level so tests can patch it as
+``maestro.services.musehub_mcp_executor.AsyncSessionLocal``.
+"""
+from __future__ import annotations
+
+import logging
+import mimetypes
+import os
+from dataclasses import dataclass, field
+from typing import Literal
+
+from maestro.contracts.json_types import JSONValue
+from maestro.db.database import AsyncSessionLocal
+from maestro.services import musehub_repository
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+MusehubErrorCode = Literal[
+    "not_found",
+    "invalid_dimension",
+    "invalid_mode",
+    "db_unavailable",
+]
+"""Enumeration of error codes returned by MuseHub MCP executors.
+
+Callers pattern-match on these to build appropriate error messages:
+  - ``not_found``         — repo or object does not exist
+  - ``invalid_dimension`` — unrecognised analysis dimension
+  - ``invalid_mode``      — unrecognised search mode
+  - ``db_unavailable``    — DB session factory not initialised (startup race)
+"""
+
+
+@dataclass(frozen=True)
+class MusehubToolResult:
+    """Result of executing a single musehub_* MCP tool.
+
+    ``ok`` is the primary success/failure signal.  On success, ``data``
+    holds the JSON-serialisable payload for the MCP content block.  On
+    failure, ``error_code`` and ``error_message`` describe what went wrong.
+
+    This type is the contract between the executor functions and the MCP
+    server's routing layer — do not bypass it with raw exceptions.
+    """
+
+    ok: bool
+    data: dict[str, JSONValue] = field(default_factory=dict)
+    error_code: MusehubErrorCode | None = None
+    error_message: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_EXTRA_MIME: dict[str, str] = {
+    ".mid": "audio/midi",
+    ".midi": "audio/midi",
+    ".mp3": "audio/mpeg",
+    ".webp": "image/webp",
+}
+
+
+def _mime_for_path(path: str) -> str:
+    """Resolve MIME type from a file path extension."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext in _EXTRA_MIME:
+        return _EXTRA_MIME[ext]
+    guessed, _ = mimetypes.guess_type(path)
+    return guessed or "application/octet-stream"
+
+
+# ---------------------------------------------------------------------------
+# Tool executors
+# ---------------------------------------------------------------------------
+
+
+async def execute_browse_repo(repo_id: str) -> MusehubToolResult:
+    """Return repo metadata, branch list, and the 10 most recent commits.
+
+    This is the entry-point tool for orienting an agent before it calls more
+    specific tools.  It aggregates three repository queries into one response
+    to minimise round-trips for the common "explore a new repo" case.
+
+    Args:
+        repo_id: UUID of the target MuseHub repository.
+
+    Returns:
+        ``MusehubToolResult`` with ``data`` containing ``repo``, ``branches``,
+        and ``recent_commits`` keys, or ``error_code="not_found"`` if the
+        repo does not exist.
+    """
+    async with AsyncSessionLocal() as session:
+        repo = await musehub_repository.get_repo(session, repo_id)
+        if repo is None:
+            return MusehubToolResult(
+                ok=False,
+                error_code="not_found",
+                error_message=f"Repository '{repo_id}' not found.",
+            )
+
+        branches = await musehub_repository.list_branches(session, repo_id)
+        commits, total = await musehub_repository.list_commits(
+            session, repo_id, limit=10
+        )
+
+        data: dict[str, JSONValue] = {
+            "repo": {
+                "repo_id": repo.repo_id,
+                "name": repo.name,
+                "visibility": repo.visibility,
+                "owner_user_id": repo.owner_user_id,
+                "clone_url": repo.clone_url,
+                "created_at": repo.created_at.isoformat(),
+            },
+            "branches": [
+                {
+                    "branch_id": b.branch_id,
+                    "name": b.name,
+                    "head_commit_id": b.head_commit_id,
+                }
+                for b in branches
+            ],
+            "recent_commits": [
+                {
+                    "commit_id": c.commit_id,
+                    "branch": c.branch,
+                    "message": c.message,
+                    "author": c.author,
+                    "timestamp": c.timestamp.isoformat(),
+                }
+                for c in commits
+            ],
+            "total_commits": total,
+            "branch_count": len(branches),
+        }
+        return MusehubToolResult(ok=True, data=data)
+
+
+async def execute_list_branches(repo_id: str) -> MusehubToolResult:
+    """Return all branches for a MuseHub repository.
+
+    Agents call this before ``execute_list_commits`` to discover available
+    branch names and their current head commit IDs.
+
+    Args:
+        repo_id: UUID of the target MuseHub repository.
+
+    Returns:
+        ``MusehubToolResult`` with ``data.branches`` as a list of branch
+        dicts, or ``error_code="not_found"`` if the repo does not exist.
+    """
+    from maestro.db.database import AsyncSessionLocal
+    from maestro.services import musehub_repository
+
+    async with AsyncSessionLocal() as session:
+        repo = await musehub_repository.get_repo(session, repo_id)
+        if repo is None:
+            return MusehubToolResult(
+                ok=False,
+                error_code="not_found",
+                error_message=f"Repository '{repo_id}' not found.",
+            )
+
+        branches = await musehub_repository.list_branches(session, repo_id)
+        data: dict[str, JSONValue] = {
+            "repo_id": repo_id,
+            "branches": [
+                {
+                    "branch_id": b.branch_id,
+                    "name": b.name,
+                    "head_commit_id": b.head_commit_id,
+                }
+                for b in branches
+            ],
+            "branch_count": len(branches),
+        }
+        return MusehubToolResult(ok=True, data=data)
+
+
+async def execute_list_commits(
+    repo_id: str,
+    branch: str | None = None,
+    limit: int = 20,
+) -> MusehubToolResult:
+    """Return paginated commits for a MuseHub repository, newest first.
+
+    Args:
+        repo_id: UUID of the target MuseHub repository.
+        branch:  Optional branch name filter; None returns across all branches.
+        limit:   Maximum commits to return (clamped to 1–100).
+
+    Returns:
+        ``MusehubToolResult`` with ``data.commits`` and ``data.total``,
+        or ``error_code="not_found"`` if the repo does not exist.
+    """
+    from maestro.db.database import AsyncSessionLocal
+    from maestro.services import musehub_repository
+
+    limit = max(1, min(limit, 100))
+
+    async with AsyncSessionLocal() as session:
+        repo = await musehub_repository.get_repo(session, repo_id)
+        if repo is None:
+            return MusehubToolResult(
+                ok=False,
+                error_code="not_found",
+                error_message=f"Repository '{repo_id}' not found.",
+            )
+
+        commits, total = await musehub_repository.list_commits(
+            session, repo_id, branch=branch, limit=limit
+        )
+
+        commit_list: list[JSONValue] = []
+        for c in commits:
+            # parent_ids is list[str]; build list[JSONValue] explicitly (list invariance).
+            parent_ids_json: list[JSONValue] = []
+            for pid in c.parent_ids:
+                parent_ids_json.append(pid)
+            commit_list.append({
+                "commit_id": c.commit_id,
+                "branch": c.branch,
+                "parent_ids": parent_ids_json,
+                "message": c.message,
+                "author": c.author,
+                "timestamp": c.timestamp.isoformat(),
+                "snapshot_id": c.snapshot_id,
+            })
+
+        data: dict[str, JSONValue] = {
+            "repo_id": repo_id,
+            "branch_filter": branch,
+            "commits": commit_list,
+            "returned": len(commits),
+            "total": total,
+        }
+        return MusehubToolResult(ok=True, data=data)
+
+
+async def execute_read_file(repo_id: str, object_id: str) -> MusehubToolResult:
+    """Return metadata for a stored artifact in a MuseHub repo.
+
+    Returns path, size_bytes, mime_type, and object_id.  Binary content is
+    intentionally excluded — MCP tool responses must be text-safe JSON.
+    Agents that need the raw bytes should use the HTTP objects endpoint.
+
+    Args:
+        repo_id:   UUID of the target MuseHub repository.
+        object_id: Content-addressed ID (e.g. ``sha256:abc...``).
+
+    Returns:
+        ``MusehubToolResult`` with file metadata, or ``error_code="not_found"``
+        if the repo or object does not exist.
+    """
+    from maestro.db.database import AsyncSessionLocal
+    from maestro.services import musehub_repository
+
+    async with AsyncSessionLocal() as session:
+        repo = await musehub_repository.get_repo(session, repo_id)
+        if repo is None:
+            return MusehubToolResult(
+                ok=False,
+                error_code="not_found",
+                error_message=f"Repository '{repo_id}' not found.",
+            )
+
+        obj = await musehub_repository.get_object_row(session, repo_id, object_id)
+        if obj is None:
+            return MusehubToolResult(
+                ok=False,
+                error_code="not_found",
+                error_message=f"Object '{object_id}' not found in repository '{repo_id}'.",
+            )
+
+        data: dict[str, JSONValue] = {
+            "object_id": obj.object_id,
+            "repo_id": repo_id,
+            "path": obj.path,
+            "size_bytes": obj.size_bytes,
+            "mime_type": _mime_for_path(obj.path),
+            "created_at": obj.created_at.isoformat(),
+        }
+        return MusehubToolResult(ok=True, data=data)
+
+
+async def execute_get_analysis(
+    repo_id: str,
+    dimension: str = "overview",
+) -> MusehubToolResult:
+    """Return structured analysis for a MuseHub repository.
+
+    Supported dimensions:
+    - ``overview``  — repo stats: branch count, commit count, object count,
+                      most active author, most recent commit timestamp.
+    - ``commits``   — commit activity: total, per-branch breakdown, author
+                      distribution, and a sample of the most recent messages.
+    - ``objects``   — artifact inventory: total size, per-MIME-type counts
+                      and sizes, and a sample of object paths.
+
+    MIDI audio analysis (key, tempo, harmonic content) requires Storpheus
+    integration and is not yet available; those fields will be ``null``.
+
+    Args:
+        repo_id:   UUID of the target MuseHub repository.
+        dimension: Analysis dimension — one of ``overview``, ``commits``,
+                   ``objects``.
+
+    Returns:
+        ``MusehubToolResult`` with analysis data, or an error code on failure.
+    """
+    from maestro.db.database import AsyncSessionLocal
+    from maestro.services import musehub_repository
+
+    valid_dimensions = {"overview", "commits", "objects"}
+    if dimension not in valid_dimensions:
+        return MusehubToolResult(
+            ok=False,
+            error_code="invalid_dimension",
+            error_message=(
+                f"Unknown dimension '{dimension}'. "
+                f"Valid values: {', '.join(sorted(valid_dimensions))}."
+            ),
+        )
+
+    async with AsyncSessionLocal() as session:
+        repo = await musehub_repository.get_repo(session, repo_id)
+        if repo is None:
+            return MusehubToolResult(
+                ok=False,
+                error_code="not_found",
+                error_message=f"Repository '{repo_id}' not found.",
+            )
+
+        if dimension == "overview":
+            branches = await musehub_repository.list_branches(session, repo_id)
+            commits, total_commits = await musehub_repository.list_commits(
+                session, repo_id, limit=1
+            )
+            objects = await musehub_repository.list_objects(session, repo_id)
+
+            last_commit_at: JSONValue = None
+            most_recent_author: JSONValue = None
+            if commits:
+                last_commit_at = commits[0].timestamp.isoformat()
+                most_recent_author = commits[0].author
+
+            data: dict[str, JSONValue] = {
+                "repo_id": repo_id,
+                "dimension": "overview",
+                "repo_name": repo.name,
+                "visibility": repo.visibility,
+                "branch_count": len(branches),
+                "commit_count": total_commits,
+                "object_count": len(objects),
+                "last_commit_at": last_commit_at,
+                "most_recent_author": most_recent_author,
+                "midi_analysis": None,
+            }
+            return MusehubToolResult(ok=True, data=data)
+
+        if dimension == "commits":
+            all_commits, total = await musehub_repository.list_commits(
+                session, repo_id, limit=100
+            )
+
+            by_branch: dict[str, int] = {}
+            by_author: dict[str, int] = {}
+            for c in all_commits:
+                by_branch[c.branch] = by_branch.get(c.branch, 0) + 1
+                by_author[c.author] = by_author.get(c.author, 0) + 1
+
+            data = {
+                "repo_id": repo_id,
+                "dimension": "commits",
+                "total_commits": total,
+                "commits_in_sample": len(all_commits),
+                "by_branch": {k: v for k, v in by_branch.items()},
+                "by_author": {k: v for k, v in by_author.items()},
+                "recent_messages": [c.message for c in all_commits[:5]],
+            }
+            return MusehubToolResult(ok=True, data=data)
+
+        # dimension == "objects"
+        objects = await musehub_repository.list_objects(session, repo_id)
+
+        by_mime: dict[str, int] = {}
+        size_by_mime: dict[str, int] = {}
+        total_size = 0
+        for obj in objects:
+            mime = _mime_for_path(obj.path)
+            by_mime[mime] = by_mime.get(mime, 0) + 1
+            size_by_mime[mime] = size_by_mime.get(mime, 0) + obj.size_bytes
+            total_size += obj.size_bytes
+
+        data = {
+            "repo_id": repo_id,
+            "dimension": "objects",
+            "total_objects": len(objects),
+            "total_size_bytes": total_size,
+            "by_mime_type": {k: v for k, v in by_mime.items()},
+            "size_by_mime_type": {k: v for k, v in size_by_mime.items()},
+            "sample_paths": [obj.path for obj in objects[:10]],
+        }
+        return MusehubToolResult(ok=True, data=data)
+
+
+async def execute_search(
+    repo_id: str,
+    query: str,
+    mode: str = "path",
+) -> MusehubToolResult:
+    """Search within a MuseHub repository by substring match.
+
+    Search is case-insensitive substring matching.  Two modes are supported:
+    - ``path``   — matches object file paths (e.g. ``tracks/jazz_4b.mid``).
+    - ``commit`` — matches commit messages (e.g. ``add bass intro``).
+
+    The search operates on the full in-memory dataset (no DB-level LIKE query)
+    so results are consistent across database backends.  For very large repos
+    (>10 k objects/commits) this may be slow — index-backed search is a
+    planned future enhancement.
+
+    Args:
+        repo_id: UUID of the target MuseHub repository.
+        query:   Case-insensitive substring to search for.
+        mode:    ``"path"`` or ``"commit"``.
+
+    Returns:
+        ``MusehubToolResult`` with ``data.results`` list, or an error on failure.
+    """
+    from maestro.db.database import AsyncSessionLocal
+    from maestro.services import musehub_repository
+
+    valid_modes = {"path", "commit"}
+    if mode not in valid_modes:
+        return MusehubToolResult(
+            ok=False,
+            error_code="invalid_mode",
+            error_message=(
+                f"Unknown search mode '{mode}'. "
+                f"Valid values: {', '.join(sorted(valid_modes))}."
+            ),
+        )
+
+    q = query.lower()
+
+    async with AsyncSessionLocal() as session:
+        repo = await musehub_repository.get_repo(session, repo_id)
+        if repo is None:
+            return MusehubToolResult(
+                ok=False,
+                error_code="not_found",
+                error_message=f"Repository '{repo_id}' not found.",
+            )
+
+        if mode == "path":
+            objects = await musehub_repository.list_objects(session, repo_id)
+            results: list[JSONValue] = [
+                {
+                    "object_id": obj.object_id,
+                    "path": obj.path,
+                    "size_bytes": obj.size_bytes,
+                    "mime_type": _mime_for_path(obj.path),
+                }
+                for obj in objects
+                if q in obj.path.lower()
+            ]
+        else:  # mode == "commit"
+            commits, _ = await musehub_repository.list_commits(
+                session, repo_id, limit=100
+            )
+            results = [
+                {
+                    "commit_id": c.commit_id,
+                    "branch": c.branch,
+                    "message": c.message,
+                    "author": c.author,
+                    "timestamp": c.timestamp.isoformat(),
+                }
+                for c in commits
+                if q in c.message.lower()
+            ]
+
+        data: dict[str, JSONValue] = {
+            "repo_id": repo_id,
+            "query": query,
+            "mode": mode,
+            "result_count": len(results),
+            "results": results,
+        }
+        return MusehubToolResult(ok=True, data=data)
+
+
+async def execute_get_context(repo_id: str) -> MusehubToolResult:
+    """Return the full AI context document for a MuseHub repository.
+
+    This is the primary read-side interface for music generation agents.
+    It aggregates repo metadata, all branches, the 10 most recent commits
+    across all branches, and the full artifact inventory into a single
+    structured document — ready to paste into an agent's context window.
+
+    Feed this document to the agent before generating new music to ensure
+    harmonic and structural coherence with existing work in the repository.
+
+    Musical analysis fields (key, tempo, time_signature) are ``null`` until
+    Storpheus MIDI analysis integration is complete.
+
+    Args:
+        repo_id: UUID of the target MuseHub repository.
+
+    Returns:
+        ``MusehubToolResult`` with ``data.context`` (the full context doc),
+        or ``error_code="not_found"`` if the repo does not exist.
+    """
+    from maestro.db.database import AsyncSessionLocal
+    from maestro.services import musehub_repository
+
+    async with AsyncSessionLocal() as session:
+        repo = await musehub_repository.get_repo(session, repo_id)
+        if repo is None:
+            return MusehubToolResult(
+                ok=False,
+                error_code="not_found",
+                error_message=f"Repository '{repo_id}' not found.",
+            )
+
+        branches = await musehub_repository.list_branches(session, repo_id)
+        commits, total_commits = await musehub_repository.list_commits(
+            session, repo_id, limit=10
+        )
+        objects = await musehub_repository.list_objects(session, repo_id)
+
+        by_mime: dict[str, int] = {}
+        for obj in objects:
+            mime = _mime_for_path(obj.path)
+            by_mime[mime] = by_mime.get(mime, 0) + 1
+
+        context: dict[str, JSONValue] = {
+            "repo": {
+                "repo_id": repo.repo_id,
+                "name": repo.name,
+                "visibility": repo.visibility,
+                "owner_user_id": repo.owner_user_id,
+                "created_at": repo.created_at.isoformat(),
+            },
+            "branches": [
+                {
+                    "name": b.name,
+                    "head_commit_id": b.head_commit_id,
+                }
+                for b in branches
+            ],
+            "recent_commits": [
+                {
+                    "commit_id": c.commit_id,
+                    "branch": c.branch,
+                    "message": c.message,
+                    "author": c.author,
+                    "timestamp": c.timestamp.isoformat(),
+                }
+                for c in commits
+            ],
+            "commit_stats": {
+                "total": total_commits,
+                "shown": len(commits),
+            },
+            "artifacts": {
+                "total_count": len(objects),
+                "by_mime_type": {k: v for k, v in by_mime.items()},
+                "paths": [obj.path for obj in objects],
+            },
+            "musical_analysis": {
+                "key": None,
+                "tempo": None,
+                "time_signature": None,
+                "note": (
+                    "Musical analysis requires Storpheus MIDI integration "
+                    "(not yet available — fields will be populated in a future release)."
+                ),
+            },
+        }
+
+        data: dict[str, JSONValue] = {
+            "repo_id": repo_id,
+            "context": context,
+        }
+        return MusehubToolResult(ok=True, data=data)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -25,9 +25,12 @@ class TestMCPTools:
 
     def test_tool_names_are_prefixed(self) -> None:
 
-        """All MCP tools should be prefixed with 'stori_'."""
+        """All MCP tools should be prefixed with 'stori_' (DAW tools) or 'musehub_' (browsing tools)."""
+        valid_prefixes = ("stori_", "musehub_")
         for tool in MCP_TOOLS:
-            assert tool["name"].startswith("stori_"), f"Tool {tool['name']} should start with 'stori_'"
+            assert tool["name"].startswith(valid_prefixes), (
+                f"Tool {tool['name']} should start with one of {valid_prefixes}"
+            )
 
     def test_tool_categories_complete(self) -> None:
 
@@ -45,6 +48,13 @@ class TestMCPTools:
 
         """Generation tools should be marked as server-side."""
         assert "stori_generate_midi" in SERVER_SIDE_TOOLS
+
+    def test_musehub_tools_are_server_side(self) -> None:
+
+        """MuseHub browsing tools should all be in SERVER_SIDE_TOOLS."""
+        from maestro.mcp.tools import MUSEHUB_TOOL_NAMES
+        for name in MUSEHUB_TOOL_NAMES:
+            assert name in SERVER_SIDE_TOOLS, f"MuseHub tool '{name}' not in SERVER_SIDE_TOOLS"
 
 
 class TestMCPServer:

--- a/tests/test_mcp_musehub.py
+++ b/tests/test_mcp_musehub.py
@@ -1,0 +1,586 @@
+"""Tests for MuseHub MCP tools — issue #246.
+
+Covers all acceptance criteria:
+  - musehub_browse_repo returns repo stats, branches, recent commits
+  - musehub_read_file returns file metadata with MIME type
+  - musehub_list_commits returns paginated commit list
+  - musehub_get_analysis returns analysis for overview/commits/objects dimensions
+  - musehub_search supports path and commit modes
+  - musehub_get_context returns full AI context document
+  - All tools registered in MCP server with proper schemas
+  - Tools handle errors gracefully (not_found, invalid dimension/mode)
+
+Tests use conftest db_session (in-memory SQLite) and mock the executor's
+AsyncSessionLocal to use the test session so no live DB is required.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import (
+    MusehubBranch,
+    MusehubCommit,
+    MusehubObject,
+    MusehubRepo,
+)
+from maestro.mcp.server import MaestroMCPServer, ToolCallResult
+from maestro.mcp.tools import MCP_TOOLS, MUSEHUB_TOOL_NAMES, TOOL_CATEGORIES
+from maestro.mcp.tools.musehub import MUSEHUB_TOOLS
+from maestro.services import musehub_mcp_executor as executor
+from maestro.services.musehub_mcp_executor import MusehubToolResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc(year: int = 2024, month: int = 1, day: int = 1) -> datetime:
+    return datetime(year, month, day, tzinfo=timezone.utc)
+
+
+async def _seed_repo(session: AsyncSession) -> MusehubRepo:
+    """Insert a minimal repo, branch, commit, and object for tests."""
+    repo = MusehubRepo(
+        repo_id="repo-test-001",
+        name="jazz-sessions",
+        visibility="public",
+        owner_user_id="user-001",
+        created_at=_utc(),
+    )
+    session.add(repo)
+
+    branch = MusehubBranch(
+        branch_id="branch-001",
+        repo_id="repo-test-001",
+        name="main",
+        head_commit_id="commit-001",
+    )
+    session.add(branch)
+
+    commit = MusehubCommit(
+        commit_id="commit-001",
+        repo_id="repo-test-001",
+        branch="main",
+        parent_ids=[],
+        message="add bass track",
+        author="alice",
+        timestamp=_utc(2024, 6, 15),
+        snapshot_id="snap-001",
+    )
+    session.add(commit)
+
+    obj = MusehubObject(
+        object_id="sha256:abc123",
+        repo_id="repo-test-001",
+        path="tracks/bass.mid",
+        size_bytes=2048,
+        disk_path="/tmp/bass.mid",
+        created_at=_utc(),
+    )
+    session.add(obj)
+
+    await session.commit()
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestMusehubToolsRegistered:
+    """Verify that all musehub_* tools appear in the combined MCP registry."""
+
+    def test_musehub_tools_in_mcp_tools(self) -> None:
+        """All MUSEHUB_TOOLS appear in the combined MCP_TOOLS list."""
+        registered_names = {t["name"] for t in MCP_TOOLS}
+        for tool in MUSEHUB_TOOLS:
+            assert tool["name"] in registered_names, (
+                f"MuseHub tool '{tool['name']}' missing from MCP_TOOLS"
+            )
+
+    def test_musehub_tool_names_set_correct(self) -> None:
+        """MUSEHUB_TOOL_NAMES matches the names declared in MUSEHUB_TOOLS."""
+        expected = {t["name"] for t in MUSEHUB_TOOLS}
+        assert MUSEHUB_TOOL_NAMES == expected
+
+    def test_musehub_tools_in_categories(self) -> None:
+        """Every musehub_* tool has an entry in TOOL_CATEGORIES."""
+        for name in MUSEHUB_TOOL_NAMES:
+            assert name in TOOL_CATEGORIES, f"Tool '{name}' missing from TOOL_CATEGORIES"
+            assert TOOL_CATEGORIES[name] == "musehub"
+
+    def test_musehub_tools_have_required_fields(self) -> None:
+        """Every musehub_* tool has name, description, and inputSchema."""
+        for tool in MUSEHUB_TOOLS:
+            assert "name" in tool
+            assert "description" in tool
+            assert "inputSchema" in tool
+            assert tool["name"].startswith("musehub_")
+
+    def test_musehub_tools_are_server_side(self) -> None:
+        """Every musehub_* tool is marked server_side=True."""
+        for tool in MUSEHUB_TOOLS:
+            assert tool.get("server_side") is True, (
+                f"Tool '{tool['name']}' must be server_side=True"
+            )
+
+    def test_all_seven_tools_defined(self) -> None:
+        """Exactly the seven MuseHub tools from issue #246 are defined."""
+        expected = {
+            "musehub_browse_repo",
+            "musehub_list_branches",
+            "musehub_list_commits",
+            "musehub_read_file",
+            "musehub_get_analysis",
+            "musehub_search",
+            "musehub_get_context",
+        }
+        assert MUSEHUB_TOOL_NAMES == expected
+
+
+# ---------------------------------------------------------------------------
+# Executor unit tests (using db_session fixture from conftest)
+# ---------------------------------------------------------------------------
+
+
+class TestMusehubExecutors:
+    """Unit tests for each executor function using the in-memory test DB."""
+
+    @pytest.mark.anyio
+    async def test_mcp_browse_repo_returns_repo_data(
+        self, db_session: AsyncSession
+    ) -> None:
+        """musehub_browse_repo returns repo, branches, and recent commits."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_browse_repo("repo-test-001")
+
+        assert result.ok is True
+        # JSONValue union includes list[JSONValue] which rejects str keys — narrow at test boundary.
+        assert result.data["repo"]["name"] == "jazz-sessions"  # type: ignore[index, call-overload]
+        assert result.data["branch_count"] == 1
+        assert len(result.data["branches"]) == 1  # type: ignore[arg-type]
+        assert len(result.data["recent_commits"]) == 1  # type: ignore[arg-type]
+        assert result.data["total_commits"] == 1
+
+    @pytest.mark.anyio
+    async def test_mcp_browse_repo_not_found(self, db_session: AsyncSession) -> None:
+        """musehub_browse_repo returns error for unknown repo."""
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_browse_repo("nonexistent-repo")
+
+        assert result.ok is False
+        assert result.error_code == "not_found"
+
+    @pytest.mark.anyio
+    async def test_mcp_list_branches_returns_branches(
+        self, db_session: AsyncSession
+    ) -> None:
+        """musehub_list_branches returns all branches with head commit IDs."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_list_branches("repo-test-001")
+
+        assert result.ok is True
+        branches = result.data["branches"]
+        assert isinstance(branches, list)
+        assert len(branches) == 1
+        # JSONValue union includes list[JSONValue] which rejects str keys — narrow at test boundary.
+        assert branches[0]["name"] == "main"  # type: ignore[index, call-overload]
+        assert branches[0]["head_commit_id"] == "commit-001"  # type: ignore[index, call-overload]
+
+    @pytest.mark.anyio
+    async def test_mcp_list_commits_returns_paginated_list(
+        self, db_session: AsyncSession
+    ) -> None:
+        """musehub_list_commits returns commits with total count."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_list_commits(
+                "repo-test-001", branch="main", limit=10
+            )
+
+        assert result.ok is True
+        assert result.data["total"] == 1
+        commits = result.data["commits"]
+        assert isinstance(commits, list)
+        assert len(commits) == 1
+        # JSONValue union includes list[JSONValue] which rejects str keys — narrow at test boundary.
+        assert commits[0]["message"] == "add bass track"  # type: ignore[index, call-overload]
+        assert commits[0]["author"] == "alice"  # type: ignore[index, call-overload]
+
+    @pytest.mark.anyio
+    async def test_mcp_list_commits_limit_clamped(
+        self, db_session: AsyncSession
+    ) -> None:
+        """musehub_list_commits clamps limit to [1, 100]."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            # limit=0 should be clamped to 1
+            result = await executor.execute_list_commits("repo-test-001", limit=0)
+
+        assert result.ok is True
+
+    @pytest.mark.anyio
+    async def test_mcp_read_file_returns_metadata(
+        self, db_session: AsyncSession
+    ) -> None:
+        """musehub_read_file returns path, size_bytes, and mime_type."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_read_file("repo-test-001", "sha256:abc123")
+
+        assert result.ok is True
+        assert result.data["path"] == "tracks/bass.mid"
+        assert result.data["size_bytes"] == 2048
+        assert result.data["mime_type"] == "audio/midi"
+        assert result.data["object_id"] == "sha256:abc123"
+
+    @pytest.mark.anyio
+    async def test_mcp_read_file_not_found(self, db_session: AsyncSession) -> None:
+        """musehub_read_file returns not_found for unknown object."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_read_file("repo-test-001", "sha256:missing")
+
+        assert result.ok is False
+        assert result.error_code == "not_found"
+
+    @pytest.mark.anyio
+    async def test_mcp_get_analysis_overview(self, db_session: AsyncSession) -> None:
+        """musehub_get_analysis overview dimension returns repo stats."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_get_analysis(
+                "repo-test-001", dimension="overview"
+            )
+
+        assert result.ok is True
+        assert result.data["dimension"] == "overview"
+        assert result.data["branch_count"] == 1
+        assert result.data["commit_count"] == 1
+        assert result.data["object_count"] == 1
+        assert result.data["midi_analysis"] is None
+
+    @pytest.mark.anyio
+    async def test_mcp_get_analysis_commits(self, db_session: AsyncSession) -> None:
+        """musehub_get_analysis commits dimension returns commit activity summary."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_get_analysis(
+                "repo-test-001", dimension="commits"
+            )
+
+        assert result.ok is True
+        assert result.data["dimension"] == "commits"
+        assert result.data["total_commits"] == 1
+        by_author = result.data["by_author"]
+        assert isinstance(by_author, dict)
+        assert by_author.get("alice") == 1  # type: ignore[index, call-overload]
+
+    @pytest.mark.anyio
+    async def test_mcp_get_analysis_objects(self, db_session: AsyncSession) -> None:
+        """musehub_get_analysis objects dimension returns artifact inventory."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_get_analysis(
+                "repo-test-001", dimension="objects"
+            )
+
+        assert result.ok is True
+        assert result.data["dimension"] == "objects"
+        assert result.data["total_objects"] == 1
+        assert result.data["total_size_bytes"] == 2048
+
+    @pytest.mark.anyio
+    async def test_mcp_get_analysis_invalid_dimension(
+        self, db_session: AsyncSession
+    ) -> None:
+        """musehub_get_analysis returns error for unknown dimension."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_get_analysis(
+                "repo-test-001", dimension="harmonics"
+            )
+
+        assert result.ok is False
+        assert result.error_code == "invalid_dimension"
+
+    @pytest.mark.anyio
+    async def test_mcp_search_by_path(self, db_session: AsyncSession) -> None:
+        """musehub_search path mode returns matching artifacts."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_search("repo-test-001", "bass", mode="path")
+
+        assert result.ok is True
+        assert result.data["mode"] == "path"
+        assert result.data["result_count"] == 1
+        results = result.data["results"]
+        assert isinstance(results, list)
+        # JSONValue union includes list[JSONValue] which rejects str keys — narrow at test boundary.
+        assert results[0]["path"] == "tracks/bass.mid"  # type: ignore[index, call-overload]
+
+    @pytest.mark.anyio
+    async def test_mcp_search_by_path_no_match(
+        self, db_session: AsyncSession
+    ) -> None:
+        """musehub_search returns empty results when nothing matches."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_search(
+                "repo-test-001", "drums", mode="path"
+            )
+
+        assert result.ok is True
+        assert result.data["result_count"] == 0
+
+    @pytest.mark.anyio
+    async def test_mcp_search_by_commit(self, db_session: AsyncSession) -> None:
+        """musehub_search commit mode searches commit messages."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_search(
+                "repo-test-001", "bass", mode="commit"
+            )
+
+        assert result.ok is True
+        assert result.data["mode"] == "commit"
+        assert result.data["result_count"] == 1
+        results = result.data["results"]
+        assert isinstance(results, list)
+        # JSONValue union includes list[JSONValue] which rejects str keys — narrow at test boundary.
+        assert results[0]["message"] == "add bass track"  # type: ignore[index, call-overload]
+
+    @pytest.mark.anyio
+    async def test_mcp_search_invalid_mode(self, db_session: AsyncSession) -> None:
+        """musehub_search returns error for unknown mode."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_search(
+                "repo-test-001", "bass", mode="fuzzy"
+            )
+
+        assert result.ok is False
+        assert result.error_code == "invalid_mode"
+
+    @pytest.mark.anyio
+    async def test_mcp_search_case_insensitive(self, db_session: AsyncSession) -> None:
+        """musehub_search is case-insensitive."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_search(
+                "repo-test-001", "BASS", mode="path"
+            )
+
+        assert result.ok is True
+        assert result.data["result_count"] == 1
+
+    @pytest.mark.anyio
+    async def test_mcp_get_context_returns_ai_context(
+        self, db_session: AsyncSession
+    ) -> None:
+        """musehub_get_context returns full AI context document."""
+        await _seed_repo(db_session)
+
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_get_context("repo-test-001")
+
+        assert result.ok is True
+        ctx = result.data["context"]
+        assert isinstance(ctx, dict)
+        # JSONValue union includes list[JSONValue] which rejects str keys — narrow at test boundary.
+        assert ctx["repo"]["name"] == "jazz-sessions"  # type: ignore[index, call-overload]
+        assert len(ctx["branches"]) == 1  # type: ignore[arg-type]
+        assert len(ctx["recent_commits"]) == 1  # type: ignore[arg-type]
+        assert ctx["artifacts"]["total_count"] == 1  # type: ignore[index, call-overload]
+        assert ctx["musical_analysis"]["key"] is None  # type: ignore[index, call-overload]
+
+    @pytest.mark.anyio
+    async def test_mcp_get_context_not_found(self, db_session: AsyncSession) -> None:
+        """musehub_get_context returns not_found for unknown repo."""
+        with patch(
+            "maestro.services.musehub_mcp_executor.AsyncSessionLocal",
+            return_value=db_session,
+        ):
+            result = await executor.execute_get_context("ghost-repo")
+
+        assert result.ok is False
+        assert result.error_code == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# MCP server routing tests
+# ---------------------------------------------------------------------------
+
+
+class TestMusehubMcpServerRouting:
+    """Verify that the MCP server correctly routes musehub_* calls."""
+
+    @pytest.fixture
+    def server(self) -> MaestroMCPServer:
+        with patch("maestro.config.get_settings") as mock_settings:
+            mock_settings.return_value = MagicMock(app_version="0.0.0-test")
+            return MaestroMCPServer()
+
+    @pytest.mark.anyio
+    async def test_musehub_browse_repo_routed_to_executor(
+        self, server: MaestroMCPServer
+    ) -> None:
+        """call_tool routes musehub_browse_repo to the MuseHub executor."""
+        mock_result = MusehubToolResult(
+            ok=True,
+            data={"repo": {"name": "test"}, "branches": [], "recent_commits": [], "total_commits": 0, "branch_count": 0},
+        )
+        with patch(
+            "maestro.services.musehub_mcp_executor.execute_browse_repo",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            result = await server.call_tool(
+                "musehub_browse_repo", {"repo_id": "repo-001"}
+            )
+
+        assert result.success is True
+        assert result.is_error is False
+
+    @pytest.mark.anyio
+    async def test_musehub_tool_not_found_returns_error(
+        self, server: MaestroMCPServer
+    ) -> None:
+        """musehub_browse_repo propagates not_found as an error response."""
+        mock_result = MusehubToolResult(
+            ok=False,
+            error_code="not_found",
+            error_message="Repository 'bad-id' not found.",
+        )
+        with patch(
+            "maestro.services.musehub_mcp_executor.execute_browse_repo",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            result = await server.call_tool(
+                "musehub_browse_repo", {"repo_id": "bad-id"}
+            )
+
+        assert result.success is False
+        assert result.is_error is True
+
+    @pytest.mark.anyio
+    async def test_musehub_invalid_dimension_is_bad_request(
+        self, server: MaestroMCPServer
+    ) -> None:
+        """invalid_dimension error is surfaced as bad_request=True."""
+        mock_result = MusehubToolResult(
+            ok=False,
+            error_code="invalid_dimension",
+            error_message="Unknown dimension 'xyz'.",
+        )
+        with patch(
+            "maestro.services.musehub_mcp_executor.execute_get_analysis",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            result = await server.call_tool(
+                "musehub_get_analysis", {"repo_id": "r", "dimension": "xyz"}
+            )
+
+        assert result.bad_request is True
+
+    @pytest.mark.anyio
+    async def test_musehub_get_context_response_is_json(
+        self, server: MaestroMCPServer
+    ) -> None:
+        """musehub_get_context response content is valid JSON."""
+        mock_result = MusehubToolResult(
+            ok=True,
+            data={"repo_id": "r", "context": {"repo": {}, "branches": [], "recent_commits": [], "commit_stats": {"total": 0, "shown": 0}, "artifacts": {"total_count": 0, "by_mime_type": {}, "paths": []}, "musical_analysis": {"key": None, "tempo": None, "time_signature": None, "note": ""}}},
+        )
+        with patch(
+            "maestro.services.musehub_mcp_executor.execute_get_context",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            result = await server.call_tool(
+                "musehub_get_context", {"repo_id": "r"}
+            )
+
+        assert result.success is True
+        # Content must be parseable JSON
+        text = result.content[0]["text"]
+        parsed = json.loads(text)
+        assert "context" in parsed


### PR DESCRIPTION
## Summary
Closes #246 — adds seven server-side MCP tools that allow AI agents in Cursor/Claude to explore MuseHub repositories without a connected DAW.

## Root Cause / Motivation
AI agents had no way to access MuseHub data through MCP. To compose music that is coherent with existing work in a MuseHub repo, agents needed to be able to browse the repo's commit history, read artifact metadata, inspect musical analysis, and search — all via MCP tools.

## Solution
Added a complete `musehub_*` tool layer:

**New files:**
- `maestro/mcp/tools/musehub.py` — `MCPToolDef` TypedDicts for all 7 tools, all `server_side=True`, with agent-oriented descriptions and usage examples
- `maestro/services/musehub_mcp_executor.py` — async executor functions using `AsyncSessionLocal`; delegates to `musehub_repository`; returns typed `MusehubToolResult` (no exceptions propagate to the MCP server)
- `tests/test_mcp_musehub.py` — 28 tests: registry validation, executor unit tests (in-memory SQLite), server routing, error handling, case-insensitive search, JSON response format

**Modified files:**
- `maestro/mcp/tools/__init__.py` — merged `MCP_TOOLS` (DAW + MuseHub), updated `SERVER_SIDE_TOOLS` and `TOOL_CATEGORIES` with `"musehub"` category
- `maestro/mcp/server.py` — `_execute_musehub_tool()` method; routes `musehub_*` calls before DAW/generation handlers
- `tests/test_mcp.py` — prefix test now allows `musehub_` alongside `stori_`; added test asserting all MuseHub tools are in `SERVER_SIDE_TOOLS`
- `docs/guides/integrate.md` — MuseHub MCP tools table, recommended agent workflow, error codes
- `docs/reference/type_contracts.md` — `MusehubToolResult` and `MusehubErrorCode`

**Tools:**

| Tool | Returns |
|------|---------|
| `musehub_browse_repo` | Repo stats, all branches, 10 most-recent commits |
| `musehub_list_branches` | All branches with head commit IDs |
| `musehub_list_commits` | Paginated commits (opt: branch filter, limit) |
| `musehub_read_file` | Artifact metadata: path, size_bytes, MIME type |
| `musehub_get_analysis` | Structured analysis: `overview` / `commits` / `objects` |
| `musehub_search` | Substring search by `path` or `commit` message |
| `musehub_get_context` | Full AI context document (primary agent entry point) |

## Layers Affected
- [x] MCP
- [ ] DAW Adapter (MuseHub tools are server-side — never forwarded)
- [ ] SSE Protocol (no changes)

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (pre-existing import-untyped errors only, not from this branch)
- [x] `tests/test_mcp_musehub.py` — 28 passed
- [x] `tests/test_mcp.py` + `tests/test_mcp_server.py` — 34 passed (no regressions)
- [x] Docs updated in same commit

## Tests Added
- `test_musehub_tools_in_mcp_tools` — all tools appear in combined registry
- `test_musehub_tools_are_server_side` — all tools have server_side=True
- `test_all_seven_tools_defined` — exact set from issue #246
- `test_mcp_browse_repo_returns_repo_data` — repo stats, branches, commits
- `test_mcp_read_file_returns_metadata` — path, size_bytes, MIME type
- `test_mcp_list_commits_returns_paginated_list` — commits + total count
- `test_mcp_get_analysis_overview/commits/objects` — all three dimensions
- `test_mcp_get_analysis_invalid_dimension` — error handling
- `test_mcp_search_by_path/commit` — both search modes
- `test_mcp_search_case_insensitive` — lowercase query matches uppercase path
- `test_mcp_get_context_returns_ai_context` — full context document structure
- `test_musehub_invalid_dimension_is_bad_request` — bad_request=True for input errors
- `test_musehub_get_context_response_is_json` — MCP response is valid JSON

## Handoff
N/A — no SSE protocol changes. New MCP tool schemas added under `musehub_*` prefix. MCP clients discover via `tools/list`; no breaking changes to existing tools. Musical analysis fields (`key`, `tempo`, `time_signature`) in `musehub_get_analysis` and `musehub_get_context` are `null` pending Storpheus MIDI analysis integration.