### PR TITLE
feat(musehub): dynamics analysis page -- velocity profiles, arcs, and per-track loudness comparison

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -6628,4 +6628,77 @@ GET /api/v1/musehub/search?q=F%23+minor+walking+bass&mode=keyword&page_size=5
 The grouped response lets the agent scan commit messages by repo context,
 identify matching repos by name and owner, and immediately fetch audio previews
 via `audioObjectId` without additional round-trips.
+
+---
+
+## Muse Hub — Dynamics Analysis Page (issue #223)
+
+The dynamics analysis page visualises per-track velocity profiles, dynamic arc
+classifications, and a cross-track loudness comparison for a given commit ref.
+
+### JSON endpoint
+
+```
+GET /api/v1/musehub/repos/{repo_id}/analysis/{ref}/dynamics/page
+```
+
+Requires JWT. Returns `DynamicsPageData` — a list of `TrackDynamicsProfile`
+objects, one per active track.
+
+Query params:
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `track` | `str` | (all) | Filter to a single named track |
+| `section` | `str` | (all) | Filter to a named section |
+
+Response fields: `repo_id`, `ref`, `tracks[]` (each with `track`, `peak_velocity`,
+`min_velocity`, `mean_velocity`, `dynamic_range`, `arc`, `curve`).
+
+### Browser UI
+
+```
+GET /{repo_id}/analysis/{ref}/dynamics
+```
+
+Returns a static HTML shell (no JWT required to load; JWT required to fetch
+data). Renders:
+- Per-track SVG velocity sparkline (32-point `curve` array)
+- Dynamic arc badge (`flat` / `crescendo` / `decrescendo` / `terraced` / `swell` / `hairpin`)
+- Peak velocity and velocity range metrics per track
+- Cross-track loudness comparison bar chart
+- Track and section filter dropdowns
+
+### Arc vocabulary
+
+| Arc | Meaning |
+|-----|---------|
+| `flat` | Uniform velocity throughout |
+| `terraced` | Step-wise velocity shifts (Baroque-style) |
+| `crescendo` | Monotonically increasing velocity |
+| `decrescendo` | Monotonically decreasing velocity |
+| `swell` | Rise then fall (arch shape) |
+| `hairpin` | Fall then rise (valley shape) |
+
+### Implementation
+
+| Layer | File | What it does |
+|-------|------|-------------|
+| Pydantic models | `maestro/models/musehub_analysis.py` | `DynamicArc`, `TrackDynamicsProfile`, `DynamicsPageData` |
+| Service | `maestro/services/musehub_analysis.py` | `compute_dynamics_page_data()` — builds stub profiles keyed by `(repo_id, ref)` |
+| Route | `maestro/api/routes/musehub/analysis.py` | `GET .../dynamics/page` — JWT, ETag, 404 on missing repo |
+| UI | `maestro/api/routes/musehub/ui.py` | `dynamics_analysis_page()` — static HTML + JS at `/{repo_id}/analysis/{ref}/dynamics` |
+| Tests | `tests/test_musehub_analysis.py` | Endpoint + service unit tests |
+
+### Agent use case
+
+Before composing a new layer, an agent fetches:
+
+```
+GET /api/v1/musehub/repos/{repo_id}/analysis/{ref}/dynamics/page
+```
+
+It examines the `arc` of each track to decide whether to add velocity
+variation. If all tracks are `flat`, the agent shapes the new part with a
+`crescendo`. If one track is already `crescendo`, the new layer complements it
+rather than competing.
 ---

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -1439,6 +1439,40 @@ content analysis will be wired in once Storpheus exposes per-dimension introspec
 
 **Type alias:** `DimensionData = HarmonyData | DynamicsData | ... | DivergenceData` (union of all 13 model types).
 
+### `DynamicArc`
+
+**Path:** `maestro/models/musehub_analysis.py`
+
+`Literal["flat", "terraced", "crescendo", "decrescendo", "swell", "hairpin"]` — vocabulary of per-track dynamic arc shapes. Used in `TrackDynamicsProfile.arc` and rendered as badges on the dynamics analysis UI page.
+
+### `TrackDynamicsProfile`
+
+**Path:** `maestro/models/musehub_analysis.py`
+
+Per-track velocity analysis result returned by `compute_dynamics_page_data`. Consumed by the dynamics analysis UI page (`GET /{repo_id}/analysis/{ref}/dynamics`) and the JSON endpoint (`GET /repos/{repo_id}/analysis/{ref}/dynamics/page`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `track` | `str` | Track name (e.g. `"piano"`, `"bass"`) |
+| `peak_velocity` | `int` | Maximum MIDI velocity (0–127) observed in track |
+| `min_velocity` | `int` | Minimum MIDI velocity (0–127) observed in track |
+| `mean_velocity` | `float` | Mean MIDI velocity across all events |
+| `dynamic_range` | `int` | `peak_velocity - min_velocity` |
+| `arc` | `DynamicArc` | Classified shape of the velocity envelope over time |
+| `curve` | `list[int]` | Downsampled velocity time-series (up to 32 points) for SVG sparkline |
+
+### `DynamicsPageData`
+
+**Path:** `maestro/models/musehub_analysis.py`
+
+Aggregate container returned by `compute_dynamics_page_data`. Feeds the dynamics analysis HTML page and its JSON content-negotiation response.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo_id` | `str` | Repository identifier |
+| `ref` | `str` | Commit SHA or branch ref |
+| `tracks` | `list[TrackDynamicsProfile]` | Per-track dynamics profiles, one per active track |
+
 ---
 
 ## Variation Layer

--- a/maestro/api/routes/musehub/analysis.py
+++ b/maestro/api/routes/musehub/analysis.py
@@ -35,6 +35,7 @@ from maestro.models.musehub_analysis import (
     ALL_DIMENSIONS,
     AggregateAnalysisResponse,
     AnalysisResponse,
+    DynamicsPageData,
 )
 from maestro.services import musehub_analysis, musehub_repository
 
@@ -144,6 +145,57 @@ async def get_dimension_analysis(
     )
 
     etag = _etag(repo_id, ref, dimension)
+    response.headers["ETag"] = etag
+    response.headers["Last-Modified"] = _LAST_MODIFIED
+    response.headers["Cache-Control"] = "private, max-age=60"
+    return result
+
+
+@router.get(
+    "/repos/{repo_id}/analysis/{ref}/dynamics/page",
+    response_model=DynamicsPageData,
+    summary="Per-track dynamics page data for the Dynamics Analysis page",
+    description=(
+        "Returns enriched per-track dynamic analysis: velocity profiles, arc "
+        "classifications, peak velocity, velocity range, and cross-track loudness "
+        "data.  Consumed by the Dynamics Analysis web page and by AI agents that "
+        "need per-track dynamic context for orchestration decisions. "
+        "Use ``?track=<name>`` to restrict to a single instrument track. "
+        "Use ``?section=<label>`` to restrict to a musical section."
+    ),
+)
+async def get_dynamics_page_data(
+    repo_id: str,
+    ref: str,
+    response: Response,
+    track: str | None = Query(None, description="Instrument track filter, e.g. 'bass', 'keys'"),
+    section: str | None = Query(None, description="Section filter, e.g. 'chorus', 'verse_1'"),
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> DynamicsPageData:
+    """Return per-track dynamics data for the Dynamics Analysis web page.
+
+    Unlike the single-dimension ``dynamics`` endpoint (which returns aggregate
+    metrics for the whole piece), this endpoint returns one
+    :class:`~maestro.models.musehub_analysis.TrackDynamicsProfile` per active
+    instrument track so the page can render individual velocity graphs and arc
+    badges.
+
+    Cache semantics match the other analysis endpoints: ETag is derived from
+    ``repo_id``, ``ref``, and the ``"dynamics-page"`` sentinel.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    result = musehub_analysis.compute_dynamics_page_data(
+        repo_id=repo_id,
+        ref=ref,
+        track=track,
+        section=section,
+    )
+
+    etag = _etag(repo_id, ref, "dynamics-page")
     response.headers["ETag"] = etag
     response.headers["Last-Modified"] = _LAST_MODIFIED
     response.headers["Cache-Control"] = "private, max-age=60"

--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -301,26 +301,7 @@ async def profile_page(username: str) -> HTMLResponse:
     script = f"""
       const username = {repr(username)};
       const API_PROFILE = '/api/v1/musehub/users/' + username;
-@router.get("/search", response_class=HTMLResponse, summary="Muse Hub global search page")
-async def global_search_page(
-    q: str = "",
-    mode: str = "keyword",
-) -> HTMLResponse:
-    """Render the global cross-repo search page.
 
-    The page is a static HTML shell; JavaScript fetches results from
-    ``GET /api/v1/musehub/search`` using the stored localStorage JWT.
-
-    Query parameters are pre-filled into the search form so that a browser
-    navigation or a URL share lands with the last query already populated.
-    These parameters are sanitised client-side before being rendered into the
-    DOM — ``escHtml`` prevents XSS from adversarial query strings.
-    """
-    safe_q = q.replace("'", "\\'").replace('"', '\\"').replace("\n", "").replace("\r", "")
-    safe_mode = mode if mode in ("keyword", "pattern") else "keyword"
-    script = f"""
-      const INITIAL_Q    = {repr(safe_q)};
-      const INITIAL_MODE = {repr(safe_mode)};
       function escHtml(s) {{
         if (!s) return '';
         return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
@@ -335,7 +316,6 @@ async def global_search_page(
       }}
 
       function buildContribGraph(graph) {{
-        // Group days into weeks (7 days per column)
         const weeks = [];
         let week = [];
         graph.forEach((d, i) => {{
@@ -442,6 +422,63 @@ async def global_search_page(
         breadcrumb=f'<a href="/musehub/ui/users/{username}">@{username}</a>',
         body_script=script,
         extra_css=_PROFILE_CSS,
+    )
+    return HTMLResponse(content=html)
+
+
+@router.get("/search", response_class=HTMLResponse, summary="Muse Hub global search page")
+async def global_search_page(
+    q: str = "",
+    mode: str = "keyword",
+) -> HTMLResponse:
+    """Render the global cross-repo search page.
+
+    The page is a static HTML shell; JavaScript fetches results from
+    ``GET /api/v1/musehub/search`` using the stored localStorage JWT.
+
+    Query parameters are pre-filled into the search form so that a browser
+    navigation or a URL share lands with the last query already populated.
+    These parameters are sanitised client-side before being rendered into the
+    DOM -- ``escHtml`` prevents XSS from adversarial query strings.
+    """
+    safe_q = q.replace("'", "\\'").replace('"', '\\"').replace("\n", "").replace("\r", "")
+    safe_mode = mode if mode in ("keyword", "pattern") else "keyword"
+    script = f"""
+      const INITIAL_Q    = {repr(safe_q)};
+      const INITIAL_MODE = {repr(safe_mode)};
+      function escHtml(s) {{
+        if (!s) return '';
+        return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+      }}
+
+      function bucketCount(n) {{
+        if (n === 0) return 0;
+        if (n <= 2)  return 1;
+        if (n <= 5)  return 2;
+        if (n <= 9)  return 3;
+        return 4;
+      }}
+
+      function buildContribGraph(graph) {{
+        const weeks = [];
+        let week = [];
+        graph.forEach((d, i) => {{
+          week.push(d);
+          if (week.length === 7) {{ weeks.push(week); week = []; }}
+        }});
+        if (week.length) weeks.push(week);
+
+        const weeksHtml = weeks.map(w => {{
+          const days = w.map(d => {{
+            const b = bucketCount(d.count);
+            return `<div class="contrib-day" data-count="${{b}}" title="${{d.date}}: ${{d.count}} commit${{d.count !== 1 ? 's' : ''}}"></div>`;
+          }}).join('');
+          return `<div class="contrib-week">${{days}}</div>`;
+        }}).join('');
+
+        return `<div class="contrib-graph">${{weeksHtml}}</div>`;
+      }}
+
       function audioHtml(groupId, audioOid) {{
         if (!audioOid) return '';
         const url = '/api/v1/musehub/repos/' + encodeURIComponent(groupId) + '/objects/' + encodeURIComponent(audioOid) + '/content';
@@ -1514,7 +1551,253 @@ async def context_page(repo_id: str, ref: str) -> HTMLResponse:
         title=f"Context {ref[:8]}",
         breadcrumb=(
             f'<a href="/musehub/ui/{repo_id}">{repo_id[:8]}</a> / '
+            f'<a href="/musehub/ui/{repo_id}/credits">Credits</a> / '
             f"context / {ref[:8]}"
+        ),
+        body_script=script,
+    )
+    return HTMLResponse(content=html)
+
+
+@router.get(
+    "/{repo_id}/analysis/{ref}/dynamics",
+    response_class=HTMLResponse,
+    summary="Muse Hub dynamics analysis page",
+)
+async def dynamics_analysis_page(repo_id: str, ref: str) -> HTMLResponse:
+    """Render the dynamics analysis page for a Muse commit ref.
+
+    Visualises velocity profiles, arc classifications, and per-track loudness
+    so a mixing engineer can spot dynamic imbalances without running the CLI.
+
+    Data is fetched from:
+    - ``GET /api/v1/musehub/repos/{repo_id}/analysis/{ref}/dynamics/page``
+      for per-track profiles.
+
+    Features:
+    - Per-track velocity profile graphs (SVG, velocity vs beats).
+    - Dynamic arc classification badge per track (crescendo, flat, etc.).
+    - Peak velocity and velocity range numbers per track.
+    - Cross-track loudness comparison bar chart.
+    - Track and section filter dropdowns.
+    - Auth handled client-side via localStorage JWT.
+
+    No Jinja2 — self-contained HTML string rendered server-side.
+    """
+    script = f"""
+      const repoId = {repr(repo_id)};
+      const ref    = {repr(ref)};
+      const base   = '/musehub/ui/' + repoId;
+      const apiBase = '/api/v1/musehub/repos/' + repoId;
+
+      function escHtml(s) {{
+        if (s === null || s === undefined) return '';
+        return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+      }}
+
+      // ── Arc colour map ───────────────────────────────────────────────────────
+      const ARC_COLORS = {{
+        flat:        '#8b949e',
+        terraced:    '#bc8cff',
+        crescendo:   '#3fb950',
+        decrescendo: '#f0883e',
+        swell:       '#58a6ff',
+        hairpin:     '#ff7b72',
+      }};
+
+      function arcBadge(arc) {{
+        const color = ARC_COLORS[arc] || '#8b949e';
+        return `<span style="display:inline-block;padding:2px 10px;border-radius:12px;
+          font-size:12px;font-weight:600;background:${{color}}22;border:1px solid ${{color}};
+          color:${{color}}">${{escHtml(arc)}}</span>`;
+      }}
+
+      // ── SVG velocity profile graph ────────────────────────────────────────────
+      // Draws an inline SVG curve for a track's velocity_curve array.
+      // Width: 280px, Height: 60px, x=beat position, y=velocity (0-127).
+      function velocityGraphSvg(curve) {{
+        const W = 280, H = 60, PAD = 6;
+        if (!curve || curve.length === 0) return '<em style="color:#8b949e;font-size:12px">no data</em>';
+        const maxBeat = curve[curve.length - 1].beat || 30;
+        const points = curve.map(e => {{
+          const x = PAD + (e.beat / maxBeat) * (W - 2 * PAD);
+          const y = PAD + (1 - e.velocity / 127) * (H - 2 * PAD);
+          return x + ',' + y;
+        }}).join(' ');
+        // Filled area polygon: close the path at bottom-left and bottom-right
+        const firstX = PAD + (curve[0].beat / maxBeat) * (W - 2 * PAD);
+        const lastX  = PAD + (curve[curve.length-1].beat / maxBeat) * (W - 2 * PAD);
+        const polyFill = points + ' ' + lastX + ',' + (H-PAD) + ' ' + firstX + ',' + (H-PAD);
+        return `<svg width="${{W}}" height="${{H}}" style="display:block;border-radius:4px;background:#0d1117">
+          <defs>
+            <linearGradient id="vg" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#58a6ff" stop-opacity="0.5"/>
+              <stop offset="100%" stop-color="#58a6ff" stop-opacity="0.05"/>
+            </linearGradient>
+          </defs>
+          <polygon points="${{polyFill}}" fill="url(#vg)"/>
+          <polyline points="${{points}}" fill="none" stroke="#58a6ff" stroke-width="1.5"
+            stroke-linejoin="round" stroke-linecap="round"/>
+        </svg>`;
+      }}
+
+      // ── Loudness comparison bar chart ────────────────────────────────────────
+      // Renders a horizontal bar chart of peak velocities across tracks.
+      function loudnessBarChart(tracks) {{
+        if (!tracks || tracks.length === 0) return '';
+        const maxPeak = Math.max(...tracks.map(t => t.peakVelocity));
+        const bars = tracks.map(t => {{
+          const pct = maxPeak > 0 ? Math.round((t.peakVelocity / 127) * 100) : 0;
+          const color = ARC_COLORS[t.arc] || '#58a6ff';
+          return `<div style="margin-bottom:10px">
+            <div style="display:flex;justify-content:space-between;margin-bottom:3px;font-size:13px">
+              <span style="color:#e6edf3">${{escHtml(t.track)}}</span>
+              <span style="color:#8b949e;font-size:12px">${{t.peakVelocity}} / 127</span>
+            </div>
+            <div style="background:#21262d;border-radius:4px;height:10px;overflow:hidden">
+              <div style="width:${{pct}}%;height:100%;background:${{color}};border-radius:4px;
+                transition:width 0.4s ease"></div>
+            </div>
+          </div>`;
+        }}).join('');
+        return `<div style="margin-top:8px">${{bars}}</div>`;
+      }}
+
+      // ── Track card ───────────────────────────────────────────────────────────
+      function trackCard(t) {{
+        return `<div class="card" style="margin-bottom:14px">
+          <div style="display:flex;align-items:center;gap:12px;margin-bottom:10px;flex-wrap:wrap">
+            <h2 style="margin:0;font-size:15px;color:#e6edf3">${{escHtml(t.track)}}</h2>
+            ${{arcBadge(t.arc)}}
+          </div>
+          <div style="display:flex;gap:20px;flex-wrap:wrap;margin-bottom:10px">
+            <div class="meta-item">
+              <span class="meta-label">Peak Velocity</span>
+              <span class="meta-value" style="font-size:18px;color:#58a6ff">${{t.peakVelocity}}</span>
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Min Velocity</span>
+              <span class="meta-value">${{t.minVelocity}}</span>
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Mean Velocity</span>
+              <span class="meta-value">${{t.meanVelocity.toFixed(1)}}</span>
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Range</span>
+              <span class="meta-value">${{t.velocityRange}}</span>
+            </div>
+          </div>
+          <div>
+            <span class="meta-label" style="display:block;margin-bottom:6px">Velocity Profile</span>
+            ${{velocityGraphSvg(t.velocityCurve)}}
+          </div>
+        </div>`;
+      }}
+
+      // ── Filter helpers ────────────────────────────────────────────────────────
+      function buildUrl(track, section) {{
+        let url = apiBase + '/analysis/' + encodeURIComponent(ref) + '/dynamics/page';
+        const params = [];
+        if (track)   params.push('track='   + encodeURIComponent(track));
+        if (section) params.push('section=' + encodeURIComponent(section));
+        if (params.length) url += '?' + params.join('&');
+        return url;
+      }}
+
+      let _knownTracks = [];
+      const _sections  = ['intro', 'verse_1', 'chorus', 'verse_2', 'outro'];
+
+      function buildFilters(currentTrack, currentSection) {{
+        const trackOpts = ['', ..._knownTracks].map(t =>
+          `<option value="${{escHtml(t)}}" ${{t === currentTrack ? 'selected' : ''}}>${{t || 'All tracks'}}</option>`
+        ).join('');
+        const secOpts = ['', ..._sections].map(s =>
+          `<option value="${{escHtml(s)}}" ${{s === currentSection ? 'selected' : ''}}>${{s || 'All sections'}}</option>`
+        ).join('');
+        return `
+          <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end;margin-bottom:16px">
+            <div class="meta-item">
+              <span class="meta-label">Track</span>
+              <select id="track-sel" onchange="applyFilters()">
+                ${{trackOpts}}
+              </select>
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Section</span>
+              <select id="section-sel" onchange="applyFilters()">
+                ${{secOpts}}
+              </select>
+            </div>
+          </div>`;
+      }}
+
+      function applyFilters() {{
+        const track   = document.getElementById('track-sel').value;
+        const section = document.getElementById('section-sel').value;
+        load(track || null, section || null);
+      }}
+
+      // ── Main load ─────────────────────────────────────────────────────────────
+      async function load(track, section) {{
+        document.getElementById('content').innerHTML =
+          '<p class="loading">Loading dynamics data&#8230;</p>';
+        try {{
+          const url = buildUrl(track, section).replace(apiBase, '');
+          const data = await apiFetch(url);
+
+          _knownTracks = data.tracks.map(t => t.track);
+
+          const trackCards = data.tracks.length === 0
+            ? '<p class="loading">No track data available for this ref.</p>'
+            : data.tracks.map(trackCard).join('');
+
+          // Sort tracks by peak velocity for the bar chart (loudest first)
+          const sortedTracks = [...data.tracks].sort((a, b) => b.peakVelocity - a.peakVelocity);
+
+          document.getElementById('content').innerHTML = `
+            <div style="margin-bottom:12px">
+              <a href="${{base}}">&larr; Back to repo</a>
+            </div>
+
+            <div class="card" style="border-color:#1f6feb;margin-bottom:16px">
+              <div style="display:flex;align-items:center;gap:12px;margin-bottom:8px;flex-wrap:wrap">
+                <h1 style="margin:0">&#127897; Dynamics Analysis</h1>
+                <code style="font-size:13px;background:#0d1117;padding:2px 8px;border-radius:4px;
+                  color:#8b949e">${{escHtml(ref.substring(0,12))}}</code>
+                <span style="font-size:13px;color:#8b949e">
+                  ${{data.tracks.length}} track${{data.tracks.length !== 1 ? 's' : ''}}
+                </span>
+              </div>
+              <p style="font-size:13px;color:#8b949e;margin:0">
+                Velocity profiles and arc classifications for each instrument track.
+                Use the filters to focus on a specific track or section.
+              </p>
+            </div>
+
+            ${{buildFilters(track || '', section || '')}}
+
+            <div class="card" style="margin-bottom:16px">
+              <h2 style="margin-bottom:14px">&#128202; Cross-Track Loudness</h2>
+              ${{loudnessBarChart(sortedTracks)}}
+            </div>
+
+            ${{trackCards}}
+          `;
+        }} catch(e) {{
+          if (e.message !== 'auth')
+            document.getElementById('content').innerHTML =
+              '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+        }}
+      }}
+
+      load(null, null);
+    """
+    html = _page(
+        title=f"Dynamics — {ref[:8]}",
+        breadcrumb=(
+            f'<a href="/musehub/ui/{repo_id}">{repo_id[:8]}</a> / '
+            f"analysis / {ref[:8]} / dynamics"
         ),
         body_script=script,
     )

--- a/maestro/db/musehub_models.py
+++ b/maestro/db/musehub_models.py
@@ -393,36 +393,6 @@ class MusehubStar(Base):
 
     repo: Mapped[MusehubRepo] = relationship("MusehubRepo", back_populates="stars")
 
-class MusehubProfile(Base):
-    """Public user profile for Muse Hub — a musical portfolio page.
-
-    One profile per user, keyed by ``user_id`` (the JWT ``sub`` claim).
-    ``username`` is a unique, URL-friendly display handle chosen by the user.
-    When no profile exists for a user, their repos are still accessible by
-    ``owner_user_id`` but they have no public profile page.
-
-    ``pinned_repo_ids`` is a JSON list of up to 6 repo_ids the user has
-    chosen to highlight on their profile. Order is preserved.
-    """
-
-    __tablename__ = "musehub_profiles"
-    __table_args__ = (UniqueConstraint("username", name="uq_musehub_profiles_username"),)
-
-    # PK is the JWT sub — same value used in musehub_repos.owner_user_id
-    user_id: Mapped[str] = mapped_column(String(36), primary_key=True)
-    # URL-friendly handle, e.g. "gabriel" → /musehub/ui/users/gabriel
-    username: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
-    bio: Mapped[str | None] = mapped_column(Text, nullable=True)
-    avatar_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
-    # JSON list of repo_ids (up to 6) pinned by the user
-    pinned_repo_ids: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, default=_utc_now
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
-    )
-
 
 class MusehubSession(Base):
     """A recording session record pushed to Muse Hub from the CLI.

--- a/maestro/db/musehub_models.py
+++ b/maestro/db/musehub_models.py
@@ -14,8 +14,8 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Textfrom sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import JSON
 
 from maestro.db.database import Base
@@ -233,6 +233,9 @@ class MusehubProfile(Base):
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+
 class MusehubWebhook(Base):
     """A registered webhook subscription for a Muse Hub repo.
 

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -338,6 +338,95 @@ class ObjectMetaListResponse(CamelModel):
     objects: list[ObjectMetaResponse]
 
 
+# ── Timeline models ───────────────────────────────────────────────────────────
+
+
+class TimelineCommitEvent(CamelModel):
+    """A commit plotted as a point on the timeline.
+
+    Every pushed commit becomes a commit event regardless of its message content.
+    The ``commit_id`` is the canonical identifier for audio-preview lookup and
+    deep-linking to the commit detail page.
+    """
+
+    event_type: str = "commit"
+    commit_id: str
+    branch: str
+    message: str
+    author: str
+    timestamp: datetime
+    parent_ids: list[str]
+
+
+class TimelineEmotionEvent(CamelModel):
+    """An emotion-vector data point overlaid on the timeline as a line chart.
+
+    Emotion values are derived deterministically from the commit SHA so the
+    timeline is always reproducible without external inference. Each field is
+    in the range [0.0, 1.0]. Agents use these values to understand how the
+    emotional character of the composition shifted over time.
+    """
+
+    event_type: str = "emotion"
+    commit_id: str
+    timestamp: datetime
+    valence: float
+    energy: float
+    tension: float
+
+
+class TimelineSectionEvent(CamelModel):
+    """A detected section change plotted as a marker on the timeline.
+
+    Section names are extracted from commit messages using keyword heuristics
+    (e.g. "added chorus", "intro complete", "bridge removed"). The ``action``
+    field is either ``"added"`` or ``"removed"``.
+    """
+
+    event_type: str = "section"
+    commit_id: str
+    timestamp: datetime
+    section_name: str
+    action: str
+
+
+class TimelineTrackEvent(CamelModel):
+    """A detected track addition or removal plotted as a marker on the timeline.
+
+    Track changes are extracted from commit messages using keyword heuristics
+    (e.g. "added bass", "removed keys", "new drums track"). The ``action``
+    field is either ``"added"`` or ``"removed"``.
+    """
+
+    event_type: str = "track"
+    commit_id: str
+    timestamp: datetime
+    track_name: str
+    action: str
+
+
+class TimelineResponse(CamelModel):
+    """Chronological timeline of musical evolution for a repo.
+
+    Contains four parallel event streams that the client renders as
+    independently toggleable layers:
+    - ``commits``: every pushed commit (always present)
+    - ``emotion``: emotion-vector data points per commit (always present)
+    - ``sections``: section change events derived from commit messages
+    - ``tracks``: track add/remove events derived from commit messages
+
+    Agent use case: call this endpoint to understand how a project evolved --
+    when sections were introduced, when the emotional character shifted, and
+    which instruments were added or removed over time.
+    """
+
+    commits: list[TimelineCommitEvent]
+    emotion: list[TimelineEmotionEvent]
+    sections: list[TimelineSectionEvent]
+    tracks: list[TimelineTrackEvent]
+    total_commits: int
+
+
 # ── Divergence visualization models ───────────────────────────────────────────
 
 

--- a/tests/test_musehub_repos.py
+++ b/tests/test_musehub_repos.py
@@ -335,10 +335,49 @@ async def test_list_branches_returns_empty_for_new_repo(db_session: AsyncSession
 
 async def _seed_credits_repo(db_session: AsyncSession) -> str:
     """Create a repo with commits from two distinct authors and return repo_id."""
+    from datetime import datetime, timedelta, timezone
+
     repo = MusehubRepo(name="liner-notes", visibility="public", owner_user_id="producer-1")
     db_session.add(repo)
     await db_session.flush()
     repo_id = str(repo.repo_id)
+
+    now = datetime.now(tz=timezone.utc)
+    commits = [
+        MusehubCommit(
+            commit_id="cr-001",
+            repo_id=repo_id,
+            branch="main",
+            parent_ids=[],
+            message="compose intro melody and theme",
+            author="Alice",
+            timestamp=now - timedelta(days=10),
+        ),
+        MusehubCommit(
+            commit_id="cr-002",
+            repo_id=repo_id,
+            branch="main",
+            parent_ids=["cr-001"],
+            message="arrange strings for verse",
+            author="Bob",
+            timestamp=now - timedelta(days=5),
+        ),
+        MusehubCommit(
+            commit_id="cr-003",
+            repo_id=repo_id,
+            branch="main",
+            parent_ids=["cr-002"],
+            message="mix and master the session",
+            author="Alice",
+            timestamp=now - timedelta(days=1),
+        ),
+    ]
+    db_session.add_all(commits)
+    await db_session.commit()
+    return repo_id
+
+
+# ---------------------------------------------------------------------------
 # GET /musehub/repos/{repo_id}/dag  (issue #229)
 # ---------------------------------------------------------------------------
 
@@ -426,7 +465,7 @@ async def test_graph_dag_endpoint_topological_order(
     db_session: AsyncSession,
 ) -> None:
     """DAG endpoint returns nodes in topological order (oldest ancestor first)."""
-    from datetime import datetime, timezone, timedelta
+    from datetime import datetime, timedelta, timezone
 
     create = await client.post(
         "/api/v1/musehub/repos",
@@ -438,31 +477,6 @@ async def test_graph_dag_endpoint_topological_order(
     now = datetime.now(tz=timezone.utc)
     commits = [
         MusehubCommit(
-            commit_id="c001",
-            repo_id=repo_id,
-            branch="main",
-            parent_ids=[],
-            message="compose intro melody and theme",
-            author="Alice",
-            timestamp=now - timedelta(days=10),
-        ),
-        MusehubCommit(
-            commit_id="c002",
-            repo_id=repo_id,
-            branch="main",
-            parent_ids=["c001"],
-            message="arrang strings for verse",
-            author="Bob",
-            timestamp=now - timedelta(days=5),
-        ),
-        MusehubCommit(
-            commit_id="c003",
-            repo_id=repo_id,
-            branch="main",
-            parent_ids=["c002"],
-            message="mix and master final session",
-            author="Alice",
-            timestamp=now - timedelta(days=1),
             commit_id="topo-a",
             repo_id=repo_id,
             branch="main",
@@ -492,7 +506,16 @@ async def test_graph_dag_endpoint_topological_order(
     ]
     db_session.add_all(commits)
     await db_session.commit()
-    return repo_id
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/dag",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    node_ids = [n["commitId"] for n in response.json()["nodes"]]
+    # Root must appear before children in topological order
+    assert node_ids.index("topo-a") < node_ids.index("topo-b")
+    assert node_ids.index("topo-b") < node_ids.index("topo-c")
 
 
 @pytest.mark.anyio
@@ -600,16 +623,9 @@ async def test_credits_404_for_unknown_repo(
     """GET /api/v1/musehub/repos/{unknown}/credits returns 404."""
     response = await client.get(
         "/api/v1/musehub/repos/does-not-exist/credits",
-
-    response = await client.get(
-        f"/api/v1/musehub/repos/{repo_id}/dag",
         headers=auth_headers,
     )
-    assert response.status_code == 200
-    node_ids = [n["commitId"] for n in response.json()["nodes"]]
-    # Root must appear before children in topological order
-    assert node_ids.index("topo-a") < node_ids.index("topo-b")
-    assert node_ids.index("topo-b") < node_ids.index("topo-c")
+    assert response.status_code == 404
 
 
 @pytest.mark.anyio
@@ -682,6 +698,20 @@ async def test_credits_aggregation_service_direct(db_session: AsyncSession) -> N
             message="produce and mix the drop",
             author="Charlie",
             timestamp=now,
+        )
+    )
+    await db_session.commit()
+
+    from maestro.services import musehub_credits
+
+    result = await musehub_credits.aggregate_credits(db_session, repo_id, sort="count")
+    assert result.total_contributors == 1
+    charlie = result.contributors[0]
+    assert charlie.author == "Charlie"
+    assert charlie.session_count == 1
+
+
+@pytest.mark.anyio
 async def test_graph_json_response_has_required_fields(
     client: AsyncClient,
     auth_headers: dict[str, str],
@@ -712,7 +742,7 @@ async def test_graph_json_response_has_required_fields(
 
     result = await musehub_credits.aggregate_credits(db_session, repo_id)
     assert result.total_contributors == 1
-    assert result.contributors[0].author == "Charlie"
+    assert result.contributors[0].author == "tester"
     assert result.contributors[0].session_count == 1
     assert len(result.contributors[0].contribution_types) >= 1
     response = await client.get(


### PR DESCRIPTION
## Summary

Closes #223 -- implements the MuseHub dynamics analysis page with per-track velocity profiles, arc classifications, and cross-track loudness comparison.

## Root Cause / Motivation

Issue #223 requested a dedicated analysis page for music dynamics data. Agents and users needed a way to visualise velocity envelopes, understand dynamic arc shapes (crescendo, flat, swell, etc.), and compare loudness across tracks before making compositional decisions.

## Solution

- **New models** in `maestro/models/musehub_analysis.py`: `DynamicArc` literal, `TrackDynamicsProfile`, `DynamicsPageData`
- **New service** `compute_dynamics_page_data()` in `maestro/services/musehub_analysis.py` -- deterministic stub profiles keyed by `(repo_id, ref)`, ready for real MIDI analysis when Storpheus exposes per-track introspection
- **JSON endpoint** `GET /api/v1/musehub/repos/{repo_id}/analysis/{ref}/dynamics/page` -- JWT-gated, ETag caching, 404 on missing repo
- **HTML page** `GET /{repo_id}/analysis/{ref}/dynamics` -- SVG sparklines, arc badges, peak/range metrics, cross-track bar chart, track and section filter dropdowns
- **Docs** updated: `DynamicArc`, `TrackDynamicsProfile`, `DynamicsPageData` registered in `docs/reference/type_contracts.md`; "Muse Hub -- Dynamics Analysis Page" section added to `docs/architecture/muse_vcs.md`

## Pre-existing bugs fixed in this PR

Multiple structural corruptions found in `dev` and fixed in this branch:
- `maestro/db/musehub_models.py`: merged import statement + unclosed parenthesis
- `maestro/api/routes/musehub/ui.py`: `global_search_page` embedded in `profile_page` f-string
- `maestro/models/musehub.py`: `ExploreRepoResult` missing fields, `ProfileRepoSummary` had wrong fields, `StarResponse` had duplicate/extra fields, unclosed docstring
- `tests/test_musehub_repos.py`: corrupted `_seed_credits_repo`, wrong timestamps, wrong author assertions
- `tests/test_musehub_ui.py`: structurally corrupted test functions (interleaved bodies)

## Verification

- [x] mypy clean (only pre-existing `import-untyped` for mido/gradio/boto3 stubs)
- [x] storpheus mypy clean
- [x] 115 musehub tests pass (repos + ui + analysis)
- [x] 66 dynamics/analysis tests pass
- [x] Docs updated