### PR TITLE
feat(musehub): branch list and tag browser — divergence scores and namespace filtering

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -1790,6 +1790,7 @@ Displays all releases as browseable tags, grouped by namespace prefix:
 - **View commit** link per tag.
 
 Content negotiation: `?format=json` or `Accept: application/json` returns `TagListResponse` (camelCase) including a `namespaces` list. Optional `?namespace=<ns>` query parameter filters by namespace server-side.
+
 ### Repo Home Page
 
 **Purpose:** Provide an "album cover" view of a Muse Hub repo — hearing the latest mix, seeing the arrangement structure, and understanding project activity at a glance.  Replaces the plain commit-list landing page with a rich dashboard suited for musicians, collaborators, and AI agents.

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -6948,6 +6948,88 @@ when the corresponding package is unavailable.
 | Field | Type | Description |
 |-------|------|-------------|
 | `releases` | `list[ReleaseResponse]` | All releases, newest first |
+
+---
+
+## `BranchDivergenceScores`
+
+**Module:** `maestro.models.musehub`
+**Used by:** `BranchDetailResponse.divergence` field.
+
+Placeholder musical divergence scores between a branch and the repo's default branch. All five dimensions mirror the `muse divergence` command output. Values are floats in `[0.0, 1.0]` where `0` = identical and `1` = maximally different. All fields are `None` until audio snapshots are attached to commits and server-side computation is implemented.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `melodic` | `float \| None` | Melodic divergence `[0–1]`; `None` = not yet computable |
+| `harmonic` | `float \| None` | Harmonic divergence `[0–1]`; `None` = not yet computable |
+| `rhythmic` | `float \| None` | Rhythmic divergence `[0–1]`; `None` = not yet computable |
+| `structural` | `float \| None` | Structural divergence `[0–1]`; `None` = not yet computable |
+| `dynamic` | `float \| None` | Dynamic divergence `[0–1]`; `None` = not yet computable |
+
+---
+
+## `BranchDetailResponse`
+
+**Module:** `maestro.models.musehub`
+**Used by:** `BranchDetailListResponse.branches`, `GET /api/v1/musehub/repos/{repo_id}/branches/detail`.
+
+Branch pointer enriched with ahead/behind counts and musical divergence scores. Ahead/behind are set-difference approximations over the `musehub_commits` table — suitable for display, not for merge-base computation.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `branch_id` | `str` | Internal UUID of the branch row |
+| `name` | `str` | Branch name (e.g. `"main"`, `"feat/jazz-bridge"`) |
+| `head_commit_id` | `str \| None` | HEAD commit ID; `None` for an empty branch |
+| `is_default` | `bool` | `True` when this is the repo's default branch |
+| `ahead_count` | `int` | Commits on this branch not yet on the default branch |
+| `behind_count` | `int` | Commits on the default branch not yet on this branch |
+| `divergence` | `BranchDivergenceScores` | Musical divergence scores vs the default branch (placeholder until computable) |
+
+---
+
+## `BranchDetailListResponse`
+
+**Module:** `maestro.models.musehub`
+**Used by:** `GET /api/v1/musehub/repos/{repo_id}/branches/detail`, `GET /musehub/ui/{owner}/{repo_slug}/branches` (JSON variant).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `branches` | `list[BranchDetailResponse]` | All branches, sorted alphabetically by name |
+| `default_branch` | `str` | Name of the repo's default branch (prefers `"main"`, else first alphabetically) |
+
+---
+
+## `TagResponse`
+
+**Module:** `maestro.models.musehub`
+**Used by:** `TagListResponse.tags`, `GET /musehub/ui/{owner}/{repo_slug}/tags` (JSON variant).
+
+A single tag entry sourced from a `musehub_releases` row. The `namespace` field is derived from the tag name: `emotion:happy` → `emotion`; tags without a colon fall into the `version` namespace.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tag` | `str` | Full tag string (e.g. `"emotion:happy"`, `"v1.0"`) |
+| `namespace` | `str` | Namespace prefix extracted from the tag (e.g. `"emotion"`, `"genre"`, `"version"`) |
+| `commit_id` | `str \| None` | Commit this tag is pinned to, or `None` |
+| `message` | `str` | Release title / description (empty string if unset) |
+| `created_at` | `datetime` | Tag creation timestamp (ISO-8601 UTC) |
+
+---
+
+## `TagListResponse`
+
+**Module:** `maestro.models.musehub`
+**Used by:** `GET /musehub/ui/{owner}/{repo_slug}/tags` (JSON variant, `?format=json` or `Accept: application/json`).
+
+All tags for a repo, optionally filtered by `?namespace=<ns>` server-side. The flat `tags` list is sorted by creation time (newest first from the releases table). Clients may group by the `namespace` field client-side.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tags` | `list[TagResponse]` | Tags (filtered by `?namespace` when provided; all tags otherwise) |
+| `namespaces` | `list[str]` | Sorted list of all distinct namespace strings present in the repo (always the full set, unaffected by `?namespace` filter) |
+
+---
+
 ## ExploreRepoResult
 
 **Module:** `maestro.models.musehub`

--- a/maestro/api/routes/musehub/repos.py
+++ b/maestro/api/routes/musehub/repos.py
@@ -31,6 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from maestro.auth.dependencies import TokenClaims, optional_token, require_valid_token
 from maestro.db import get_db
 from maestro.models.musehub import (
+    BranchDetailListResponse,
     BranchListResponse,
     CommitListResponse,
     CommitResponse,
@@ -156,6 +157,34 @@ async def list_branches(
     _guard_visibility(repo, claims)
     branches = await musehub_repository.list_branches(db, repo_id)
     return BranchListResponse(branches=branches)
+
+
+@router.get(
+    "/repos/{repo_id}/branches/detail",
+    response_model=BranchDetailListResponse,
+    operation_id="listRepoBranchesDetail",
+    summary="List branches with ahead/behind counts and divergence scores",
+    tags=["Branches"],
+)
+async def list_branches_detail(
+    repo_id: str,
+    db: AsyncSession = Depends(get_db),
+    claims: TokenClaims | None = Depends(optional_token),
+) -> BranchDetailListResponse:
+    """Return branches enriched with ahead/behind counts vs the default branch.
+
+    Each branch includes:
+    - ``aheadCount``: commits on this branch not yet on the default branch
+    - ``behindCount``: commits on the default branch not yet merged here
+    - ``isDefault``: whether this is the repo's default branch
+    - ``divergence``: musical divergence scores (placeholder ``null`` until computable)
+
+    Used by the MuseHub branch list page to help musicians decide which branches
+    to merge or discard.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    _guard_visibility(repo, claims)
+    return await musehub_repository.list_branches_with_detail(db, repo_id)
 
 
 @router.get(

--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -62,7 +62,15 @@ from starlette.responses import Response as StarletteResponse
 
 from maestro.api.routes.musehub.negotiate import negotiate_response
 from maestro.db import get_db
-from maestro.models.musehub import CommitListResponse, CommitResponse, RepoResponse
+from maestro.models.musehub import (
+    BranchDetailListResponse,
+    CommitListResponse,
+    CommitResponse,
+    RepoResponse,
+    TagListResponse,
+    TagResponse,
+)
+from maestro.services import musehub_releases
 from maestro.services import musehub_repository
 
 logger = logging.getLogger(__name__)
@@ -1474,6 +1482,116 @@ async def groove_check_page(
             "base_url": base_url,
             "current_page": "groove-check",
         },
+    )
+
+
+@router.get(
+    "/{owner}/{repo_slug}/branches",
+    summary="Muse Hub branch list page",
+)
+async def branches_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    format: str | None = Query(None, description="Force response format: 'json' or omit for HTML"),
+    db: AsyncSession = Depends(get_db),
+) -> StarletteResponse:
+    """Render the branch list page or return structured branch data as JSON.
+
+    HTML (default): lists all branches with HEAD commit info, ahead/behind counts,
+    musical divergence scores (placeholder), compare links, and New Pull Request buttons.
+    JSON (``Accept: application/json`` or ``?format=json``): returns
+    ``BranchDetailListResponse`` with per-branch ahead/behind counts.
+
+    Content negotiation — one URL, two audiences: musicians get rich HTML,
+    agents get structured JSON to programmatically inspect branch state.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    branch_data: BranchDetailListResponse = (
+        await musehub_repository.list_branches_with_detail(db, repo_id)
+    )
+    return await negotiate_response(
+        request=request,
+        template_name="musehub/pages/branches.html",
+        context={
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "base_url": base_url,
+            "current_page": "branches",
+        },
+        templates=templates,
+        json_data=branch_data,
+        format_param=format,
+    )
+
+
+@router.get(
+    "/{owner}/{repo_slug}/tags",
+    summary="Muse Hub tag browser page",
+)
+async def tags_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    namespace: str | None = Query(None, description="Filter tags by namespace prefix"),
+    format: str | None = Query(None, description="Force response format: 'json' or omit for HTML"),
+    db: AsyncSession = Depends(get_db),
+) -> StarletteResponse:
+    """Render the tag browser page or return structured tag data as JSON.
+
+    Tags are sourced from repo releases.  The tag browser groups tags by their
+    namespace prefix (the text before ``:``, e.g. ``emotion``, ``genre``,
+    ``instrument``) — tags without a colon fall into the ``version`` namespace.
+
+    HTML (default): filterable list of tags grouped by namespace with commit info.
+    JSON (``Accept: application/json`` or ``?format=json``): returns
+    ``TagListResponse`` with namespace grouping and optional ``?namespace`` filtering.
+
+    Click a tag to navigate to the commit detail page for that release's commit.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    releases = await musehub_releases.list_releases(db, repo_id)
+
+    all_tags: list[TagResponse] = []
+    for release in releases:
+        tag_str = release.tag
+        if ":" in tag_str:
+            ns, _ = tag_str.split(":", 1)
+        else:
+            ns = "version"
+        all_tags.append(
+            TagResponse(
+                tag=tag_str,
+                namespace=ns,
+                commit_id=release.commit_id,
+                message=release.title,
+                created_at=release.created_at,
+            )
+        )
+
+    if namespace:
+        filtered_tags = [t for t in all_tags if t.namespace == namespace]
+    else:
+        filtered_tags = all_tags
+
+    namespaces: list[str] = sorted({t.namespace for t in all_tags})
+    tag_data = TagListResponse(tags=filtered_tags, namespaces=namespaces)
+
+    return await negotiate_response(
+        request=request,
+        template_name="musehub/pages/tags.html",
+        context={
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "base_url": base_url,
+            "current_page": "tags",
+            "active_namespace": namespace or "",
+        },
+        templates=templates,
+        json_data=tag_data,
+        format_param=format,
     )
 
 

--- a/maestro/services/musehub_repository.py
+++ b/maestro/services/musehub_repository.py
@@ -24,6 +24,9 @@ from maestro.db import musehub_models as db
 from maestro.models.musehub import (
     SessionListResponse,
     SessionResponse,
+    BranchDetailListResponse,
+    BranchDetailResponse,
+    BranchDivergenceScores,
     BranchResponse,
     CommitResponse,
     GlobalSearchCommitMatch,
@@ -196,6 +199,66 @@ async def list_branches(session: AsyncSession, repo_id: str) -> list[BranchRespo
     )
     rows = (await session.execute(stmt)).scalars().all()
     return [_to_branch_response(r) for r in rows]
+
+
+async def list_branches_with_detail(
+    session: AsyncSession, repo_id: str
+) -> BranchDetailListResponse:
+    """Return branches enriched with ahead/behind counts vs the default branch.
+
+    The default branch is whichever branch is named "main"; if no "main" branch
+    exists, the first branch alphabetically is used.  Ahead/behind counts are
+    computed by comparing the set of commit IDs on each branch vs the default
+    branch — a set-difference approximation suitable for display purposes.
+
+    Musical divergence scores are not yet computable server-side (they require
+    audio snapshots), so all divergence fields are returned as ``None`` (placeholder).
+    """
+    branch_stmt = (
+        select(db.MusehubBranch)
+        .where(db.MusehubBranch.repo_id == repo_id)
+        .order_by(db.MusehubBranch.name)
+    )
+    branch_rows = (await session.execute(branch_stmt)).scalars().all()
+    if not branch_rows:
+        return BranchDetailListResponse(branches=[], default_branch="main")
+
+    # Determine default branch name: prefer "main", fall back to first alphabetically.
+    branch_names = [r.name for r in branch_rows]
+    default_branch_name = "main" if "main" in branch_names else branch_names[0]
+
+    # Load commit IDs per branch in one query.
+    commit_stmt = select(db.MusehubCommit.commit_id, db.MusehubCommit.branch).where(
+        db.MusehubCommit.repo_id == repo_id
+    )
+    commit_rows = (await session.execute(commit_stmt)).all()
+    commits_by_branch: dict[str, set[str]] = {}
+    for commit_id, branch_name in commit_rows:
+        commits_by_branch.setdefault(branch_name, set()).add(commit_id)
+
+    default_commits: set[str] = commits_by_branch.get(default_branch_name, set())
+
+    results: list[BranchDetailResponse] = []
+    for row in branch_rows:
+        is_default = row.name == default_branch_name
+        branch_commits: set[str] = commits_by_branch.get(row.name, set())
+        ahead = len(branch_commits - default_commits) if not is_default else 0
+        behind = len(default_commits - branch_commits) if not is_default else 0
+        results.append(
+            BranchDetailResponse(
+                branch_id=row.branch_id,
+                name=row.name,
+                head_commit_id=row.head_commit_id,
+                is_default=is_default,
+                ahead_count=ahead,
+                behind_count=behind,
+                divergence=BranchDivergenceScores(
+                    melodic=None, harmonic=None, rhythmic=None, structural=None, dynamic=None
+                ),
+            )
+        )
+
+    return BranchDetailListResponse(branches=results, default_branch=default_branch_name)
 
 
 def _to_object_meta_response(row: db.MusehubObject) -> ObjectMetaResponse:

--- a/maestro/templates/musehub/pages/branches.html
+++ b/maestro/templates/musehub/pages/branches.html
@@ -1,0 +1,112 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Branches{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> / branches
+{% endblock %}
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block page_data %}
+const repoId  = {{ repo_id | tojson }};
+const apiBase = '/api/v1/musehub/repos/' + repoId;
+const uiBase  = {{ base_url | tojson }};
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+const DIMENSIONS = ['melodic', 'harmonic', 'rhythmic', 'structural', 'dynamic'];
+
+function scoreBar(value) {
+  if (value === null || value === undefined) {
+    return '<span style="color:#8b949e;font-size:11px">—</span>';
+  }
+  const pct = Math.round(value * 100);
+  const color = pct < 25 ? '#3fb950' : pct < 55 ? '#f0883e' : '#f85149';
+  return `<span style="display:inline-flex;align-items:center;gap:4px;font-size:11px">
+    <span style="display:inline-block;width:${pct}px;max-width:60px;height:6px;border-radius:3px;background:${color}"></span>
+    <span style="color:#8b949e">${pct}%</span>
+  </span>`;
+}
+
+function divergenceRow(div) {
+  if (!div) return '';
+  return DIMENSIONS.map(dim => `
+    <div style="display:flex;align-items:center;gap:8px;margin:2px 0">
+      <span style="width:68px;font-size:11px;color:#8b949e;text-transform:capitalize">${dim}</span>
+      ${scoreBar(div[dim])}
+    </div>`).join('');
+}
+
+function ahead_behind(ahead, behind) {
+  const parts = [];
+  if (ahead > 0) parts.push(`<span style="color:#3fb950">&#8593;${ahead} ahead</span>`);
+  if (behind > 0) parts.push(`<span style="color:#f85149">&#8595;${behind} behind</span>`);
+  if (parts.length === 0) return '<span style="color:#8b949e;font-size:11px">up to date</span>';
+  return parts.join(' &bull; ');
+}
+
+async function load() {
+  initRepoNav(repoId);
+  try {
+    const data = await apiFetch('/repos/' + repoId + '/branches/detail');
+    const branches = data.branches || [];
+    const defaultBranch = data.defaultBranch || 'main';
+
+    const rows = branches.length === 0
+      ? '<p class="loading">No branches found.</p>'
+      : branches.map(b => {
+          const sha = b.headCommitId ? b.headCommitId.substring(0, 8) : '—';
+          const compareUrl = `${uiBase}/compare/${encodeURIComponent(defaultBranch)}...${encodeURIComponent(b.name)}`;
+          const prUrl = `${uiBase}/pulls/new?head=${encodeURIComponent(b.name)}`;
+
+          return `
+          <div class="branch-row" style="padding:16px 0;border-bottom:1px solid #21262d">
+            <div style="display:flex;align-items:flex-start;gap:12px">
+              <div style="flex:1;min-width:0">
+                <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
+                  <span style="font-weight:600;font-size:14px;color:#e6edf3">${escHtml(b.name)}</span>
+                  ${b.isDefault ? '<span class="badge badge-open" style="font-size:10px">default</span>' : ''}
+                </div>
+                <div style="font-size:12px;color:#8b949e;display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+                  <span style="font-family:monospace">${sha}</span>
+                  ${b.isDefault ? '' : ahead_behind(b.aheadCount, b.behindCount)}
+                </div>
+                ${b.isDefault ? '' : `
+                <div style="margin-top:8px">
+                  <span style="font-size:11px;color:#8b949e;display:block;margin-bottom:4px">Musical divergence</span>
+                  ${divergenceRow(b.divergence)}
+                </div>`}
+              </div>
+              ${b.isDefault ? '' : `
+              <div style="display:flex;flex-direction:column;gap:6px;flex-shrink:0">
+                <a href="${compareUrl}" class="btn btn-secondary" style="font-size:12px;padding:4px 10px">
+                  Compare
+                </a>
+                <a href="${prUrl}" class="btn btn-primary" style="font-size:12px;padding:4px 10px">
+                  New Pull Request
+                </a>
+              </div>`}
+            </div>
+          </div>`;
+        }).join('');
+
+    document.getElementById('content').innerHTML = `
+      <div style="margin-bottom:12px">
+        <a href="${uiBase}">&larr; Back to repo</a>
+      </div>
+      <div class="card">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px">
+          <h1 style="margin:0">&#127807; Branches</h1>
+          <span style="font-size:13px;color:#8b949e">${branches.length} branch${branches.length === 1 ? '' : 'es'}</span>
+        </div>
+        ${rows}
+      </div>`;
+  } catch(e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML = '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/maestro/templates/musehub/pages/tags.html
+++ b/maestro/templates/musehub/pages/tags.html
@@ -1,0 +1,151 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Tags{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> / tags
+{% endblock %}
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block page_data %}
+const repoId    = {{ repo_id | tojson }};
+const apiBase   = '/api/v1/musehub/repos/' + repoId;
+const uiBase    = {{ base_url | tojson }};
+const initialNs = {{ active_namespace | tojson }};
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+const NS_ICONS = {
+  emotion:    '&#127768;',
+  genre:      '&#127911;',
+  instrument: '&#127929;',
+  version:    '&#127991;',
+  custom:     '&#127991;',
+};
+
+function nsIcon(ns) { return NS_ICONS[ns] || '&#127991;'; }
+
+function nsColor(ns) {
+  return { emotion:'#d2a8ff', genre:'#79c0ff', instrument:'#56d364',
+           version:'#f0883e', custom:'#8b949e' }[ns] || '#8b949e';
+}
+
+function tagNamespace(tag) {
+  return tag.includes(':') ? tag.split(':')[0] : 'version';
+}
+
+let allTags = [];
+let allNamespaces = [];
+let activeNs = initialNs || '';
+
+function renderTags() {
+  const filtered = activeNs ? allTags.filter(t => t.namespace === activeNs) : allTags;
+
+  if (filtered.length === 0) {
+    return '<p class="loading">No tags' + (activeNs ? ` in namespace "<strong>${escHtml(activeNs)}</strong>"` : '') + '.</p>';
+  }
+
+  // Group by namespace
+  const byNs = {};
+  for (const t of filtered) {
+    (byNs[t.namespace] = byNs[t.namespace] || []).push(t);
+  }
+
+  return Object.entries(byNs).map(([ns, tags]) => {
+    const rows = tags.map(t => {
+      const sha = t.commitId ? t.commitId.substring(0, 8) : '—';
+      const commitUrl = t.commitId ? `${uiBase}/commits/${t.commitId}` : null;
+      return `
+        <div class="tag-row" style="padding:12px 0;border-bottom:1px solid #21262d">
+          <div style="display:flex;align-items:flex-start;gap:12px">
+            <div style="flex:1">
+              <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
+                <span style="font-weight:600;font-size:14px;color:#e6edf3">${escHtml(t.tag)}</span>
+              </div>
+              <div style="font-size:12px;color:#8b949e;display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+                ${commitUrl
+                  ? `<a href="${commitUrl}" style="font-family:monospace;color:#58a6ff">${sha}</a>`
+                  : '<span style="font-family:monospace;color:#8b949e">no commit</span>'}
+                ${t.message ? `&bull; <span>${escHtml(t.message)}</span>` : ''}
+                &bull; <span>${fmtDate(t.createdAt)}</span>
+              </div>
+            </div>
+            ${commitUrl ? `
+            <a href="${commitUrl}" class="btn btn-secondary" style="font-size:12px;padding:4px 10px;flex-shrink:0">
+              View commit
+            </a>` : ''}
+          </div>
+        </div>`;
+    }).join('');
+
+    return `
+      <div class="card" style="margin-bottom:16px">
+        <h2 style="margin-bottom:12px;display:flex;align-items:center;gap:8px">
+          <span>${nsIcon(ns)}</span>
+          <span style="color:${nsColor(ns)};text-transform:capitalize">${escHtml(ns)}</span>
+          <span style="font-size:13px;font-weight:400;color:#8b949e">
+            ${tags.length} tag${tags.length === 1 ? '' : 's'}
+          </span>
+        </h2>
+        ${rows}
+      </div>`;
+  }).join('');
+}
+
+function setNamespace(ns) {
+  activeNs = ns;
+  document.getElementById('tag-count').textContent =
+    (activeNs ? allTags.filter(t => t.namespace === ns).length : allTags.length)
+    + ' tag' + ((activeNs ? allTags.filter(t => t.namespace === ns).length : allTags.length) === 1 ? '' : 's');
+  document.getElementById('tag-list').innerHTML = renderTags();
+}
+
+async function load() {
+  initRepoNav(repoId);
+  try {
+    // Releases are the tag source: their `tag` field carries namespaced names.
+    const data = await apiFetch('/repos/' + repoId + '/releases');
+    const releases = data.releases || [];
+
+    allTags = releases.map(r => ({
+      tag:       r.tag,
+      namespace: tagNamespace(r.tag),
+      commitId:  r.commitId || null,
+      message:   r.title || '',
+      createdAt: r.createdAt,
+    }));
+
+    // Collect ordered namespaces (preserve insertion order of first appearance)
+    const nsSet = new Set();
+    allTags.forEach(t => nsSet.add(t.namespace));
+    allNamespaces = Array.from(nsSet).sort();
+
+    const nsOptions = ['<option value="">All namespaces</option>']
+      .concat(allNamespaces.map(ns =>
+        `<option value="${escHtml(ns)}"${activeNs === ns ? ' selected' : ''}>${nsIcon(ns)} ${escHtml(ns)}</option>`
+      )).join('');
+
+    const totalLabel = allTags.length + ' tag' + (allTags.length === 1 ? '' : 's');
+
+    document.getElementById('content').innerHTML = `
+      <div style="margin-bottom:12px">
+        <a href="${uiBase}">&larr; Back to repo</a>
+      </div>
+      <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;flex-wrap:wrap">
+        <h1 style="margin:0">&#127991; Tags</h1>
+        <select id="ns-filter" onchange="setNamespace(this.value)" style="margin-left:auto">
+          ${nsOptions}
+        </select>
+        <span id="tag-count" style="font-size:13px;color:#8b949e">${totalLabel}</span>
+      </div>
+      <div id="tag-list">${renderTags()}</div>`;
+  } catch(e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML =
+        '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/maestro/templates/musehub/partials/repo_nav.html
+++ b/maestro/templates/musehub/partials/repo_nav.html
@@ -6,7 +6,7 @@
     repo_slug   str  — repo slug
     base_url    str  — canonical UI base URL (/musehub/ui/{owner}/{repo_slug})
     current_page str — active tab key:
-                       commits | graph | pulls | issues | releases |
+                       commits | graph | pulls | issues | branches | tags | releases |
                        sessions | timeline | analysis | credits | search | insights
 
   The repo_id is set as a JS global by each page's {% block page_data %}.

--- a/maestro/templates/musehub/partials/repo_tabs.html
+++ b/maestro/templates/musehub/partials/repo_tabs.html
@@ -45,6 +45,18 @@
     <span class="tab-count" id="nav-issue-count" style="display:none"></span>
   </a>
 
+  <a href="{{ base_url }}/branches"
+     class="repo-tab{% if current_page == 'branches' %} active{% endif %}"
+     {% if current_page == 'branches' %}aria-current="page"{% endif %}>
+    &#127807; Branches
+  </a>
+
+  <a href="{{ base_url }}/tags"
+     class="repo-tab{% if current_page == 'tags' %} active{% endif %}"
+     {% if current_page == 'tags' %}aria-current="page"{% endif %}>
+    &#127991; Tags
+  </a>
+
   <a href="{{ base_url }}/releases"
      class="repo-tab{% if current_page == 'releases' %} active{% endif %}"
      {% if current_page == 'releases' %}aria-current="page"{% endif %}>

--- a/tests/test_musehub_ui.py
+++ b/tests/test_musehub_ui.py
@@ -52,6 +52,16 @@ Covers issue #221 (analysis dashboard):
 - test_analysis_dashboard_sparkline_logic_present — sparkline JS present
 - test_analysis_dashboard_card_links_to_dimensions — /analysis/ path in page
 See also test_musehub_analysis.py::test_analysis_aggregate_endpoint_returns_all_dimensions
+
+Covers issue #208 (branch list and tag browser):
+- test_branches_page_lists_all          — GET /musehub/ui/{owner}/{slug}/branches returns 200 HTML
+- test_branches_default_marked          — default branch badge present in JSON response
+- test_branches_compare_link            — compare link JS present on branches page
+- test_branches_new_pr_button           — new pull request link JS present
+- test_branches_json_response           — JSON returns BranchDetailListResponse with ahead/behind
+- test_tags_page_lists_all             — GET /musehub/ui/{owner}/{slug}/tags returns 200 HTML
+- test_tags_namespace_filter           — namespace filter JS present on tags page
+- test_tags_json_response              — JSON returns TagListResponse with namespace grouping
 """
 from __future__ import annotations
 
@@ -66,6 +76,7 @@ from maestro.db.musehub_models import (
     MusehubCommit,
     MusehubObject,
     MusehubProfile,
+    MusehubRelease,
     MusehubRepo,
     MusehubSession,
 )
@@ -3372,3 +3383,260 @@ async def test_harmony_json_response(
     # Total beats
     assert "totalBeats" in data
     assert data["totalBeats"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #208 — Branch list and tag browser tests
+# ---------------------------------------------------------------------------
+
+
+async def _make_repo_with_branches(
+    db_session: AsyncSession,
+) -> tuple[str, str, str]:
+    """Seed a repo with two branches (main + feature) and return (repo_id, owner, slug)."""
+    repo = MusehubRepo(
+        name="branch-test",
+        owner="testuser",
+        slug="branch-test",
+        visibility="private",
+        owner_user_id="test-owner",
+    )
+    db_session.add(repo)
+    await db_session.flush()
+    repo_id = str(repo.repo_id)
+
+    main_branch = MusehubBranch(repo_id=repo_id, name="main", head_commit_id="aaa000")
+    feat_branch = MusehubBranch(repo_id=repo_id, name="feat/jazz-bridge", head_commit_id="bbb111")
+    db_session.add_all([main_branch, feat_branch])
+
+    # Two commits on main, one unique commit on feat/jazz-bridge
+    now = datetime.now(UTC)
+    c1 = MusehubCommit(
+        commit_id="aaa000",
+        repo_id=repo_id,
+        branch="main",
+        parent_ids=[],
+        message="Initial commit",
+        author="composer@stori.com",
+        timestamp=now,
+    )
+    c2 = MusehubCommit(
+        commit_id="aaa001",
+        repo_id=repo_id,
+        branch="main",
+        parent_ids=["aaa000"],
+        message="Add bridge",
+        author="composer@stori.com",
+        timestamp=now,
+    )
+    c3 = MusehubCommit(
+        commit_id="bbb111",
+        repo_id=repo_id,
+        branch="feat/jazz-bridge",
+        parent_ids=["aaa000"],
+        message="Add jazz chord",
+        author="composer@stori.com",
+        timestamp=now,
+    )
+    db_session.add_all([c1, c2, c3])
+    await db_session.commit()
+    return repo_id, "testuser", "branch-test"
+
+
+async def _make_repo_with_releases(
+    db_session: AsyncSession,
+) -> tuple[str, str, str]:
+    """Seed a repo with namespaced releases used as tags."""
+    repo = MusehubRepo(
+        name="tag-test",
+        owner="testuser",
+        slug="tag-test",
+        visibility="private",
+        owner_user_id="test-owner",
+    )
+    db_session.add(repo)
+    await db_session.flush()
+    repo_id = str(repo.repo_id)
+
+    now = datetime.now(UTC)
+    releases = [
+        MusehubRelease(
+            repo_id=repo_id, tag="emotion:happy", title="Happy vibes", body="",
+            commit_id="abc001", author="composer", created_at=now, download_urls={},
+        ),
+        MusehubRelease(
+            repo_id=repo_id, tag="genre:jazz", title="Jazz release", body="",
+            commit_id="abc002", author="composer", created_at=now, download_urls={},
+        ),
+        MusehubRelease(
+            repo_id=repo_id, tag="v1.0", title="Version 1.0", body="",
+            commit_id="abc003", author="composer", created_at=now, download_urls={},
+        ),
+    ]
+    db_session.add_all(releases)
+    await db_session.commit()
+    return repo_id, "testuser", "tag-test"
+
+
+@pytest.mark.anyio
+async def test_branches_page_lists_all(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/branches returns 200 HTML."""
+    await _make_repo_with_branches(db_session)
+    resp = await client.get("/musehub/ui/testuser/branch-test/branches")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    body = resp.text
+    assert "Muse Hub" in body
+    # Page-specific JS identifiers
+    assert "branch-row" in body or "branches" in body.lower()
+
+
+@pytest.mark.anyio
+async def test_branches_default_marked(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """JSON response marks the default branch with isDefault=true."""
+    await _make_repo_with_branches(db_session)
+    resp = await client.get(
+        "/musehub/ui/testuser/branch-test/branches",
+        headers={"Accept": "application/json"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "branches" in data
+    default_branches = [b for b in data["branches"] if b.get("isDefault")]
+    assert len(default_branches) == 1
+    assert default_branches[0]["name"] == "main"
+
+
+@pytest.mark.anyio
+async def test_branches_compare_link(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Branches page HTML contains compare link JavaScript."""
+    await _make_repo_with_branches(db_session)
+    resp = await client.get("/musehub/ui/testuser/branch-test/branches")
+    assert resp.status_code == 200
+    body = resp.text
+    # The JS template must reference the compare URL pattern
+    assert "compare" in body.lower()
+
+
+@pytest.mark.anyio
+async def test_branches_new_pr_button(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Branches page HTML contains New Pull Request link JavaScript."""
+    await _make_repo_with_branches(db_session)
+    resp = await client.get("/musehub/ui/testuser/branch-test/branches")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Pull Request" in body
+
+
+@pytest.mark.anyio
+async def test_branches_json_response(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """JSON response includes branches with ahead/behind counts and divergence placeholder."""
+    await _make_repo_with_branches(db_session)
+    resp = await client.get(
+        "/musehub/ui/testuser/branch-test/branches?format=json",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "branches" in data
+    assert "defaultBranch" in data
+    assert data["defaultBranch"] == "main"
+
+    branches_by_name = {b["name"]: b for b in data["branches"]}
+    assert "main" in branches_by_name
+    assert "feat/jazz-bridge" in branches_by_name
+
+    main = branches_by_name["main"]
+    assert main["isDefault"] is True
+    assert main["aheadCount"] == 0
+    assert main["behindCount"] == 0
+
+    feat = branches_by_name["feat/jazz-bridge"]
+    assert feat["isDefault"] is False
+    # feat has 1 unique commit (bbb111); main has 2 commits (aaa000, aaa001) not shared with feat
+    assert feat["aheadCount"] == 1
+    assert feat["behindCount"] == 2
+
+    # Divergence is a placeholder (all None)
+    div = feat["divergence"]
+    assert div["melodic"] is None
+    assert div["harmonic"] is None
+
+
+@pytest.mark.anyio
+async def test_tags_page_lists_all(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/tags returns 200 HTML."""
+    await _make_repo_with_releases(db_session)
+    resp = await client.get("/musehub/ui/testuser/tag-test/tags")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    body = resp.text
+    assert "Muse Hub" in body
+    assert "Tags" in body
+
+
+@pytest.mark.anyio
+async def test_tags_namespace_filter(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Tags page HTML includes namespace filter dropdown JavaScript."""
+    await _make_repo_with_releases(db_session)
+    resp = await client.get("/musehub/ui/testuser/tag-test/tags")
+    assert resp.status_code == 200
+    body = resp.text
+    # Namespace filter select element is rendered by JS
+    assert "ns-filter" in body or "namespace" in body.lower()
+    # Namespace icons present
+    assert "&#127768;" in body or "emotion" in body
+
+
+@pytest.mark.anyio
+async def test_tags_json_response(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """JSON response returns TagListResponse with namespace grouping."""
+    await _make_repo_with_releases(db_session)
+    resp = await client.get(
+        "/musehub/ui/testuser/tag-test/tags?format=json",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "tags" in data
+    assert "namespaces" in data
+
+    # All three releases become tags
+    assert len(data["tags"]) == 3
+
+    tags_by_name = {t["tag"]: t for t in data["tags"]}
+    assert "emotion:happy" in tags_by_name
+    assert "genre:jazz" in tags_by_name
+    assert "v1.0" in tags_by_name
+
+    assert tags_by_name["emotion:happy"]["namespace"] == "emotion"
+    assert tags_by_name["genre:jazz"]["namespace"] == "genre"
+    assert tags_by_name["v1.0"]["namespace"] == "version"
+
+    # Namespaces are sorted
+    assert sorted(data["namespaces"]) == data["namespaces"]
+    assert "emotion" in data["namespaces"]
+    assert "genre" in data["namespaces"]
+    assert "version" in data["namespaces"]


### PR DESCRIPTION
## Summary
Closes #208 — Adds branch list and tag browser pages to MuseHub with musical divergence scores, ahead/behind counts, and tag namespace filtering.

## Root Cause / Motivation
MuseHub had no page to view branches or tags. Musicians with multiple experimental branches need to see how each has diverged musically from the main line and browse tags by namespace (emotion:, genre:, instrument:).

## Solution
- New `branches.html` template with per-branch divergence scores (placeholder), ahead/behind counts, compare and PR links
- New `tags.html` template with namespace grouping and filter dropdown (sourced from releases)
- New `branches_page()` and `tags_page()` handlers in `ui.py` with content negotiation
- New `GET /api/v1/musehub/repos/{repo_id}/branches/detail` endpoint returning `BranchDetailListResponse`
- New models: `BranchDetailResponse`, `BranchDivergenceScores`, `BranchDetailListResponse`, `TagResponse`, `TagListResponse`
- Branches and Tags tabs added to `repo_tabs.html` partial
- Content negotiation: JSON responses for both pages
- 8 new tests covering all acceptance criteria

## Verification
- [x] mypy clean
- [x] 8 tests pass (`test_branches_page_lists_all`, `test_branches_default_marked`, `test_branches_compare_link`, `test_branches_new_pr_button`, `test_branches_json_response`, `test_tags_page_lists_all`, `test_tags_namespace_filter`, `test_tags_json_response`)
- [x] Docs updated in `docs/architecture/muse_vcs.md`