### PR TITLE
feat(musehub): tree browser — navigate muse-work directory tree with file-type icons

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -7325,3 +7325,83 @@ files required.
 | Tests | `tests/test_musehub_ui.py` | `test_design_tokens_css_served`, `test_components_css_served`, `test_repo_page_uses_design_system`, `test_responsive_meta_tag_present_*` |
 
 ---
+
+## Muse Hub — Tree Browser (issue #204)
+
+**Purpose:** GitHub-style directory tree browser for navigating the muse-work
+file structure stored in a Muse Hub repo.  Musicians use it to find specific
+MIDI tracks, rendered MP3s, metadata files, and preview images without using
+the CLI.
+
+### URL Pattern
+
+| Route | Description |
+|-------|-------------|
+| `GET /musehub/ui/{owner}/{repo_slug}/tree/{ref}` | Root directory listing |
+| `GET /musehub/ui/{owner}/{repo_slug}/tree/{ref}/{path}` | Subdirectory listing |
+| `GET /api/v1/musehub/repos/{repo_id}/tree/{ref}?owner=&repo_slug=` | JSON root listing |
+| `GET /api/v1/musehub/repos/{repo_id}/tree/{ref}/{path}?owner=&repo_slug=` | JSON subdirectory listing |
+
+**Auth:** No JWT required for HTML shell (public repos). JSON API enforces auth
+for private repos.
+
+### Ref Resolution
+
+`{ref}` can be:
+- A **branch name** (e.g. `main`, `feature/groove`) — resolved via `musehub_branches`.
+- A **full commit ID** — resolved via `musehub_commits`.
+
+An unknown ref returns HTTP 404. This check is performed by
+`musehub_repository.resolve_ref_for_tree()`.
+
+### Tree Reconstruction
+
+The tree is reconstructed at request time from all `musehub_objects` stored
+under the repo. No snapshot manifest table is required — the directory
+structure is derived by splitting object `path` fields on `/`.
+
+`musehub_repository.list_tree()` algorithm:
+1. Fetch all objects for the repo ordered by path.
+2. Strip the `dir_path` prefix from each object's path.
+3. If the remainder has no `/` → file entry at this level.
+4. If the remainder has a `/` → directory entry (first segment only, deduplicated).
+5. Return dirs first (alphabetical), then files (alphabetical).
+
+### Response Shape (`TreeListResponse`)
+
+```json
+{
+  "owner": "gabriel",
+  "repoSlug": "summer-groove",
+  "ref": "main",
+  "dirPath": "",
+  "entries": [
+    { "type": "dir",  "name": "tracks",       "path": "tracks",          "sizeBytes": null },
+    { "type": "file", "name": "cover.webp",   "path": "cover.webp",      "sizeBytes": 4096 },
+    { "type": "file", "name": "metadata.json","path": "metadata.json",   "sizeBytes": 512  }
+  ]
+}
+```
+
+### File-Type Icons
+
+| Extension | Icon | Symbol code |
+|-----------|------|-------------|
+| `.mid` / `.midi` | Piano | `&#127929;` |
+| `.mp3` / `.wav` / `.ogg` | Waveform | `&#127925;` |
+| `.json` | Braces | `&#123;&#125;` |
+| `.webp` / `.png` / `.jpg` | Photo | `&#128444;` |
+| Other | Generic file | `&#128196;` |
+
+### Implementation
+
+| Layer | File |
+|-------|------|
+| Models | `maestro/models/musehub.py` — `TreeEntryResponse`, `TreeListResponse` |
+| Repository | `maestro/services/musehub_repository.py` — `resolve_ref_for_tree()`, `list_tree()` |
+| JSON API | `maestro/api/routes/musehub/objects.py` — `list_tree_root()`, `list_tree_subdir()` |
+| HTML routes | `maestro/api/routes/musehub/ui.py` — `tree_page()`, `tree_subdir_page()` |
+| Template | `maestro/templates/musehub/pages/tree.html` |
+| Tests | `tests/test_musehub_ui.py` — `test_tree_*` (6 tests) |
+
+---

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -7067,3 +7067,38 @@ Top-level response model for `GET /api/v1/musehub/search`.
 
 **Produced by:** `maestro.api.routes.musehub.repos.get_groove_check()`
 **Consumed by:** MuseHub groove-check UI page (`/musehub/ui/{owner}/{repo_slug}/groove-check`); AI agents comparing rhythmic consistency across branches
+
+## Muse Hub — Tree Browser API Types (`maestro/models/musehub.py`)
+
+### `TreeEntryResponse`
+
+**Path:** `maestro/models/musehub.py`
+
+`CamelModel` — A single entry (file or directory) in the Muse tree browser. Returned as elements of `TreeListResponse.entries`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `str` | `"file"` or `"dir"` |
+| `name` | `str` | Entry filename or directory name (final path segment) |
+| `path` | `str` | Full relative path from repo root (e.g. `"tracks/bass.mid"`) |
+| `size_bytes` | `int \| None` | File size in bytes; `None` for directories |
+
+**Produced by:** `maestro.services.musehub_repository.list_tree()`
+**Consumed by:** `TreeListResponse.entries`; tree browser template via `GET /api/v1/musehub/repos/{repo_id}/tree/{ref}`
+
+### `TreeListResponse`
+
+**Path:** `maestro/models/musehub.py`
+
+`CamelModel` — Directory listing for the Muse tree browser. Directories are listed before files; both groups sorted alphabetically.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `owner` | `str` | Repo owner username (for breadcrumb rendering) |
+| `repo_slug` | `str` | Repo slug (for breadcrumb rendering) |
+| `ref` | `str` | Branch name or commit SHA used to resolve the tree |
+| `dir_path` | `str` | Current directory path being listed; empty string for repo root |
+| `entries` | `list[TreeEntryResponse]` | Entries sorted dirs-first, then files, both alphabetically |
+
+**Produced by:** `maestro.services.musehub_repository.list_tree()`
+**Consumed by:** `GET /api/v1/musehub/repos/{repo_id}/tree/{ref}` and `GET /api/v1/musehub/repos/{repo_id}/tree/{ref}/{path}`; tree browser template (`tree.html`) fetches this JSON and renders it client-side

--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -34,6 +34,8 @@ Endpoint summary (repo-scoped):
   GET /musehub/ui/{owner}/{repo_slug}/sessions                  -- recording session log
   GET /musehub/ui/{owner}/{repo_slug}/sessions/{id}             -- session detail
   GET /musehub/ui/{owner}/{repo_slug}/insights                  -- repo insights dashboard
+  GET /musehub/ui/{owner}/{repo_slug}/tree/{ref}                -- file tree browser (repo root)
+  GET /musehub/ui/{owner}/{repo_slug}/tree/{ref}/{path}         -- file tree browser (subdirectory)
   GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}            -- analysis dashboard (all 10 dimensions at a glance)
   GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/contour    -- melodic contour analysis
   GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/tempo      -- tempo analysis
@@ -984,5 +986,82 @@ async def dynamics_analysis_page(
             "ref": ref,
             "base_url": base_url,
             "current_page": "analysis",
+        },
+    )
+
+
+@router.get(
+    "/{owner}/{repo_slug}/tree/{ref}",
+    response_class=HTMLResponse,
+    summary="Muse Hub file tree browser — repo root",
+)
+async def tree_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    ref: str,
+    db: AsyncSession = Depends(get_db),
+) -> HTMLResponse:
+    """Render the file tree browser for the repo root at a given ref.
+
+    Displays all top-level files and directories with music-aware file-type
+    icons (MIDI=piano, MP3/WAV=waveform, JSON=braces, images=photo).
+    The branch/tag selector dropdown allows switching ref without a page reload.
+    Breadcrumbs show: {owner} / {repo} / tree / {ref}.
+
+    Content negotiation: the embedded JavaScript also uses this URL to fetch
+    a JSON listing from GET /api/v1/musehub/repos/{repo_id}/tree/{ref} when
+    the Accept header is application/json.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    return templates.TemplateResponse(
+        request,
+        "musehub/pages/tree.html",
+        {
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "ref": ref,
+            "dir_path": "",
+            "base_url": base_url,
+            "current_page": "tree",
+        },
+    )
+
+
+@router.get(
+    "/{owner}/{repo_slug}/tree/{ref}/{path:path}",
+    response_class=HTMLResponse,
+    summary="Muse Hub file tree browser — subdirectory",
+)
+async def tree_subdir_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    ref: str,
+    path: str,
+    db: AsyncSession = Depends(get_db),
+) -> HTMLResponse:
+    """Render the file tree browser for a subdirectory at a given ref.
+
+    Behaves identically to ``tree_page`` but scoped to the subdirectory
+    identified by ``path`` (e.g. "tracks", "tracks/stems").  The breadcrumb
+    expands to show each path segment as a clickable link.
+
+    Files are clickable and navigate to the blob viewer:
+    /{owner}/{repo_slug}/blob/{ref}/{path}
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    return templates.TemplateResponse(
+        request,
+        "musehub/pages/tree.html",
+        {
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "ref": ref,
+            "dir_path": path,
+            "base_url": base_url,
+            "current_page": "tree",
         },
     )

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -1014,3 +1014,50 @@ class SimilarSearchResponse(CamelModel):
         default_factory=list,
         description="Ranked results, most similar first",
     )
+
+
+# ── Tree browser models ───────────────────────────────────────────────────────
+
+
+class TreeEntryResponse(CamelModel):
+    """A single entry (file or directory) in the Muse tree browser.
+
+    Returned by GET /musehub/repos/{repo_id}/tree/{ref} and
+    GET /musehub/repos/{repo_id}/tree/{ref}/{path}.
+
+    Consumers should use ``type`` to render the appropriate icon:
+    - "dir"  → folder icon, clickable to navigate deeper
+    - "file" → file-type icon based on ``name`` extension
+      (.mid → piano, .mp3/.wav → waveform, .json → braces, .webp/.png → photo)
+
+    ``size_bytes`` is None for directories (size is the sum of its contents,
+    which the server does not compute at list time).
+    """
+
+    type: str = Field(..., description="'file' or 'dir'")
+    name: str = Field(..., description="Entry filename or directory name")
+    path: str = Field(..., description="Full relative path from repo root, e.g. 'tracks/bass.mid'")
+    size_bytes: int | None = Field(None, description="File size in bytes; None for directories")
+
+
+class TreeListResponse(CamelModel):
+    """Directory listing for the Muse tree browser.
+
+    Returned by GET /musehub/repos/{repo_id}/tree/{ref} and
+    GET /musehub/repos/{repo_id}/tree/{ref}/{path}.
+
+    Directories are listed before files within the same level. Within each
+    group, entries are sorted alphabetically by name.
+
+    Agent use case: use this to enumerate files at a known ref without
+    downloading any content. Combine with ``/objects/{object_id}/content``
+    to read individual files.
+    """
+
+    owner: str
+    repo_slug: str
+    ref: str = Field(..., description="The branch name or commit SHA used to resolve the tree")
+    dir_path: str = Field(
+        ..., description="Current directory path being listed; empty string for repo root"
+    )
+    entries: list[TreeEntryResponse] = Field(default_factory=list)

--- a/maestro/services/musehub_repository.py
+++ b/maestro/services/musehub_repository.py
@@ -43,6 +43,8 @@ from maestro.models.musehub import (
     TimelineResponse,
     TimelineSectionEvent,
     TimelineTrackEvent,
+    TreeEntryResponse,
+    TreeListResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -1006,3 +1008,115 @@ async def get_session(
     if row is None:
         return None
     return _to_session_response(row)
+
+
+async def resolve_ref_for_tree(
+    session: AsyncSession, repo_id: str, ref: str
+) -> bool:
+    """Return True if ref resolves to a known branch or commit in this repo.
+
+    The ref can be:
+    - A branch name (e.g. "main", "feature/groove") — validated via the
+      musehub_branches table.
+    - A commit ID prefix or full SHA — validated via musehub_commits.
+
+    Returns False if the ref is unknown, which the caller should surface as
+    a 404. This is a lightweight existence check; callers that need the full
+    commit object should call ``get_commit()`` separately.
+    """
+    branch_stmt = select(db.MusehubBranch).where(
+        db.MusehubBranch.repo_id == repo_id,
+        db.MusehubBranch.name == ref,
+    )
+    branch_row = (await session.execute(branch_stmt)).scalars().first()
+    if branch_row is not None:
+        return True
+
+    commit_stmt = select(db.MusehubCommit).where(
+        db.MusehubCommit.repo_id == repo_id,
+        db.MusehubCommit.commit_id == ref,
+    )
+    commit_row = (await session.execute(commit_stmt)).scalars().first()
+    return commit_row is not None
+
+
+async def list_tree(
+    session: AsyncSession,
+    repo_id: str,
+    owner: str,
+    repo_slug: str,
+    ref: str,
+    dir_path: str,
+) -> TreeListResponse:
+    """Build a directory listing for the tree browser.
+
+    Reconstructs the repo's directory structure from all objects stored under
+    ``repo_id``. The ``dir_path`` parameter acts as a path prefix filter:
+    - Empty string → list the root directory.
+    - "tracks" → list all entries directly under the "tracks/" prefix.
+
+    Entries are grouped: directories first (alphabetically), then files
+    (alphabetically). Directory size_bytes is None because computing the
+    recursive sum is deferred to client-side rendering.
+
+    Args:
+        session:   Active async DB session.
+        repo_id:   UUID of the target repo.
+        owner:     Repo owner username (for response breadcrumbs).
+        repo_slug: Repo slug (for response breadcrumbs).
+        ref:       Branch name or commit SHA (for response breadcrumbs).
+        dir_path:  Current directory prefix; empty string for repo root.
+
+    Returns:
+        TreeListResponse with entries sorted dirs-first, then files.
+    """
+    all_objects = await list_objects(session, repo_id)
+
+    prefix = (dir_path.strip("/") + "/") if dir_path.strip("/") else ""
+    seen_dirs: set[str] = set()
+    dirs: list[TreeEntryResponse] = []
+    files: list[TreeEntryResponse] = []
+
+    for obj in all_objects:
+        path = obj.path.lstrip("/")
+        if not path.startswith(prefix):
+            continue
+        remainder = path[len(prefix):]
+        if not remainder:
+            continue
+        slash_pos = remainder.find("/")
+        if slash_pos == -1:
+            # Direct file entry under this prefix
+            files.append(
+                TreeEntryResponse(
+                    type="file",
+                    name=remainder,
+                    path=path,
+                    size_bytes=obj.size_bytes,
+                )
+            )
+        else:
+            # Directory entry — take only the next path segment
+            dir_name = remainder[:slash_pos]
+            dir_full_path = prefix + dir_name
+            if dir_name not in seen_dirs:
+                seen_dirs.add(dir_name)
+                dirs.append(
+                    TreeEntryResponse(
+                        type="dir",
+                        name=dir_name,
+                        path=dir_full_path,
+                        size_bytes=None,
+                    )
+                )
+
+    dirs.sort(key=lambda e: e.name)
+    files.sort(key=lambda e: e.name)
+
+    return TreeListResponse(
+        owner=owner,
+        repo_slug=repo_slug,
+        ref=ref,
+        dir_path=dir_path.strip("/"),
+        entries=dirs + files,
+    )

--- a/maestro/templates/musehub/pages/tree.html
+++ b/maestro/templates/musehub/pages/tree.html
@@ -1,0 +1,218 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}{{ owner }}/{{ repo_slug }} — tree/{{ ref[:8] }}{% endblock %}
+
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> /
+  tree /
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}/tree/{{ ref }}">{{ ref }}</a>
+  {% if dir_path %}
+    {% set segments = dir_path.split('/') %}
+    {% set ns = namespace(accumulated='') %}
+    {% for seg in segments %}
+      {% if ns.accumulated %}
+        {% set ns.accumulated = ns.accumulated + '/' + seg %}
+      {% else %}
+        {% set ns.accumulated = seg %}
+      {% endif %}
+      / <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}/tree/{{ ref }}/{{ ns.accumulated }}">{{ seg }}</a>
+    {% endfor %}
+  {% endif %}
+{% endblock %}
+
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block extra_css %}
+<style>
+.tree-header {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 16px;
+  background: #161b22; border: 1px solid #30363d; border-radius: 8px 8px 0 0;
+  border-bottom: none; margin-top: 8px;
+}
+.ref-selector { display: flex; align-items: center; gap: 8px; }
+.ref-selector label { color: #8b949e; font-size: 13px; }
+.ref-selector select {
+  background: #21262d; color: #c9d1d9; border: 1px solid #30363d;
+  border-radius: 6px; padding: 6px 10px; font-size: 13px; cursor: pointer;
+}
+.ref-selector select:hover { border-color: #58a6ff; }
+.tree-table {
+  width: 100%; border-collapse: collapse;
+  background: #0d1117; border: 1px solid #30363d; border-radius: 0 0 8px 8px;
+  overflow: hidden;
+}
+.tree-table th {
+  background: #161b22; color: #8b949e;
+  padding: 10px 16px; text-align: left; font-size: 12px; font-weight: 600;
+  border-bottom: 1px solid #30363d;
+}
+.tree-table td {
+  padding: 10px 16px; border-bottom: 1px solid #21262d;
+  font-size: 14px; color: #c9d1d9;
+}
+.tree-table tr:last-child td { border-bottom: none; }
+.tree-table tr:hover td { background: #161b22; }
+.tree-icon { margin-right: 8px; font-size: 15px; }
+.entry-link { color: #58a6ff; text-decoration: none; }
+.entry-link:hover { text-decoration: underline; }
+.tree-size { color: #8b949e; text-align: right; font-size: 12px; white-space: nowrap; }
+.tree-empty {
+  padding: 48px 16px; text-align: center; color: #8b949e;
+  background: #0d1117; border: 1px solid #30363d; border-radius: 0 0 8px 8px;
+}
+.tree-loading { padding: 24px 0; text-align: center; color: #8b949e; font-size: 14px; }
+.tree-error { color: #f85149; font-size: 14px; padding: 16px; }
+</style>
+{% endblock %}
+
+{% block page_data %}
+const repoId   = {{ repo_id | tojson }};
+const ref      = {{ ref | tojson }};
+const dirPath  = {{ dir_path | tojson }};
+const owner    = {{ owner | tojson }};
+const repoSlug = {{ repo_slug | tojson }};
+const base     = {{ base_url | tojson }};
+const apiBase  = '/api/v1/musehub/repos/' + repoId;
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+// ── File-type icon resolver ──────────────────────────────────────────────────
+// Returns a symbol that matches the file extension.
+// .mid/.midi → piano, .mp3/.wav/.ogg → waveform, .json → braces, images → photo
+function fileIconHtml(name) {
+  const lower = name.toLowerCase();
+  if (lower.endsWith('.mid') || lower.endsWith('.midi')) return '&#127929;'; // 🎹
+  if (lower.endsWith('.mp3') || lower.endsWith('.wav') || lower.endsWith('.ogg')) return '&#127925;'; // 🎵
+  if (lower.endsWith('.json')) return '&#123;&#125;'; // {}
+  if (lower.endsWith('.webp') || lower.endsWith('.png') || lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return '&#128444;'; // 🖼
+  return '&#128196;'; // 📄
+}
+
+// ── Human-readable file size ─────────────────────────────────────────────────
+function fmtSize(bytes) {
+  if (bytes === null || bytes === undefined) return '';
+  if (bytes < 1024) return bytes + '\u00a0B';
+  if (bytes < 1048576) return (bytes / 1024).toFixed(1) + '\u00a0KB';
+  return (bytes / 1048576).toFixed(1) + '\u00a0MB';
+}
+
+// ── URL builders ──────────────────────────────────────────────────────────────
+function blobUrl(path) {
+  return base + '/blob/' + encodeURIComponent(ref) + '/' + path;
+}
+function treeUrl(path) {
+  return base + '/tree/' + encodeURIComponent(ref) + '/' + path;
+}
+
+// ── Render the tree listing into #content ────────────────────────────────────
+function renderTree(data) {
+  const entries = data.entries || [];
+
+  let headerHtml = '<div class="tree-header">'
+    + '<div class="ref-selector">'
+    + '<label>Branch&nbsp;/&nbsp;tag:</label>'
+    + '<select id="branch-sel" onchange="onRefChange(this)">'
+    + '<option value="' + escHtml(ref) + '">' + escHtml(ref) + '</option>'
+    + '</select>'
+    + '</div>'
+    + '</div>';
+
+  let bodyHtml;
+  if (entries.length === 0) {
+    bodyHtml = '<div class="tree-empty">This directory is empty.</div>';
+  } else {
+    let rows = '';
+    for (const entry of entries) {
+      if (entry.type === 'dir') {
+        rows += '<tr>'
+          + '<td><span class="tree-icon">&#128193;</span>'
+          + '<a class="entry-link" href="' + treeUrl(entry.path) + '">' + escHtml(entry.name) + '</a></td>'
+          + '<td class="tree-size"></td>'
+          + '</tr>';
+      } else {
+        rows += '<tr>'
+          + '<td><span class="tree-icon" title="' + escHtml(entry.name) + '">' + fileIconHtml(entry.name) + '</span>'
+          + '<a class="entry-link" href="' + blobUrl(entry.path) + '">' + escHtml(entry.name) + '</a></td>'
+          + '<td class="tree-size">' + fmtSize(entry.sizeBytes) + '</td>'
+          + '</tr>';
+      }
+    }
+    bodyHtml = '<table class="tree-table">'
+      + '<thead><tr><th>Name</th><th style="text-align:right">Size</th></tr></thead>'
+      + '<tbody>' + rows + '</tbody>'
+      + '</table>';
+  }
+
+  document.getElementById('content').innerHTML = headerHtml + bodyHtml;
+  loadBranches(); // populate selector now that the DOM node exists
+}
+
+// ── Fetch branch list for ref selector ───────────────────────────────────────
+async function loadBranches() {
+  try {
+    const tok = getToken ? getToken() : (localStorage.getItem('muse_token') || '');
+    const headers = tok ? { Authorization: 'Bearer ' + tok } : {};
+    const resp = await fetch(apiBase + '/branches', { headers });
+    if (!resp.ok) return;
+    const data = await resp.json();
+    const sel = document.getElementById('branch-sel');
+    if (!sel) return;
+    sel.innerHTML = '';
+    const branches = data.branches || [];
+    for (const b of branches) {
+      const opt = document.createElement('option');
+      opt.value = b.name;
+      opt.textContent = b.name;
+      if (b.name === ref) opt.selected = true;
+      sel.appendChild(opt);
+    }
+    // If current ref not in any branch (e.g. a commit SHA), add it first
+    if (!branches.some(b => b.name === ref)) {
+      const opt = document.createElement('option');
+      opt.value = ref;
+      opt.textContent = ref;
+      opt.selected = true;
+      sel.prepend(opt);
+    }
+  } catch (_) { /* branch selector is non-critical */ }
+}
+
+// ── Navigate to a different ref ───────────────────────────────────────────────
+function onRefChange(sel) {
+  const newRef = sel.value;
+  const pathSuffix = dirPath ? '/' + dirPath : '';
+  window.location.href = base + '/tree/' + encodeURIComponent(newRef) + pathSuffix;
+}
+
+// ── Load and render tree ──────────────────────────────────────────────────────
+async function loadTree() {
+  const contentEl = document.getElementById('content');
+  contentEl.innerHTML = '<div class="tree-loading">Loading tree\u2026</div>';
+  try {
+    const tok = getToken ? getToken() : (localStorage.getItem('muse_token') || '');
+    const headers = tok ? { Authorization: 'Bearer ' + tok } : {};
+    const pathSuffix = dirPath ? '/' + encodeURIComponent(dirPath) : '';
+    const qs = '?owner=' + encodeURIComponent(owner) + '&repo_slug=' + encodeURIComponent(repoSlug);
+    const url = apiBase + '/tree/' + encodeURIComponent(ref) + pathSuffix + qs;
+    const resp = await fetch(url, { headers });
+    if (resp.status === 404) {
+      contentEl.innerHTML = '<div class="tree-error">&#10060; Ref or path not found.</div>';
+      return;
+    }
+    if (!resp.ok) {
+      contentEl.innerHTML = '<div class="tree-error">&#10060; Failed to load tree (HTTP ' + resp.status + ').</div>';
+      return;
+    }
+    const data = await resp.json();
+    renderTree(data);
+  } catch (err) {
+    document.getElementById('content').innerHTML =
+      '<div class="tree-error">&#10060; ' + escHtml(String(err)) + '</div>';
+  }
+}
+
+loadTree();
+{% endraw %}
+{% endblock %}

--- a/tests/test_musehub_ui.py
+++ b/tests/test_musehub_ui.py
@@ -10,6 +10,14 @@ Covers the minimum acceptance criteria from issue #43 and issue #232:
 - test_context_includes_musical_state  — response includes active_tracks field
 - test_context_unknown_ref_404         — nonexistent ref returns 404
 
+Covers acceptance criteria from issue #204 (tree browser):
+- test_tree_root_lists_directories
+- test_tree_subdirectory_lists_files
+- test_tree_file_icons_by_type
+- test_tree_breadcrumbs_correct
+- test_tree_json_response
+- test_tree_unknown_ref_404
+
 Covers acceptance criteria from issue #244 (embed player):
 - test_embed_page_renders              — GET /musehub/ui/{repo_id}/embed/{ref} returns 200
 - test_embed_no_auth_required          — Public embed accessible without JWT
@@ -34,13 +42,20 @@ See also test_musehub_analysis.py::test_analysis_aggregate_endpoint_returns_all_
 """
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from maestro.db.musehub_models import MusehubCommit, MusehubProfile, MusehubRepo, MusehubSession
+from maestro.db.musehub_models import (
+    MusehubBranch,
+    MusehubCommit,
+    MusehubObject,
+    MusehubProfile,
+    MusehubRepo,
+    MusehubSession,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -1845,3 +1860,172 @@ async def test_motifs_page_shows_transformation_badges(
     body = response.text
     assert "transformationsHtml" in body
     assert "inversion" in body
+
+
+# ---------------------------------------------------------------------------
+# Tree browser tests — issue #204
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tree_fixtures(db_session: AsyncSession) -> str:
+    """Seed a public repo with a branch and objects for tree browser tests.
+
+    Creates:
+    - repo: testuser/tree-test (public)
+    - branch: main (head pointing at a dummy commit)
+    - objects: tracks/bass.mid, tracks/keys.mp3, metadata.json, cover.webp
+    Returns repo_id.
+    """
+    repo = MusehubRepo(
+        name="tree-test",
+        owner="testuser",
+        slug="tree-test",
+        visibility="public",
+        owner_user_id="test-owner",
+    )
+    db_session.add(repo)
+    await db_session.flush()
+
+    commit = MusehubCommit(
+        commit_id="abc123def456",
+        repo_id=str(repo.repo_id),
+        message="initial",
+        branch="main",
+        author="testuser",
+        timestamp=datetime.now(tz=UTC),
+    )
+    db_session.add(commit)
+
+    branch = MusehubBranch(
+        repo_id=str(repo.repo_id),
+        name="main",
+        head_commit_id="abc123def456",
+    )
+    db_session.add(branch)
+
+    for path, size in [
+        ("tracks/bass.mid", 2048),
+        ("tracks/keys.mp3", 8192),
+        ("metadata.json", 512),
+        ("cover.webp", 4096),
+    ]:
+        obj = MusehubObject(
+            object_id=f"sha256:{path.replace('/', '_')}",
+            repo_id=str(repo.repo_id),
+            path=path,
+            size_bytes=size,
+            disk_path=f"/tmp/{path.replace('/', '_')}",
+        )
+        db_session.add(obj)
+
+    await db_session.commit()
+    return str(repo.repo_id)
+
+
+@pytest.mark.anyio
+async def test_tree_root_lists_directories(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{repo}/tree/{ref} returns 200 HTML with tree JS."""
+    await _seed_tree_fixtures(db_session)
+    response = await client.get("/musehub/ui/testuser/tree-test/tree/main")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "tree" in body
+    assert "branch-sel" in body or "ref-selector" in body or "loadTree" in body
+
+
+@pytest.mark.anyio
+async def test_tree_subdirectory_lists_files(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /{owner}/{repo}/tree/{ref}/tracks returns 200 HTML for the subdirectory."""
+    await _seed_tree_fixtures(db_session)
+    response = await client.get("/musehub/ui/testuser/tree-test/tree/main/tracks")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "tracks" in body
+    assert "loadTree" in body
+
+
+@pytest.mark.anyio
+async def test_tree_file_icons_by_type(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Tree template includes JS that maps extensions to file-type icons."""
+    await _seed_tree_fixtures(db_session)
+    response = await client.get("/musehub/ui/testuser/tree-test/tree/main")
+    assert response.status_code == 200
+    body = response.text
+    # Piano icon for .mid files
+    assert ".mid" in body or "midi" in body
+    # Waveform icon for .mp3/.wav files
+    assert ".mp3" in body or ".wav" in body
+    # Braces for .json
+    assert ".json" in body
+    # Photo for images
+    assert ".webp" in body or ".png" in body
+
+
+@pytest.mark.anyio
+async def test_tree_breadcrumbs_correct(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Tree page breadcrumb contains owner, repo, tree, and ref."""
+    await _seed_tree_fixtures(db_session)
+    response = await client.get("/musehub/ui/testuser/tree-test/tree/main")
+    assert response.status_code == 200
+    body = response.text
+    assert "testuser" in body
+    assert "tree-test" in body
+    assert "tree" in body
+    assert "main" in body
+
+
+@pytest.mark.anyio
+async def test_tree_json_response(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /api/v1/musehub/repos/{repo_id}/tree/{ref} returns JSON with tree entries."""
+    repo_id = await _seed_tree_fixtures(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/tree/main"
+        f"?owner=testuser&repo_slug=tree-test"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "entries" in data
+    assert data["ref"] == "main"
+    assert data["dirPath"] == ""
+    # Root should show: 'tracks' dir, 'metadata.json', 'cover.webp'
+    names = {e["name"] for e in data["entries"]}
+    assert "tracks" in names
+    assert "metadata.json" in names
+    assert "cover.webp" in names
+    # 'bass.mid' should NOT appear at root (it's under tracks/)
+    assert "bass.mid" not in names
+    # tracks entry must be a directory
+    tracks_entry = next(e for e in data["entries"] if e["name"] == "tracks")
+    assert tracks_entry["type"] == "dir"
+    assert tracks_entry["sizeBytes"] is None
+
+
+@pytest.mark.anyio
+async def test_tree_unknown_ref_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /api/v1/musehub/repos/{repo_id}/tree/{unknown_ref} returns 404."""
+    repo_id = await _seed_tree_fixtures(db_session)
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/tree/does-not-exist"
+        f"?owner=testuser&repo_slug=tree-test"
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
Closes #204 — Adds a file tree browser to MuseHub for navigating the muse-work directory structure with music-aware file-type icons.

## Root Cause / Motivation
There was no way to browse the file tree of a Muse repo on MuseHub. Musicians need GitHub-style directory navigation to find specific MIDI tracks, rendered MP3s, metadata files, and preview images.

## Solution
- New `tree.html` template with directory listing, file-type icons (MIDI=piano 🎹, MP3/WAV=waveform 🎵, JSON=braces `{}`, images=photo 🖼), breadcrumbs, and branch selector
- `tree_page()` and `tree_subdir_page()` route handlers in `ui.py` for `GET /{owner}/{repo}/tree/{ref}` and nested paths
- `list_tree_root()` and `list_tree_subdir()` JSON endpoints in `objects.py` reconstructing directory structure from all repo objects
- `resolve_ref_for_tree()` validates ref against branches and commits → 404 for unknown refs
- `list_tree()` in `musehub_repository.py` builds entries sorted dirs-first then files, both alphabetical
- New `TreeEntryResponse` and `TreeListResponse` Pydantic models

## Verification
- [x] mypy clean (626 source files, no issues)
- [x] Tests pass: 6 new `test_tree_*` tests all green
- [x] Docs updated (`docs/architecture/muse_vcs.md` — tree browser section added)