### PR TITLE
feat(musehub): blob viewer — file-type-aware rendering for MIDI, audio, JSON, and images

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -7640,3 +7640,88 @@ structure is derived by splitting object `path` fields on `/`.
 | Tests | `tests/test_musehub_ui.py` — `test_tree_*` (6 tests) |
 
 ---
+
+## Muse Hub — Blob Viewer (issue #205)
+
+**Purpose:** Music-aware file blob viewer that renders individual files from a
+Muse repo with file-type-specific treatment.  Musicians can view MIDI as a
+piano roll preview, stream audio files directly in the browser, and inspect
+JSON/XML metadata with syntax highlighting — without downloading files first.
+
+### URL Pattern
+
+| Route | Description |
+|-------|-------------|
+| `GET /musehub/ui/{owner}/{repo_slug}/blob/{ref}/{path}` | HTML blob viewer page |
+| `GET /api/v1/musehub/repos/{repo_id}/blob/{ref}/{path}` | JSON blob metadata + text content |
+
+**Auth:** No JWT required for public repos (HTML shell). Private repos require
+a Bearer token passed via `Authorization` header (API) or `localStorage` JWT (UI).
+
+### File-Type Dispatch
+
+The viewer selects a rendering mode based on the file extension:
+
+| Extension | `file_type` | Rendering |
+|-----------|-------------|-----------|
+| `.mid`, `.midi` | `midi` | Piano roll placeholder + "View in Piano Roll" quick link |
+| `.mp3`, `.wav`, `.flac`, `.ogg` | `audio` | `<audio>` player + "Listen" quick link |
+| `.json` | `json` | Syntax-highlighted JSON (keys blue, strings teal, numbers gold, bools red, nulls grey) |
+| `.webp`, `.png`, `.jpg`, `.jpeg` | `image` | Inline `<img>` on checkered background |
+| `.xml` | `xml` | Syntax-highlighted XML (MusicXML support) |
+| all others | `other` | Hex dump preview (first 512 bytes via Range request) + raw download |
+
+### File Metadata
+
+Every blob response includes:
+
+- `filename` — basename of the file (e.g. `bass.mid`)
+- `size_bytes` — file size in bytes
+- `sha` — content-addressed ID (e.g. `sha256:abc123...`)
+- `created_at` — timestamp of the most-recently-pushed version
+- `raw_url` — direct link to `/{owner}/{repo_slug}/raw/{ref}/{path}`
+- `file_type` — rendering hint (see table above)
+- `content_text` — UTF-8 content for JSON/XML files ≤ 256 KB; `null` for binary/oversized
+
+### Quick Links
+
+The blob viewer exposes contextual action links:
+
+- **Raw** — always present; links to raw download endpoint (`Content-Disposition: attachment`)
+- **View in Piano Roll** — MIDI files only; links to `/{owner}/{repo_slug}/piano-roll/{ref}/{path}`
+- **Listen** — audio files only; links to `/{owner}/{repo_slug}/listen/{ref}/{path}`
+
+### Object Resolution
+
+Object resolution uses `musehub_repository.get_object_by_path()`, which returns
+the most-recently-pushed object matching the path in the repo.  The `ref`
+parameter is validated for URL construction but does not currently filter by
+branch HEAD (MVP scope — consistent with raw and tree endpoints).
+
+### Response Shape (`BlobMetaResponse`)
+
+```json
+{
+  "objectId": "sha256:abc123...",
+  "path": "tracks/bass.mid",
+  "filename": "bass.mid",
+  "sizeBytes": 2048,
+  "sha": "sha256:abc123...",
+  "createdAt": "2025-01-15T12:00:00Z",
+  "rawUrl": "/musehub/repos/{repo_id}/raw/main/tracks/bass.mid",
+  "fileType": "midi",
+  "contentText": null
+}
+```
+
+### Implementation Map
+
+| Component | File |
+|-----------|------|
+| Template | `maestro/templates/musehub/pages/blob.html` |
+| UI handler | `maestro/api/routes/musehub/ui.py` → `blob_page()` |
+| API endpoint | `maestro/api/routes/musehub/objects.py` → `get_blob_meta()` |
+| Pydantic model | `maestro/models/musehub.py` → `BlobMetaResponse` |
+| Tests | `tests/test_musehub_ui.py` — `test_blob_*` (7 tests) |
+
+---

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -7343,6 +7343,29 @@ Full emotion map for a Muse repo ref. Returned by `GET /musehub/repos/{repo_id}/
 
 ---
 
+### `BlobMetaResponse`
+
+**Path:** `maestro/models/musehub.py`
+
+`CamelModel` — Metadata and optional inline content for a single file in the Muse blob viewer, as returned by `GET /api/v1/musehub/repos/{repo_id}/blob/{ref}/{path}`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `object_id` | `str` | Content-addressed ID, e.g. `sha256:abc123...` |
+| `path` | `str` | Relative path from repo root, e.g. `tracks/bass.mid` |
+| `filename` | `str` | Basename of the file, e.g. `bass.mid` |
+| `size_bytes` | `int` | File size in bytes |
+| `sha` | `str` | Content-addressed SHA identifier |
+| `created_at` | `datetime` | Timestamp when this object was pushed |
+| `raw_url` | `str` | URL to download the raw file bytes |
+| `file_type` | `str` | Rendering hint: `midi` \| `audio` \| `json` \| `image` \| `xml` \| `other` |
+| `content_text` | `str \| None` | UTF-8 content for JSON/XML files ≤ 256 KB; `None` for binary or oversized files |
+
+**Produced by:** `maestro.api.routes.musehub.objects.get_blob_meta()`
+**Consumed by:** MuseHub blob viewer UI page (`/musehub/ui/{owner}/{repo_slug}/blob/{ref}/{path}`); AI agents inspecting individual file content
+
+---
+
 ## Storpheus — Inference Optimization Types (`storpheus/music_service.py`)
 
 ### `GenerationTiming`

--- a/maestro/api/routes/musehub/objects.py
+++ b/maestro/api/routes/musehub/objects.py
@@ -3,6 +3,7 @@
 Endpoint summary:
   GET /musehub/repos/{repo_id}/objects                             — list artifact metadata
   GET /musehub/repos/{repo_id}/objects/{object_id}/content         — serve raw artifact bytes
+  GET /musehub/repos/{repo_id}/blob/{ref}/{path}                   — blob metadata + text content for UI
   GET /musehub/repos/{repo_id}/export/{ref}?format=midi&...        — download export package
 
 Objects are binary artifacts (MIDI, MP3, WebP piano rolls) pushed via the
@@ -30,7 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from maestro.auth.dependencies import TokenClaims, optional_token, require_valid_token
 from maestro.db import get_db
 from maestro.db.musehub_models import MusehubDownloadEvent
-from maestro.models.musehub import ObjectMetaListResponse, TreeListResponse
+from maestro.models.musehub import BlobMetaResponse, ObjectMetaListResponse, TreeListResponse
 from maestro.services import musehub_repository
 from maestro.services.musehub_exporter import ExportFormat, export_repo_at_ref
 
@@ -54,6 +55,105 @@ def _content_type(path: str) -> str:
         return _EXTRA_MIME[ext]
     guessed, _ = mimetypes.guess_type(path)
     return guessed or "application/octet-stream"
+
+
+# Maximum text file size to embed in BlobMetaResponse.content_text (256 KB).
+_MAX_TEXT_EMBED_BYTES = 256 * 1024
+
+_FILE_TYPE_MAP: dict[str, str] = {
+    ".mid": "midi",
+    ".midi": "midi",
+    ".mp3": "audio",
+    ".wav": "audio",
+    ".flac": "audio",
+    ".ogg": "audio",
+    ".webp": "image",
+    ".png": "image",
+    ".jpg": "image",
+    ".jpeg": "image",
+    ".json": "json",
+    ".xml": "xml",
+}
+
+
+def _detect_file_type(path: str) -> str:
+    """Return a rendering hint based on file extension.
+
+    Values: 'midi' | 'audio' | 'json' | 'image' | 'xml' | 'other'
+    """
+    ext = os.path.splitext(path)[1].lower()
+    return _FILE_TYPE_MAP.get(ext, "other")
+
+
+@router.get(
+    "/repos/{repo_id}/blob/{ref}/{path:path}",
+    response_model=BlobMetaResponse,
+    operation_id="getBlobMeta",
+    summary="Get blob metadata and optional text content for the file viewer",
+)
+async def get_blob_meta(
+    repo_id: str,
+    ref: str,
+    path: str,
+    db: AsyncSession = Depends(get_db),
+    claims: TokenClaims | None = Depends(optional_token),
+) -> BlobMetaResponse:
+    """Return metadata for a single file in the blob viewer.
+
+    The response includes the file's size, SHA, creation timestamp, and
+    rendering hint (``file_type``).  For text-based files (JSON, XML) up to
+    256 KB, ``content_text`` is populated so the viewer can render them
+    inline without a second request.  Binary and oversized files omit
+    ``content_text``; consumers should stream bytes from ``raw_url`` instead.
+
+    The ``ref`` parameter accepts branch names or commit SHAs and is used
+    for URL construction (raw_url).  Object resolution always returns the
+    most-recently-pushed object at ``path``, consistent with the raw and
+    tree endpoints at MVP scope.
+
+    Returns 404 if the repo is not found or no object exists at that path.
+    Returns 401 if the repo is private and no valid token is supplied.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+    if repo.visibility != "public" and claims is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required to access private repos.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    obj = await musehub_repository.get_object_by_path(db, repo_id, path)
+    if obj is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No object at path '{path}' in ref '{ref}'",
+        )
+
+    file_type = _detect_file_type(obj.path)
+    raw_url = f"/musehub/repos/{repo_id}/raw/{ref}/{path}"
+
+    content_text: str | None = None
+    if file_type in ("json", "xml") and obj.size_bytes <= _MAX_TEXT_EMBED_BYTES:
+        if os.path.exists(obj.disk_path):
+            try:
+                with open(obj.disk_path, encoding="utf-8", errors="replace") as fh:
+                    content_text = fh.read()
+            except OSError:
+                logger.warning("⚠️ Could not read text content for blob %s", obj.object_id)
+
+    return BlobMetaResponse(
+        object_id=obj.object_id,
+        path=obj.path,
+        filename=os.path.basename(obj.path),
+        size_bytes=obj.size_bytes,
+        sha=obj.object_id,
+        created_at=obj.created_at,
+        raw_url=raw_url,
+        file_type=file_type,
+        content_text=content_text,
+    )
 
 
 @router.get(

--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -36,6 +36,7 @@ Endpoint summary (repo-scoped):
   GET /musehub/ui/{owner}/{repo_slug}/insights                  -- repo insights dashboard
   GET /musehub/ui/{owner}/{repo_slug}/tree/{ref}                -- file tree browser (repo root)
   GET /musehub/ui/{owner}/{repo_slug}/tree/{ref}/{path}         -- file tree browser (subdirectory)
+  GET /musehub/ui/{owner}/{repo_slug}/blob/{ref}/{path}         -- music-aware file blob viewer
   GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}            -- analysis dashboard (all 10 dimensions at a glance)
   GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/contour    -- melodic contour analysis
   GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/tempo      -- tempo analysis
@@ -1433,6 +1434,54 @@ async def tree_subdir_page(
             "repo_id": repo_id,
             "ref": ref,
             "dir_path": path,
+            "base_url": base_url,
+            "current_page": "tree",
+        },
+    )
+
+
+@router.get(
+    "/{owner}/{repo_slug}/blob/{ref}/{path:path}",
+    response_class=HTMLResponse,
+    summary="Muse Hub file blob viewer — music-aware file rendering",
+)
+async def blob_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    ref: str,
+    path: str,
+    db: AsyncSession = Depends(get_db),
+) -> HTMLResponse:
+    """Render the music-aware blob viewer for a single file at a given ref.
+
+    Dispatches to the appropriate rendering mode based on file extension:
+    - .mid/.midi → piano roll preview with "View in Piano Roll" quick link
+    - .mp3/.wav/.flac → <audio> player with "Listen" quick link
+    - .json → syntax-highlighted, formatted JSON with collapsible sections
+    - .webp/.png/.jpg → inline <img> display
+    - .xml → syntax-highlighted XML (MusicXML support)
+    - Other → hex dump preview with raw download link
+
+    Metadata shown: filename, size, SHA, commit date.
+    Raw download button links to /{owner}/{repo_slug}/raw/{ref}/{path}.
+
+    Auth: no JWT required for public repos.  Private-repo auth is
+    handled client-side via localStorage JWT (consistent with other
+    MuseHub UI pages).
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    filename = path.split("/")[-1] if path else ""
+    return templates.TemplateResponse(
+        request,
+        "musehub/pages/blob.html",
+        {
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "ref": ref,
+            "file_path": path,
+            "filename": filename,
             "base_url": base_url,
             "current_page": "tree",
         },

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -1202,6 +1202,34 @@ class GrooveCommitEntry(CamelModel):
     midi_files: int = Field(..., description="Number of MIDI snapshots analysed")
 
 
+class BlobMetaResponse(CamelModel):
+    """Wire representation of a single file (blob) in the Muse tree browser.
+
+    Returned by GET /musehub/repos/{repo_id}/blob/{ref}/{path}.
+    Consumers use ``file_type`` to choose the appropriate rendering mode
+    (piano roll for MIDI, audio player for MP3/WAV, inline img for images,
+    syntax-highlighted text for JSON/XML, hex dump for unknown binaries).
+    ``content_text`` is populated only for text files up to 256 KB; binary
+    files should use ``raw_url`` to stream content.
+    """
+
+    object_id: str = Field(..., description="Content-addressed ID, e.g. 'sha256:abc123...'")
+    path: str = Field(..., description="Relative path from repo root, e.g. 'tracks/bass.mid'")
+    filename: str = Field(..., description="Basename of the file, e.g. 'bass.mid'")
+    size_bytes: int = Field(..., description="File size in bytes")
+    sha: str = Field(..., description="Content-addressed SHA identifier")
+    created_at: datetime = Field(..., description="Timestamp when this object was pushed")
+    raw_url: str = Field(..., description="URL to download the raw file bytes")
+    file_type: str = Field(
+        ...,
+        description="Rendering hint: 'midi' | 'audio' | 'json' | 'image' | 'xml' | 'other'",
+    )
+    content_text: str | None = Field(
+        None,
+        description="UTF-8 content for JSON/XML files up to 256 KB; None for binary or oversized files",
+    )
+
+
 class GrooveCheckResponse(CamelModel):
     """Rhythmic consistency dashboard data for a commit range in a Muse Hub repo.
 

--- a/maestro/templates/musehub/pages/blob.html
+++ b/maestro/templates/musehub/pages/blob.html
@@ -1,0 +1,329 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}{{ owner }}/{{ repo_slug }} — {{ filename }}{% endblock %}
+
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> /
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}/tree/{{ ref }}">{{ ref[:8] }}</a>
+  {% if file_path %}
+    {% set segments = file_path.split('/') %}
+    {% set ns = namespace(accumulated='') %}
+    {% for seg in segments[:-1] %}
+      {% if ns.accumulated %}
+        {% set ns.accumulated = ns.accumulated + '/' + seg %}
+      {% else %}
+        {% set ns.accumulated = seg %}
+      {% endif %}
+      / <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}/tree/{{ ref }}/{{ ns.accumulated }}">{{ seg }}</a>
+    {% endfor %}
+    / {{ filename }}
+  {% endif %}
+{% endblock %}
+
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block extra_css %}
+<style>
+/* ── Blob header ─────────────────────────────────────────────────────── */
+.blob-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 16px;
+  background: #161b22; border: 1px solid #30363d; border-radius: 8px 8px 0 0;
+  border-bottom: none; margin-top: 8px; gap: 12px; flex-wrap: wrap;
+}
+.blob-filename {
+  font-size: 14px; font-weight: 600; color: #c9d1d9;
+  display: flex; align-items: center; gap: 8px;
+}
+.blob-meta {
+  font-size: 12px; color: #8b949e; display: flex; gap: 16px; flex-wrap: wrap;
+}
+.blob-meta span { display: flex; align-items: center; gap: 4px; }
+.blob-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.btn-blob {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: 6px; font-size: 13px;
+  text-decoration: none; font-weight: 500; border: 1px solid transparent;
+  cursor: pointer;
+}
+.btn-blob-primary {
+  background: #238636; border-color: #2ea043; color: #ffffff;
+}
+.btn-blob-primary:hover { background: #2ea043; }
+.btn-blob-secondary {
+  background: #21262d; border-color: #30363d; color: #c9d1d9;
+}
+.btn-blob-secondary:hover { background: #30363d; }
+
+/* ── Blob body ───────────────────────────────────────────────────────── */
+.blob-body {
+  background: #0d1117; border: 1px solid #30363d; border-radius: 0 0 8px 8px;
+  min-height: 120px; overflow: hidden;
+}
+.blob-loading { padding: 40px; text-align: center; color: #8b949e; font-size: 14px; }
+.blob-error { padding: 24px; color: #f85149; font-size: 14px; }
+
+/* ── MIDI / piano-roll placeholder ──────────────────────────────────── */
+.blob-midi-banner {
+  padding: 48px 24px; text-align: center; background: #0d1117;
+}
+.blob-midi-icon { font-size: 64px; margin-bottom: 16px; display: block; }
+.blob-midi-title { font-size: 20px; font-weight: 600; color: #c9d1d9; margin-bottom: 8px; }
+.blob-midi-sub { font-size: 14px; color: #8b949e; margin-bottom: 24px; }
+
+/* ── Audio player ─────────────────────────────────────────────────────── */
+.blob-audio-wrap {
+  padding: 40px 24px; text-align: center; background: #0d1117;
+}
+.blob-audio-icon { font-size: 48px; margin-bottom: 16px; display: block; }
+.blob-audio-player {
+  width: 100%; max-width: 560px; margin: 16px auto 0;
+  display: block; accent-color: #58a6ff;
+}
+
+/* ── JSON / XML viewer ─────────────────────────────────────────────────── */
+.blob-code-wrap {
+  overflow: auto; max-height: 680px; border-radius: 0 0 8px 8px;
+}
+.blob-code {
+  margin: 0; padding: 16px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px; line-height: 1.6; color: #c9d1d9;
+  white-space: pre-wrap; word-break: break-word;
+  background: #0d1117; tab-size: 2;
+}
+.blob-code .json-key { color: #79c0ff; }
+.blob-code .json-str { color: #a5d6ff; }
+.blob-code .json-num { color: #f2cc60; }
+.blob-code .json-bool { color: #ff7b72; }
+.blob-code .json-null { color: #8b949e; }
+
+/* ── Image viewer ───────────────────────────────────────────────────────── */
+.blob-img-wrap {
+  padding: 24px; display: flex; justify-content: center; align-items: center;
+  background: repeating-conic-gradient(#161b22 0% 25%, #0d1117 0% 50%) 0 0 / 20px 20px;
+  min-height: 200px; border-radius: 0 0 8px 8px;
+}
+.blob-img { max-width: 100%; max-height: 640px; border-radius: 4px; box-shadow: 0 4px 16px rgba(0,0,0,.6); }
+
+/* ── Hex dump / binary ─────────────────────────────────────────────────── */
+.blob-hex-wrap { overflow: auto; max-height: 400px; }
+.blob-hex {
+  margin: 0; padding: 16px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px; line-height: 1.7; color: #8b949e;
+  background: #0d1117; white-space: pre;
+}
+.blob-hex .hex-offset { color: #6e7681; margin-right: 12px; }
+.blob-hex .hex-bytes { color: #c9d1d9; margin-right: 12px; }
+.blob-hex .hex-ascii { color: #8b949e; }
+.blob-binary-notice {
+  padding: 24px; text-align: center; color: #8b949e; font-size: 14px;
+  border-top: 1px solid #21262d;
+}
+</style>
+{% endblock %}
+
+{% block page_data %}
+const repoId   = {{ repo_id | tojson }};
+const ref      = {{ ref | tojson }};
+const filePath = {{ file_path | tojson }};
+const filename = {{ filename | tojson }};
+const owner    = {{ owner | tojson }};
+const repoSlug = {{ repo_slug | tojson }};
+const base     = {{ base_url | tojson }};
+const apiBase  = '/api/v1/musehub/repos/' + repoId;
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+// ── Utility ──────────────────────────────────────────────────────────────────
+function fmtSize(bytes) {
+  if (bytes === null || bytes === undefined) return '';
+  if (bytes < 1024) return bytes + '\u00a0B';
+  if (bytes < 1048576) return (bytes / 1024).toFixed(1) + '\u00a0KB';
+  return (bytes / 1048576).toFixed(1) + '\u00a0MB';
+}
+
+function fmtDate(iso) {
+  if (!iso) return '';
+  try { return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }); }
+  catch (_) { return iso; }
+}
+
+function shortSha(sha) {
+  const idx = sha.indexOf(':');
+  const hex = idx >= 0 ? sha.slice(idx + 1) : sha;
+  return hex.slice(0, 12);
+}
+
+// ── JSON syntax highlight (safe — operates on text, never eval) ──────────────
+function highlightJson(text) {
+  const escaped = escHtml(text);
+  return escaped.replace(
+    /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^"\\])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g,
+    function(match) {
+      if (/^"/.test(match)) {
+        if (/:$/.test(match)) return '<span class="json-key">' + match + '</span>';
+        return '<span class="json-str">' + match + '</span>';
+      }
+      if (/true|false/.test(match)) return '<span class="json-bool">' + match + '</span>';
+      if (/null/.test(match))       return '<span class="json-null">' + match + '</span>';
+      return '<span class="json-num">' + match + '</span>';
+    }
+  );
+}
+
+// ── Hex dump (first 512 bytes of a binary blob) ──────────────────────────────
+function renderHexDump(arrayBuffer) {
+  const bytes = new Uint8Array(arrayBuffer);
+  const limit = Math.min(bytes.length, 512);
+  let out = '';
+  for (let i = 0; i < limit; i += 16) {
+    const chunk = bytes.slice(i, i + 16);
+    const offset = i.toString(16).padStart(8, '0');
+    const hexPart = Array.from(chunk).map(b => b.toString(16).padStart(2, '0')).join(' ').padEnd(47, ' ');
+    const asciiPart = Array.from(chunk).map(b => (b >= 32 && b < 127) ? String.fromCharCode(b) : '.').join('');
+    out += '<span class="hex-offset">' + offset + '</span>'
+         + '<span class="hex-bytes">' + escHtml(hexPart) + '</span>'
+         + '<span class="hex-ascii">' + escHtml(asciiPart) + '</span>\n';
+  }
+  return out;
+}
+
+// ── Build action buttons ──────────────────────────────────────────────────────
+function buildActions(data, rawUrl) {
+  const rollUrl   = base + '/piano-roll/' + encodeURIComponent(ref) + '/' + filePath;
+  const listenUrl = base + '/listen/'     + encodeURIComponent(ref) + '/' + filePath;
+  let actions = '<a class="btn-blob btn-blob-secondary" href="' + escHtml(rawUrl) + '" download>'
+    + '&#11015;&#65039;&nbsp;Raw</a>';
+  if (data.fileType === 'midi') {
+    actions += '&nbsp;<a class="btn-blob btn-blob-primary" href="' + escHtml(rollUrl) + '">'
+      + '&#127929;&nbsp;View in Piano Roll</a>';
+  } else if (data.fileType === 'audio') {
+    actions += '&nbsp;<a class="btn-blob btn-blob-primary" href="' + escHtml(listenUrl) + '">'
+      + '&#127925;&nbsp;Listen</a>';
+  }
+  return actions;
+}
+
+// ── Render body by file type ─────────────────────────────────────────────────
+function renderBlobBody(data, rawUrl) {
+  const rollUrl = base + '/piano-roll/' + encodeURIComponent(ref) + '/' + filePath;
+  switch (data.fileType) {
+    case 'midi':
+      return '<div class="blob-midi-banner">'
+        + '<span class="blob-midi-icon">&#127929;</span>'
+        + '<div class="blob-midi-title">' + escHtml(data.filename || filename) + '</div>'
+        + '<div class="blob-midi-sub">MIDI file \u2014 interactive piano roll coming in Phase 2</div>'
+        + '<a class="btn-blob btn-blob-primary" href="' + escHtml(rollUrl) + '">&#127929;&nbsp;View in Piano Roll</a>'
+        + '</div>';
+    case 'audio':
+      return '<div class="blob-audio-wrap">'
+        + '<span class="blob-audio-icon">&#127925;</span>'
+        + '<div style="color:#c9d1d9;font-size:16px;font-weight:600;margin-bottom:4px">' + escHtml(data.filename || filename) + '</div>'
+        + '<audio class="blob-audio-player" controls preload="metadata" src="' + escHtml(rawUrl) + '">'
+        + 'Your browser does not support audio playback. <a href="' + escHtml(rawUrl) + '">Download</a> instead.'
+        + '</audio></div>';
+    case 'json':
+      if (data.contentText) {
+        let pretty = data.contentText;
+        try { pretty = JSON.stringify(JSON.parse(data.contentText), null, 2); } catch (_) {}
+        return '<div class="blob-code-wrap"><pre class="blob-code"><code>' + highlightJson(pretty) + '</code></pre></div>';
+      }
+      return '<div class="blob-binary-notice">File too large to display inline. '
+        + '<a href="' + escHtml(rawUrl) + '">Download raw</a></div>';
+    case 'xml':
+      if (data.contentText) {
+        return '<div class="blob-code-wrap"><pre class="blob-code"><code>' + escHtml(data.contentText) + '</code></pre></div>';
+      }
+      return '<div class="blob-binary-notice">File too large to display inline. '
+        + '<a href="' + escHtml(rawUrl) + '">Download raw</a></div>';
+    case 'image':
+      return '<div class="blob-img-wrap">'
+        + '<img class="blob-img" src="' + escHtml(rawUrl) + '" alt="' + escHtml(data.filename || filename) + '">'
+        + '</div>';
+    default:
+      return null; // async hex-dump path
+  }
+}
+
+// ── Hex preview for binary/unknown files (Range request for first 512 B) ──────
+async function fetchHexPreview(rawUrl, bodyEl, sizeBytes) {
+  try {
+    const resp = await fetch(rawUrl, { headers: { Range: 'bytes=0-511' } });
+    if (resp.ok || resp.status === 206) {
+      const buf  = await resp.arrayBuffer();
+      const hex  = renderHexDump(buf);
+      bodyEl.innerHTML =
+        '<div class="blob-hex-wrap"><pre class="blob-hex">' + hex + '</pre></div>'
+        + '<div class="blob-binary-notice">Showing first ' + Math.min(512, sizeBytes)
+        + ' bytes of ' + fmtSize(sizeBytes) + '. '
+        + '<a href="' + escHtml(rawUrl) + '" download>Download full file</a></div>';
+    } else {
+      bodyEl.innerHTML = '<div class="blob-binary-notice">Binary file \u2014 <a href="' + escHtml(rawUrl) + '" download>Download</a></div>';
+    }
+  } catch (_) {
+    bodyEl.innerHTML = '<div class="blob-binary-notice">Binary file \u2014 <a href="' + escHtml(rawUrl) + '" download>Download</a></div>';
+  }
+}
+
+// ── Render full page structure into #content ──────────────────────────────────
+async function renderBlob(data) {
+  const rawUrl = data.rawUrl || (base + '/raw/' + encodeURIComponent(ref) + '/' + filePath);
+
+  const metaHtml =
+    '<span title="Size">&#128196;&nbsp;' + fmtSize(data.sizeBytes) + '</span>'
+    + '<span title="SHA">&#128273;&nbsp;' + escHtml(shortSha(data.sha || '')) + '</span>'
+    + '<span title="Last pushed">&#128197;&nbsp;' + escHtml(fmtDate(data.createdAt)) + '</span>';
+
+  const headerHtml =
+    '<div class="blob-header">'
+    + '<div class="blob-filename">&#128196;&nbsp;' + escHtml(data.filename || filename) + '</div>'
+    + '<div class="blob-meta">' + metaHtml + '</div>'
+    + '<div class="blob-actions">' + buildActions(data, rawUrl) + '</div>'
+    + '</div>';
+
+  const syncBody = renderBlobBody(data, rawUrl);
+  const bodyPlaceholder = '<div class="blob-body" id="blob-body-inner">'
+    + (syncBody !== null ? syncBody : '<div class="blob-loading">Rendering\u2026</div>')
+    + '</div>';
+
+  document.getElementById('content').innerHTML = headerHtml + bodyPlaceholder;
+
+  if (syncBody === null) {
+    const bodyEl = document.getElementById('blob-body-inner');
+    await fetchHexPreview(rawUrl, bodyEl, data.sizeBytes);
+  }
+}
+
+// ── Load blob metadata from JSON API ─────────────────────────────────────────
+async function loadBlob() {
+  const contentEl = document.getElementById('content');
+  contentEl.innerHTML = '<div class="blob-loading">Loading\u2026</div>';
+  try {
+    const tok = getToken ? getToken() : (localStorage.getItem('muse_token') || '');
+    const headers = tok ? { Authorization: 'Bearer ' + tok } : {};
+    const url = apiBase + '/blob/' + encodeURIComponent(ref) + '/' + filePath;
+    const resp = await fetch(url, { headers });
+    if (resp.status === 404) {
+      contentEl.innerHTML = '<div class="blob-error">&#10060; File not found: <code>' + escHtml(filePath) + '</code></div>';
+      return;
+    }
+    if (resp.status === 401) {
+      contentEl.innerHTML = '<div class="blob-error">&#128274; Private repo \u2014 sign in to view this file.</div>';
+      return;
+    }
+    if (!resp.ok) {
+      contentEl.innerHTML = '<div class="blob-error">&#10060; Failed to load file (HTTP ' + resp.status + ').</div>';
+      return;
+    }
+    const data = await resp.json();
+    await renderBlob(data);
+  } catch (err) {
+    document.getElementById('content').innerHTML =
+      '<div class="blob-error">&#10060; ' + escHtml(String(err)) + '</div>';
+  }
+}
+
+loadBlob();
+{% endraw %}
+{% endblock %}


### PR DESCRIPTION
## Summary
Closes #205 — Adds a music-aware blob viewer page to MuseHub with file-type-specific rendering for MIDI, audio, JSON, images, and other file types.

## Root Cause / Motivation
MuseHub had no way to view individual files from a Muse repo. Musicians need to preview MIDI as piano rolls, audio files as players, and JSON/XML with syntax highlighting — without downloading files first.

## Solution
- New blob viewer page at `/{owner}/{repo}/blob/{ref}/{path}` with file-type dispatch
- New `blob.html` template: MIDI → piano roll placeholder + quick link, audio → `<audio>` player, JSON → syntax-highlighted (no eval), images → inline `<img>`, XML → highlighted, other → hex dump first 512 bytes via Range request
- New `blob_page()` handler in `ui.py`
- New `get_blob_meta()` endpoint in `objects.py` returning `BlobMetaResponse` JSON (metadata + text content for JSON/XML ≤ 256 KB)
- New `BlobMetaResponse` Pydantic model in `models/musehub.py`
- Docs updated in `docs/architecture/muse_vcs.md`

## File-Type Rendering

| Extension | Mode | Quick Link |
|-----------|------|------------|
| `.mid`/`.midi` | Piano roll placeholder | View in Piano Roll |
| `.mp3`/`.wav`/`.flac` | `<audio>` player | Listen |
| `.json` | Syntax-highlighted JSON | — |
| `.webp`/`.png`/`.jpg` | Inline `<img>` | — |
| `.xml` | Syntax-highlighted XML | — |
| other | Hex dump (first 512 B) | Raw download |

## Verification
- [x] mypy clean (631 source files, 0 issues)
- [x] 7 blob tests pass: `test_blob_midi_shows_piano_roll_link`, `test_blob_mp3_shows_audio_player`, `test_blob_json_syntax_highlighted`, `test_blob_image_shows_inline`, `test_blob_raw_button`, `test_blob_404_unknown_path`, `test_blob_json_response`
- [x] Docs updated in `docs/architecture/muse_vcs.md`
- [x] Synced with `origin/dev` (merge conflict in `test_musehub_ui.py` resolved — kept all tests from both sides)