### PR TITLE
chore: update parallel agent prompt files

### DIFF
--- a/.cursor/PARALLEL_BUGS_TO_ISSUES.md
+++ b/.cursor/PARALLEL_BUGS_TO_ISSUES.md
@@ -53,6 +53,10 @@ cleanup, run `git worktree prune` from the main repo.
 Run from anywhere inside the main repo. Paths are derived automatically.
 **Fill in the bug descriptions in each `.agent-task` before launching agents.**
 
+> **GitHub repo slug:** Always `cgcardona/maestro`. The local path
+> (`/Users/gabriel/dev/tellurstori/maestro`) is misleading — `tellurstori` is
+> NOT the GitHub org. Never derive the slug from `basename` or `pwd`.
+
 ```bash
 REPO=$(git rev-parse --show-toplevel)
 PRTREES="$HOME/.cursor/worktrees/$(basename "$REPO")"
@@ -102,13 +106,18 @@ Prompt below.
 
 ```bash
 # Derive main repo path if needed
-REPO=$(git worktree list | head -1 | awk '{print $1}')
+REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only
+
+# GitHub repo slug — HARDCODED. NEVER derive from local path or directory name.
+# The local path is /Users/gabriel/dev/tellurstori/maestro — "tellurstori" is NOT the GitHub org.
+export GH_REPO=cgcardona/maestro
 ```
 
 | Item | Value |
 |------|-------|
 | Your worktree root | current directory (contains `.agent-task`) |
-| Main repo | first entry of `git worktree list` |
+| Main repo (local path) | first entry of `git worktree list` |
+| GitHub repo slug | `cgcardona/maestro` — always hardcoded, never derived |
 | GitHub CLI | `gh` — already authenticated |
 
 **No Docker needed.** Issues are created via `gh issue create` — no code
@@ -125,7 +134,12 @@ STEP 0 — READ YOUR TASK:
   cat .agent-task
   This file contains your batch of bug reports to convert into GitHub issues.
 
-STEP 1 — VERIFY GH AUTH:
+STEP 1 — SET GITHUB REPO AND VERIFY AUTH:
+  # GitHub repo slug — ALWAYS hardcoded. NEVER derive from directory name or local path.
+  # The local path contains "tellurstori" but the GitHub org is "cgcardona".
+  export GH_REPO=cgcardona/maestro
+  # All gh commands pick this up automatically. You may also pass --repo "$GH_REPO" explicitly.
+
   gh auth status
 
 STEP 2 — CREATE ISSUES:

--- a/.cursor/PARALLEL_ISSUE_TO_PR.md
+++ b/.cursor/PARALLEL_ISSUE_TO_PR.md
@@ -86,6 +86,10 @@ Run from anywhere inside the main repo. Paths are derived automatically.
 > `dev` directly. This prevents the "dev is already used by worktree" error when
 > the main repo has `dev` checked out.
 
+> **GitHub repo slug:** Always `cgcardona/maestro`. The local path
+> (`/Users/gabriel/dev/tellurstori/maestro`) is misleading — `tellurstori` is
+> NOT the GitHub org. Never derive the slug from `basename` or `pwd`.
+
 ```bash
 REPO=$(git rev-parse --show-toplevel)
 PRTREES="$HOME/.cursor/worktrees/$(basename "$REPO")"
@@ -96,19 +100,19 @@ cd "$REPO"
 DEV_SHA=$(git rev-parse dev)
 
 # --- define issues (confirmed independent — zero file overlap) ---
-# Batch: #232, #231, #230, #229 (MuseHub Phase 4 — Visualization)
-# Known shared files:
-#   maestro/api/routes/musehub/ui.py
-#     (#230 adds timeline_page(), #231 adds divergence_page(), #232 adds context_page())
-#   maestro/api/routes/musehub/repos.py
-#     (#230 adds timeline endpoint, #231 adds divergence endpoint, #232 adds context endpoint)
-# #229 adds DAG graph (new dag.py + D3.js frontend — independent new files only)
-# Resolution: pre-push sync in STEP 4 handles ui.py and repos.py — keep ALL handler/endpoint functions from all sides.
+# Batch: #320, #312, #311, #310 (MuseHub — Social tests + UI enrichments)
+# File ownership (no overlap):
+#   #320 → tests/test_musehub_social.py          (new file — social API test suite)
+#   #312 → maestro/templates/musehub/pages/context.html   (context viewer visual state + AI modal)
+#   #311 → maestro/templates/musehub/pages/repo.html      (repo sidebar analytics sparkline)
+#   #310 → maestro/templates/musehub/pages/insights.html  (insights branch activity + issue/PR health)
+# All four use existing APIs via client-side JS — no new Python route changes required.
+# Load-bearing order: #320 (social API validated) → #312 (compose modal pattern) → #311/#310 (UI polish).
 declare -a ISSUES=(
-  "232|feat: context viewer — human-readable view of the AI musical context document"
-  "231|feat: divergence visualization — radar chart and side-by-side comparison between branches"
-  "230|feat: timeline view — chronological evolution with emotion, section, and track layers"
-  "229|feat: interactive DAG graph — D3.js-based commit graph with branch coloring and zoom/pan"
+  "320|test: add test coverage for social layer endpoints in social.py"
+  "312|feat: context viewer — visual musical state and Implement suggestion button"
+  "311|feat: repo sidebar — view count sparkline and open PR/issue counts"
+  "310|feat: insights dashboard — branch activity and open PR/issue counts"
 )
 
 # --- create worktrees + task files ---
@@ -140,15 +144,20 @@ in its `issue-<N>` directory, and paste the Kickoff Prompt below.
 
 ```bash
 # Derive paths — run these at the start of your session
-REPO=$(git worktree list | head -1 | awk '{print $1}')   # main repo
+REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path to main repo
 WTNAME=$(basename "$(pwd)")                               # this worktree's name
 # Docker path to your worktree: /worktrees/$WTNAME
+
+# GitHub repo slug — HARDCODED. NEVER derive from local path or directory name.
+# The local path is /Users/gabriel/dev/tellurstori/maestro — "tellurstori" is NOT the GitHub org.
+export GH_REPO=cgcardona/maestro
 ```
 
 | Item | Value |
 |------|-------|
 | Your worktree root | current directory (contains `.agent-task`) |
-| Main repo | first entry of `git worktree list` |
+| Main repo (local path) | first entry of `git worktree list` |
+| GitHub repo slug | `cgcardona/maestro` — always hardcoded, never derived |
 | Docker compose location | main repo |
 | Your worktree inside Docker | `/worktrees/$WTNAME` |
 
@@ -205,10 +214,15 @@ STEP 0 — READ YOUR TASK:
   issue number wherever you see <N> below.
 
 STEP 1 — DERIVE PATHS:
-  REPO=$(git worktree list | head -1 | awk '{print $1}')
+  REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only
   WTNAME=$(basename "$(pwd)")
   # Your worktree is live in Docker at /worktrees/$WTNAME — NO file copying needed.
   # All docker compose commands: cd "$REPO" && docker compose exec maestro <cmd>
+
+  # GitHub repo slug — ALWAYS hardcoded. NEVER derive from directory name or local path.
+  # The local path contains "tellurstori" but the GitHub org is "cgcardona".
+  export GH_REPO=cgcardona/maestro
+  # All gh commands pick this up automatically. You may also pass --repo "$GH_REPO" explicitly.
 
 STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until

--- a/.cursor/PARALLEL_PR_REVIEW.md
+++ b/.cursor/PARALLEL_PR_REVIEW.md
@@ -66,6 +66,10 @@ Run from anywhere inside the main repo. Paths are derived automatically.
 > `dev` directly. This prevents the "dev is already used by worktree" error when
 > the main repo has `dev` checked out.
 
+> **GitHub repo slug:** Always `cgcardona/maestro`. The local path
+> (`/Users/gabriel/dev/tellurstori/maestro`) is misleading — `tellurstori` is
+> NOT the GitHub org. Never derive the slug from `basename` or `pwd`.
+
 ```bash
 REPO=$(git rev-parse --show-toplevel)
 PRTREES="$HOME/.cursor/worktrees/$(basename "$REPO")"
@@ -76,12 +80,12 @@ cd "$REPO"
 DEV_SHA=$(git rev-parse dev)
 
 # --- define PRs ---
-# Batch: #259, #260, #261, #262 (MuseHub Phase 8 — Sessions, Search, Context Viewer)
+# Batch: #315, #316, #317, #318 (MuseHub — Notifications, Sessions, Explore, Insights)
 declare -a PRS=(
-  "259|feat(musehub): session detail page — full session view with participants, commits, and notes"
-  "260|feat(musehub): cross-repo search — global search across all public repos with result grouping"
-  "261|feat(musehub): in-repo search — musical property, natural language, keyword, and pattern search"
-  "262|feat: context viewer — human-readable view of the AI musical context document"
+  "315|feat(musehub): unread notification badge in nav header"
+  "316|feat(musehub): session detail — participant avatars, profile links, commit cards"
+  "317|feat(musehub): explore and trending — richer repo cards with BPM, key, tags"
+  "318|feat(musehub): insights dashboard — view count, download count, traffic sparkline"
 )
 
 # --- create worktrees + task files ---
@@ -113,15 +117,20 @@ in its `pr-<N>` directory, and paste the Kickoff Prompt below.
 
 ```bash
 # Derive paths — run these at the start of your session
-REPO=$(git worktree list | head -1 | awk '{print $1}')   # main repo
+REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path to main repo
 WTNAME=$(basename "$(pwd)")                               # this worktree's name
 # Docker path to your worktree: /worktrees/$WTNAME
+
+# GitHub repo slug — HARDCODED. NEVER derive from local path or directory name.
+# The local path is /Users/gabriel/dev/tellurstori/maestro — "tellurstori" is NOT the GitHub org.
+export GH_REPO=cgcardona/maestro
 ```
 
 | Item | Value |
 |------|-------|
 | Your worktree root | current directory (contains `.agent-task`) |
-| Main repo | first entry of `git worktree list` |
+| Main repo (local path) | first entry of `git worktree list` |
+| GitHub repo slug | `cgcardona/maestro` — always hardcoded, never derived |
 | Docker compose location | main repo |
 | Your worktree inside Docker | `/worktrees/$WTNAME` |
 
@@ -177,10 +186,15 @@ STEP 0 — READ YOUR TASK:
   PR number wherever you see <N> below.
 
 STEP 1 — DERIVE PATHS:
-  REPO=$(git worktree list | head -1 | awk '{print $1}')
+  REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only
   WTNAME=$(basename "$(pwd)")
   # Your worktree is live in Docker at /worktrees/$WTNAME — NO file copying needed.
   # All docker compose commands: cd "$REPO" && docker compose exec maestro <cmd>
+
+  # GitHub repo slug — ALWAYS hardcoded. NEVER derive from directory name or local path.
+  # The local path contains "tellurstori" but the GitHub org is "cgcardona".
+  export GH_REPO=cgcardona/maestro
+  # All gh commands pick this up automatically. You may also pass --repo "$GH_REPO" explicitly.
 
 STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT checkout a branch, run mypy, or add a review


### PR DESCRIPTION
## Summary

Updates to the three parallel agent prompt files following today's debugging session.

## Changes

- **PARALLEL_ISSUE_TO_PR.md** — swap the active batch to issues #320, #312, #311, #310 (social layer tests + three independent UI template enrichments); add per-issue file-ownership comments and load-bearing rationale to the batch header
- **PARALLEL_BUGS_TO_ISSUES.md** — prompt refinements from session
- **PARALLEL_PR_REVIEW.md** — prompt refinements from session

## Also fixed (not committed — lives in `.git/hooks/`)

Installed a `pre-commit` hook that blocks direct commits to `dev`, forcing all work through feature branches. This prevents the divergence pattern identified today where an interactive agent session committed directly to local `dev` instead of a feature branch.

## Verification
- [ ] No code changes — prompt/doc only