### PR TITLE
fix(musehub): fix artifact 401 — add auth to content URL requests

### DIFF
--- a/maestro/templates/musehub/pages/commit.html
+++ b/maestro/templates/musehub/pages/commit.html
@@ -33,8 +33,7 @@ function artifactHtml(obj, repoName) {
 
   if (IMAGE_EXTS.has(ext)) {
     return `<div class="artifact-card">
-      <img src="${url}" alt="${escHtml(obj.path)}" loading="lazy"
-           onerror="this.src='';this.alt='Preview unavailable'" />
+      <img data-content-url="${url}" alt="${escHtml(obj.path)}" loading="lazy" />
       <span class="path">${escHtml(name)}</span>
     </div>`;
   }
@@ -45,10 +44,10 @@ function artifactHtml(obj, repoName) {
               onclick="queueAudio('${url}', '${escHtml(name)}', '${escHtml(repoName)}')">
         &#9654; Play
       </button>
-      <a class="btn btn-secondary btn-sm" style="width:100%;justify-content:center"
-         href="${url}" download="${escHtml(name)}">
+      <button class="btn btn-secondary btn-sm" style="width:100%;justify-content:center"
+              onclick="downloadArtifact('${url}','${escHtml(name)}')">
         &#11015; Download
-      </a>
+      </button>
       <span class="path icon-mp3">${escHtml(name)}</span>
     </div>`;
   }
@@ -58,10 +57,10 @@ function artifactHtml(obj, repoName) {
       <div class="midi-preview" id="midi-${escHtml(obj.objectId)}" data-url="${url}">
         <div class="midi-roll-placeholder">&#127929; MIDI — ${escHtml(name)}</div>
       </div>
-      <a class="btn btn-secondary btn-sm" style="width:100%;justify-content:center"
-         href="${url}" download="${escHtml(name)}">
+      <button class="btn btn-secondary btn-sm" style="width:100%;justify-content:center"
+              onclick="downloadArtifact('${url}','${escHtml(name)}')">
         &#11015; Download MIDI
-      </a>
+      </button>
       <span class="path icon-mid">${escHtml(name)}</span>
     </div>`;
   }
@@ -71,21 +70,33 @@ function artifactHtml(obj, repoName) {
       <div class="score-preview" id="score-${escHtml(obj.objectId)}" data-url="${url}" data-ext="${ext}">
         <p class="text-muted text-sm" style="padding:var(--space-2)">&#127926; ${escHtml(ext.toUpperCase())} Score — loading…</p>
       </div>
-      <a class="btn btn-secondary btn-sm" style="width:100%;justify-content:center"
-         href="${url}" download="${escHtml(name)}">
+      <button class="btn btn-secondary btn-sm" style="width:100%;justify-content:center"
+              onclick="downloadArtifact('${url}','${escHtml(name)}')">
         &#11015; Download Score
-      </a>
+      </button>
       <span class="path">${escHtml(name)}</span>
     </div>`;
   }
 
   return `<div class="artifact-card">
-    <a class="btn btn-secondary btn-sm" style="width:100%;justify-content:center"
-       href="${url}" download="${escHtml(name)}">
+    <button class="btn btn-secondary btn-sm" style="width:100%;justify-content:center"
+            onclick="downloadArtifact('${url}','${escHtml(name)}')">
       &#11015; Download
-    </a>
+    </button>
     <span class="path">${escHtml(name)}</span>
   </div>`;
+}
+
+async function hydrateImages() {
+  document.querySelectorAll('img[data-content-url]').forEach(async img => {
+    const url = img.dataset.contentUrl;
+    try {
+      const blobUrl = await _fetchBlobUrl(url);
+      img.src = blobUrl;
+    } catch (_) {
+      img.alt = 'Preview unavailable';
+    }
+  });
 }
 
 function parseInstruments(message) {
@@ -275,6 +286,8 @@ async function load() {
 
     // Load ABC score previews if abcjs is available
     renderScorePreviews();
+    // Hydrate image artifact cards with authed blob URLs to avoid 401
+    hydrateImages();
 
   } catch(e) {
     if (e.message !== 'auth')


### PR DESCRIPTION
## Summary
Closes #176 — Fix 401 errors on Muse Hub artifact images/audio by adding auth to content URL requests.

## Root Cause / Motivation
The `artifactHtml()` function in `commit.html` built content URLs for `/objects/{id}/content` but used them bare (no auth) in `<img src>`, `<a href download>`, and as `queueAudio()` arguments. The browser sent these requests without an `Authorization` header, causing 401s on every artifact.

## Solution — JS Blob URL Proxy (Option B)
No token ever appears in a URL or in browser history. All content is fetched via `fetch()` with `Authorization: Bearer <token>` and served to the DOM as ephemeral `blob:` URLs.

### Changes
- **`musehub.js`** — `_fetchBlobUrl(url)`: shared helper that fetches a content URL with auth and returns a `URL.createObjectURL(blob)`.
- **`musehub.js`** — `queueAudio()`: rewritten as `async`; fetches blob before setting `audio.src`; revokes previous blob URL to avoid memory leaks; `closePlayer()` also revokes on close.
- **`musehub.js`** — `downloadArtifact(url, filename)`: new helper that fetches blob with auth and triggers a programmatic `<a>.click()` download — replaces all bare `<a href download>` links.
- **`commit.html`** — `artifactHtml()`: images now use `data-content-url` (no `src=`); all download `<a>` tags replaced with `<button onclick="downloadArtifact(...)">`.
- **`commit.html`** — `hydrateImages()`: post-hydrates `img[data-content-url]` elements after DOM insertion by fetching blobs with auth.
- **`commit.html`**: `hydrateImages()` called alongside `renderScorePreviews()` after DOM update.

## Verification
- [x] mypy clean (631 source files, no issues)
- [x] `test_ui_commit_page_shows_artifact_links` passes
- [x] `test_ui_commit_page_artifact_auth_uses_blob_proxy` added and passes (asserts `data-content-url`, `downloadArtifact`, `hydrateImages`, `_fetchBlobUrl` present; asserts no bare `src="/api/v1/musehub"`)