### PR TITLE
feat(musehub): OpenAPI 3.1 specification — auto-generated API docs for all MuseHub endpoints

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -915,6 +915,28 @@ See also: [integrate.md](../guides/integrate.md) for MCP setup (stdio, Cursor, W
 
 Remote collaboration backend for Muse VCS — the server-side equivalent of a Git remote. All endpoints are under `/api/v1/musehub/` and require `Authorization: Bearer <token>`.
 
+### Interactive API docs
+
+The full MuseHub API is available as a machine-readable OpenAPI 3.1 specification:
+
+| Resource | URL |
+|----------|-----|
+| **OpenAPI 3.1 JSON spec** | `GET /api/v1/openapi.json` |
+| **Swagger UI** (interactive, debug mode only) | `GET /docs` |
+| **ReDoc** (debug mode only) | `GET /redoc` |
+
+The spec is always available at `/api/v1/openapi.json` regardless of `DEBUG` mode, enabling agent SDK generation and third-party integrations without enabling the interactive UI in production.
+
+```bash
+# Fetch the spec for SDK generation
+curl https://your-domain.com/api/v1/openapi.json | jq '.info'
+
+# List all MuseHub operationIds
+curl https://your-domain.com/api/v1/openapi.json | jq '[.paths | to_entries[] | .value | to_entries[] | .value.operationId] | sort | .[]'
+```
+
+Every endpoint has a camelCase `operationId` (e.g. `listRepoCommits`, `getAnalysisHarmony`, `mergePullRequest`) that maps 1:1 to generated SDK method names.
+
 ### POST /api/v1/musehub/repos
 
 Create a new remote Muse repository. The `slug` is auto-generated from `name` (lowercase, hyphens). Returns `409` if the `(owner, name)` combination already exists.

--- a/maestro/api/routes/musehub/__init__.py
+++ b/maestro/api/routes/musehub/__init__.py
@@ -31,22 +31,21 @@ from maestro.api.routes.musehub import (
 
 router = APIRouter(
     prefix="/musehub",
-    tags=["musehub"],
 )
 
 # All fixed-path subrouters are included BEFORE repos.router so they are matched
 # first and are not shadowed by the /{owner}/{repo_slug} wildcard route declared
 # last in repos.py.
-router.include_router(issues.router)
-router.include_router(pull_requests.router)
-router.include_router(releases.router)
-router.include_router(sync.router)
-router.include_router(objects.router)
-router.include_router(search.router)
-router.include_router(analysis.router)
-router.include_router(webhooks.router)
-router.include_router(social.router)
+router.include_router(issues.router, tags=["Issues"])
+router.include_router(pull_requests.router, tags=["Pull Requests"])
+router.include_router(releases.router, tags=["Releases"])
+router.include_router(sync.router, tags=["Sync"])
+router.include_router(objects.router, tags=["Objects"])
+router.include_router(search.router, tags=["Search"])
+router.include_router(analysis.router, tags=["Analysis"])
+router.include_router(webhooks.router, tags=["Webhooks"])
+router.include_router(social.router, tags=["Social"])
 # repos.router last — contains the /{owner}/{repo_slug} wildcard route.
-router.include_router(repos.router)
+router.include_router(repos.router, tags=["Repos"])
 
 __all__ = ["router"]

--- a/maestro/api/routes/musehub/analysis.py
+++ b/maestro/api/routes/musehub/analysis.py
@@ -55,6 +55,7 @@ def _etag(repo_id: str, ref: str, dimension: str) -> str:
 @router.get(
     "/repos/{repo_id}/analysis/{ref}",
     response_model=AggregateAnalysisResponse,
+    operation_id="getAnalysis",
     summary="Aggregate analysis — all 13 musical dimensions for a ref",
     description=(
         "Returns structured JSON for all 13 musical dimensions of a Muse commit ref "
@@ -105,6 +106,7 @@ async def get_aggregate_analysis(
 @router.get(
     "/repos/{repo_id}/analysis/{ref}/{dimension}",
     response_model=AnalysisResponse,
+    operation_id="getAnalysisDimension",
     summary="Single-dimension analysis for a Muse ref",
     description=(
         "Returns structured JSON for one of the 13 supported musical dimensions. "
@@ -166,6 +168,7 @@ async def get_dimension_analysis(
 @router.get(
     "/repos/{repo_id}/analysis/{ref}/dynamics/page",
     response_model=DynamicsPageData,
+    operation_id="getAnalysisDynamicsPage",
     summary="Per-track dynamics page data for the Dynamics Analysis page",
     description=(
         "Returns enriched per-track dynamic analysis: velocity profiles, arc "

--- a/maestro/api/routes/musehub/discover.py
+++ b/maestro/api/routes/musehub/discover.py
@@ -27,8 +27,8 @@ logger = logging.getLogger(__name__)
 
 # Two routers: one public (no auth dependency) and one authed (star/unstar).
 # Both are exported and registered separately so the auth contract is explicit.
-router = APIRouter(tags=["musehub-discover"])
-star_router = APIRouter(tags=["musehub-discover"])
+router = APIRouter()
+star_router = APIRouter()
 
 _VALID_SORTS = {"stars", "activity", "commits", "created"}
 
@@ -36,6 +36,7 @@ _VALID_SORTS = {"stars", "activity", "commits", "created"}
 @router.get(
     "/musehub/discover/repos",
     response_model=ExploreResponse,
+    operation_id="listPublicRepos",
     summary="Browse public Muse Hub repos with optional filters and sorting",
 )
 async def list_public_repos(
@@ -84,6 +85,7 @@ async def list_public_repos(
     "/musehub/repos/{repo_id}/star",
     response_model=StarResponse,
     status_code=status.HTTP_200_OK,
+    operation_id="starRepo",
     summary="Star a public Muse Hub repo",
 )
 async def star_repo(
@@ -109,6 +111,7 @@ async def star_repo(
     "/musehub/repos/{repo_id}/star",
     response_model=StarResponse,
     status_code=status.HTTP_200_OK,
+    operation_id="unstarRepo",
     summary="Unstar a Muse Hub repo",
 )
 async def unstar_repo(

--- a/maestro/api/routes/musehub/issues.py
+++ b/maestro/api/routes/musehub/issues.py
@@ -34,6 +34,7 @@ router = APIRouter()
     "/repos/{repo_id}/issues",
     response_model=IssueResponse,
     status_code=status.HTTP_201_CREATED,
+    operation_id="createIssue",
     summary="Open a new issue against a Muse Hub repo",
 )
 async def create_issue(
@@ -77,6 +78,7 @@ async def create_issue(
 @router.get(
     "/repos/{repo_id}/issues",
     response_model=IssueListResponse,
+    operation_id="listIssues",
     summary="List issues for a Muse Hub repo",
 )
 async def list_issues(
@@ -107,6 +109,7 @@ async def list_issues(
 @router.get(
     "/repos/{repo_id}/issues/{issue_number}",
     response_model=IssueResponse,
+    operation_id="getIssue",
     summary="Get a single issue by its per-repo number",
 )
 async def get_issue(
@@ -134,6 +137,7 @@ async def get_issue(
 @router.post(
     "/repos/{repo_id}/issues/{issue_number}/close",
     response_model=IssueResponse,
+    operation_id="closeIssue",
     summary="Close an issue",
 )
 async def close_issue(

--- a/maestro/api/routes/musehub/objects.py
+++ b/maestro/api/routes/musehub/objects.py
@@ -59,6 +59,7 @@ def _content_type(path: str) -> str:
 @router.get(
     "/repos/{repo_id}/objects",
     response_model=ObjectMetaListResponse,
+    operation_id="listObjects",
     summary="List artifact metadata for a Muse Hub repo",
 )
 async def list_objects(
@@ -87,6 +88,7 @@ async def list_objects(
 
 @router.get(
     "/repos/{repo_id}/objects/{object_id}/content",
+    operation_id="getObjectContent",
     summary="Download raw artifact bytes",
     response_class=FileResponse,
 )
@@ -130,6 +132,7 @@ async def get_object_content(
 
 @router.get(
     "/repos/{repo_id}/export/{ref}",
+    operation_id="exportArtifacts",
     summary="Download an export package of artifacts at a commit ref",
     responses={
         200: {"description": "Artifact or ZIP archive ready for download"},

--- a/maestro/api/routes/musehub/pull_requests.py
+++ b/maestro/api/routes/musehub/pull_requests.py
@@ -39,6 +39,7 @@ router = APIRouter()
     "/repos/{repo_id}/pull-requests",
     response_model=PRResponse,
     status_code=status.HTTP_201_CREATED,
+    operation_id="createPullRequest",
     summary="Open a pull request against a Muse Hub repo",
 )
 async def create_pull_request(
@@ -98,6 +99,7 @@ async def create_pull_request(
 @router.get(
     "/repos/{repo_id}/pull-requests",
     response_model=PRListResponse,
+    operation_id="listPullRequests",
     summary="List pull requests for a Muse Hub repo",
 )
 async def list_pull_requests(
@@ -130,6 +132,7 @@ async def list_pull_requests(
 @router.get(
     "/repos/{repo_id}/pull-requests/{pr_id}",
     response_model=PRResponse,
+    operation_id="getPullRequest",
     summary="Get a single pull request by ID",
 )
 async def get_pull_request(
@@ -157,6 +160,7 @@ async def get_pull_request(
 @router.post(
     "/repos/{repo_id}/pull-requests/{pr_id}/merge",
     response_model=PRMergeResponse,
+    operation_id="mergePullRequest",
     summary="Merge an open pull request",
 )
 async def merge_pull_request(

--- a/maestro/api/routes/musehub/releases.py
+++ b/maestro/api/routes/musehub/releases.py
@@ -35,6 +35,7 @@ router = APIRouter()
     "/repos/{repo_id}/releases",
     response_model=ReleaseResponse,
     status_code=status.HTTP_201_CREATED,
+    operation_id="createRelease",
     summary="Create a release for a Muse Hub repo",
 )
 async def create_release(
@@ -71,6 +72,7 @@ async def create_release(
 @router.get(
     "/repos/{repo_id}/releases",
     response_model=ReleaseListResponse,
+    operation_id="listReleases",
     summary="List all releases for a Muse Hub repo",
 )
 async def list_releases(
@@ -97,6 +99,7 @@ async def list_releases(
 @router.get(
     "/repos/{repo_id}/releases/{tag}",
     response_model=ReleaseResponse,
+    operation_id="getRelease",
     summary="Get a single release by tag",
 )
 async def get_release(

--- a/maestro/api/routes/musehub/repos.py
+++ b/maestro/api/routes/musehub/repos.py
@@ -68,7 +68,9 @@ def _guard_visibility(repo: RepoResponse | None, claims: TokenClaims | None) -> 
     "/repos",
     response_model=RepoResponse,
     status_code=status.HTTP_201_CREATED,
+    operation_id="createRepo",
     summary="Create a remote Muse repo",
+    tags=["Repos"],
 )
 async def create_repo(
     body: CreateRepoRequest,
@@ -108,7 +110,9 @@ async def create_repo(
 @router.get(
     "/repos/{repo_id}",
     response_model=RepoResponse,
+    operation_id="getRepo",
     summary="Get remote repo metadata",
+    tags=["Repos"],
 )
 async def get_repo(
     repo_id: str,
@@ -124,7 +128,9 @@ async def get_repo(
 @router.get(
     "/repos/{repo_id}/branches",
     response_model=BranchListResponse,
+    operation_id="listRepoBranches",
     summary="List all branches in a remote repo",
+    tags=["Branches"],
 )
 async def list_branches(
     repo_id: str,
@@ -141,7 +147,9 @@ async def list_branches(
 @router.get(
     "/repos/{repo_id}/commits",
     response_model=CommitListResponse,
+    operation_id="listRepoCommits",
     summary="List commits in a remote repo (newest first)",
+    tags=["Commits"],
 )
 async def list_commits(
     repo_id: str,
@@ -162,7 +170,9 @@ async def list_commits(
 @router.get(
     "/repos/{repo_id}/commits/{commit_id}",
     response_model=CommitResponse,
+    operation_id="getRepoCommit",
     summary="Get a single commit by ID",
+    tags=["Commits"],
 )
 async def get_commit(
     repo_id: str,
@@ -190,7 +200,9 @@ async def get_commit(
 @router.get(
     "/repos/{repo_id}/timeline",
     response_model=TimelineResponse,
+    operation_id="getRepoTimeline",
     summary="Chronological timeline of musical evolution",
+    tags=["Commits"],
 )
 async def get_timeline(
     repo_id: str,
@@ -218,7 +230,9 @@ async def get_timeline(
 @router.get(
     "/repos/{repo_id}/divergence",
     response_model=DivergenceResponse,
+    operation_id="getRepoDivergence",
     summary="Compute musical divergence between two branches",
+    tags=["Branches"],
 )
 async def get_divergence(
     repo_id: str,
@@ -283,7 +297,9 @@ async def get_divergence(
 @router.get(
     "/repos/{repo_id}/credits",
     response_model=CreditsResponse,
+    operation_id="getRepoCredits",
     summary="Get aggregated contributor credits for a repo",
+    tags=["Repos"],
 )
 async def get_credits(
     repo_id: str,
@@ -317,7 +333,9 @@ async def get_credits(
 @router.get(
     "/repos/{repo_id}/context/{ref}",
     response_model=MuseHubContextResponse,
+    operation_id="getRepoContextByRef",
     summary="Get musical context document for a commit",
+    tags=["Commits"],
 )
 async def get_context(
     repo_id: str,
@@ -346,7 +364,9 @@ async def get_context(
 
 @router.get(
     "/repos/{repo_id}/context",
+    operation_id="getAgentContext",
     summary="Get complete agent context for a repo ref",
+    tags=["Repos"],
     responses={
         200: {"description": "Agent context document (JSON or YAML)"},
         404: {"description": "Repo not found or ref has no commits"},
@@ -407,7 +427,9 @@ async def get_agent_context(
 @router.get(
     "/repos/{repo_id}/dag",
     response_model=DagGraphResponse,
+    operation_id="getCommitDag",
     summary="Get the full commit DAG for a repo",
+    tags=["Commits"],
 )
 async def get_commit_dag(
     repo_id: str,
@@ -437,7 +459,9 @@ async def get_commit_dag(
     "/repos/{repo_id}/sessions",
     response_model=SessionResponse,
     status_code=status.HTTP_201_CREATED,
+    operation_id="createSession",
     summary="Create a recording session entry",
+    tags=["Sessions"],
 )
 async def create_session(
     repo_id: str,
@@ -469,7 +493,9 @@ async def create_session(
 @router.get(
     "/repos/{repo_id}/sessions",
     response_model=SessionListResponse,
+    operation_id="listSessions",
     summary="List recording sessions for a repo (newest first)",
+    tags=["Sessions"],
 )
 async def list_sessions(
     repo_id: str,
@@ -491,7 +517,9 @@ async def list_sessions(
 @router.get(
     "/repos/{repo_id}/sessions/{session_id}",
     response_model=SessionResponse,
+    operation_id="getSession",
     summary="Get a single recording session by ID",
+    tags=["Sessions"],
 )
 async def get_session(
     repo_id: str,
@@ -514,7 +542,9 @@ async def get_session(
 @router.post(
     "/repos/{repo_id}/sessions/{session_id}/stop",
     response_model=SessionResponse,
+    operation_id="stopSession",
     summary="Mark a recording session as ended",
+    tags=["Sessions"],
 )
 async def stop_session(
     repo_id: str,
@@ -545,7 +575,9 @@ async def stop_session(
 @router.get(
     "/{owner}/{repo_slug}",
     response_model=RepoResponse,
+    operation_id="getRepoByOwnerSlug",
     summary="Get repo metadata by owner/slug",
+    tags=["Repos"],
 )
 async def get_repo_by_owner_slug(
     owner: str,

--- a/maestro/api/routes/musehub/search.py
+++ b/maestro/api/routes/musehub/search.py
@@ -54,6 +54,7 @@ _REPO_VALID_MODES = frozenset({"property", "ask", "keyword", "pattern"})
 @router.get(
     "/search",
     response_model=GlobalSearchResult,
+    operation_id="globalSearch",
     summary="Global cross-repo search across all public Muse Hub repos",
 )
 async def global_search(
@@ -121,6 +122,7 @@ def _get_qdrant_client() -> MusehubQdrantClient:
 @router.get(
     "/search/similar",
     response_model=SimilarSearchResponse,
+    operation_id="searchSimilar",
     summary="Find musically similar commits across public repos",
 )
 async def search_similar(
@@ -188,6 +190,7 @@ async def search_similar(
 @router.get(
     "/repos/{repo_id}/search",
     response_model=SearchResponse,
+    operation_id="searchRepo",
     summary="Search Muse repo commits",
 )
 async def search_repo(

--- a/maestro/api/routes/musehub/social.py
+++ b/maestro/api/routes/musehub/social.py
@@ -56,7 +56,7 @@ from maestro.services import musehub_repository
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["musehub-social"])
+router = APIRouter()
 
 _ALLOWED_EMOJIS = {"👍", "👎", "❤️", "🎵", "🔥", "✨", "🎸", "🥁"}
 
@@ -186,7 +186,7 @@ class ViewAnalyticsDayResult(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-@router.get("/repos/{repo_id}/comments", summary="List comments on a target object")
+@router.get("/repos/{repo_id}/comments", operation_id="listComments", summary="List comments on a target object")
 async def list_comments(
     repo_id: str,
     target_type: str = Query(...),
@@ -219,7 +219,7 @@ async def list_comments(
 
 
 @router.post("/repos/{repo_id}/comments", status_code=status.HTTP_201_CREATED,
-             summary="Post a comment on a target object")
+             operation_id="createComment", summary="Post a comment on a target object")
 async def create_comment(
     repo_id: str,
     body: CommentCreate,
@@ -250,7 +250,7 @@ async def create_comment(
 
 
 @router.delete("/repos/{repo_id}/comments/{comment_id}",
-               status_code=status.HTTP_204_NO_CONTENT, summary="Soft-delete a comment")
+               status_code=status.HTTP_204_NO_CONTENT, operation_id="deleteComment", summary="Soft-delete a comment")
 async def delete_comment(
     repo_id: str,
     comment_id: str,
@@ -277,7 +277,7 @@ async def delete_comment(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/repos/{repo_id}/reactions", summary="Get reaction counts for a target")
+@router.get("/repos/{repo_id}/reactions", operation_id="getReactions", summary="Get reaction counts for a target")
 async def list_reactions(
     repo_id: str,
     target_type: str = Query(...),
@@ -317,7 +317,7 @@ async def list_reactions(
 
 
 @router.post("/repos/{repo_id}/reactions", status_code=status.HTTP_201_CREATED,
-             summary="Toggle a reaction on a target")
+             operation_id="toggleReaction", summary="Toggle a reaction on a target")
 async def toggle_reaction(
     repo_id: str,
     body: ReactionCreate,
@@ -365,7 +365,7 @@ async def toggle_reaction(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/users/{username}/followers", summary="Get follower count for a user")
+@router.get("/users/{username}/followers", operation_id="getFollowers", summary="Get follower count for a user")
 async def get_followers(
     username: str,
     db: AsyncSession = Depends(get_db),
@@ -387,7 +387,7 @@ async def get_followers(
 
 
 @router.post("/users/{username}/follow", status_code=status.HTTP_201_CREATED,
-             summary="Follow a user")
+             operation_id="followUser", summary="Follow a user")
 async def follow_user(
     username: str,
     db: AsyncSession = Depends(get_db),
@@ -410,7 +410,7 @@ async def follow_user(
 
 
 @router.delete("/users/{username}/follow", status_code=status.HTTP_204_NO_CONTENT,
-               summary="Unfollow a user")
+               operation_id="unfollowUser", summary="Unfollow a user")
 async def unfollow_user(
     username: str,
     db: AsyncSession = Depends(get_db),
@@ -431,7 +431,7 @@ async def unfollow_user(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/repos/{repo_id}/watches", summary="Get watch count for a repo")
+@router.get("/repos/{repo_id}/watches", operation_id="getWatchCount", summary="Get watch count for a repo")
 async def get_watches(
     repo_id: str,
     db: AsyncSession = Depends(get_db),
@@ -453,7 +453,7 @@ async def get_watches(
 
 
 @router.post("/repos/{repo_id}/watch", status_code=status.HTTP_201_CREATED,
-             summary="Watch a repo")
+             operation_id="watchRepo", summary="Watch a repo")
 async def watch_repo(
     repo_id: str,
     db: AsyncSession = Depends(get_db),
@@ -474,7 +474,7 @@ async def watch_repo(
 
 
 @router.delete("/repos/{repo_id}/watch", status_code=status.HTTP_204_NO_CONTENT,
-               summary="Unwatch a repo")
+               operation_id="unwatchRepo", summary="Unwatch a repo")
 async def unwatch_repo(
     repo_id: str,
     db: AsyncSession = Depends(get_db),
@@ -495,7 +495,7 @@ async def unwatch_repo(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/notifications", summary="Get notification inbox")
+@router.get("/notifications", operation_id="listNotifications", summary="Get notification inbox")
 async def list_notifications(
     unread_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200),
@@ -511,7 +511,7 @@ async def list_notifications(
     return [NotificationResponse.model_validate(r) for r in rows]
 
 
-@router.post("/notifications/{notif_id}/read", summary="Mark a notification as read")
+@router.post("/notifications/{notif_id}/read", operation_id="markNotificationRead", summary="Mark a notification as read")
 async def mark_notification_read(
     notif_id: str,
     db: AsyncSession = Depends(get_db),
@@ -531,7 +531,7 @@ async def mark_notification_read(
     return NotificationReadResult(read=True, notif_id=notif_id)
 
 
-@router.post("/notifications/read-all", summary="Mark all notifications as read")
+@router.post("/notifications/read-all", operation_id="markAllNotificationsRead", summary="Mark all notifications as read")
 async def mark_all_notifications_read(
     db: AsyncSession = Depends(get_db),
     claims: TokenClaims = Depends(require_valid_token),
@@ -554,7 +554,7 @@ async def mark_all_notifications_read(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/repos/{repo_id}/forks", summary="List forks of a repo")
+@router.get("/repos/{repo_id}/forks", operation_id="listForks", summary="List forks of a repo")
 async def list_forks(
     repo_id: str,
     db: AsyncSession = Depends(get_db),
@@ -575,7 +575,7 @@ async def list_forks(
 
 
 @router.post("/repos/{repo_id}/fork", status_code=status.HTTP_201_CREATED,
-             summary="Fork a repo")
+             operation_id="forkRepo", summary="Fork a repo")
 async def fork_repo(
     repo_id: str,
     db: AsyncSession = Depends(get_db),
@@ -633,7 +633,7 @@ async def fork_repo(
 
 
 @router.post("/repos/{repo_id}/view", status_code=status.HTTP_204_NO_CONTENT,
-             summary="Record a page view for analytics")
+             operation_id="recordView", summary="Record a page view for analytics")
 async def record_view(
     repo_id: str,
     request: Request,
@@ -662,7 +662,7 @@ async def record_view(
         await db.rollback()  # already viewed today — no-op
 
 
-@router.get("/repos/{repo_id}/analytics", summary="Repo analytics summary")
+@router.get("/repos/{repo_id}/analytics", operation_id="getRepoAnalytics", summary="Repo analytics summary")
 async def get_analytics(
     repo_id: str,
     db: AsyncSession = Depends(get_db),
@@ -688,7 +688,7 @@ async def get_analytics(
     return AnalyticsSummaryResult(repo_id=repo_id, view_count=view_count, download_count=dl_count)
 
 
-@router.get("/repos/{repo_id}/analytics/views", summary="Daily view counts")
+@router.get("/repos/{repo_id}/analytics/views", operation_id="getRepoViewAnalytics", summary="Daily view counts")
 async def get_view_analytics(
     repo_id: str,
     days: int = Query(default=30, ge=1, le=90),
@@ -720,7 +720,7 @@ async def get_view_analytics(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/feed", summary="Activity feed for the calling user")
+@router.get("/feed", operation_id="getActivityFeed", summary="Activity feed for the calling user")
 async def get_feed(
     limit: int = Query(50, ge=1, le=200),
     db: AsyncSession = Depends(get_db),

--- a/maestro/api/routes/musehub/sync.py
+++ b/maestro/api/routes/musehub/sync.py
@@ -40,6 +40,7 @@ router = APIRouter()
 @router.post(
     "/repos/{repo_id}/push",
     response_model=PushResponse,
+    operation_id="pushCommits",
     summary="Push commits and objects to a remote Muse repo",
 )
 async def push(
@@ -121,6 +122,7 @@ async def push(
 @router.post(
     "/repos/{repo_id}/pull",
     response_model=PullResponse,
+    operation_id="pullCommits",
     summary="Fetch missing commits and objects from a remote Muse repo",
 )
 async def pull(

--- a/maestro/api/routes/musehub/users.py
+++ b/maestro/api/routes/musehub/users.py
@@ -28,7 +28,7 @@ from maestro.services import musehub_profile as profile_svc
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["musehub-users"])
+router = APIRouter()
 
 
 # ---------------------------------------------------------------------------
@@ -53,6 +53,7 @@ class CreateProfileBody(CamelModel):
 @router.get(
     "/users/{username}",
     response_model=ProfileResponse,
+    operation_id="getUserProfile",
     summary="Get a Muse Hub user profile (public)",
 )
 async def get_user_profile(
@@ -79,6 +80,7 @@ async def get_user_profile(
     "/users",
     response_model=ProfileResponse,
     status_code=status.HTTP_201_CREATED,
+    operation_id="createUserProfile",
     summary="Create a Muse Hub user profile",
 )
 async def create_user_profile(
@@ -128,6 +130,7 @@ async def create_user_profile(
 @router.put(
     "/users/{username}",
     response_model=ProfileResponse,
+    operation_id="updateUserProfile",
     summary="Update a Muse Hub user profile (owner only)",
 )
 async def update_user_profile(

--- a/maestro/api/routes/musehub/webhooks.py
+++ b/maestro/api/routes/musehub/webhooks.py
@@ -37,6 +37,7 @@ router = APIRouter()
     "/repos/{repo_id}/webhooks",
     response_model=WebhookResponse,
     status_code=status.HTTP_201_CREATED,
+    operation_id="createWebhook",
     summary="Register a webhook subscription for a repo",
 )
 async def create_webhook(
@@ -76,6 +77,7 @@ async def create_webhook(
 @router.get(
     "/repos/{repo_id}/webhooks",
     response_model=WebhookListResponse,
+    operation_id="listWebhooks",
     summary="List webhook subscriptions for a repo",
 )
 async def list_webhooks(
@@ -95,6 +97,7 @@ async def list_webhooks(
 @router.delete(
     "/repos/{repo_id}/webhooks/{webhook_id}",
     status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="deleteWebhook",
     summary="Delete a webhook subscription",
 )
 async def delete_webhook(
@@ -117,6 +120,7 @@ async def delete_webhook(
 @router.get(
     "/repos/{repo_id}/webhooks/{webhook_id}/deliveries",
     response_model=WebhookDeliveryListResponse,
+    operation_id="listWebhookDeliveries",
     summary="List delivery history for a webhook",
 )
 async def list_deliveries(

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -19,13 +19,32 @@ from maestro.models.base import CamelModel
 class CommitInput(CamelModel):
     """A single commit record transferred in a push payload."""
 
-    commit_id: str
-    parent_ids: list[str] = Field(default_factory=list)
-    message: str
-    snapshot_id: str | None = None
-    timestamp: datetime
+    commit_id: str = Field(
+        ...,
+        description="Content-addressed commit ID (e.g. SHA-256 hex)",
+        examples=["a3f8c1d2e4b5"],
+    )
+    parent_ids: list[str] = Field(
+        default_factory=list,
+        description="Parent commit IDs; empty for the initial commit",
+        examples=[["b2a7d9e1c3f4"]],
+    )
+    message: str = Field(
+        ...,
+        description="Musical commit message describing the compositional change",
+        examples=["Add dominant 7th chord progression in the bridge — Fm7→Bb7→EbMaj7"],
+    )
+    snapshot_id: str | None = Field(
+        default=None,
+        description="Optional snapshot ID linking this commit to a stored MIDI artifact",
+    )
+    timestamp: datetime = Field(..., description="Commit creation time (ISO-8601 UTC)")
     # Optional -- falls back to the JWT ``sub`` when absent
-    author: str | None = None
+    author: str | None = Field(
+        default=None,
+        description="Commit author identifier; defaults to the JWT sub claim when absent",
+        examples=["composer@stori.com"],
+    )
 
 
 class ObjectInput(CamelModel):
@@ -43,19 +62,31 @@ class ObjectInput(CamelModel):
 class PushRequest(CamelModel):
     """Body for POST /musehub/repos/{repo_id}/push."""
 
-    branch: str
-    head_commit_id: str
-    commits: list[CommitInput] = Field(default_factory=list)
-    objects: list[ObjectInput] = Field(default_factory=list)
+    branch: str = Field(
+        ...,
+        description="Branch name to push to (e.g. 'main', 'feat/jazz-bridge')",
+        examples=["feat/jazz-bridge"],
+    )
+    head_commit_id: str = Field(
+        ...,
+        description="The commit ID that becomes the new branch head after push",
+        examples=["a3f8c1d2e4b5"],
+    )
+    commits: list[CommitInput] = Field(default_factory=list, description="New commits to push")
+    objects: list[ObjectInput] = Field(default_factory=list, description="Binary artifacts to upload")
     # Set true to allow non-fast-forward updates (overwrites remote head)
-    force: bool = False
+    force: bool = Field(False, description="Allow non-fast-forward push (overwrites remote head)")
 
 
 class PushResponse(CamelModel):
     """Response for POST /musehub/repos/{repo_id}/push."""
 
-    ok: bool
-    remote_head: str
+    ok: bool = Field(..., description="True when the push succeeded", examples=[True])
+    remote_head: str = Field(
+        ...,
+        description="The new branch head commit ID on the remote after push",
+        examples=["a3f8c1d2e4b5"],
+    )
 
 
 class PullRequest(CamelModel):
@@ -122,38 +153,42 @@ class RepoResponse(CamelModel):
     ``repo_id`` is the internal UUID primary key — never exposed in external URLs.
     """
 
-    repo_id: str
-    name: str
-    owner: str
-    slug: str
-    visibility: str
-    owner_user_id: str
-    clone_url: str
-    description: str = ""
-    tags: list[str] = Field(default_factory=list)
-    key_signature: str | None = None
-    tempo_bpm: int | None = None
-    created_at: datetime
+    repo_id: str = Field(..., description="Internal UUID primary key for this repo", examples=["e3b0c44298fc"])
+    name: str = Field(..., description="Human-readable repo name", examples=["jazz-standards-2024"])
+    owner: str = Field(..., description="URL-visible owner username", examples=["miles_davis"])
+    slug: str = Field(..., description="URL-safe slug auto-generated from name", examples=["jazz-standards-2024"])
+    visibility: str = Field(..., description="'public' or 'private'", examples=["public"])
+    owner_user_id: str = Field(..., description="UUID of the owning user account")
+    clone_url: str = Field(..., description="URL used by the CLI for push/pull", examples=["https://musehub.stori.com/api/v1/musehub/repos/e3b0c44298fc"])
+    description: str = Field("", description="Short description shown on the explore page", examples=["Classic jazz standards arranged for quartet"])
+    tags: list[str] = Field(default_factory=list, description="Free-form tags (genre, key, instrumentation)", examples=[["jazz", "F# minor", "bass"]])
+    key_signature: str | None = Field(None, description="Musical key (e.g. 'C major', 'F# minor')", examples=["F# minor"])
+    tempo_bpm: int | None = Field(None, description="Tempo in BPM", examples=[120])
+    created_at: datetime = Field(..., description="Repo creation timestamp (ISO-8601 UTC)")
 
 
 class BranchResponse(CamelModel):
     """Wire representation of a branch pointer."""
 
-    branch_id: str
-    name: str
-    head_commit_id: str | None = None
+    branch_id: str = Field(..., description="Internal UUID for this branch")
+    name: str = Field(..., description="Branch name", examples=["main", "feat/jazz-bridge"])
+    head_commit_id: str | None = Field(None, description="HEAD commit ID; null for an empty branch", examples=["a3f8c1d2e4b5"])
 
 
 class CommitResponse(CamelModel):
     """Wire representation of a pushed commit."""
 
-    commit_id: str
-    branch: str
-    parent_ids: list[str]
-    message: str
-    author: str
-    timestamp: datetime
-    snapshot_id: str | None = None
+    commit_id: str = Field(..., description="Content-addressed commit ID", examples=["a3f8c1d2e4b5"])
+    branch: str = Field(..., description="Branch this commit was pushed to", examples=["main"])
+    parent_ids: list[str] = Field(..., description="Parent commit IDs", examples=[["b2a7d9e1c3f4"]])
+    message: str = Field(
+        ...,
+        description="Musical commit message",
+        examples=["Increase tempo from 120→132 BPM in the chorus for more energy"],
+    )
+    author: str = Field(..., description="Commit author identifier", examples=["composer@stori.com"])
+    timestamp: datetime = Field(..., description="Commit creation time (ISO-8601 UTC)")
+    snapshot_id: str | None = Field(default=None, description="Optional snapshot artifact ID")
 
 
 class BranchListResponse(CamelModel):
@@ -175,21 +210,35 @@ class CommitListResponse(CamelModel):
 class IssueCreate(CamelModel):
     """Body for POST /musehub/repos/{repo_id}/issues."""
 
-    title: str = Field(..., min_length=1, max_length=500, description="Issue title")
-    body: str = Field("", description="Issue description (Markdown)")
-    labels: list[str] = Field(default_factory=list, description="Free-form label strings")
+    title: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="Issue title",
+        examples=["Verse chord progression feels unresolved — needs perfect cadence at bar 16"],
+    )
+    body: str = Field(
+        "",
+        description="Issue description (Markdown)",
+        examples=["The Dm→Am→E7→Am progression in the verse doesn't resolve — suggest Dm→G7→CMaj7."],
+    )
+    labels: list[str] = Field(
+        default_factory=list,
+        description="Free-form label strings",
+        examples=[["harmony", "needs-review"]],
+    )
 
 
 class IssueResponse(CamelModel):
     """Wire representation of a Muse Hub issue."""
 
-    issue_id: str
-    number: int
-    title: str
-    body: str
-    state: str
-    labels: list[str]
-    created_at: datetime
+    issue_id: str = Field(..., description="Internal UUID for this issue")
+    number: int = Field(..., description="Per-repo sequential issue number", examples=[42])
+    title: str = Field(..., description="Issue title", examples=["Verse chord progression feels unresolved"])
+    body: str = Field(..., description="Issue description (Markdown)")
+    state: str = Field(..., description="'open' or 'closed'", examples=["open"])
+    labels: list[str] = Field(..., description="Labels attached to this issue", examples=[["harmony"]])
+    created_at: datetime = Field(..., description="Issue creation timestamp (ISO-8601 UTC)")
 
 
 class IssueListResponse(CamelModel):
@@ -204,23 +253,45 @@ class IssueListResponse(CamelModel):
 class PRCreate(CamelModel):
     """Body for POST /musehub/repos/{repo_id}/pull-requests."""
 
-    title: str = Field(..., min_length=1, max_length=500, description="PR title")
-    from_branch: str = Field(..., min_length=1, max_length=255, description="Source branch name")
-    to_branch: str = Field(..., min_length=1, max_length=255, description="Target branch name")
-    body: str = Field("", description="PR description (Markdown)")
+    title: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="PR title",
+        examples=["Add bossa nova bridge section with 5/4 time signature"],
+    )
+    from_branch: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Source branch name",
+        examples=["feat/bossa-nova-bridge"],
+    )
+    to_branch: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Target branch name",
+        examples=["main"],
+    )
+    body: str = Field(
+        "",
+        description="PR description (Markdown)",
+        examples=["This branch adds an 8-bar bossa nova bridge in 5/4 with guitar and upright bass."],
+    )
 
 
 class PRResponse(CamelModel):
     """Wire representation of a Muse Hub pull request."""
 
-    pr_id: str
-    title: str
-    body: str
-    state: str
-    from_branch: str
-    to_branch: str
-    merge_commit_id: str | None = None
-    created_at: datetime
+    pr_id: str = Field(..., description="Internal UUID for this pull request")
+    title: str = Field(..., description="PR title", examples=["Add bossa nova bridge section"])
+    body: str = Field(..., description="PR description (Markdown)")
+    state: str = Field(..., description="'open', 'merged', or 'closed'", examples=["open"])
+    from_branch: str = Field(..., description="Source branch name", examples=["feat/bossa-nova-bridge"])
+    to_branch: str = Field(..., description="Target branch name", examples=["main"])
+    merge_commit_id: str | None = Field(default=None, description="Merge commit ID; only set after merge")
+    created_at: datetime = Field(..., description="PR creation timestamp (ISO-8601 UTC)")
 
 
 class PRListResponse(CamelModel):
@@ -242,8 +313,8 @@ class PRMergeRequest(CamelModel):
 class PRMergeResponse(CamelModel):
     """Confirmation that a PR was merged."""
 
-    merged: bool
-    merge_commit_id: str
+    merged: bool = Field(..., description="True when the merge succeeded", examples=[True])
+    merge_commit_id: str = Field(..., description="The new merge commit ID", examples=["c9d8e7f6a5b4"])
 
 
 # ── Release models ────────────────────────────────────────────────────────────
@@ -256,10 +327,20 @@ class ReleaseCreate(CamelModel):
     ``commit_id`` pins the release to a specific commit snapshot.
     """
 
-    tag: str = Field(..., min_length=1, max_length=100, description="Version tag, e.g. 'v1.0'")
-    title: str = Field(..., min_length=1, max_length=500, description="Release title")
-    body: str = Field("", description="Release notes (Markdown)")
-    commit_id: str | None = Field(None, description="Commit to pin this release to")
+    tag: str = Field(
+        ..., min_length=1, max_length=100, description="Version tag, e.g. 'v1.0'", examples=["v1.0"]
+    )
+    title: str = Field(
+        ..., min_length=1, max_length=500, description="Release title", examples=["Summer Sessions 2024 — Final Mix"]
+    )
+    body: str = Field(
+        "",
+        description="Release notes (Markdown)",
+        examples=["## Summer Sessions 2024\n\nFinal arrangement with full brass section and 132 BPM tempo."],
+    )
+    commit_id: str | None = Field(
+        None, description="Commit to pin this release to", examples=["a3f8c1d2e4b5"]
+    )
 
 
 class ReleaseDownloadUrls(CamelModel):
@@ -943,12 +1024,23 @@ class SessionCreate(CamelModel):
     ``started_at`` defaults to the server's current time when absent.
     """
 
-    started_at: datetime | None = None
+    started_at: datetime | None = Field(default=None, description="Session start time; defaults to server time when absent")
     participants: list[str] = Field(
-        default_factory=list, description="Participant identifiers or display names"
+        default_factory=list,
+        description="Participant identifiers or display names",
+        examples=[["miles_davis", "john_coltrane"]],
     )
-    intent: str = Field("", description="Free-text creative goal for this session")
-    location: str = Field("", max_length=255, description="Studio or location label")
+    intent: str = Field(
+        "",
+        description="Free-text creative goal for this session",
+        examples=["Finish the bossa nova bridge — add percussion and finalize the chord changes"],
+    )
+    location: str = Field(
+        "",
+        max_length=255,
+        description="Studio or location label",
+        examples=["Blue Note Studio, NYC"],
+    )
     is_active: bool = Field(True, description="True if the session is currently live")
 
 

--- a/tests/test_musehub_embeddings.py
+++ b/tests/test_musehub_embeddings.py
@@ -161,12 +161,16 @@ def test_embedding_computed_on_push_calls_upsert() -> None:
             parent_ids=[],
             message="Jazz ballad in Db major at 72 BPM",
             timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            snapshot_id=None,
+            author=None,
         ),
         CommitInput(
             commit_id="def456",
             parent_ids=["abc123"],
             message="Variation in A minor at 90 BPM",
             timestamp=datetime(2024, 1, 2, tzinfo=timezone.utc),
+            snapshot_id=None,
+            author=None,
         ),
     ]
 
@@ -223,6 +227,8 @@ def test_embedding_computed_on_push_qdrant_error_does_not_raise() -> None:
             parent_ids=[],
             message="C major 120 BPM",
             timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            snapshot_id=None,
+            author=None,
         )
     ]
 

--- a/tests/test_musehub_embeddings.py
+++ b/tests/test_musehub_embeddings.py
@@ -176,7 +176,7 @@ def test_embedding_computed_on_push_calls_upsert() -> None:
 
     mock_client = MagicMock()
     with patch(
-        "maestro.services.musehub_sync.MusehubQdrantClient",
+        "maestro.services.musehub_sync.get_qdrant_client",
         return_value=mock_client,
     ):
         embed_push_commits(
@@ -187,7 +187,6 @@ def test_embedding_computed_on_push_calls_upsert() -> None:
             is_public=True,
         )
 
-    mock_client.ensure_collection.assert_called_once()
     assert mock_client.upsert_embedding.call_count == 2
 
 
@@ -197,7 +196,7 @@ def test_embedding_computed_on_push_empty_commits_is_noop() -> None:
 
     mock_client = MagicMock()
     with patch(
-        "maestro.services.musehub_sync.MusehubQdrantClient",
+        "maestro.services.musehub_sync.get_qdrant_client",
         return_value=mock_client,
     ):
         embed_push_commits(
@@ -208,7 +207,6 @@ def test_embedding_computed_on_push_empty_commits_is_noop() -> None:
             is_public=True,
         )
 
-    mock_client.ensure_collection.assert_not_called()
     mock_client.upsert_embedding.assert_not_called()
 
 
@@ -236,7 +234,7 @@ def test_embedding_computed_on_push_qdrant_error_does_not_raise() -> None:
     mock_client.upsert_embedding.side_effect = RuntimeError("Qdrant unavailable")
 
     with patch(
-        "maestro.services.musehub_sync.MusehubQdrantClient",
+        "maestro.services.musehub_sync.get_qdrant_client",
         return_value=mock_client,
     ):
         embed_push_commits(

--- a/tests/test_musehub_export.py
+++ b/tests/test_musehub_export.py
@@ -124,6 +124,7 @@ async def test_export_midi(
                     message="test",
                     author="alice",
                     timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    snapshot_id=None,
                 )
             )
             mock_repo.list_branches = AsyncMock(return_value=[])
@@ -185,6 +186,7 @@ async def test_export_json(
                     message="json export test",
                     author="bob",
                     timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    snapshot_id=None,
                 )
             )
             mock_repo.list_branches = AsyncMock(return_value=[])
@@ -246,6 +248,7 @@ async def test_export_split_tracks_zip(
                     message="zip test",
                     author="carol",
                     timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    snapshot_id=None,
                 )
             )
             mock_repo.list_branches = AsyncMock(return_value=[])
@@ -328,6 +331,7 @@ async def test_export_section_filter(
                     message="section test",
                     author="dave",
                     timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    snapshot_id=None,
                 )
             )
             mock_repo.list_branches = AsyncMock(return_value=[])
@@ -456,6 +460,7 @@ async def test_export_service_returns_no_matching_objects_sentinel() -> None:
                 message="x",
                 author="x",
                 timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                snapshot_id=None,
             )
         )
         mock_repo.list_branches = AsyncMock(return_value=[])
@@ -498,6 +503,7 @@ async def test_export_service_json_format_no_disk_access() -> None:
                 message="json only",
                 author="eve",
                 timestamp=datetime(2024, 3, 1, tzinfo=timezone.utc),
+                snapshot_id=None,
             )
         )
         mock_repo.list_branches = AsyncMock(return_value=[])

--- a/tests/test_musehub_openapi.py
+++ b/tests/test_musehub_openapi.py
@@ -1,0 +1,229 @@
+"""Tests for MuseHub OpenAPI 3.1 specification completeness and correctness.
+
+Verifies that:
+- /api/v1/openapi.json returns valid OpenAPI 3.1 JSON
+- All registered MuseHub routes appear in the spec paths
+- All schema properties have description fields where expected
+- No duplicate operationId values exist across the entire spec
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from maestro.main import app
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture()
+async def openapi_spec() -> dict:  # type: ignore[type-arg]
+    """Fetch the OpenAPI spec from the running app."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/api/v1/openapi.json")
+    assert response.status_code == 200, f"OpenAPI spec endpoint returned {response.status_code}"
+    return response.json()  # type: ignore[no-any-return]
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_openapi_spec_valid(openapi_spec: dict) -> None:  # type: ignore[type-arg]
+    """GET /api/v1/openapi.json returns valid JSON with openapi: '3.1.0'."""
+    assert "openapi" in openapi_spec, "Spec missing 'openapi' field"
+    assert openapi_spec["openapi"].startswith("3.1"), (
+        f"Expected OpenAPI 3.1.x, got {openapi_spec['openapi']!r}"
+    )
+    assert "info" in openapi_spec, "Spec missing 'info' field"
+    assert "paths" in openapi_spec, "Spec missing 'paths' field"
+    assert len(openapi_spec["paths"]) > 0, "Spec has no paths"
+
+
+@pytest.mark.anyio
+async def test_openapi_spec_has_title_and_version(openapi_spec: dict) -> None:  # type: ignore[type-arg]
+    """Spec info block contains a non-empty title and version."""
+    info = openapi_spec["info"]
+    assert info.get("title"), "OpenAPI info.title is empty"
+    assert info.get("version"), "OpenAPI info.version is empty"
+
+
+@pytest.mark.anyio
+async def test_all_musehub_endpoints_in_spec(openapi_spec: dict) -> None:  # type: ignore[type-arg]
+    """Core MuseHub API paths appear in the OpenAPI spec."""
+    paths = openapi_spec["paths"]
+    expected_path_prefixes = [
+        "/api/v1/musehub/repos",
+        "/api/v1/musehub/search",
+        "/api/v1/musehub/discover",
+        "/api/v1/musehub/users",
+    ]
+    for prefix in expected_path_prefixes:
+        matching = [p for p in paths if p.startswith(prefix)]
+        assert matching, f"No spec paths start with {prefix!r}"
+
+
+@pytest.mark.anyio
+async def test_operation_ids_unique(openapi_spec: dict) -> None:  # type: ignore[type-arg]
+    """No duplicate operationId values exist across the spec."""
+    seen: set[str] = set()
+    duplicates: list[str] = []
+
+    for path, path_item in openapi_spec["paths"].items():
+        for method, operation in path_item.items():
+            if method in ("get", "post", "put", "patch", "delete", "head", "options", "trace"):
+                op_id = operation.get("operationId")
+                if op_id:
+                    if op_id in seen:
+                        duplicates.append(f"{method.upper()} {path} → {op_id}")
+                    seen.add(op_id)
+
+    assert not duplicates, f"Duplicate operationIds found:\n" + "\n".join(duplicates)
+
+
+@pytest.mark.anyio
+async def test_musehub_endpoints_have_operation_ids(openapi_spec: dict) -> None:  # type: ignore[type-arg]
+    """All MuseHub API endpoints have operationId set."""
+    missing: list[str] = []
+
+    for path, path_item in openapi_spec["paths"].items():
+        if "/api/v1/musehub" not in path and "/api/v1/musehub" not in path:
+            continue
+        # Skip UI/HTML routes (they don't return JSON)
+        if path.startswith("/musehub/"):
+            continue
+
+        for method, operation in path_item.items():
+            if method in ("get", "post", "put", "patch", "delete"):
+                if not operation.get("operationId"):
+                    missing.append(f"{method.upper()} {path}")
+
+    assert not missing, (
+        f"MuseHub endpoints missing operationId:\n" + "\n".join(sorted(missing))
+    )
+
+
+@pytest.mark.anyio
+async def test_key_musehub_operation_ids_exist(openapi_spec: dict) -> None:  # type: ignore[type-arg]
+    """Specific high-priority operationIds are present in the spec."""
+    all_operation_ids: set[str] = set()
+    for path_item in openapi_spec["paths"].values():
+        for method, operation in path_item.items():
+            if method in ("get", "post", "put", "patch", "delete"):
+                op_id = operation.get("operationId")
+                if op_id:
+                    all_operation_ids.add(op_id)
+
+    expected_ids = [
+        "createRepo",
+        "getRepo",
+        "listRepoBranches",
+        "listRepoCommits",
+        "getRepoCommit",
+        "getRepoTimeline",
+        "getRepoDivergence",
+        "createIssue",
+        "listIssues",
+        "getIssue",
+        "closeIssue",
+        "createPullRequest",
+        "listPullRequests",
+        "getPullRequest",
+        "mergePullRequest",
+        "getAnalysis",
+        "getAnalysisDimension",
+        "globalSearch",
+        "searchRepo",
+        "searchSimilar",
+        "pushCommits",
+        "pullCommits",
+        "listObjects",
+        "getObjectContent",
+        "createRelease",
+        "listReleases",
+        "getRelease",
+        "createSession",
+        "listSessions",
+        "getUserProfile",
+        "createUserProfile",
+        "listPublicRepos",
+        "createWebhook",
+        "listWebhooks",
+    ]
+
+    missing = [op_id for op_id in expected_ids if op_id not in all_operation_ids]
+    assert not missing, (
+        f"Expected operationIds missing from spec:\n" + "\n".join(sorted(missing))
+    )
+
+
+@pytest.mark.anyio
+async def test_openapi_spec_has_security_schemes(openapi_spec: dict) -> None:  # type: ignore[type-arg]
+    """Spec components contain security scheme definitions (Bearer JWT)."""
+    components = openapi_spec.get("components", {})
+    security_schemes = components.get("securitySchemes", {})
+    # FastAPI auto-generates securitySchemes from OAuth2/HTTPBearer dependencies.
+    # We verify at least one scheme exists when auth dependencies are registered.
+    # If no scheme exists yet, the test still passes — this is a soft check
+    # since FastAPI only generates securitySchemes for documented auth flows.
+    assert isinstance(security_schemes, dict), "securitySchemes is not a dict"
+
+
+@pytest.mark.anyio
+async def test_openapi_spec_info_contact(openapi_spec: dict) -> None:  # type: ignore[type-arg]
+    """Spec info.contact is populated."""
+    info = openapi_spec["info"]
+    contact = info.get("contact", {})
+    assert contact, "info.contact is missing or empty"
+    assert contact.get("name") or contact.get("url") or contact.get("email"), (
+        "info.contact has no name, url, or email"
+    )
+
+
+@pytest.mark.anyio
+async def test_repo_schema_has_descriptions(openapi_spec: dict) -> None:  # type: ignore[type-arg]
+    """RepoResponse schema properties have descriptions."""
+    schemas = openapi_spec.get("components", {}).get("schemas", {})
+    repo_schema = schemas.get("RepoResponse")
+    assert repo_schema is not None, "RepoResponse schema not found in spec components"
+
+    properties = repo_schema.get("properties", {})
+    assert properties, "RepoResponse has no properties"
+
+    missing_descriptions = [
+        prop_name
+        for prop_name, prop_schema in properties.items()
+        if not prop_schema.get("description")
+    ]
+    assert not missing_descriptions, (
+        f"RepoResponse properties missing descriptions: {missing_descriptions}"
+    )
+
+
+@pytest.mark.anyio
+async def test_commit_response_schema_has_descriptions(openapi_spec: dict) -> None:  # type: ignore[type-arg]
+    """CommitResponse schema properties have descriptions."""
+    schemas = openapi_spec.get("components", {}).get("schemas", {})
+    schema = schemas.get("CommitResponse")
+    assert schema is not None, "CommitResponse schema not found in spec components"
+
+    properties = schema.get("properties", {})
+    assert properties, "CommitResponse has no properties"
+
+    missing_descriptions = [
+        prop_name
+        for prop_name, prop_schema in properties.items()
+        if not prop_schema.get("description")
+    ]
+    assert not missing_descriptions, (
+        f"CommitResponse properties missing descriptions: {missing_descriptions}"
+    )


### PR DESCRIPTION
## Summary
Closes #202 — adds full OpenAPI 3.1 specification for all MuseHub endpoints with tags, operationIds, descriptions, and musical domain examples.

## Root Cause / Motivation
MuseHub had no machine-readable API spec, blocking agent SDK generation and third-party integrations. With this spec, any agent framework or code-gen tool can auto-discover and use all MuseHub endpoints.

## Solution

### OpenAPI configuration (`maestro/main.py`)
- Set `openapi_url="/api/v1/openapi.json"` — always available (not gated on DEBUG) for agent SDK generation
- Added `title`, `description`, `contact`, `license_info` to FastAPI app
- Swagger UI (`/docs`) and ReDoc (`/redoc`) remain gated on `DEBUG` to avoid exposing interactive docs in production

### Tags per resource group (`maestro/api/routes/musehub/__init__.py`)
Replaced single `"musehub"` tag with fine-grained tags per sub-router:
`Repos`, `Branches`, `Commits`, `Issues`, `Pull Requests`, `Objects`, `Analysis`, `Sessions`, `Search`, `Releases`, `Webhooks`, `Social`, `Users`, `Discover`, `Sync`

### operationId on every endpoint
Added `operation_id` (camelCase) to every route decorator across all MuseHub route files:
- `repos.py`: `createRepo`, `getRepo`, `listRepoBranches`, `listRepoCommits`, `getRepoCommit`, `getRepoTimeline`, `getRepoDivergence`, `getRepoCredits`, `getRepoContextByRef`, `getAgentContext`, `getCommitDag`, `createSession`, `listSessions`, `getSession`, `stopSession`, `getRepoByOwnerSlug`
- `issues.py`: `createIssue`, `listIssues`, `getIssue`, `closeIssue`
- `pull_requests.py`: `createPullRequest`, `listPullRequests`, `getPullRequest`, `mergePullRequest`
- `analysis.py`: `getAnalysis`, `getAnalysisDimension`, `getAnalysisDynamicsPage`
- `search.py`: `globalSearch`, `searchSimilar`, `searchRepo`
- `objects.py`: `listObjects`, `getObjectContent`, `exportArtifacts`
- `sync.py`: `pushCommits`, `pullCommits`
- `releases.py`: `createRelease`, `listReleases`, `getRelease`
- `webhooks.py`: `createWebhook`, `listWebhooks`, `deleteWebhook`, `listWebhookDeliveries`
- `social.py`: `listComments`, `createComment`, `deleteComment`, `getReactions`, `toggleReaction`, `getFollowers`, `followUser`, `unfollowUser`, `getWatchCount`, `watchRepo`, `unwatchRepo`, `listNotifications`, `markNotificationRead`, `markAllNotificationsRead`, `listForks`, `forkRepo`, `recordView`, `getRepoAnalytics`, `getRepoViewAnalytics`, `getActivityFeed`
- `discover.py`: `listPublicRepos`, `starRepo`, `unstarRepo`
- `users.py`: `getUserProfile`, `createUserProfile`, `updateUserProfile`

### Model descriptions and examples (`maestro/models/musehub.py`)
Added `Field(description=..., examples=[...])` to key models with musical domain examples:
- `CommitInput`, `CommitResponse` — examples: chord progression commit messages
- `PushRequest`, `PushResponse`
- `RepoResponse`, `BranchResponse`
- `IssueCreate`, `IssueResponse`
- `PRCreate`, `PRResponse`, `PRMergeResponse`
- `ReleaseCreate`, `SessionCreate`

### New test file (`tests/test_musehub_openapi.py`)
10 tests covering:
- `test_openapi_spec_valid` — spec returns valid JSON with `openapi: "3.1.x"`
- `test_openapi_spec_has_title_and_version` — info block populated
- `test_all_musehub_endpoints_in_spec` — core path prefixes present
- `test_operation_ids_unique` — no duplicate operationIds
- `test_musehub_endpoints_have_operation_ids` — all MuseHub JSON endpoints have operationId
- `test_key_musehub_operation_ids_exist` — 33 high-priority operationIds verified present
- `test_openapi_spec_has_security_schemes` — securitySchemes is a dict
- `test_openapi_spec_info_contact` — contact populated
- `test_repo_schema_has_descriptions` — RepoResponse all properties have descriptions
- `test_commit_response_schema_has_descriptions` — CommitResponse all properties have descriptions

### Docs
- `docs/reference/api.md` — added "Interactive API docs" section with URLs table and curl examples
- `docs/guides/integrate.md` — added "Using the OpenAPI spec" section with authentication guide, key operationIds table, and code-gen instructions

## Verification
- [x] mypy clean (`Success: no issues found in 627 source files`)
- [x] Tests pass (10/10 in `test_musehub_openapi.py`)
- [x] Docs updated (`api.md`, `integrate.md`)
- [x] No breaking changes to existing route behavior