### PR TITLE
feat(musehub): issue list page enrichment — body preview, label filter, closed tab

### DIFF
--- a/maestro/templates/musehub/pages/issue_list.html
+++ b/maestro/templates/musehub/pages/issue_list.html
@@ -18,6 +18,8 @@ let allIssues   = [];     // full list from API (state-filtered only)
 let activeLabel = null;   // label string currently filtering, or null
 let activeSort  = 'newest'; // 'newest' | 'oldest' | 'most-commented'
 let commentCounts = {};   // { issue_id: count } — populated on demand
+let cachedOpen   = null;  // cached open issues array after first fetch
+let cachedClosed = null;  // cached closed issues array after first fetch
 
 // ── Body preview ───────────────────────────────────────────────────────────
 function bodyPreview(body) {
@@ -119,16 +121,19 @@ async function changeSort(value) {
 async function load(state) {
   initRepoNav(repoId);
   try {
-    // Fetch open + closed counts in parallel
+    // Fetch only what is not yet cached — both needed on first load for tab counts.
     const [openData, closedData] = await Promise.all([
-      apiFetch('/repos/' + repoId + '/issues?state=open'),
-      apiFetch('/repos/' + repoId + '/issues?state=closed'),
+      cachedOpen   !== null ? Promise.resolve({ issues: cachedOpen })   : apiFetch('/repos/' + repoId + '/issues?state=open'),
+      cachedClosed !== null ? Promise.resolve({ issues: cachedClosed }) : apiFetch('/repos/' + repoId + '/issues?state=closed'),
     ]);
 
-    const openCount   = (openData.issues   || []).length;
-    const closedCount = (closedData.issues  || []).length;
+    cachedOpen   = openData.issues   || [];
+    cachedClosed = closedData.issues || [];
 
-    allIssues   = state === 'closed' ? (closedData.issues || []) : (openData.issues || []);
+    const openCount   = cachedOpen.length;
+    const closedCount = cachedClosed.length;
+
+    allIssues   = state === 'closed' ? cachedClosed : cachedOpen;
     activeLabel = null;
 
     document.getElementById('content').innerHTML = `
@@ -158,9 +163,9 @@ async function load(state) {
         <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap">
           <span style="font-size:13px;color:#8b949e">Sort by:</span>
           <div style="display:flex;gap:var(--space-1)">
-            <button class="btn btn-ghost btn-sm sort-btn${activeSort==='newest'?' sort-active':''}" onclick="changeSort('newest')">Newest</button>
-            <button class="btn btn-ghost btn-sm sort-btn${activeSort==='oldest'?' sort-active':''}" onclick="changeSort('oldest')">Oldest</button>
-            <button class="btn btn-ghost btn-sm sort-btn${activeSort==='most-commented'?' sort-active':''}" onclick="changeSort('most-commented')">Most commented</button>
+            <button class="btn btn-ghost btn-sm sort-btn${activeSort==='newest'?' sort-active':''}" data-sort="newest" onclick="changeSort('newest')">Newest</button>
+            <button class="btn btn-ghost btn-sm sort-btn${activeSort==='oldest'?' sort-active':''}" data-sort="oldest" onclick="changeSort('oldest')">Oldest</button>
+            <button class="btn btn-ghost btn-sm sort-btn${activeSort==='most-commented'?' sort-active':''}" data-sort="most-commented" onclick="changeSort('most-commented')">Most commented</button>
           </div>
           <span id="sort-loading" style="display:none;font-size:12px;color:#8b949e">Loading…</span>
           <div id="label-filter-bar"></div>
@@ -211,12 +216,10 @@ async function load(state) {
 }
 
 // ── Keep sort button active styles in sync ─────────────────────────────────
+// Buttons carry data-sort attributes matching the activeSort values.
 function updateSortButtons() {
-  document.querySelectorAll('.sort-btn').forEach(btn => {
-    btn.classList.toggle('sort-active', btn.textContent.trim().toLowerCase().replace(' ', '-') === activeSort ||
-      (btn.textContent.trim() === 'Newest' && activeSort === 'newest') ||
-      (btn.textContent.trim() === 'Oldest' && activeSort === 'oldest') ||
-      (btn.textContent.trim() === 'Most commented' && activeSort === 'most-commented'));
+  document.querySelectorAll('.sort-btn[data-sort]').forEach(btn => {
+    btn.classList.toggle('sort-active', btn.dataset.sort === activeSort);
   });
 }
 

--- a/maestro/templates/musehub/pages/issue_list.html
+++ b/maestro/templates/musehub/pages/issue_list.html
@@ -13,51 +13,169 @@ const base   = {{ base_url | tojson }};
 
 {% block page_script %}
 {% raw %}
+// ── State ──────────────────────────────────────────────────────────────────
+let allIssues   = [];     // full list from API (state-filtered only)
+let activeLabel = null;   // label string currently filtering, or null
+let activeSort  = 'newest'; // 'newest' | 'oldest' | 'most-commented'
+let commentCounts = {};   // { issue_id: count } — populated on demand
+
+// ── Body preview ───────────────────────────────────────────────────────────
+function bodyPreview(body) {
+  if (!body) return '';
+  const first = body.split('\n')[0].trim();
+  return first.length > 100 ? first.slice(0, 97) + '…' : first;
+}
+
+// ── Sorting ────────────────────────────────────────────────────────────────
+function sortedIssues(issues) {
+  const copy = [...issues];
+  if (activeSort === 'oldest') {
+    copy.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+  } else if (activeSort === 'most-commented') {
+    copy.sort((a, b) => (commentCounts[b.issueId] || 0) - (commentCounts[a.issueId] || 0));
+  } else {
+    // newest (default)
+    copy.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  }
+  return copy;
+}
+
+// ── Label filter ───────────────────────────────────────────────────────────
+function setLabelFilter(label) {
+  activeLabel = (activeLabel === label) ? null : label;
+  renderRows();
+}
+
+// ── Render rows ────────────────────────────────────────────────────────────
+function renderRows() {
+  let issues = allIssues;
+  if (activeLabel) {
+    issues = issues.filter(i => (i.labels || []).includes(activeLabel));
+  }
+  issues = sortedIssues(issues);
+
+  const container = document.getElementById('issue-rows');
+  if (!container) return;
+
+  if (issues.length === 0) {
+    container.innerHTML = activeLabel
+      ? `<p class="loading">No issues with label "<strong>${escHtml(activeLabel)}</strong>". <a href="#" onclick="setLabelFilter(null);return false;">Clear filter</a></p>`
+      : '<p class="loading">No issues found.</p>';
+    return;
+  }
+
+  container.innerHTML = issues.map(i => {
+    const preview = bodyPreview(i.body);
+    const labels  = (i.labels || []);
+    const commentCount = commentCounts[i.issueId];
+    const commentBadge = commentCount != null
+      ? `<span style="font-size:11px;color:#8b949e;margin-left:auto">&#128172; ${commentCount}</span>`
+      : '';
+    return `
+      <div class="issue-row" data-issue-id="${i.issueId}">
+        <span class="badge badge-${i.state}">#${i.number}</span>
+        <div style="flex:1;min-width:0">
+          <a href="${base}/issues/${i.number}">${escHtml(i.title)}</a>
+          ${preview ? `<div class="issue-preview">${escHtml(preview)}</div>` : ''}
+          <div style="display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;margin-top:4px">
+            ${labels.map(l => `<span class="label label-pill${activeLabel === l ? ' label-active' : ''}" onclick="setLabelFilter(${JSON.stringify(l)})" style="cursor:pointer" title="Filter by ${escHtml(l)}">${escHtml(l)}</span>`).join('')}
+            <span style="font-size:11px;color:#8b949e">Opened ${fmtDate(i.createdAt)}</span>
+            ${commentBadge}
+          </div>
+        </div>
+        <span class="badge badge-${i.state}">${i.state}</span>
+      </div>`;
+  }).join('');
+}
+
+// ── Load comment counts (called when sort=most-commented) ──────────────────
+async function loadCommentCounts(issues) {
+  await Promise.all(issues.map(async i => {
+    try {
+      const rows = await apiFetch('/repos/' + repoId + '/comments?target_type=issue&target_id=' + encodeURIComponent(i.issueId));
+      commentCounts[i.issueId] = Array.isArray(rows) ? rows.length : 0;
+    } catch (_) {
+      commentCounts[i.issueId] = 0;
+    }
+  }));
+}
+
+// ── Sort control handler ───────────────────────────────────────────────────
+async function changeSort(value) {
+  activeSort = value;
+  if (activeSort === 'most-commented' && allIssues.length > 0) {
+    // fetch counts only on first request — cache in commentCounts
+    const uncounted = allIssues.filter(i => commentCounts[i.issueId] == null);
+    if (uncounted.length > 0) {
+      document.getElementById('sort-loading').style.display = '';
+      await loadCommentCounts(uncounted);
+      document.getElementById('sort-loading').style.display = 'none';
+    }
+  }
+  renderRows();
+}
+
+// ── Main load ──────────────────────────────────────────────────────────────
 async function load(state) {
   initRepoNav(repoId);
   try {
-    const data   = await apiFetch('/repos/' + repoId + '/issues?state=' + state);
-    const issues = data.issues || [];
+    // Fetch open + closed counts in parallel
+    const [openData, closedData] = await Promise.all([
+      apiFetch('/repos/' + repoId + '/issues?state=open'),
+      apiFetch('/repos/' + repoId + '/issues?state=closed'),
+    ]);
 
-    const rows = issues.length === 0
-      ? '<p class="loading">No issues found.</p>'
-      : issues.map(i => `
-        <div class="issue-row">
-          <span class="badge badge-${i.state}">#${i.number}</span>
-          <div style="flex:1">
-            <a href="${base}/issues/${i.number}">${escHtml(i.title)}</a>
-            <div style="margin-top:4px">
-              ${(i.labels||[]).map(l => '<span class="label">' + escHtml(l) + '</span>').join('')}
-            </div>
-            <div style="font-size:12px;color:#8b949e;margin-top:2px">
-              Opened ${fmtDate(i.createdAt)}
-            </div>
-          </div>
-          <span class="badge badge-${i.state}">${i.state}</span>
-        </div>`).join('');
+    const openCount   = (openData.issues   || []).length;
+    const closedCount = (closedData.issues  || []).length;
+
+    allIssues   = state === 'closed' ? (closedData.issues || []) : (openData.issues || []);
+    activeLabel = null;
 
     document.getElementById('content').innerHTML = `
       <div class="card">
-        <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4);flex-wrap:wrap">
+        <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap">
           <h1 style="margin:0">Issues</h1>
-          <select class="form-select" style="width:auto" onchange="load(this.value)">
-            <option value="open"   ${state==='open'  ?'selected':''}>Open</option>
-            <option value="closed" ${state==='closed'?'selected':''}>Closed</option>
-            <option value="all"    ${state==='all'   ?'selected':''}>All</option>
-          </select>
           <div style="margin-left:auto;display:flex;gap:var(--space-2)">
             <button class="btn btn-secondary btn-sm" onclick="showCreateIssue()">
               + New Issue
             </button>
           </div>
         </div>
-        ${rows.length > 0 || issues.length > 0 ? rows : `
+
+        <!-- Open / Closed tabs -->
+        <div style="display:flex;gap:0;border-bottom:1px solid var(--color-border);margin-bottom:var(--space-3)">
+          <button id="tab-open" class="tab-btn${state !== 'closed' ? ' tab-active' : ''}"
+                  onclick="load('open')">
+            &#9711; Open <span class="tab-count">${openCount}</span>
+          </button>
+          <button id="tab-closed" class="tab-btn${state === 'closed' ? ' tab-active' : ''}"
+                  onclick="load('closed')">
+            &#10003; Closed <span class="tab-count">${closedCount}</span>
+          </button>
+        </div>
+
+        <!-- Sort + label-clear bar -->
+        <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap">
+          <span style="font-size:13px;color:#8b949e">Sort by:</span>
+          <div style="display:flex;gap:var(--space-1)">
+            <button class="btn btn-ghost btn-sm sort-btn${activeSort==='newest'?' sort-active':''}" onclick="changeSort('newest')">Newest</button>
+            <button class="btn btn-ghost btn-sm sort-btn${activeSort==='oldest'?' sort-active':''}" onclick="changeSort('oldest')">Oldest</button>
+            <button class="btn btn-ghost btn-sm sort-btn${activeSort==='most-commented'?' sort-active':''}" onclick="changeSort('most-commented')">Most commented</button>
+          </div>
+          <span id="sort-loading" style="display:none;font-size:12px;color:#8b949e">Loading…</span>
+          <div id="label-filter-bar"></div>
+        </div>
+
+        <!-- Issue rows -->
+        <div id="issue-rows"></div>
+
+        ${openCount === 0 && closedCount === 0 ? `
           <div class="empty-state">
             <div class="empty-icon">&#128203;</div>
             <p class="empty-title">No issues yet</p>
             <p class="empty-desc">Found a musical problem or want to track something? Open an issue.</p>
             <button class="btn btn-primary" onclick="showCreateIssue()">Open first issue</button>
-          </div>`}
+          </div>` : ''}
       </div>
       <div id="create-issue-panel" style="display:none">
         <div class="card" style="border-color:var(--color-accent)">
@@ -82,10 +200,24 @@ async function load(state) {
           </div>
         </div>
       </div>`;
+
+    // Initial render
+    renderRows();
+    updateSortButtons();
   } catch(e) {
     if (e.message !== 'auth')
       document.getElementById('content').innerHTML = '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
   }
+}
+
+// ── Keep sort button active styles in sync ─────────────────────────────────
+function updateSortButtons() {
+  document.querySelectorAll('.sort-btn').forEach(btn => {
+    btn.classList.toggle('sort-active', btn.textContent.trim().toLowerCase().replace(' ', '-') === activeSort ||
+      (btn.textContent.trim() === 'Newest' && activeSort === 'newest') ||
+      (btn.textContent.trim() === 'Oldest' && activeSort === 'oldest') ||
+      (btn.textContent.trim() === 'Most commented' && activeSort === 'most-commented'));
+  });
 }
 
 function showCreateIssue() {

--- a/maestro/templates/musehub/static/components.css
+++ b/maestro/templates/musehub/static/components.css
@@ -550,6 +550,79 @@ textarea:focus {
   margin: 2px;
 }
 
+/* Clickable label pill for client-side filtering */
+.label-pill {
+  transition: opacity 0.1s, outline 0.1s;
+}
+
+.label-pill:hover {
+  opacity: 0.8;
+  outline: 1px solid var(--color-accent);
+}
+
+/* Active (selected) label filter pill */
+.label-active {
+  outline: 2px solid var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 15%, var(--bg-hover));
+  color: var(--color-accent);
+}
+
+/* -------------------------------------------------------------------------
+ * Issue body preview (subtitle line under issue title)
+ * ------------------------------------------------------------------------- */
+.issue-preview {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* -------------------------------------------------------------------------
+ * Open/Closed tabs and sort buttons for issue list page
+ * ------------------------------------------------------------------------- */
+.tab-btn {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tab-btn:hover {
+  color: var(--text-primary);
+}
+
+.tab-btn.tab-active {
+  color: var(--text-primary);
+  border-bottom-color: var(--color-accent);
+  font-weight: 600;
+}
+
+.tab-count {
+  display: inline-block;
+  background: var(--bg-hover);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  padding: 0 6px;
+  margin-left: 4px;
+  color: var(--text-muted);
+}
+
+.sort-btn {
+  font-size: var(--font-size-xs);
+  padding: 2px var(--space-2);
+}
+
+.sort-btn.sort-active {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
 /* -------------------------------------------------------------------------
  * Code blocks
  * ------------------------------------------------------------------------- */

--- a/tests/test_musehub_ui.py
+++ b/tests/test_musehub_ui.py
@@ -4,7 +4,11 @@ Covers the minimum acceptance criteria from issue #43 and issue #232:
 - test_ui_repo_page_returns_200        — GET /musehub/ui/{repo_id} returns HTML
 - test_ui_commit_page_shows_artifact_links — commit page HTML mentions img/download
 - test_ui_pr_list_page_returns_200     — PR list page renders without error
-- test_ui_issue_list_page_returns_200  — Issue list page renders without error
+- test_ui_issue_list_page_returns_200          — Issue list page renders without error
+- test_ui_issue_list_has_open_closed_tabs      — Open/Closed tab buttons present (#299)
+- test_ui_issue_list_has_sort_controls         — Sort buttons (newest/oldest/most-commented) present (#299)
+- test_ui_issue_list_has_label_filter_js       — Client-side label filter JS present (#299)
+- test_ui_issue_list_has_body_preview_js       — Body preview helper and CSS class present (#299)
 - test_context_page_renders            — context viewer page returns 200 HTML
 - test_context_json_response           — JSON returns MuseHubContextResponse structure
 - test_context_includes_musical_state  — response includes active_tracks field
@@ -164,6 +168,71 @@ async def test_ui_issue_list_page_returns_200(
     body = response.text
     assert "Issues" in body
     assert "Muse Hub" in body
+
+
+@pytest.mark.anyio
+async def test_ui_issue_list_has_open_closed_tabs(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Issue list page HTML includes Open and Closed tab buttons and count spans."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/issues")
+    assert response.status_code == 200
+    body = response.text
+    # Tab buttons for open and closed state
+    assert "tab-open" in body
+    assert "tab-closed" in body
+    # Tab count placeholders are rendered client-side; structural markers exist
+    assert "tab-count" in body
+    assert "Open" in body
+    assert "Closed" in body
+
+
+@pytest.mark.anyio
+async def test_ui_issue_list_has_sort_controls(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Issue list page HTML includes Newest, Oldest, and Most commented sort buttons."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/issues")
+    assert response.status_code == 200
+    body = response.text
+    assert "Newest" in body
+    assert "Oldest" in body
+    assert "Most commented" in body
+    assert "changeSort" in body
+
+
+@pytest.mark.anyio
+async def test_ui_issue_list_has_label_filter_js(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Issue list page HTML includes client-side label filter logic."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/issues")
+    assert response.status_code == 200
+    body = response.text
+    # JS function for label filtering
+    assert "setLabelFilter" in body
+    assert "label-pill" in body
+    assert "activeLabel" in body
+
+
+@pytest.mark.anyio
+async def test_ui_issue_list_has_body_preview_js(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Issue list page HTML includes bodyPreview helper for truncated body subtitles."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/issues")
+    assert response.status_code == 200
+    body = response.text
+    assert "bodyPreview" in body
+    assert "issue-preview" in body
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
Closes #299 — enriches the issue list page with body preview, clickable label filter pills, Open/Closed tabs with counts, and sort controls.

## Root Cause / Motivation
The issue list page rendered sparse rows with no body context, no interactive label filtering, and a plain dropdown for state switching instead of the more discoverable Open/Closed tab pattern.

## Solution
- **Open/Closed tabs with counts** — replaced the state `<select>` with two tab buttons (`.tab-btn` / `.tab-active`) that show live issue counts fetched in parallel from the API.
- **Body preview** — `bodyPreview()` helper extracts the first line of the issue body and truncates to 100 chars, rendered as `.issue-preview` subtitle under the title.
- **Clickable label pills** — each label renders as `.label-pill`; clicking toggles `activeLabel` for client-side filtering. Active pill gets `.label-active` outline highlight and a clear-filter link appears.
- **Sort controls** — Newest / Oldest / Most commented buttons; the most-commented sort lazily fetches comment counts via the social API (`/repos/{id}/comments`) on first use, caching results in `commentCounts`.
- **CSS additions** — added `.label-pill`, `.label-active`, `.issue-preview`, `.tab-btn`, `.tab-active`, `.tab-count`, `.sort-btn`, `.sort-active` to `components.css`.

No backend changes required — `IssueResponse` already carries `body`, `labels[]`, `state`, and `created_at`. The `?state=closed` endpoint already exists.

## Verification
- [x] mypy clean (626 source files, 0 issues)
- [x] 5 targeted tests pass (`test_ui_issue_list_*`)
- [x] Docs: test file docstring updated with new test names