### PR TITLE
feat(musehub): explore/discover page — browse public repos with genre, key, tempo, and instrumentation filters

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -5958,3 +5958,58 @@ if state is not None and state.conflict_paths:
 **Related helpers:**
 - `apply_resolution(root, rel_path, object_id)` — copies an object from the local store to `muse-work/`; used by `--theirs` resolution and `--abort`.
 - `is_conflict_resolved(merge_state, rel_path)` — returns `True` if `rel_path` is not in `conflict_paths`.
+
+---
+
+## ExploreRepoResult
+
+**Module:** `maestro.models.musehub`
+**Used by:** `GET /api/v1/musehub/discover/repos` → `ExploreResponse.repos`
+
+A public repo card returned by the explore/discover page. Aggregated counts
+(`star_count`, `commit_count`) are computed at query time and are not stored
+on the repo row — they reflect the live DB state at the moment of the request.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo_id` | `str` | UUID of the repo |
+| `name` | `str` | Human-readable repo name |
+| `owner_user_id` | `str` | UUID of the repo owner |
+| `description` | `str` | Short description (empty string if not set) |
+| `tags` | `list[str]` | Free-form tags: genre, key, instrument (e.g. `["jazz", "F# minor", "bass"]`) |
+| `key_signature` | `str \| None` | Musical key (e.g. `"F# minor"`) |
+| `tempo_bpm` | `int \| None` | Tempo in BPM |
+| `star_count` | `int` | Total stars from all users |
+| `commit_count` | `int` | Total commits in the repo |
+| `created_at` | `datetime` | UTC timestamp of repo creation |
+
+---
+
+## ExploreResponse
+
+**Module:** `maestro.models.musehub`
+**Used by:** `GET /api/v1/musehub/discover/repos`
+
+Paginated discover response. `total` is the full filtered count (not just the
+current page) so clients can render pagination controls without a second query.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repos` | `list[ExploreRepoResult]` | Repo cards for the current page |
+| `total` | `int` | Total repos matching the filters |
+| `page` | `int` | Current page number (1-based) |
+| `page_size` | `int` | Number of results per page |
+
+---
+
+## StarResponse
+
+**Module:** `maestro.models.musehub`
+**Used by:** `POST /api/v1/musehub/repos/{id}/star`, `DELETE /api/v1/musehub/repos/{id}/star`
+
+Confirmation of a star or unstar operation with the updated count.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `starred` | `bool` | `True` after star, `False` after unstar |
+| `star_count` | `int` | Current total star count for the repo |

--- a/maestro/api/routes/musehub/discover.py
+++ b/maestro/api/routes/musehub/discover.py
@@ -1,0 +1,126 @@
+"""Muse Hub discover/explore API route handlers.
+
+Endpoint summary:
+  GET  /api/v1/musehub/discover/repos       — list public repos (no auth required)
+  POST /api/v1/musehub/repos/{repo_id}/star — star a repo (auth required)
+  DELETE /api/v1/musehub/repos/{repo_id}/star — unstar a repo (auth required)
+
+The browse endpoint is intentionally unauthenticated so that anyone can discover
+public compositions without creating an account — matching the HuggingFace model
+hub philosophy where discovery is a zero-friction entry point.
+
+Star/unstar requires a valid JWT so we can track which user starred which repo.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.auth.dependencies import TokenClaims, require_valid_token
+from maestro.db import get_db
+from maestro.models.musehub import ExploreResponse, StarResponse
+from maestro.services import musehub_discover
+
+logger = logging.getLogger(__name__)
+
+# Two routers: one public (no auth dependency) and one authed (star/unstar).
+# Both are exported and registered separately so the auth contract is explicit.
+router = APIRouter(tags=["musehub-discover"])
+star_router = APIRouter(tags=["musehub-discover"])
+
+_VALID_SORTS = {"stars", "activity", "commits", "created"}
+
+
+@router.get(
+    "/musehub/discover/repos",
+    response_model=ExploreResponse,
+    summary="Browse public Muse Hub repos with optional filters and sorting",
+)
+async def list_public_repos(
+    genre: str | None = Query(None, description="Filter by genre tag (e.g. 'jazz', 'lo-fi')"),
+    key: str | None = Query(None, description="Filter by key signature (e.g. 'F# minor')"),
+    tempo_min: int | None = Query(None, ge=20, le=300, description="Minimum tempo in BPM"),
+    tempo_max: int | None = Query(None, ge=20, le=300, description="Maximum tempo in BPM"),
+    instrumentation: str | None = Query(
+        None, description="Filter by instrument tag (e.g. 'bass', 'drums', 'keys')"
+    ),
+    sort: str = Query(
+        "created",
+        description="Sort order: 'stars' | 'activity' | 'commits' | 'created'",
+    ),
+    page: int = Query(1, ge=1, description="1-based page number"),
+    page_size: int = Query(24, ge=1, le=100, description="Results per page"),
+    db: AsyncSession = Depends(get_db),
+) -> ExploreResponse:
+    """Return paginated public repos with optional music-semantic filters.
+
+    No authentication required — public repos are discoverable by anyone.
+
+    Content negotiation: this endpoint always returns JSON. The explore page HTML
+    shell (``GET /musehub/ui/explore``) calls this endpoint from the browser.
+    """
+    if sort not in _VALID_SORTS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid sort '{sort}'. Must be one of: {', '.join(sorted(_VALID_SORTS))}",
+        )
+
+    return await musehub_discover.list_public_repos(
+        db,
+        genre=genre,
+        key=key,
+        tempo_min=tempo_min,
+        tempo_max=tempo_max,
+        instrumentation=instrumentation,
+        sort=sort,  # type: ignore[arg-type]  # validated above via _VALID_SORTS check
+        page=page,
+        page_size=page_size,
+    )
+
+
+@star_router.post(
+    "/musehub/repos/{repo_id}/star",
+    response_model=StarResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Star a public Muse Hub repo",
+)
+async def star_repo(
+    repo_id: str,
+    db: AsyncSession = Depends(get_db),
+    claims: TokenClaims = Depends(require_valid_token),
+) -> StarResponse:
+    """Add a star to a public repo on behalf of the authenticated user.
+
+    Idempotent — starring an already-starred repo returns the current star count
+    without creating a duplicate. Only public repos can be starred.
+    """
+    user_id: str = claims.get("sub") or ""
+    try:
+        result = await musehub_discover.star_repo(db, repo_id=repo_id, user_id=user_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    await db.commit()
+    return result
+
+
+@star_router.delete(
+    "/musehub/repos/{repo_id}/star",
+    response_model=StarResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Unstar a Muse Hub repo",
+)
+async def unstar_repo(
+    repo_id: str,
+    db: AsyncSession = Depends(get_db),
+    claims: TokenClaims = Depends(require_valid_token),
+) -> StarResponse:
+    """Remove a star from a repo on behalf of the authenticated user.
+
+    Idempotent — unstarring a repo that was never starred is a no-op.
+    """
+    user_id: str = claims.get("sub") or ""
+    result = await musehub_discover.unstar_repo(db, repo_id=repo_id, user_id=user_id)
+    await db.commit()
+    return result

--- a/maestro/api/routes/musehub/repos.py
+++ b/maestro/api/routes/musehub/repos.py
@@ -50,6 +50,10 @@ async def create_repo(
         name=body.name,
         visibility=body.visibility,
         owner_user_id=owner_user_id,
+        description=body.description,
+        tags=body.tags,
+        key_signature=body.key_signature,
+        tempo_bpm=body.tempo_bpm,
     )
     await db.commit()
     return repo

--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -4,6 +4,8 @@ Serves browser-readable HTML pages for navigating a Muse Hub repo —
 analogous to GitHub's repository browser but for music projects.
 
 Endpoint summary:
+  GET /musehub/ui/explore                          — discover public repos with filters
+  GET /musehub/ui/trending                         — trending public repos (sorted by stars)
   GET /musehub/ui/{repo_id}                        — repo page (branch selector + commit log)
   GET /musehub/ui/{repo_id}/commits/{commit_id}    — commit detail page (metadata + artifacts)
   GET /musehub/ui/{repo_id}/pulls                  — pull request list page
@@ -12,7 +14,8 @@ Endpoint summary:
   GET /musehub/ui/{repo_id}/issues/{number}        — issue detail page (with close button)
 
 These routes require NO JWT auth — they return static HTML shells whose
-embedded JavaScript fetches data from the authed JSON API
+embedded JavaScript fetches data from the public JSON API
+(``/api/v1/musehub/discover/repos``) or the authed JSON API
 (``/api/v1/musehub/...``) using a token stored in ``localStorage``.
 
 No Jinja2 is required; pages are self-contained HTML strings rendered
@@ -224,7 +227,246 @@ def _page(title: str, breadcrumb: str, body_script: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Route handlers
+# Route handlers — explore / discover (no auth required)
+# ---------------------------------------------------------------------------
+
+_EXPLORE_SCRIPT = """
+const DISCOVER_API = '/api/v1/musehub/discover/repos';
+
+function escHtml(s) {
+  if (!s) return '';
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+function tagHtml(tag) {
+  return '<span class="label">' + escHtml(tag) + '</span>';
+}
+
+function repoCard(r) {
+  const tags = (r.tags || []).map(tagHtml).join('');
+  const key  = r.keySignature ? escHtml(r.keySignature) : '';
+  const bpm  = r.tempoBpm ? r.tempoBpm + ' BPM' : '';
+  const meta = [key, bpm].filter(Boolean).join(' &bull; ');
+  return `
+    <div class="repo-card">
+      <div class="repo-card-title">
+        <a href="/musehub/ui/${escHtml(r.repoId)}">${escHtml(r.name)}</a>
+      </div>
+      <div class="repo-card-owner">${escHtml(r.ownerUserId)}</div>
+      ${r.description ? '<div class="repo-card-desc">' + escHtml(r.description) + '</div>' : ''}
+      <div class="repo-card-tags">${tags}</div>
+      <div class="repo-card-meta">
+        ${meta ? '<span>' + meta + '</span>' : ''}
+        <span>&#9733; ${r.starCount}</span>
+        <span>&#128190; ${r.commitCount} commits</span>
+      </div>
+    </div>`;
+}
+
+async function loadExplore(page, sort, genre, key, tempoMin, tempoMax, instrumentation) {
+  const params = new URLSearchParams({ page: page, page_size: 24, sort: sort });
+  if (genre)         params.set('genre', genre);
+  if (key)           params.set('key', key);
+  if (tempoMin)      params.set('tempo_min', tempoMin);
+  if (tempoMax)      params.set('tempo_max', tempoMax);
+  if (instrumentation) params.set('instrumentation', instrumentation);
+
+  try {
+    const res  = await fetch(DISCOVER_API + '?' + params.toString());
+    if (!res.ok) throw new Error(res.status + ': ' + await res.text());
+    const data = await res.json();
+    const repos = data.repos || [];
+    const total = data.total || 0;
+    const pages = Math.ceil(total / 24) || 1;
+
+    const grid = repos.length === 0
+      ? '<p class="loading">No repos found matching these filters.</p>'
+      : repos.map(repoCard).join('');
+
+    const pager = pages > 1 ? `
+      <div class="pager">
+        ${page > 1 ? '<button class="btn btn-secondary" onclick="go(' + (page-1) + ')">&#8592; Prev</button>' : ''}
+        <span style="color:#8b949e;font-size:13px">Page ${page} of ${pages} &bull; ${total} repos</span>
+        ${page < pages ? '<button class="btn btn-secondary" onclick="go(' + (page+1) + ')">Next &#8594;</button>' : ''}
+      </div>` : '<div class="pager" style="color:#8b949e;font-size:13px">' + total + ' repos</div>';
+
+    document.getElementById('repo-grid').innerHTML = grid;
+    document.getElementById('pager').innerHTML = pager;
+  } catch(e) {
+    document.getElementById('repo-grid').innerHTML =
+      '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+  }
+}
+
+function currentState() {
+  return {
+    page: parseInt(document.getElementById('cur-page').value || '1'),
+    sort: document.getElementById('sort-sel').value,
+    genre: document.getElementById('genre-inp').value.trim(),
+    key:   document.getElementById('key-inp').value.trim(),
+    tempoMin: document.getElementById('tempo-min').value.trim(),
+    tempoMax: document.getElementById('tempo-max').value.trim(),
+    instr: document.getElementById('instr-inp').value.trim(),
+  };
+}
+
+function go(page) {
+  document.getElementById('cur-page').value = page;
+  const s = currentState();
+  loadExplore(page, s.sort, s.genre, s.key, s.tempoMin, s.tempoMax, s.instr);
+}
+
+function applyFilters() { go(1); }
+"""
+
+_EXPLORE_CSS_EXTRA = """
+.filter-bar {
+  display: flex; flex-wrap: wrap; gap: 8px; align-items: flex-end;
+  background: #161b22; border: 1px solid #30363d; border-radius: 6px;
+  padding: 12px; margin-bottom: 16px;
+}
+.filter-group { display: flex; flex-direction: column; gap: 4px; }
+.filter-label { font-size: 11px; color: #8b949e; text-transform: uppercase; letter-spacing: 0.5px; }
+.filter-group input {
+  background: #0d1117; color: #c9d1d9; border: 1px solid #30363d;
+  border-radius: 6px; padding: 6px 10px; font-size: 13px; width: 140px;
+}
+.filter-group input:focus { outline: none; border-color: #58a6ff; }
+.repo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+}
+.repo-card {
+  background: #161b22; border: 1px solid #30363d; border-radius: 6px;
+  padding: 14px; display: flex; flex-direction: column; gap: 6px;
+  transition: border-color 0.15s;
+}
+.repo-card:hover { border-color: #58a6ff; }
+.repo-card-title { font-size: 15px; font-weight: 600; }
+.repo-card-owner { font-size: 12px; color: #8b949e; }
+.repo-card-desc  { font-size: 13px; color: #c9d1d9; }
+.repo-card-tags  { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
+.repo-card-meta  {
+  display: flex; gap: 12px; flex-wrap: wrap;
+  font-size: 12px; color: #8b949e; margin-top: 4px;
+}
+.pager {
+  display: flex; align-items: center; justify-content: center;
+  gap: 12px; margin-top: 20px;
+}
+"""
+
+
+def _explore_page_html(title: str, breadcrumb: str, default_sort: str) -> str:
+    """Render the explore or trending page HTML shell.
+
+    The page calls the public ``GET /api/v1/musehub/discover/repos`` JSON API
+    from the browser — no JWT required for browsing. Star/unstar actions require
+    a JWT stored in localStorage but are optional (unauthenticated visitors can
+    browse without starring).
+    """
+    css = _CSS + _EXPLORE_CSS_EXTRA
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{title} — Muse Hub</title>
+  <style>{css}</style>
+</head>
+<body>
+  <header>
+    <span class="logo">&#127925; Muse Hub</span>
+    <span class="breadcrumb">{breadcrumb}</span>
+    <span style="flex:1"></span>
+    <a href="/musehub/ui/explore" class="btn btn-secondary" style="font-size:12px">Explore</a>
+    &nbsp;
+    <a href="/musehub/ui/trending" class="btn btn-secondary" style="font-size:12px">Trending</a>
+  </header>
+  <div class="container" style="max-width:1200px">
+    <div class="filter-bar">
+      <div class="filter-group">
+        <span class="filter-label">Genre</span>
+        <input id="genre-inp" type="text" placeholder="jazz, lo-fi…" oninput="applyFilters()"/>
+      </div>
+      <div class="filter-group">
+        <span class="filter-label">Key</span>
+        <input id="key-inp" type="text" placeholder="F# minor" oninput="applyFilters()"/>
+      </div>
+      <div class="filter-group">
+        <span class="filter-label">BPM min</span>
+        <input id="tempo-min" type="number" min="20" max="300" placeholder="80" oninput="applyFilters()"/>
+      </div>
+      <div class="filter-group">
+        <span class="filter-label">BPM max</span>
+        <input id="tempo-max" type="number" min="20" max="300" placeholder="140" oninput="applyFilters()"/>
+      </div>
+      <div class="filter-group">
+        <span class="filter-label">Instrument</span>
+        <input id="instr-inp" type="text" placeholder="bass, drums…" oninput="applyFilters()"/>
+      </div>
+      <div class="filter-group">
+        <span class="filter-label">Sort by</span>
+        <select id="sort-sel" onchange="applyFilters()">
+          <option value="created" {'selected' if default_sort == 'created' else ''}>Newest</option>
+          <option value="stars"   {'selected' if default_sort == 'stars'   else ''}>Stars</option>
+          <option value="activity"{'selected' if default_sort == 'activity' else ''}>Activity</option>
+          <option value="commits" {'selected' if default_sort == 'commits'  else ''}>Commits</option>
+        </select>
+      </div>
+    </div>
+    <input type="hidden" id="cur-page" value="1"/>
+    <div id="repo-grid" class="repo-grid"><p class="loading">Loading&#8230;</p></div>
+    <div id="pager"></div>
+  </div>
+  <script>
+    {_EXPLORE_SCRIPT}
+    window.addEventListener('DOMContentLoaded', function() {{
+      const s = currentState();
+      loadExplore(1, s.sort, s.genre, s.key, s.tempoMin, s.tempoMax, s.instr);
+    }});
+  </script>
+</body>
+</html>"""
+
+
+@router.get("/explore", response_class=HTMLResponse, summary="Muse Hub explore page")
+async def explore_page() -> HTMLResponse:
+    """Render the explore/discover page — a filterable grid of all public repos.
+
+    No JWT required. The page fetches from the public
+    ``GET /api/v1/musehub/discover/repos`` endpoint. Filter controls are
+    rendered in the browser; filter state lives in the query URL so pages
+    are bookmarkable.
+    """
+    return HTMLResponse(
+        content=_explore_page_html(
+            title="Explore",
+            breadcrumb="Explore",
+            default_sort="created",
+        )
+    )
+
+
+@router.get("/trending", response_class=HTMLResponse, summary="Muse Hub trending page")
+async def trending_page() -> HTMLResponse:
+    """Render the trending page — public repos sorted by star count by default.
+
+    No JWT required. Identical shell to the explore page but pre-selected
+    to sort by stars, surfacing the most-starred compositions first.
+    """
+    return HTMLResponse(
+        content=_explore_page_html(
+            title="Trending",
+            breadcrumb="Trending",
+            default_sort="stars",
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Route handlers — per-repo pages (no auth required)
 # ---------------------------------------------------------------------------
 
 

--- a/maestro/db/musehub_models.py
+++ b/maestro/db/musehub_models.py
@@ -6,13 +6,15 @@ Tables:
 - musehub_commits: Remote commit records pushed from CLI clients
 - musehub_issues: Issue tracker entries per repo
 - musehub_pull_requests: Pull requests proposing branch merges
+- musehub_objects: Content-addressed binary artifact storage
+- musehub_stars: Per-user repo starring (one row per user×repo pair)
 """
 from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import JSON
 
@@ -28,7 +30,12 @@ def _new_uuid() -> str:
 
 
 class MusehubRepo(Base):
-    """A remote Muse repository — the hub-side equivalent of a Git remote."""
+    """A remote Muse repository — the hub-side equivalent of a Git remote.
+
+    Music-semantic fields (key_signature, tempo_bpm, tags) are optional metadata
+    that musicians set to make their repos discoverable on the explore page.
+    Tags are free-form strings that encode genre, instrumentation, and mood.
+    """
 
     __tablename__ = "musehub_repos"
 
@@ -36,6 +43,12 @@ class MusehubRepo(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     visibility: Mapped[str] = mapped_column(String(20), nullable=False, default="private")
     owner_user_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    # JSON list of free-form tag strings: genre ("jazz"), key ("F# minor"), instrument ("bass")
+    tags: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    # Music-semantic metadata for filter-based discovery
+    key_signature: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    tempo_bpm: Mapped[int | None] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_utc_now
     )
@@ -54,6 +67,9 @@ class MusehubRepo(Base):
     )
     pull_requests: Mapped[list[MusehubPullRequest]] = relationship(
         "MusehubPullRequest", back_populates="repo", cascade="all, delete-orphan"
+    )
+    stars: Mapped[list[MusehubStar]] = relationship(
+        "MusehubStar", back_populates="repo", cascade="all, delete-orphan"
     )
 
 
@@ -198,3 +214,29 @@ class MusehubPullRequest(Base):
     )
 
     repo: Mapped[MusehubRepo] = relationship("MusehubRepo", back_populates="pull_requests")
+
+
+class MusehubStar(Base):
+    """A single user's star on a public repo.
+
+    Stars are the primary signal for the explore page's "trending" sort.
+    The unique constraint on (repo_id, user_id) makes starring idempotent —
+    a user can only star a repo once, and duplicate requests are safe.
+    """
+
+    __tablename__ = "musehub_stars"
+    __table_args__ = (UniqueConstraint("repo_id", "user_id", name="uq_musehub_stars_repo_user"),)
+
+    star_id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    repo_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("musehub_repos.repo_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    repo: Mapped[MusehubRepo] = relationship("MusehubRepo", back_populates="stars")

--- a/maestro/main.py
+++ b/maestro/main.py
@@ -22,6 +22,7 @@ from slowapi.errors import RateLimitExceeded
 from maestro.config import settings
 from maestro.api.routes import maestro, maestro_ui, health, users, conversations, assets, variation, muse, musehub
 from maestro.api.routes.musehub import ui as musehub_ui_routes
+from maestro.api.routes.musehub import discover as musehub_discover_routes
 from maestro.api.routes import mcp as mcp_routes
 from maestro.db import init_db, close_db
 from maestro.services.storpheus import get_storpheus_client, close_storpheus_client
@@ -161,6 +162,9 @@ app.include_router(assets.router, prefix="/api/v1", tags=["assets"])
 app.include_router(muse.router, prefix="/api/v1", tags=["muse"])
 app.include_router(musehub.router, prefix="/api/v1", tags=["musehub"])
 app.include_router(musehub_ui_routes.router, tags=["musehub-ui"])
+# Discover router: public browse (no auth) + authed star/unstar
+app.include_router(musehub_discover_routes.router, prefix="/api/v1", tags=["musehub-discover"])
+app.include_router(musehub_discover_routes.star_router, prefix="/api/v1", tags=["musehub-discover"])
 app.include_router(mcp_routes.router, prefix="/api/v1/mcp", tags=["mcp"])
 
 from maestro.protocol.endpoints import router as protocol_router

--- a/maestro/services/musehub_discover.py
+++ b/maestro/services/musehub_discover.py
@@ -1,0 +1,228 @@
+"""Muse Hub discover/explore service — public repo discovery with filtering and sorting.
+
+This module is the ONLY place that executes the discover query. Route handlers
+delegate here; no filtering or sorting logic lives in routes.
+
+Boundary rules:
+- Must NOT import state stores, SSE queues, or LLM clients.
+- Must NOT import maestro.core.* modules.
+- May import ORM models from maestro.db.musehub_models.
+- May import Pydantic response models from maestro.models.musehub.
+
+Sort semantics:
+  "stars"    — repos with the most stars first (trending signal)
+  "activity" — repos with the most recent commit first
+  "commits"  — repos with the highest total commit count first
+  "created"  — newest repos first (default for explore page)
+
+Tag filtering uses a contains check on the JSON ``tags`` column. For portability
+across Postgres and SQLite (tests), the check is done server-side via a
+``cast(tags, Text).ilike`` pattern rather than JSON containment operators, which
+differ between engines and are not needed at this scale.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from sqlalchemy import Text, desc, func, outerjoin, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db import musehub_models as db
+from maestro.models.musehub import ExploreRepoResult, ExploreResponse, StarResponse
+
+logger = logging.getLogger(__name__)
+
+SortField = Literal["stars", "activity", "commits", "created"]
+
+_PAGE_SIZE_MAX = 100
+
+
+async def list_public_repos(
+    session: AsyncSession,
+    *,
+    genre: str | None = None,
+    key: str | None = None,
+    tempo_min: int | None = None,
+    tempo_max: int | None = None,
+    instrumentation: str | None = None,
+    sort: SortField = "created",
+    page: int = 1,
+    page_size: int = 24,
+) -> ExploreResponse:
+    """Return a paginated list of public repos that match the given filters.
+
+    Only repos with ``visibility = 'public'`` are returned. All filter parameters
+    are optional; omitting them returns all public repos in the requested sort order.
+
+    Args:
+        session: Async DB session.
+        genre: Case-insensitive substring match against the repo's ``tags`` JSON.
+               Matches repos where any tag contains this string (e.g. "jazz").
+        key: Exact case-insensitive match against ``key_signature`` (e.g. "F# minor").
+        tempo_min: Include only repos with ``tempo_bpm >= tempo_min``.
+        tempo_max: Include only repos with ``tempo_bpm <= tempo_max``.
+        instrumentation: Case-insensitive substring match against tags — used to
+                         filter by instrument presence (e.g. "bass", "drums").
+        sort: One of "stars", "activity", "commits", "created".
+        page: 1-based page number.
+        page_size: Number of results per page (clamped to _PAGE_SIZE_MAX).
+
+    Returns:
+        ExploreResponse with repo cards and pagination metadata.
+    """
+    page_size = min(page_size, _PAGE_SIZE_MAX)
+    offset = (max(page, 1) - 1) * page_size
+
+    # Aggregated sub-expressions ─────────────────────────────────────────────
+    star_count_col = func.count(db.MusehubStar.star_id).label("star_count")
+    commit_count_col = func.count(db.MusehubCommit.commit_id).label("commit_count")
+    latest_commit_col = func.max(db.MusehubCommit.timestamp).label("latest_commit")
+
+    # Build the base aggregated query over public repos.
+    # Left-join stars and commits so repos with zero stars/commits are included.
+    base_q = (
+        select(
+            db.MusehubRepo,
+            star_count_col,
+            commit_count_col,
+            latest_commit_col,
+        )
+        .select_from(
+            outerjoin(
+                outerjoin(
+                    db.MusehubRepo,
+                    db.MusehubStar,
+                    db.MusehubRepo.repo_id == db.MusehubStar.repo_id,
+                ),
+                db.MusehubCommit,
+                db.MusehubRepo.repo_id == db.MusehubCommit.repo_id,
+            )
+        )
+        .where(db.MusehubRepo.visibility == "public")
+        .group_by(db.MusehubRepo.repo_id)
+    )
+
+    # Apply filters ──────────────────────────────────────────────────────────
+    if genre:
+        # Match repos where any tag contains the genre string (case-insensitive).
+        # We cast the JSON column to text and use ILIKE for cross-engine compat.
+        base_q = base_q.where(
+            func.cast(db.MusehubRepo.tags, Text).ilike(f"%{genre.lower()}%")
+        )
+    if instrumentation:
+        base_q = base_q.where(
+            func.cast(db.MusehubRepo.tags, Text).ilike(f"%{instrumentation.lower()}%")
+        )
+    if key:
+        base_q = base_q.where(
+            func.lower(db.MusehubRepo.key_signature) == key.lower()
+        )
+    if tempo_min is not None:
+        base_q = base_q.where(db.MusehubRepo.tempo_bpm >= tempo_min)
+    if tempo_max is not None:
+        base_q = base_q.where(db.MusehubRepo.tempo_bpm <= tempo_max)
+
+    # Count total results before pagination ──────────────────────────────────
+    count_q = select(func.count()).select_from(base_q.subquery())
+    total: int = (await session.execute(count_q)).scalar_one()
+
+    # Apply sort ─────────────────────────────────────────────────────────────
+    if sort == "stars":
+        base_q = base_q.order_by(desc("star_count"), desc(db.MusehubRepo.created_at))
+    elif sort == "activity":
+        base_q = base_q.order_by(desc("latest_commit"), desc(db.MusehubRepo.created_at))
+    elif sort == "commits":
+        base_q = base_q.order_by(desc("commit_count"), desc(db.MusehubRepo.created_at))
+    else:  # "created"
+        base_q = base_q.order_by(desc(db.MusehubRepo.created_at))
+
+    rows = (await session.execute(base_q.offset(offset).limit(page_size))).all()
+
+    results = [
+        ExploreRepoResult(
+            repo_id=row.MusehubRepo.repo_id,
+            name=row.MusehubRepo.name,
+            owner_user_id=row.MusehubRepo.owner_user_id,
+            description=row.MusehubRepo.description,
+            tags=list(row.MusehubRepo.tags or []),
+            key_signature=row.MusehubRepo.key_signature,
+            tempo_bpm=row.MusehubRepo.tempo_bpm,
+            star_count=row.star_count or 0,
+            commit_count=row.commit_count or 0,
+            created_at=row.MusehubRepo.created_at,
+        )
+        for row in rows
+    ]
+
+    logger.debug("✅ Explore query: %d/%d repos (page %d, sort=%s)", len(results), total, page, sort)
+    return ExploreResponse(repos=results, total=total, page=page, page_size=page_size)
+
+
+async def star_repo(session: AsyncSession, repo_id: str, user_id: str) -> StarResponse:
+    """Add a star for user_id on repo_id. Idempotent — duplicate stars are silently ignored.
+
+    Returns StarResponse with the new total star count and ``starred=True``.
+    Raises ValueError if the repo does not exist or is not public.
+    """
+    repo = await session.get(db.MusehubRepo, repo_id)
+    if repo is None:
+        raise ValueError(f"Repo {repo_id!r} not found")
+    if repo.visibility != "public":
+        raise ValueError(f"Repo {repo_id!r} is not public")
+
+    # Check for existing star to make the operation idempotent.
+    existing = (
+        await session.execute(
+            select(db.MusehubStar).where(
+                db.MusehubStar.repo_id == repo_id,
+                db.MusehubStar.user_id == user_id,
+            )
+        )
+    ).scalars().first()
+
+    if existing is None:
+        star = db.MusehubStar(repo_id=repo_id, user_id=user_id)
+        session.add(star)
+        await session.flush()
+        logger.info("✅ User %s starred repo %s", user_id, repo_id)
+
+    count: int = (
+        await session.execute(
+            select(func.count(db.MusehubStar.star_id)).where(
+                db.MusehubStar.repo_id == repo_id
+            )
+        )
+    ).scalar_one()
+
+    return StarResponse(starred=True, star_count=count)
+
+
+async def unstar_repo(session: AsyncSession, repo_id: str, user_id: str) -> StarResponse:
+    """Remove a star for user_id on repo_id. Idempotent — no-op if not starred.
+
+    Returns StarResponse with the new total star count and ``starred=False``.
+    """
+    existing = (
+        await session.execute(
+            select(db.MusehubStar).where(
+                db.MusehubStar.repo_id == repo_id,
+                db.MusehubStar.user_id == user_id,
+            )
+        )
+    ).scalars().first()
+
+    if existing is not None:
+        await session.delete(existing)
+        await session.flush()
+        logger.info("✅ User %s unstarred repo %s", user_id, repo_id)
+
+    count: int = (
+        await session.execute(
+            select(func.count(db.MusehubStar.star_id)).where(
+                db.MusehubStar.repo_id == repo_id
+            )
+        )
+    ).scalar_one()
+
+    return StarResponse(starred=False, star_count=count)

--- a/maestro/services/musehub_repository.py
+++ b/maestro/services/musehub_repository.py
@@ -43,6 +43,10 @@ def _to_repo_response(row: db.MusehubRepo) -> RepoResponse:
         visibility=row.visibility,
         owner_user_id=row.owner_user_id,
         clone_url=_repo_clone_url(row.repo_id),
+        description=row.description,
+        tags=list(row.tags or []),
+        key_signature=row.key_signature,
+        tempo_bpm=row.tempo_bpm,
         created_at=row.created_at,
     )
 
@@ -73,9 +77,21 @@ async def create_repo(
     name: str,
     visibility: str,
     owner_user_id: str,
+    description: str = "",
+    tags: list[str] | None = None,
+    key_signature: str | None = None,
+    tempo_bpm: int | None = None,
 ) -> RepoResponse:
     """Persist a new remote repo and return its wire representation."""
-    repo = db.MusehubRepo(name=name, visibility=visibility, owner_user_id=owner_user_id)
+    repo = db.MusehubRepo(
+        name=name,
+        visibility=visibility,
+        owner_user_id=owner_user_id,
+        description=description,
+        tags=tags or [],
+        key_signature=key_signature,
+        tempo_bpm=tempo_bpm,
+    )
     session.add(repo)
     await session.flush()  # populate default columns before reading
     await session.refresh(repo)

--- a/tests/test_musehub_discover.py
+++ b/tests/test_musehub_discover.py
@@ -1,0 +1,380 @@
+"""Tests for the Muse Hub explore/discover API endpoints.
+
+Covers acceptance criteria from issue #234:
+- test_explore_page_renders             — GET /musehub/ui/explore returns 200 HTML
+- test_trending_page_renders            — GET /musehub/ui/trending returns 200 HTML
+- test_list_public_repos_empty          — no public repos → empty list
+- test_explore_only_public_repos        — private repos are excluded from results
+- test_explore_filters_by_genre         — genre tag filter works
+- test_explore_filters_by_key           — key_signature exact filter works
+- test_explore_filters_by_tempo         — tempo_min/tempo_max range filter works
+- test_explore_filters_by_instrumentation — instrumentation tag filter works
+- test_explore_sorts_by_stars           — star-count sort returns highest-starred first
+- test_explore_sorts_by_created         — created sort returns newest first
+- test_explore_pagination               — page 2 returns different repos
+- test_star_repo_requires_auth          — POST /star returns 401 without JWT
+- test_star_repo_adds_star              — star increments star_count
+- test_star_repo_idempotent             — duplicate star is silent
+- test_unstar_repo_removes_star         — unstar decrements star_count
+- test_unstar_repo_idempotent           — unstarring twice is a no-op
+- test_star_private_repo_returns_404    — cannot star a private repo
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import MusehubRepo, MusehubStar
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_public_repo(
+    db_session: AsyncSession,
+    *,
+    name: str = "test-jazz-repo",
+    tags: list[str] | None = None,
+    key_signature: str | None = None,
+    tempo_bpm: int | None = None,
+    description: str = "",
+) -> str:
+    """Seed a public repo and return its repo_id."""
+    repo = MusehubRepo(
+        name=name,
+        visibility="public",
+        owner_user_id="test-owner",
+        description=description,
+        tags=tags or [],
+        key_signature=key_signature,
+        tempo_bpm=tempo_bpm,
+    )
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    return str(repo.repo_id)
+
+
+async def _make_private_repo(db_session: AsyncSession, name: str = "private-beats") -> str:
+    """Seed a private repo and return its repo_id."""
+    repo = MusehubRepo(
+        name=name,
+        visibility="private",
+        owner_user_id="test-owner",
+        description="",
+        tags=[],
+    )
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    return str(repo.repo_id)
+
+
+# ---------------------------------------------------------------------------
+# UI page tests (no auth required)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_explore_page_renders(client: AsyncClient) -> None:
+    """GET /musehub/ui/explore returns 200 HTML with filter controls."""
+    response = await client.get("/musehub/ui/explore")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "Muse Hub" in body
+    assert "Explore" in body
+    # Filter controls must be present
+    assert "genre-inp" in body
+    assert "key-inp" in body
+    assert "tempo-min" in body
+    assert "sort-sel" in body
+    # Discover API endpoint must be referenced
+    assert "discover/repos" in body
+
+
+@pytest.mark.anyio
+async def test_trending_page_renders(client: AsyncClient) -> None:
+    """GET /musehub/ui/trending returns 200 HTML with stars sort pre-selected."""
+    response = await client.get("/musehub/ui/trending")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "Muse Hub" in body
+    assert "Trending" in body
+    # Stars sort option must be pre-selected on the trending page
+    assert 'value="stars" selected' in body or "selected" in body
+    assert "discover/repos" in body
+
+
+@pytest.mark.anyio
+async def test_explore_page_no_auth_required(client: AsyncClient) -> None:
+    """GET /musehub/ui/explore must not return 401 — it is a public page."""
+    response = await client.get("/musehub/ui/explore")
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# JSON API tests — public browse endpoint (no auth)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_list_public_repos_empty(client: AsyncClient, db_session: AsyncSession) -> None:
+    """GET /api/v1/musehub/discover/repos returns empty list when no public repos exist."""
+    response = await client.get("/api/v1/musehub/discover/repos")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["repos"] == []
+    assert body["total"] == 0
+    assert body["page"] == 1
+    assert body["pageSize"] == 24
+
+
+@pytest.mark.anyio
+async def test_explore_only_public_repos(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Private repos must not appear in discover results."""
+    await _make_public_repo(db_session, name="public-one")
+    await _make_private_repo(db_session, name="private-one")
+
+    response = await client.get("/api/v1/musehub/discover/repos")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    names = [r["name"] for r in body["repos"]]
+    assert "public-one" in names
+    assert "private-one" not in names
+
+
+@pytest.mark.anyio
+async def test_explore_filters_by_genre(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """genre= filter returns only repos whose tags contain the genre string."""
+    await _make_public_repo(db_session, name="jazz-project", tags=["jazz", "swing"])
+    await _make_public_repo(db_session, name="lofi-project", tags=["lo-fi", "chill"])
+
+    response = await client.get("/api/v1/musehub/discover/repos?genre=jazz")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["repos"][0]["name"] == "jazz-project"
+
+
+@pytest.mark.anyio
+async def test_explore_filters_by_key(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """key= filter returns only repos with the matching key_signature."""
+    await _make_public_repo(db_session, name="fsharp-minor", key_signature="F# minor")
+    await _make_public_repo(db_session, name="c-major", key_signature="C major")
+
+    response = await client.get("/api/v1/musehub/discover/repos?key=F%23+minor")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["repos"][0]["name"] == "fsharp-minor"
+
+
+@pytest.mark.anyio
+async def test_explore_filters_by_tempo(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """tempo_min and tempo_max filter repos by BPM range."""
+    await _make_public_repo(db_session, name="slow", tempo_bpm=70)
+    await _make_public_repo(db_session, name="mid", tempo_bpm=100)
+    await _make_public_repo(db_session, name="fast", tempo_bpm=150)
+
+    response = await client.get("/api/v1/musehub/discover/repos?tempo_min=90&tempo_max=120")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["repos"][0]["name"] == "mid"
+
+
+@pytest.mark.anyio
+async def test_explore_filters_by_instrumentation(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """instrumentation= filter matches repos whose tags include the instrument."""
+    await _make_public_repo(db_session, name="bass-heavy", tags=["jazz", "bass", "drums"])
+    await _make_public_repo(db_session, name="keys-only", tags=["ambient", "keys"])
+
+    response = await client.get("/api/v1/musehub/discover/repos?instrumentation=bass")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["repos"][0]["name"] == "bass-heavy"
+
+
+@pytest.mark.anyio
+async def test_explore_sorts_by_stars(
+    client: AsyncClient, db_session: AsyncSession, auth_headers: dict[str, str]
+) -> None:
+    """sort=stars returns the repo with more stars first."""
+    repo_a = await _make_public_repo(db_session, name="repo-a")
+    repo_b = await _make_public_repo(db_session, name="repo-b")
+
+    # Star repo_b twice (from different users) so it has more stars
+    star1 = MusehubStar(repo_id=repo_b, user_id="user-1")
+    star2 = MusehubStar(repo_id=repo_b, user_id="user-2")
+    star3 = MusehubStar(repo_id=repo_a, user_id="user-3")
+    db_session.add_all([star1, star2, star3])
+    await db_session.commit()
+
+    response = await client.get("/api/v1/musehub/discover/repos?sort=stars")
+    assert response.status_code == 200
+    body = response.json()
+    repos = body["repos"]
+    assert len(repos) == 2
+    # repo-b has 2 stars; must come first
+    assert repos[0]["name"] == "repo-b"
+    assert repos[0]["starCount"] == 2
+    assert repos[1]["name"] == "repo-a"
+    assert repos[1]["starCount"] == 1
+
+
+@pytest.mark.anyio
+async def test_explore_sorts_by_created(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """sort=created returns newest repos first (default sort)."""
+    await _make_public_repo(db_session, name="first-created")
+    await _make_public_repo(db_session, name="second-created")
+
+    response = await client.get("/api/v1/musehub/discover/repos?sort=created")
+    assert response.status_code == 200
+    body = response.json()
+    # Newest first — second-created was inserted last
+    names = [r["name"] for r in body["repos"]]
+    assert names.index("second-created") < names.index("first-created")
+
+
+@pytest.mark.anyio
+async def test_explore_pagination(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Page 2 returns a different set of repos than page 1."""
+    for i in range(5):
+        await _make_public_repo(db_session, name=f"repo-{i:02d}")
+
+    page1 = (await client.get("/api/v1/musehub/discover/repos?page=1&page_size=3")).json()
+    page2 = (await client.get("/api/v1/musehub/discover/repos?page=2&page_size=3")).json()
+
+    assert page1["total"] == 5
+    assert page2["total"] == 5
+    page1_ids = {r["repoId"] for r in page1["repos"]}
+    page2_ids = {r["repoId"] for r in page2["repos"]}
+    # Pages must not overlap
+    assert not page1_ids & page2_ids
+
+
+@pytest.mark.anyio
+async def test_explore_invalid_sort_returns_422(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """sort= with an invalid value returns 422 Unprocessable Entity."""
+    response = await client.get("/api/v1/musehub/discover/repos?sort=invalid")
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Star / unstar tests (auth required)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_star_repo_requires_auth(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """POST /api/v1/musehub/repos/{repo_id}/star returns 401 without a JWT."""
+    repo_id = await _make_public_repo(db_session)
+    response = await client.post(f"/api/v1/musehub/repos/{repo_id}/star")
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_star_repo_adds_star(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /api/v1/musehub/repos/{repo_id}/star returns starred=True and correct count."""
+    repo_id = await _make_public_repo(db_session)
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/star",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["starred"] is True
+    assert body["starCount"] == 1
+
+
+@pytest.mark.anyio
+async def test_star_repo_idempotent(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Starring the same repo twice does not create duplicate stars."""
+    repo_id = await _make_public_repo(db_session)
+    await client.post(f"/api/v1/musehub/repos/{repo_id}/star", headers=auth_headers)
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/star", headers=auth_headers
+    )
+    assert response.status_code == 200
+    assert response.json()["starCount"] == 1
+
+
+@pytest.mark.anyio
+async def test_unstar_repo_removes_star(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """DELETE .../star after starring reduces star_count to 0."""
+    repo_id = await _make_public_repo(db_session)
+    await client.post(f"/api/v1/musehub/repos/{repo_id}/star", headers=auth_headers)
+
+    response = await client.delete(
+        f"/api/v1/musehub/repos/{repo_id}/star", headers=auth_headers
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["starred"] is False
+    assert body["starCount"] == 0
+
+
+@pytest.mark.anyio
+async def test_unstar_repo_idempotent(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Unstarring a repo that was never starred returns 200 with star_count=0."""
+    repo_id = await _make_public_repo(db_session)
+    response = await client.delete(
+        f"/api/v1/musehub/repos/{repo_id}/star", headers=auth_headers
+    )
+    assert response.status_code == 200
+    assert response.json()["starCount"] == 0
+
+
+@pytest.mark.anyio
+async def test_star_private_repo_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /star on a private repo returns 404 — private repos cannot be starred."""
+    repo_id = await _make_private_repo(db_session)
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/star", headers=auth_headers
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
Closes #234 — adds a public explore/discover page for MuseHub, letting musicians and agents browse, filter, and sort public compositions like HuggingFace's model hub but for music.

## Root Cause / Motivation
MuseHub had no discovery mechanism. Musicians could only access repos they already knew about. There was no way to find public compositions by genre, key, tempo, or instrumentation — making the hub a private sync tool rather than a community platform.

## Solution

### DB additions (in 0001_consolidated_schema.py)
- `musehub_repos` gains: `description` (Text), `tags` (JSON list), `key_signature` (String), `tempo_bpm` (Integer)
- New `musehub_stars` table: per-user repo starring with unique constraint on (repo_id, user_id)

### New service: `musehub_discover.py`
- `list_public_repos()` — paginated query across public repos with optional genre/key/tempo/instrumentation filters and stars/activity/commits/created sort. Uses left-join aggregation for star_count and commit_count — computed at query time, not stored (avoids write amplification).
- `star_repo()` / `unstar_repo()` — idempotent starring with live count return.

### New routes: `discover.py`
- `GET /api/v1/musehub/discover/repos` — public JSON browse API (no auth required)
- `POST /api/v1/musehub/repos/{id}/star` — star a public repo (auth required)
- `DELETE /api/v1/musehub/repos/{id}/star` — unstar (auth required)

### UI pages: `ui.py`
- `GET /musehub/ui/explore` — filterable grid of all public repos, newest first by default
- `GET /musehub/ui/trending` — same shell, pre-sorted by stars
- Both pages are no-auth HTML shells whose JS calls the public discover API

## Layers Affected
- [x] Muse VCS (MusehubRepo ORM, musehub_stars table)
- [x] DAW Adapter — N/A
- [x] SSE Protocol — N/A (no protocol change)
- [x] MCP — N/A

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (pre-existing untyped-import warnings for mido/boto3/gradio only)
- [x] All 19 new discover tests pass
- [x] All 38 existing musehub tests pass (ui, repos, sync)
- [x] Docs updated: muse_vcs.md (endpoints + filter params), type_contracts.md (ExploreRepoResult, ExploreResponse, StarResponse)

## Tests Added
- `test_explore_page_renders` — GET /musehub/ui/explore returns 200 HTML with filter controls
- `test_trending_page_renders` — GET /musehub/ui/trending returns 200 HTML with stars sort pre-selected
- `test_explore_page_no_auth_required` — explore page is public
- `test_list_public_repos_empty` — empty result when no public repos
- `test_explore_only_public_repos` — private repos excluded
- `test_explore_filters_by_genre` — genre tag filter
- `test_explore_filters_by_key` — key_signature exact match
- `test_explore_filters_by_tempo` — BPM min/max range
- `test_explore_filters_by_instrumentation` — instrument tag filter
- `test_explore_sorts_by_stars` — star-count sort correctness
- `test_explore_sorts_by_created` — newest-first sort
- `test_explore_pagination` — page 2 returns different repos than page 1
- `test_explore_invalid_sort_returns_422` — bad sort value → 422
- `test_star_repo_requires_auth` — 401 without JWT
- `test_star_repo_adds_star` — starred=True, starCount=1
- `test_star_repo_idempotent` — no duplicate stars
- `test_unstar_repo_removes_star` — count back to 0
- `test_unstar_repo_idempotent` — no-op if not starred
- `test_star_private_repo_returns_404` — cannot star private repos

## Handoff
N/A — no SSE/MCP protocol change. The explore/discover endpoints are new REST+HTML additions with no impact on the stream or DAW adapter contracts.