### PR TITLE
chore: update parallel agent prompts and dev override bind-mounts

### DIFF
--- a/.github/PR_REVIEW_PROMPT.md
+++ b/.github/PR_REVIEW_PROMPT.md
@@ -421,13 +421,20 @@ Only after you have output the grade and **"Approved for merge"**, do the follow
    git push origin --delete "$BRANCH"
    ```
 
-5. **Close the referenced issue** (find the issue number in the PR description — look for the line `Closes #N`):
+5. **Close every referenced issue** (find all `Closes #N` lines in the PR description and close each one):
    ```bash
-   # Extract issue number from PR body:
-   gh pr view <pr-number> --json body --jq '.body' | grep -o '#[0-9]*' | head -1
-   # Then close it:
-   gh issue close <issue-number> --comment "Fixed by PR #<pr-number>."
+   # Extract ALL "Closes #N" issue numbers from the PR body (handles multiple closes):
+   gh pr view <pr-number> --json body --jq '.body' \
+     | grep -oE '[Cc]loses?\s+#[0-9]+' \
+     | grep -oE '[0-9]+' \
+     | while read ISSUE_NUM; do
+         gh issue close "$ISSUE_NUM" \
+           --comment "Fixed by PR #<pr-number>." \
+           --repo "$GH_REPO"
+       done
    ```
+   ⚠️ Do NOT use `grep -o '#[0-9]*'` — it matches any `#N` in the body (commit hashes, mentions, etc.)
+   and silently closes the wrong issue. Always match `Closes #N` explicitly.
 
 6. **Return to dev and delete the local feature branch:**
    ```bash

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -42,3 +42,6 @@ services:
     volumes:
       - storpheus_cache:/data/cache
       - ./storpheus:/app
+      # Cursor worktrees — parallel review agents need this to run mypy/pytest
+      # against their worktree storpheus files via "cd /worktrees/<id> && mypy ."
+      - /Users/gabriel/.cursor/worktrees/maestro:/worktrees


### PR DESCRIPTION
## Summary

- Refreshed `.cursor/PARALLEL_ISSUE_TO_PR.md` and `.cursor/PARALLEL_PR_REVIEW.md` with latest workflow improvements
- Updated `.github/CREATE_PR_PROMPT.md` and `.github/PR_REVIEW_PROMPT.md` to match
- Added worktrees bind-mount to `docker-compose.override.yml` so parallel agents can run mypy/pytest directly against their worktree via `PYTHONPATH=/worktrees/<id>`

## Test plan

- [x] No code changes — tooling/config only
- [x] `docker compose up -d` confirmed healthy after override change