### PR TITLE
feat(musehub): listen page — full-mix and per-track audio playback with track listing

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -7264,6 +7264,45 @@ Full emotion map for a Muse repo ref. Returned by `GET /musehub/repos/{repo_id}/
 
 ---
 
+### `AudioTrackEntry`
+
+**Path:** `maestro/models/musehub.py`
+
+`CamelModel` — Wire representation of a single audio artifact on the listen page. Returned as an element in `TrackListingResponse.tracks`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `str` | Display name derived from the file path (basename without extension) |
+| `path` | `str` | Relative artifact path, e.g. `tracks/bass.mp3` |
+| `object_id` | `str` | Content-addressed object ID |
+| `audio_url` | `str` | Absolute URL to stream or download this artifact |
+| `piano_roll_url` | `str \| None` | Absolute URL to the matching piano-roll image, if available |
+| `size_bytes` | `int` | File size in bytes |
+
+**Produced by:** `maestro.api.routes.musehub.repos.list_listen_tracks()` and `maestro.api.routes.musehub.ui.listen_page()`
+**Consumed by:** MuseHub listen page (`/musehub/ui/{owner}/{repo_slug}/listen/{ref}`); AI agents enumerating audio stems
+
+---
+
+### `TrackListingResponse`
+
+**Path:** `maestro/models/musehub.py`
+
+`CamelModel` — Full-mix and per-stem audio listing for a repo at a given ref. Powers the dual-view listen page UX: full-mix player at the top, per-track listing below.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo_id` | `str` | Internal UUID of the repo |
+| `ref` | `str` | Commit ref or branch name resolved by this listing |
+| `full_mix_url` | `str \| None` | Audio URL for the first full-mix file found, or None if absent |
+| `tracks` | `list[AudioTrackEntry]` | All audio artifacts at this ref, sorted by path |
+| `has_renders` | `bool` | True when at least one audio artifact exists at this ref |
+
+**Produced by:** `maestro.api.routes.musehub.repos.list_listen_tracks()` (`GET /api/v1/musehub/repos/{repo_id}/listen/{ref}/tracks`) and `maestro.api.routes.musehub.ui.listen_page()` (JSON content negotiation)
+**Consumed by:** MuseHub listen page JS; AI agents that need to enumerate audio stems without visiting the UI
+
+---
+
 ## Storpheus — Inference Optimization Types (`storpheus/music_service.py`)
 
 ### `GenerationTiming`

--- a/maestro/api/routes/musehub/repos.py
+++ b/maestro/api/routes/musehub/repos.py
@@ -31,6 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from maestro.auth.dependencies import TokenClaims, optional_token, require_valid_token
 from maestro.db import get_db
 from maestro.models.musehub import (
+    AudioTrackEntry,
     BranchListResponse,
     CommitListResponse,
     CommitResponse,
@@ -49,6 +50,7 @@ from maestro.models.musehub import (
     SessionListResponse,
     SessionResponse,
     SessionStop,
+    TrackListingResponse,
 )
 from maestro.models.musehub_analysis import FormStructureResponse
 from maestro.models.musehub_context import (
@@ -714,6 +716,111 @@ async def get_groove_check(
         flagged_commits=result.flagged_commits,
         worst_commit=result.worst_commit,
         entries=entries,
+    )
+
+
+_AUDIO_EXTENSIONS: frozenset[str] = frozenset({".mp3", ".ogg", ".wav", ".m4a", ".flac"})
+_IMAGE_EXTENSIONS: frozenset[str] = frozenset({".webp", ".png", ".jpg", ".jpeg"})
+_FULL_MIX_KEYWORDS: tuple[str, ...] = ("mix", "full", "master", "bounce")
+
+
+def _is_audio(path: str) -> bool:
+    """Return True when the path extension is a recognised audio format."""
+    import os
+    return os.path.splitext(path)[1].lower() in _AUDIO_EXTENSIONS
+
+
+def _piano_roll_url(path: str, object_map: dict[str, str], repo_id: str) -> str | None:
+    """Return an absolute content URL for a matching piano-roll image, or None.
+
+    Looks for a .webp file whose basename (without extension) matches the
+    audio file's basename — a naming convention produced by the Stori DAW.
+    """
+    import os
+    stem = os.path.splitext(os.path.basename(path))[0]
+    for obj_path, obj_id in object_map.items():
+        ext = os.path.splitext(obj_path)[1].lower()
+        if ext in _IMAGE_EXTENSIONS and os.path.splitext(os.path.basename(obj_path))[0] == stem:
+            return f"/api/v1/musehub/repos/{repo_id}/objects/{obj_id}/content"
+    return None
+
+
+@router.get(
+    "/repos/{repo_id}/listen/{ref}/tracks",
+    response_model=TrackListingResponse,
+    operation_id="listListenTracks",
+    summary="List audio tracks and full-mix URL for the listen page",
+    tags=["Listen"],
+)
+async def list_listen_tracks(
+    repo_id: str,
+    ref: str,
+    db: AsyncSession = Depends(get_db),
+    claims: TokenClaims | None = Depends(optional_token),
+) -> TrackListingResponse:
+    """Return the full-mix and per-stem track listing for the listen page.
+
+    Scans all stored objects for the repo and filters to audio files, sorting
+    them by path.  The ``full_mix_url`` field is populated from the first file
+    whose basename contains a mix/master keyword; when no such file exists the
+    first audio file is used as the full-mix candidate.
+
+    Returns 404 if the repo does not exist or is not accessible.
+    The ``has_renders`` flag distinguishes repos with no audio from repos that
+    have audio but no recognised full-mix file.
+    """
+    import os
+
+    repo = await musehub_repository.get_repo(db, repo_id)
+    _guard_visibility(repo, claims)
+
+    objects = await musehub_repository.list_objects(db, repo_id)
+
+    object_map: dict[str, str] = {obj.path: obj.object_id for obj in objects}
+
+    audio_objects = sorted(
+        [obj for obj in objects if _is_audio(obj.path)],
+        key=lambda o: o.path,
+    )
+
+    if not audio_objects:
+        return TrackListingResponse(
+            repo_id=repo_id,
+            ref=ref,
+            full_mix_url=None,
+            tracks=[],
+            has_renders=False,
+        )
+
+    def _audio_url(object_id: str) -> str:
+        return f"/api/v1/musehub/repos/{repo_id}/objects/{object_id}/content"
+
+    full_mix_obj = next(
+        (
+            o for o in audio_objects
+            if any(kw in os.path.basename(o.path).lower() for kw in _FULL_MIX_KEYWORDS)
+        ),
+        audio_objects[0],
+    )
+
+    tracks = [
+        AudioTrackEntry(
+            name=os.path.splitext(os.path.basename(obj.path))[0],
+            path=obj.path,
+            object_id=obj.object_id,
+            audio_url=_audio_url(obj.object_id),
+            piano_roll_url=_piano_roll_url(obj.path, object_map, repo_id),
+            size_bytes=obj.size_bytes,
+        )
+        for obj in audio_objects
+    ]
+
+    return TrackListingResponse(
+        repo_id=repo_id,
+        ref=ref,
+        full_mix_url=_audio_url(full_mix_obj.object_id),
+        tracks=tracks,
+        has_renders=True,
     )
 
 

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -1226,3 +1226,52 @@ class GrooveCheckResponse(CamelModel):
         default_factory=list,
         description="Per-commit metrics, oldest-first",
     )
+
+
+# ── Listen page models ────────────────────────────────────────────────────────
+
+
+class AudioTrackEntry(CamelModel):
+    """A single audio artifact surfaced on the listen page.
+
+    Represents one stem or full-mix file at a given commit ref.  The
+    ``audio_url`` is the canonical download path served by the objects
+    endpoint.  ``piano_roll_url`` is non-None only when a matching .webp
+    piano-roll image exists at the same path prefix.
+    """
+
+    name: str = Field(..., description="Display name derived from the file path (basename without extension)")
+    path: str = Field(..., description="Relative artifact path, e.g. 'tracks/bass.mp3'")
+    object_id: str = Field(..., description="Content-addressed object ID")
+    audio_url: str = Field(
+        ..., description="Absolute URL to stream or download this artifact"
+    )
+    piano_roll_url: str | None = Field(
+        default=None, description="Absolute URL to the matching piano-roll image, if available"
+    )
+    size_bytes: int = Field(..., description="File size in bytes")
+
+
+class TrackListingResponse(CamelModel):
+    """Full-mix and per-track audio listing for a repo at a given ref.
+
+    Powers the listen page's dual-view UX: the full-mix player at the top
+    and the per-track listing below.  The ``has_renders`` flag lets the
+    client differentiate between a repo with no audio at all and one that
+    has audio but no explicit full-mix file.
+    """
+
+    repo_id: str = Field(..., description="Internal UUID of the repo")
+    ref: str = Field(..., description="Commit ref or branch name resolved by this listing")
+    full_mix_url: str | None = Field(
+        default=None,
+        description="Audio URL for the first full-mix file found, or None if absent",
+    )
+    tracks: list[AudioTrackEntry] = Field(
+        default_factory=list,
+        description="All audio artifacts at this ref, sorted by path",
+    )
+    has_renders: bool = Field(
+        ...,
+        description="True when at least one audio artifact exists at this ref",
+    )

--- a/maestro/templates/musehub/pages/listen.html
+++ b/maestro/templates/musehub/pages/listen.html
@@ -7,6 +7,11 @@
 {% endblock %}
 {% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
 
+{% block body_extra %}
+<script src="/musehub/static/vendor/wavesurfer.min.js"></script>
+<script src="/musehub/static/audio-player.js"></script>
+{% endblock %}
+
 {% block extra_css %}
 <style>
 .listen-player-card {
@@ -172,6 +177,7 @@ const repoSlug = {{ repo_slug | tojson }};
 const base     = {{ base_url | tojson }};
 const trackPath = {{ (track_path if track_path is defined else '') | tojson }};
 const apiBase  = '/api/v1/musehub/repos/' + repoId;
+const TRACK_PATH = trackPath;
 {% endblock %}
 
 {% block page_script %}
@@ -366,7 +372,20 @@ async function load() {
       + '<div class="listen-time-row">'
       + '<span id="mix-time-cur">0:00</span>'
       + '<span id="mix-time-dur">0:00</span>'
-      + '</div></div></div>';
+      + '</div>'
+      + '<div class="speed-wrap">'
+      + '<label for="speed-sel">Speed</label>'
+      + '<select id="speed-sel"></select>'
+      + '</div>'
+      + '</div>'
+      + '<div class="loop-bar">'
+      + '<span id="loop-info"></span>'
+      + '<button id="loop-clear-btn">Clear loop</button>'
+      + '</div>'
+      + '<div class="help-card" style="font-size:12px;color:#8b949e;margin-top:8px">'
+      + '<kbd>Space</kbd> play / pause &nbsp;&bull;&nbsp; <kbd>L</kbd> clear loop'
+      + '</div>'
+      + '</div>';
 
     if (hasMix) {
       html += '<div class="listen-actions">'

--- a/maestro/templates/musehub/pages/listen.html
+++ b/maestro/templates/musehub/pages/listen.html
@@ -1,0 +1,437 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Listen {{ ref[:8] }}{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> /
+  listen / {{ ref[:8] }}
+{% endblock %}
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block extra_css %}
+<style>
+.listen-player-card {
+  background: linear-gradient(135deg, #0d1117 0%, #161b22 100%);
+  border: 1px solid #1f6feb;
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 24px;
+}
+.listen-player-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #e6edf3;
+  margin-bottom: 4px;
+}
+.listen-player-sub {
+  font-size: 13px;
+  color: #8b949e;
+  margin-bottom: 16px;
+}
+.listen-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.listen-play-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: #1f6feb;
+  border: none;
+  color: #fff;
+  font-size: 18px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s, transform 0.1s;
+}
+.listen-play-btn:hover { background: #388bfd; transform: scale(1.05); }
+.listen-play-btn:disabled { background: #21262d; color: #8b949e; cursor: not-allowed; transform: none; }
+.listen-progress-wrap { flex: 1; }
+.listen-progress-bar {
+  height: 6px;
+  background: #21262d;
+  border-radius: 3px;
+  cursor: pointer;
+  position: relative;
+  margin-bottom: 6px;
+}
+.listen-progress-fill {
+  height: 100%;
+  background: #1f6feb;
+  border-radius: 3px;
+  width: 0%;
+  transition: width 0.1s linear;
+}
+.listen-time-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: #8b949e;
+  font-variant-numeric: tabular-nums;
+}
+.listen-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+.track-list { display: flex; flex-direction: column; gap: 12px; }
+.track-row {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  transition: border-color 0.15s;
+}
+.track-row:hover { border-color: #58a6ff; }
+.track-row.is-playing { border-color: #1f6feb; background: #0d1117; }
+.track-play-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #21262d;
+  border: 1px solid #30363d;
+  color: #c9d1d9;
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+.track-play-btn:hover { background: #1f6feb; border-color: #1f6feb; color: #fff; }
+.track-play-btn.is-playing { background: #1f6feb; border-color: #1f6feb; color: #fff; }
+.track-info { flex: 1; min-width: 0; }
+.track-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #e6edf3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.track-path {
+  font-size: 11px;
+  color: #8b949e;
+  font-family: monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.track-waveform {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 28px;
+  width: 80px;
+  flex-shrink: 0;
+}
+.track-waveform-bar {
+  width: 4px;
+  background: #30363d;
+  border-radius: 2px 2px 0 0;
+  transition: background 0.15s;
+}
+.track-row.is-playing .track-waveform-bar { background: #1f6feb; }
+.track-meta {
+  font-size: 11px;
+  color: #8b949e;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.track-row-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.no-renders-card {
+  text-align: center;
+  padding: 48px 24px;
+  background: #161b22;
+  border: 1px dashed #30363d;
+  border-radius: 12px;
+}
+.no-renders-icon { font-size: 48px; margin-bottom: 16px; }
+.no-renders-title { font-size: 18px; font-weight: 600; color: #e6edf3; margin-bottom: 8px; }
+.no-renders-sub { font-size: 14px; color: #8b949e; }
+</style>
+{% endblock %}
+
+{% block page_data %}
+const repoId   = {{ repo_id | tojson }};
+const ref      = {{ ref | tojson }};
+const owner    = {{ owner | tojson }};
+const repoSlug = {{ repo_slug | tojson }};
+const base     = {{ base_url | tojson }};
+const trackPath = {{ (track_path if track_path is defined else '') | tojson }};
+const apiBase  = '/api/v1/musehub/repos/' + repoId;
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+// ── Audio state ────────────────────────────────────────────────────────────
+let mixAudio    = null;
+let trackAudios = {};   // path → <audio> element
+let currentPath = null;
+
+function fmtTime(s) {
+  if (!isFinite(s) || s < 0) return '0:00';
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return m + ':' + (sec < 10 ? '0' : '') + sec;
+}
+
+function fmtBytes(n) {
+  if (n < 1024) return n + ' B';
+  if (n < 1048576) return (n / 1024).toFixed(0) + ' KB';
+  return (n / 1048576).toFixed(1) + ' MB';
+}
+
+// ── Mini waveform (deterministic from object_id) ──────────────────────────
+function miniWaveform(objectId, isPlaying) {
+  const seed = objectId ? objectId.charCodeAt(objectId.length - 1) : 0;
+  const heights = [];
+  for (let i = 0; i < 16; i++) {
+    const h = 20 + Math.abs(Math.sin((seed + i * 7) * 0.8)) * 45;
+    heights.push(Math.round(h));
+  }
+  return heights
+    .map(h => '<div class="track-waveform-bar" style="height:' + h + '%"></div>')
+    .join('');
+}
+
+// ── Full-mix player ────────────────────────────────────────────────────────
+function initMixPlayer(url, title) {
+  mixAudio = new Audio();
+  mixAudio.preload = 'metadata';
+  const playBtn  = document.getElementById('mix-play-btn');
+  const fill     = document.getElementById('mix-progress-fill');
+  const bar      = document.getElementById('mix-progress-bar');
+  const timeCur  = document.getElementById('mix-time-cur');
+  const timeDur  = document.getElementById('mix-time-dur');
+
+  mixAudio.addEventListener('canplay', () => { playBtn.disabled = false; });
+  mixAudio.addEventListener('timeupdate', () => {
+    const pct = mixAudio.duration ? (mixAudio.currentTime / mixAudio.duration) * 100 : 0;
+    fill.style.width = pct + '%';
+    timeCur.textContent = fmtTime(mixAudio.currentTime);
+  });
+  mixAudio.addEventListener('durationchange', () => {
+    timeDur.textContent = fmtTime(mixAudio.duration);
+  });
+  mixAudio.addEventListener('ended', () => {
+    playBtn.innerHTML = '&#9654;';
+    fill.style.width = '0%';
+    mixAudio.currentTime = 0;
+  });
+  mixAudio.addEventListener('error', () => {
+    playBtn.disabled = true;
+    playBtn.title = 'Audio unavailable';
+  });
+
+  playBtn.addEventListener('click', () => {
+    pauseAllTracks();
+    if (mixAudio.paused) {
+      mixAudio.src = url;
+      mixAudio.play();
+      playBtn.innerHTML = '&#9646;&#9646;';
+      currentPath = '__mix__';
+    } else {
+      mixAudio.pause();
+      playBtn.innerHTML = '&#9654;';
+      currentPath = null;
+    }
+  });
+
+  bar.addEventListener('click', (e) => {
+    if (!mixAudio.duration) return;
+    const rect = bar.getBoundingClientRect();
+    mixAudio.currentTime = ((e.clientX - rect.left) / rect.width) * mixAudio.duration;
+  });
+}
+
+// ── Per-track players ──────────────────────────────────────────────────────
+function playTrack(path, url, playBtnId, rowId) {
+  if (mixAudio && !mixAudio.paused) {
+    mixAudio.pause();
+    const btn = document.getElementById('mix-play-btn');
+    if (btn) btn.innerHTML = '&#9654;';
+  }
+
+  // Pause any other track
+  Object.keys(trackAudios).forEach(p => {
+    if (p !== path && !trackAudios[p].paused) {
+      trackAudios[p].pause();
+      const oldRow = document.getElementById('track-row-' + CSS.escape(p));
+      if (oldRow) oldRow.classList.remove('is-playing');
+      const oldBtn = document.getElementById('track-btn-' + CSS.escape(p));
+      if (oldBtn) { oldBtn.innerHTML = '&#9654;'; oldBtn.classList.remove('is-playing'); }
+    }
+  });
+
+  if (!trackAudios[path]) {
+    trackAudios[path] = new Audio();
+    trackAudios[path].preload = 'metadata';
+  }
+  const audio = trackAudios[path];
+  const btn   = document.getElementById(playBtnId);
+  const row   = document.getElementById(rowId);
+
+  if (audio.paused) {
+    audio.src = url;
+    audio.play();
+    if (btn) { btn.innerHTML = '&#9646;&#9646;'; btn.classList.add('is-playing'); }
+    if (row) row.classList.add('is-playing');
+    currentPath = path;
+    audio.addEventListener('ended', () => {
+      if (btn) { btn.innerHTML = '&#9654;'; btn.classList.remove('is-playing'); }
+      if (row) row.classList.remove('is-playing');
+      currentPath = null;
+    }, { once: true });
+  } else {
+    audio.pause();
+    if (btn) { btn.innerHTML = '&#9654;'; btn.classList.remove('is-playing'); }
+    if (row) row.classList.remove('is-playing');
+    currentPath = null;
+  }
+}
+
+function pauseAllTracks() {
+  Object.values(trackAudios).forEach(a => { if (!a.paused) a.pause(); });
+  document.querySelectorAll('.track-play-btn').forEach(b => {
+    b.innerHTML = '&#9654;';
+    b.classList.remove('is-playing');
+  });
+  document.querySelectorAll('.track-row').forEach(r => r.classList.remove('is-playing'));
+}
+
+// ── Main loader ────────────────────────────────────────────────────────────
+async function load() {
+  initRepoNav(repoId);
+
+  const content = document.getElementById('content');
+  content.innerHTML = '<p class="loading">Loading audio tracks&#8230;</p>';
+
+  try {
+    const apiToken = apiBase + '/listen/' + encodeURIComponent(ref) + '/tracks';
+    let listing;
+    try {
+      listing = await apiFetch('/repos/' + repoId + '/listen/' + encodeURIComponent(ref) + '/tracks');
+    } catch (e) {
+      // Unauthenticated visitors may not have access; render fallback shell
+      listing = { hasRenders: false, tracks: [], fullMixUrl: null, ref: ref, repoId: repoId };
+    }
+
+    const tracks  = listing.tracks  || [];
+    const hasMix  = !!listing.fullMixUrl;
+    const hasAny  = listing.hasRenders;
+
+    // ── Back link + heading ────────────────────────────────────────────────
+    let html = '<div style="margin-bottom:16px;display:flex;align-items:center;gap:12px;flex-wrap:wrap">'
+      + '<a href="' + escHtml(base) + '">&larr; Back to repo</a>'
+      + '<h1 style="margin:0;font-size:20px">&#127925; Listen</h1>'
+      + '<code class="ref-badge">' + escHtml(ref.length > 16 ? ref.substring(0, 16) + '\u2026' : ref) + '</code>'
+      + '</div>';
+
+    if (!hasAny) {
+      // ── No renders fallback ────────────────────────────────────────────
+      html += '<div class="no-renders-card">'
+        + '<div class="no-renders-icon">&#127897;</div>'
+        + '<div class="no-renders-title">No audio renders yet</div>'
+        + '<div class="no-renders-sub">Push audio artifacts (.mp3, .wav, .ogg) to this repo to enable playback.</div>'
+        + '<div style="margin-top:20px"><a class="btn btn-primary" href="' + escHtml(base) + '/tree/' + encodeURIComponent(ref) + '">Browse files</a></div>'
+        + '</div>';
+      content.innerHTML = html;
+      return;
+    }
+
+    // ── Full-mix player ────────────────────────────────────────────────────
+    const mixTitle = tracks.length > 0 ? tracks[0].name : 'Full Mix';
+    html += '<div class="listen-player-card">'
+      + '<div class="listen-player-title">&#127908; Full Mix</div>'
+      + '<div class="listen-player-sub">ref: ' + escHtml(ref.substring(0, 16)) + ' &bull; ' + tracks.length + ' track' + (tracks.length !== 1 ? 's' : '') + '</div>'
+      + '<div class="listen-controls">'
+      + '<button class="listen-play-btn" id="mix-play-btn" disabled title="Play / Pause">&#9654;</button>'
+      + '<div class="listen-progress-wrap">'
+      + '<div class="listen-progress-bar" id="mix-progress-bar">'
+      + '<div class="listen-progress-fill" id="mix-progress-fill"></div>'
+      + '</div>'
+      + '<div class="listen-time-row">'
+      + '<span id="mix-time-cur">0:00</span>'
+      + '<span id="mix-time-dur">0:00</span>'
+      + '</div></div></div>';
+
+    if (hasMix) {
+      html += '<div class="listen-actions">'
+        + '<a class="btn btn-secondary" href="' + escHtml(listing.fullMixUrl) + '" download>&#11015; Download mix</a>'
+        + '<a class="btn btn-secondary" href="' + escHtml(base) + '/embed/' + encodeURIComponent(ref) + '">&#128279; Embed</a>'
+        + '</div>';
+    }
+    html += '</div>';
+
+    // ── Track listing ──────────────────────────────────────────────────────
+    if (tracks.length > 0) {
+      html += '<div style="display:flex;align-items:center;gap:12px;margin-bottom:12px">'
+        + '<h2 style="margin:0;font-size:16px">&#127897; Tracks</h2>'
+        + '<span style="font-size:12px;color:#8b949e">' + tracks.length + ' artifact' + (tracks.length !== 1 ? 's' : '') + '</span>'
+        + '</div>';
+
+      html += '<div class="track-list">';
+      tracks.forEach((track, i) => {
+        const escapedPath = escHtml(track.path);
+        const safePath    = 'track-' + i;
+        html += '<div class="track-row" id="track-row-' + escHtml(track.objectId) + '">'
+          + '<button class="track-play-btn" id="track-btn-' + escHtml(track.objectId) + '"'
+          + ' onclick="playTrack(' + JSON.stringify(track.path) + ',' + JSON.stringify(track.audioUrl) + ','
+          + JSON.stringify('track-btn-' + track.objectId) + ',' + JSON.stringify('track-row-' + track.objectId) + ')"'
+          + ' title="Play ' + escHtml(track.name) + '">&#9654;</button>'
+          + '<div class="track-info">'
+          + '<div class="track-name">' + escHtml(track.name) + '</div>'
+          + '<div class="track-path">' + escHtml(track.path) + '</div>'
+          + '</div>'
+          + '<div class="track-waveform" aria-hidden="true">' + miniWaveform(track.objectId, false) + '</div>'
+          + '<div class="track-meta">' + escHtml(fmtBytes(track.sizeBytes || 0)) + '</div>'
+          + '<div class="track-row-actions">';
+
+        if (track.pianoRollUrl) {
+          html += '<a class="btn btn-secondary" style="font-size:11px;padding:4px 8px"'
+            + ' href="' + escHtml(base) + '/listen/' + encodeURIComponent(ref) + '/' + escapedPath + '"'
+            + ' title="View piano roll">&#127929;</a>';
+        }
+        html += '<a class="btn btn-secondary" style="font-size:11px;padding:4px 8px"'
+          + ' href="' + escHtml(track.audioUrl) + '" download title="Download">&#11015;</a>';
+
+        html += '</div></div>';
+      });
+      html += '</div>';
+    }
+
+    content.innerHTML = html;
+
+    // Init full-mix player after DOM is ready
+    if (hasMix) {
+      initMixPlayer(listing.fullMixUrl, mixTitle);
+      // Trigger preload so duration shows quickly
+      const mixAudioEl = new Audio();
+      mixAudioEl.preload = 'metadata';
+      mixAudioEl.src = listing.fullMixUrl;
+    }
+
+  } catch (e) {
+    if (e.message !== 'auth') {
+      document.getElementById('content').innerHTML =
+        '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+    }
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}


### PR DESCRIPTION
## Summary
Closes #213 — adds listen page with full-mix and per-track audio playback and track listing.

## Root Cause / Motivation
No dedicated listening experience existed on MuseHub. Musicians had to download individual files and play them in a DAW to evaluate each part's contribution.

## Solution
- New `GET /{owner}/{repo}/listen/{ref}` page with full-mix player + track listing
- New `GET /{owner}/{repo}/listen/{ref}/{path}` page for individual stem playback
- Track listing shows: instrument name, file path, mini waveform visualisation, file size, play button, optional piano-roll link, download button
- Full-mix detection by basename keyword (`mix`, `full`, `master`, `bounce`); falls back to first audio file
- Piano-roll matching: `.webp`/`.png`/`.jpg` with matching stem name auto-linked
- Client-side audio state management: playing one track pauses all others and the full-mix player
- Graceful fallback when no audio renders exist (no-renders card with tree-browser link)
- Content negotiation: `?format=json` returns `TrackListingResponse` with all audio URLs
- New `list_listen_tracks()` endpoint in repos.py (`GET /api/v1/musehub/repos/{id}/listen/{ref}/tracks`)
- `AudioTrackEntry` and `TrackListingResponse` models in musehub.py
- Docs: listen page section in `muse_vcs.md`, both types registered in `type_contracts.md`

## Verification
- mypy clean (631 source files)
- 4 new tests pass: `test_listen_page_full_mix`, `test_listen_page_track_listing`, `test_listen_page_no_renders_fallback`, `test_listen_page_json_response`