### PR TITLE
feat(musehub): render pipeline — auto-generate MP3 and piano roll images on commit push

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -33,6 +33,8 @@ This document is the single source of truth for every named entity (TypedDict, d
    - [ReleaseArtifact](#releaseartifact)
    - [ReleaseResult](#releaseresult)
    - [RenderPreviewResult](#renderpreviewresult)
+   - [PianoRollRenderResult](#pianorollrenderresult)
+   - [RenderPipelineResult](#renderpipelineresult)
 5. [Variation Layer (`app/variation/`)](#variation-layer)
    - [Event Envelope payloads](#event-envelope-payloads)
    - [PhraseRecord](#phraserecord)
@@ -1265,6 +1267,41 @@ these to HTTP 404.
 **Companion enum:**
 
 `PreviewFormat(str, Enum)` — `WAV = "wav"`, `MP3 = "mp3"`, `FLAC = "flac"`.
+
+---
+
+### `PianoRollRenderResult`
+
+**Path:** `maestro/services/musehub_piano_roll_renderer.py`
+
+`dataclass(frozen=True)` — Result of a single piano-roll PNG render operation.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `output_path` | `pathlib.Path` | Absolute path of the PNG file written to disk |
+| `width_px` | `int` | Actual render width in pixels (clamped to `[64, 1920]`) |
+| `note_count` | `int` | Total number of MIDI note events rendered across all tracks |
+| `track_index` | `int` | Zero-based MIDI track index (informational; all tracks composite into one image) |
+| `stubbed` | `bool` | `True` when no note events were found or MIDI parse failed; blank canvas returned |
+
+**Agent use case:** Agents inspect `stubbed` to decide whether a useful visualization was produced. `note_count=0` with `stubbed=True` means the MIDI file was empty or unparseable.
+
+---
+
+### `RenderPipelineResult`
+
+**Path:** `maestro/services/musehub_render_pipeline.py`
+
+`dataclass(frozen=True)` — Summary of the render pipeline execution for one commit.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commit_id` | `str` | Muse commit SHA that was rendered |
+| `status` | `str` | Final job status: `"complete"` or `"failed"` |
+| `midi_count` | `int` | Number of MIDI objects discovered in the push payload |
+| `mp3_object_ids` | `list[str]` | Object IDs of generated MP3 (or stub) artifacts |
+| `image_object_ids` | `list[str]` | Object IDs of generated piano-roll PNG artifacts |
+| `error_message` | `str` | Non-empty only when status is `"failed"` |
 
 ---
 

--- a/maestro/api/routes/musehub/repos.py
+++ b/maestro/api/routes/musehub/repos.py
@@ -1,18 +1,19 @@
 """Muse Hub repo, branch, commit, credits, and agent context route handlers.
 
 Endpoint summary:
-  POST /musehub/repos                                      — create a new remote repo
-  GET  /musehub/repos/{repo_id}                           — get repo metadata (by internal UUID)
-  GET  /musehub/{owner}/{repo_slug}                       — get repo metadata (by owner/slug)
-  GET  /musehub/repos/{repo_id}/branches                  — list all branches
-  GET  /musehub/repos/{repo_id}/commits                   — list commits (newest first)
-  GET  /musehub/repos/{repo_id}/credits                   — aggregated contributor credits
-  GET  /musehub/repos/{repo_id}/context                   — agent context briefing
-  GET  /musehub/repos/{repo_id}/timeline                  — chronological timeline with emotion/section/track layers
-  GET  /musehub/repos/{repo_id}/form-structure/{ref}      — form and structure analysis
-  POST /musehub/repos/{repo_id}/sessions                  — push a recording session
-  GET  /musehub/repos/{repo_id}/sessions                  — list recording sessions
-  GET  /musehub/repos/{repo_id}/sessions/{session_id}     — get a single session
+  POST /musehub/repos                                                     — create a new remote repo
+  GET  /musehub/repos/{repo_id}                                           — get repo metadata (by internal UUID)
+  GET  /musehub/{owner}/{repo_slug}                                       — get repo metadata (by owner/slug)
+  GET  /musehub/repos/{repo_id}/branches                                  — list all branches
+  GET  /musehub/repos/{repo_id}/commits                                   — list commits (newest first)
+  GET  /musehub/repos/{repo_id}/commits/{sha}/render-status               — render job status for a commit
+  GET  /musehub/repos/{repo_id}/credits                                   — aggregated contributor credits
+  GET  /musehub/repos/{repo_id}/context                                   — agent context briefing
+  GET  /musehub/repos/{repo_id}/timeline                                  — chronological timeline with emotion/section/track layers
+  GET  /musehub/repos/{repo_id}/form-structure/{ref}                      — form and structure analysis
+  POST /musehub/repos/{repo_id}/sessions                                  — push a recording session
+  GET  /musehub/repos/{repo_id}/sessions                                  — list recording sessions
+  GET  /musehub/repos/{repo_id}/sessions/{session_id}                     — get a single session
 
 All endpoints require a valid JWT Bearer token.
 No business logic lives here — all persistence is delegated to
@@ -30,6 +31,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from maestro.auth.dependencies import TokenClaims, optional_token, require_valid_token
 from maestro.db import get_db
+from maestro.db import musehub_models as db_models
+from sqlalchemy import select
 from maestro.models.musehub import (
     BranchListResponse,
     CommitListResponse,
@@ -45,6 +48,7 @@ from maestro.models.musehub import (
     RepoResponse,
     RepoStatsResponse,
     CreditsResponse,
+    RenderStatusResponse,
     SessionCreate,
     SessionListResponse,
     SessionResponse,
@@ -209,6 +213,63 @@ async def get_commit(
             detail=f"Commit '{commit_id}' not found in repo '{repo_id}'",
         )
     return commit
+
+
+@router.get(
+    "/repos/{repo_id}/commits/{commit_id}/render-status",
+    response_model=RenderStatusResponse,
+    operation_id="getCommitRenderStatus",
+    summary="Query render job status for auto-generated MP3 and piano-roll artifacts",
+    tags=["Commits"],
+)
+async def get_commit_render_status(
+    repo_id: str,
+    commit_id: str,
+    db: AsyncSession = Depends(get_db),
+    claims: TokenClaims | None = Depends(optional_token),
+) -> RenderStatusResponse:
+    """Return the render job status for a commit's auto-generated artifacts.
+
+    Called by the MuseHub UI and AI agents to poll whether the background
+    render pipeline has finished generating MP3 and piano-roll images for a
+    given commit.
+
+    Status lifecycle: ``pending`` → ``rendering`` → ``complete`` | ``failed``.
+
+    When no render job exists for the commit (e.g. the push contained no MIDI
+    objects, or the job has not been created yet), the response returns
+    ``status="not_found"`` with empty artifact lists rather than a 404.
+
+    Args:
+        repo_id: Internal repo UUID.
+        commit_id: Commit SHA to query.
+
+    Returns:
+        ``RenderStatusResponse`` with current job status and artifact IDs.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    _guard_visibility(repo, claims)
+
+    stmt = select(db_models.MusehubRenderJob).where(
+        db_models.MusehubRenderJob.repo_id == repo_id,
+        db_models.MusehubRenderJob.commit_id == commit_id,
+    )
+    job = (await db.execute(stmt)).scalar_one_or_none()
+
+    if job is None:
+        return RenderStatusResponse(
+            commit_id=commit_id,
+            status="not_found",
+        )
+
+    return RenderStatusResponse(
+        commit_id=job.commit_id,
+        status=job.status,
+        midi_count=job.midi_count,
+        mp3_object_ids=list(job.mp3_object_ids or []),
+        image_object_ids=list(job.image_object_ids or []),
+        error_message=job.error_message,
+    )
 
 
 @router.get(

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -1226,3 +1226,45 @@ class GrooveCheckResponse(CamelModel):
         default_factory=list,
         description="Per-commit metrics, oldest-first",
     )
+
+
+# ── Render pipeline ────────────────────────────────────────────────────────
+
+
+class RenderStatusResponse(CamelModel):
+    """Render job status for a single commit's auto-generated artifacts.
+
+    Returned by ``GET /api/v1/musehub/repos/{repo_id}/commits/{sha}/render-status``.
+
+    ``status`` lifecycle: ``pending`` → ``rendering`` → ``complete`` | ``failed``.
+    ``mp3_object_ids`` and ``image_object_ids`` are populated only when
+    status is ``complete``; both lists may be empty when no MIDI files were
+    pushed with the commit.
+
+    When no render job exists for the given commit SHA, the endpoint returns
+    ``status="not_found"`` with empty artifact lists rather than a 404, so
+    callers do not need to distinguish between "never pushed" and "not yet
+    rendered".
+    """
+
+    commit_id: str = Field(..., description="Muse commit SHA")
+    status: str = Field(
+        ...,
+        description="Render job status: pending | rendering | complete | failed | not_found",
+    )
+    midi_count: int = Field(
+        default=0,
+        description="Number of MIDI objects found in the commit",
+    )
+    mp3_object_ids: list[str] = Field(
+        default_factory=list,
+        description="Object IDs of generated MP3 (or stub) artifacts",
+    )
+    image_object_ids: list[str] = Field(
+        default_factory=list,
+        description="Object IDs of generated piano-roll PNG artifacts",
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Error details when status is 'failed'; null otherwise",
+    )

--- a/maestro/services/musehub_piano_roll_renderer.py
+++ b/maestro/services/musehub_piano_roll_renderer.py
@@ -1,0 +1,362 @@
+"""Server-side MIDI-to-PNG piano roll renderer for MuseHub.
+
+Converts raw MIDI bytes into a static piano roll image (PNG) without any
+browser or external image library dependency. Uses ``mido`` (already a
+project dependency) to parse MIDI and stdlib ``zlib``/``struct`` to encode
+a minimal PNG.
+
+The piano roll image layout:
+  - Width : ``MAX_WIDTH_PX`` (clamped), representing the MIDI timeline.
+  - Height: ``NOTE_ROWS`` (128), one row per MIDI pitch (0 = bottom, 127 = top).
+  - Background: dark charcoal (``BG_COLOR``).
+  - Octave boundary lines: slightly lighter horizontal rule at every C note.
+  - Notes: colored rectangles, colour-coded by MIDI channel.
+
+Design constraints:
+  - Zero external image dependencies (no Pillow, no cairo, no Node).
+  - Deterministic: same MIDI bytes → same PNG bytes for a given render width.
+  - Graceful degradation: a blank canvas is returned when the MIDI has no
+    note events, so callers always receive a valid PNG.
+
+Result type: ``PianoRollRenderResult`` — registered in docs/reference/type_contracts.md.
+"""
+from __future__ import annotations
+
+import io
+import logging
+import struct
+import zlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import mido
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+NOTE_ROWS: int = 128          # MIDI pitch range: 0–127
+MAX_WIDTH_PX: int = 1920      # maximum render width in pixels
+MIN_WIDTH_PX: int = 64        # minimum render width (very short clips)
+NOTE_ROW_HEIGHT: int = 2      # height in px of each pitch row
+IMAGE_HEIGHT: int = NOTE_ROWS * NOTE_ROW_HEIGHT   # total image height in pixels
+
+# Background colour (dark charcoal)
+BG_COLOR: tuple[int, int, int] = (28, 28, 34)
+# Octave-C boundary line colour (slightly lighter)
+BOUNDARY_COLOR: tuple[int, int, int] = (60, 60, 72)
+# Per-channel note colours (MIDI channels 0–15); cycles if channel > 15.
+_CHANNEL_COLORS: list[tuple[int, int, int]] = [
+    (100, 220, 130),   # ch 0  — green (bass)
+    (100, 160, 220),   # ch 1  — blue (keys)
+    (220, 140, 100),   # ch 2  — orange (lead)
+    (200, 100, 220),   # ch 3  — purple
+    (220, 220, 100),   # ch 4  — yellow
+    (100, 220, 220),   # ch 5  — cyan
+    (220, 100, 100),   # ch 6  — red
+    (140, 220, 100),   # ch 7  — lime
+    (180, 120, 220),   # ch 8  — lavender
+    (220, 180, 100),   # ch 9  — gold (often drums — colour differently)
+    (100, 200, 180),   # ch 10 — teal
+    (220, 120, 180),   # ch 11 — rose
+    (180, 200, 100),   # ch 12 — olive
+    (120, 180, 220),   # ch 13 — sky
+    (220, 160, 120),   # ch 14 — peach
+    (160, 120, 200),   # ch 15 — indigo
+]
+
+# Minimum note-render width so very short notes are always visible
+_MIN_NOTE_PX: int = 1
+
+
+# ---------------------------------------------------------------------------
+# Public result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PianoRollRenderResult:
+    """Outcome of a single piano roll render operation.
+
+    Attributes:
+        output_path: Absolute path of the PNG file written to disk.
+        width_px: Actual render width in pixels.
+        note_count: Number of MIDI note events rendered.
+        track_index: Zero-based MIDI track index that was rendered.
+        stubbed: True when the MIDI contained no note events and a blank
+            canvas was returned.
+    """
+
+    output_path: Path
+    width_px: int
+    note_count: int
+    track_index: int
+    stubbed: bool
+
+
+# ---------------------------------------------------------------------------
+# MIDI parsing helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _NoteEvent:
+    """A resolved note-on / note-off pair in absolute tick time."""
+
+    pitch: int
+    channel: int
+    start_tick: int
+    end_tick: int
+
+
+def _parse_note_events(midi: mido.MidiFile) -> list[_NoteEvent]:
+    """Extract note-on/off pairs from all tracks, returning absolute-tick events.
+
+    Pairs each note-on with the next note-off (or note-on with velocity 0) for
+    the same pitch+channel combination. Orphaned note-ons (no matching note-off)
+    are extended to the end of the track.
+
+    Args:
+        midi: Parsed ``mido.MidiFile`` object.
+
+    Returns:
+        List of ``_NoteEvent`` objects with resolved start/end tick positions.
+    """
+    events: list[_NoteEvent] = []
+
+    for track in midi.tracks:
+        # Track absolute tick alongside each message
+        pending: dict[tuple[int, int], int] = {}  # (pitch, channel) → start_tick
+        abs_tick = 0
+        last_tick = 0
+
+        for msg in track:
+            abs_tick += msg.time
+            last_tick = abs_tick
+
+            if msg.type == "note_on" and msg.velocity > 0:
+                key = (msg.note, msg.channel)
+                if key not in pending:
+                    pending[key] = abs_tick
+
+            elif msg.type == "note_off" or (msg.type == "note_on" and msg.velocity == 0):
+                key = (msg.note, msg.channel)
+                if key in pending:
+                    start = pending.pop(key)
+                    events.append(
+                        _NoteEvent(
+                            pitch=msg.note,
+                            channel=msg.channel,
+                            start_tick=start,
+                            end_tick=abs_tick,
+                        )
+                    )
+
+        # Close any orphaned note-ons at the track end
+        for (pitch, channel), start in pending.items():
+            events.append(
+                _NoteEvent(
+                    pitch=pitch,
+                    channel=channel,
+                    start_tick=start,
+                    end_tick=last_tick if last_tick > start else start + 1,
+                )
+            )
+
+    return events
+
+
+# ---------------------------------------------------------------------------
+# PNG encoder (pure stdlib — no Pillow)
+# ---------------------------------------------------------------------------
+
+# PNG magic bytes
+_PNG_SIGNATURE: bytes = b"\x89PNG\r\n\x1a\n"
+
+
+def _png_chunk(chunk_type: bytes, data: bytes) -> bytes:
+    """Encode a single PNG chunk (length + type + data + CRC)."""
+    crc = zlib.crc32(chunk_type + data) & 0xFFFFFFFF
+    return struct.pack(">I", len(data)) + chunk_type + data + struct.pack(">I", crc)
+
+
+def _encode_png(pixels: list[bytearray], width: int, height: int) -> bytes:
+    """Encode a list of RGB scanlines as a minimal PNG byte string.
+
+    Args:
+        pixels: ``height`` bytearrays, each of length ``width * 3`` (RGB).
+        width: Image width in pixels.
+        height: Image height in pixels.
+
+    Returns:
+        Complete PNG file bytes.
+    """
+    # IHDR: width, height, bit-depth=8, colour-type=2 (RGB), compression=0,
+    # filter-method=0, interlace=0
+    ihdr_data = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    ihdr = _png_chunk(b"IHDR", ihdr_data)
+
+    # IDAT: each scanline prefixed with filter byte 0 (None)
+    raw_rows = b"".join(b"\x00" + row for row in pixels)
+    idat = _png_chunk(b"IDAT", zlib.compress(raw_rows, 6))
+
+    iend = _png_chunk(b"IEND", b"")
+
+    return _PNG_SIGNATURE + ihdr + idat + iend
+
+
+# ---------------------------------------------------------------------------
+# Render logic
+# ---------------------------------------------------------------------------
+
+
+def _build_canvas(width: int) -> list[bytearray]:
+    """Allocate a blank RGB canvas of size ``width × IMAGE_HEIGHT``.
+
+    Rows are stored bottom-first (MIDI pitch 0 at index 0) but will be
+    written top-first (inverted) when encoding the PNG.
+
+    Returns:
+        ``IMAGE_HEIGHT`` bytearrays each of ``width * 3`` bytes filled with
+        ``BG_COLOR``.
+    """
+    row_template = bytearray(BG_COLOR * width)
+
+    # Draw octave-C boundary lines (every 12 semitones starting at C0 = pitch 0)
+    rows: list[bytearray] = []
+    for note in range(NOTE_ROWS):
+        if note % 12 == 0:
+            rows.append(bytearray(BOUNDARY_COLOR * width))
+        else:
+            rows.append(bytearray(row_template))
+
+    return rows
+
+
+def _draw_note(
+    rows: list[bytearray],
+    note: _NoteEvent,
+    total_ticks: int,
+    width: int,
+) -> None:
+    """Paint a single note event onto the canvas (in-place).
+
+    Args:
+        rows: Canvas from ``_build_canvas`` (bottom-first ordering).
+        note: Note event with absolute tick positions.
+        total_ticks: Total MIDI duration in ticks (used to map ticks → pixels).
+        width: Canvas width in pixels.
+    """
+    if total_ticks <= 0:
+        return
+
+    color = _CHANNEL_COLORS[note.channel % len(_CHANNEL_COLORS)]
+
+    # Map tick → pixel column
+    x_start = int(note.start_tick / total_ticks * width)
+    x_end = max(x_start + _MIN_NOTE_PX, int(note.end_tick / total_ticks * width))
+    x_end = min(x_end, width)
+
+    # Pitch row (bottom-first)
+    row_base = note.pitch * NOTE_ROW_HEIGHT
+    for dy in range(NOTE_ROW_HEIGHT):
+        row_idx = row_base + dy
+        if row_idx >= len(rows):
+            continue
+        row = rows[row_idx]
+        for x in range(x_start, x_end):
+            offset = x * 3
+            row[offset] = color[0]
+            row[offset + 1] = color[1]
+            row[offset + 2] = color[2]
+
+
+def render_piano_roll(
+    midi_bytes: bytes,
+    output_path: Path,
+    track_index: int = 0,
+    target_width: int = MAX_WIDTH_PX,
+) -> PianoRollRenderResult:
+    """Render raw MIDI bytes as a piano roll PNG image.
+
+    Parses all tracks from the MIDI file, paints each note as a coloured
+    rectangle proportional to its duration, and writes a PNG file.
+
+    Args:
+        midi_bytes: Raw bytes of a Standard MIDI File (.mid).
+        output_path: Destination path for the output PNG file.
+        track_index: Logical track index for the result metadata (informational
+            only — all tracks are rendered into a single composite image).
+        target_width: Desired render width in pixels. Clamped to
+            ``[MIN_WIDTH_PX, MAX_WIDTH_PX]``.
+
+    Returns:
+        ``PianoRollRenderResult`` describing what was written.
+
+    Raises:
+        OSError: If the output directory cannot be created or the file written.
+    """
+    width = max(MIN_WIDTH_PX, min(target_width, MAX_WIDTH_PX))
+
+    # Parse MIDI
+    try:
+        midi = mido.MidiFile(file=io.BytesIO(midi_bytes))
+    except Exception as exc:
+        logger.warning("⚠️ Failed to parse MIDI for piano roll: %s", exc)
+        # Write blank canvas so callers always get a valid PNG
+        canvas = _build_canvas(width)
+        png_bytes = _encode_png(list(reversed(canvas)), width, IMAGE_HEIGHT)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(png_bytes)
+        return PianoRollRenderResult(
+            output_path=output_path,
+            width_px=width,
+            note_count=0,
+            track_index=track_index,
+            stubbed=True,
+        )
+
+    note_events = _parse_note_events(midi)
+
+    if not note_events:
+        logger.info("ℹ️ MIDI has no note events — writing blank piano roll at %s", output_path)
+        canvas = _build_canvas(width)
+        png_bytes = _encode_png(list(reversed(canvas)), width, IMAGE_HEIGHT)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(png_bytes)
+        return PianoRollRenderResult(
+            output_path=output_path,
+            width_px=width,
+            note_count=0,
+            track_index=track_index,
+            stubbed=True,
+        )
+
+    total_ticks = max(ev.end_tick for ev in note_events)
+    canvas = _build_canvas(width)
+
+    for ev in note_events:
+        _draw_note(canvas, ev, total_ticks, width)
+
+    # PNG rows are top-first; MIDI pitches are bottom-first, so reverse.
+    png_bytes = _encode_png(list(reversed(canvas)), width, IMAGE_HEIGHT)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(png_bytes)
+
+    logger.info(
+        "✅ Piano roll rendered: %d notes → %s (%dx%d px)",
+        len(note_events),
+        output_path,
+        width,
+        IMAGE_HEIGHT,
+    )
+
+    return PianoRollRenderResult(
+        output_path=output_path,
+        width_px=width,
+        note_count=len(note_events),
+        track_index=track_index,
+        stubbed=False,
+    )

--- a/maestro/services/musehub_render_pipeline.py
+++ b/maestro/services/musehub_render_pipeline.py
@@ -1,0 +1,369 @@
+"""MuseHub render pipeline — auto-generate MP3 and piano-roll images on commit push.
+
+Orchestrates the asynchronous artifact generation triggered by every successful
+push to MuseHub.  For each new commit the pipeline:
+
+1. Checks for an existing render job (idempotency guard — re-pushing the same
+   commit SHA skips a duplicate render).
+2. Creates a ``musehub_render_jobs`` row with ``status=pending``.
+3. Discovers MIDI objects in the push payload (``path`` ends with ``.mid``
+   or ``.midi``).
+4. For each MIDI object:
+   a. Generates a piano-roll PNG image via ``musehub_piano_roll_renderer``.
+   b. Generates an MP3 audio preview stub via the same logic as
+      ``muse_render_preview`` (MIDI copy; replaced with a real Storpheus
+      ``POST /render`` call when that endpoint ships).
+5. Stores each generated artifact as a new ``musehub_objects`` row.
+6. Updates the job status to ``complete`` or ``failed``.
+
+The pipeline runs as a FastAPI ``BackgroundTask`` so it never blocks the push
+HTTP response.  Failures are logged but not re-raised — a failed render is
+recoverable; the push is not rolled back.
+
+Boundary rules (same as musehub_sync):
+  - Must NOT import state stores, SSE queues, or LLM clients.
+  - Must NOT import maestro.core.* modules.
+  - May import ORM models from maestro.db.musehub_models.
+  - May import Pydantic models from maestro.models.musehub.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.config import settings
+from maestro.db import musehub_models as db
+from maestro.db.database import AsyncSessionLocal
+from maestro.models.musehub import ObjectInput
+from maestro.services.musehub_piano_roll_renderer import render_piano_roll
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RenderPipelineResult:
+    """Summary of a single render pipeline execution for one commit.
+
+    Attributes:
+        commit_id: The Muse commit SHA that was rendered.
+        status: Final job status: ``"complete"`` or ``"failed"``.
+        midi_count: Number of MIDI objects discovered in the push payload.
+        mp3_object_ids: Object IDs of generated MP3 (or stub) artifacts.
+        image_object_ids: Object IDs of generated piano-roll PNG artifacts.
+        error_message: Non-empty only when status is ``"failed"``.
+    """
+
+    commit_id: str
+    status: str
+    midi_count: int
+    mp3_object_ids: list[str] = field(default_factory=list)
+    image_object_ids: list[str] = field(default_factory=list)
+    error_message: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _content_sha256(data: bytes) -> str:
+    """Return a ``sha256:<hex>`` content-addressed ID for ``data``."""
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _render_dir(repo_id: str) -> Path:
+    """Return the directory where rendered artifacts are written for a repo."""
+    return Path(settings.musehub_objects_dir) / repo_id / "renders"
+
+
+def _midi_filter(path: str) -> bool:
+    """Return True when the object path looks like a MIDI file."""
+    lower = path.lower()
+    return lower.endswith(".mid") or lower.endswith(".midi")
+
+
+async def _object_exists(session: AsyncSession, object_id: str) -> bool:
+    """Return True when an object with this ID already exists in the DB."""
+    stmt = select(db.MusehubObject.object_id).where(
+        db.MusehubObject.object_id == object_id
+    )
+    return (await session.execute(stmt)).scalar_one_or_none() is not None
+
+
+async def _store_object(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    object_id: str,
+    path: str,
+    disk_path: Path,
+    data: bytes,
+) -> None:
+    """Write artifact bytes to disk and upsert the musehub_objects row.
+
+    Idempotent: if the object already exists (same content-addressed ID) the
+    row is skipped; the disk file is still overwritten to ensure consistency.
+    """
+    disk_path.parent.mkdir(parents=True, exist_ok=True)
+    disk_path.write_bytes(data)
+
+    if await _object_exists(session, object_id):
+        logger.info("ℹ️ Object %s already exists — skipping DB insert", object_id)
+        return
+
+    row = db.MusehubObject(
+        object_id=object_id,
+        repo_id=repo_id,
+        path=path,
+        size_bytes=len(data),
+        disk_path=str(disk_path),
+    )
+    session.add(row)
+
+
+async def _render_job_exists(
+    session: AsyncSession, *, repo_id: str, commit_id: str
+) -> bool:
+    """Return True when a render job row already exists for this commit."""
+    stmt = select(db.MusehubRenderJob.render_job_id).where(
+        db.MusehubRenderJob.repo_id == repo_id,
+        db.MusehubRenderJob.commit_id == commit_id,
+    )
+    return (await session.execute(stmt)).scalar_one_or_none() is not None
+
+
+def _make_stub_mp3(midi_bytes: bytes, output_path: Path) -> bytes:
+    """Copy MIDI bytes to the output path as an MP3 stub.
+
+    Storpheus ``POST /render`` (MIDI-in → audio-out) is not yet deployed.
+    Until it ships, the MIDI file is copied verbatim as a placeholder.  The
+    ``stubbed`` contract from ``muse_render_preview`` is mirrored here.
+
+    Args:
+        midi_bytes: Raw MIDI file bytes.
+        output_path: Destination path for the stub file.
+
+    Returns:
+        The bytes written (identical to ``midi_bytes``).
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(midi_bytes)
+    logger.warning(
+        "⚠️ Storpheus /render not yet available — writing MIDI stub at %s", output_path
+    )
+    return midi_bytes
+
+
+# ---------------------------------------------------------------------------
+# Core render logic
+# ---------------------------------------------------------------------------
+
+
+async def _render_commit(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    commit_id: str,
+    objects: list[ObjectInput],
+) -> RenderPipelineResult:
+    """Perform the full render pipeline for a single commit.
+
+    Discovers MIDI objects in ``objects``, renders piano-roll PNGs and MP3
+    stubs, stores artifacts, and returns a ``RenderPipelineResult``.
+
+    This function creates DB rows but does NOT commit the session — that is the
+    caller's responsibility (keeping it composable with the job status update).
+    """
+    import base64
+
+    midi_objects = [o for o in objects if _midi_filter(o.path)]
+    render_dir = _render_dir(repo_id)
+    mp3_ids: list[str] = []
+    image_ids: list[str] = []
+
+    for idx, obj in enumerate(midi_objects):
+        try:
+            midi_bytes = base64.b64decode(obj.content_b64)
+        except Exception as exc:
+            logger.warning(
+                "⚠️ Could not decode base64 for object %s: %s", obj.object_id, exc
+            )
+            continue
+
+        stem = Path(obj.path).stem
+
+        # ── Piano-roll PNG ──────────────────────────────────────────────────
+        pr_filename = f"{commit_id[:8]}_{stem}_piano_roll.png"
+        pr_disk_path = render_dir / pr_filename
+
+        try:
+            pr_result = render_piano_roll(
+                midi_bytes=midi_bytes,
+                output_path=pr_disk_path,
+                track_index=idx,
+            )
+            pr_bytes = pr_disk_path.read_bytes()
+            pr_object_id = _content_sha256(pr_bytes)
+            pr_path = f"renders/{pr_filename}"
+            await _store_object(
+                session,
+                repo_id=repo_id,
+                object_id=pr_object_id,
+                path=pr_path,
+                disk_path=pr_disk_path,
+                data=pr_bytes,
+            )
+            image_ids.append(pr_object_id)
+            logger.info(
+                "✅ Piano-roll rendered: commit=%s track=%s notes=%d stubbed=%s",
+                commit_id[:8],
+                stem,
+                pr_result.note_count,
+                pr_result.stubbed,
+            )
+        except Exception as exc:
+            logger.error(
+                "❌ Piano-roll render failed for %s (commit=%s): %s",
+                obj.path,
+                commit_id[:8],
+                exc,
+            )
+
+        # ── MP3 stub ────────────────────────────────────────────────────────
+        mp3_filename = f"{commit_id[:8]}_{stem}.mp3"
+        mp3_disk_path = render_dir / mp3_filename
+
+        try:
+            mp3_bytes = _make_stub_mp3(midi_bytes, mp3_disk_path)
+            mp3_object_id = _content_sha256(mp3_bytes)
+            mp3_path = f"renders/{mp3_filename}"
+            await _store_object(
+                session,
+                repo_id=repo_id,
+                object_id=mp3_object_id,
+                path=mp3_path,
+                disk_path=mp3_disk_path,
+                data=mp3_bytes,
+            )
+            mp3_ids.append(mp3_object_id)
+        except Exception as exc:
+            logger.error(
+                "❌ MP3 stub generation failed for %s (commit=%s): %s",
+                obj.path,
+                commit_id[:8],
+                exc,
+            )
+
+    return RenderPipelineResult(
+        commit_id=commit_id,
+        status="complete",
+        midi_count=len(midi_objects),
+        mp3_object_ids=mp3_ids,
+        image_object_ids=image_ids,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public background-task entry point
+# ---------------------------------------------------------------------------
+
+
+async def trigger_render_background(
+    *,
+    repo_id: str,
+    commit_id: str,
+    objects: list[ObjectInput],
+) -> None:
+    """Background task: render artifacts for a pushed commit and persist them.
+
+    Designed for use with FastAPI ``BackgroundTasks``::
+
+        background_tasks.add_task(
+            trigger_render_background,
+            repo_id=repo_id,
+            commit_id=head_commit_id,
+            objects=body.objects,
+        )
+
+    Idempotency: if a render job already exists for ``(repo_id, commit_id)``
+    the function returns immediately without creating a duplicate.
+
+    Failures are logged but never raised — a failed render does not block the
+    push or affect subsequent requests.
+
+    Args:
+        repo_id: UUID of the MuseHub repository.
+        commit_id: SHA of the pushed commit being rendered.
+        objects: Object payloads from the push request (may include non-MIDI).
+    """
+    try:
+        async with AsyncSessionLocal() as session:
+            # Idempotency gate
+            if await _render_job_exists(session, repo_id=repo_id, commit_id=commit_id):
+                logger.info(
+                    "ℹ️ Render job already exists for commit=%s — skipping",
+                    commit_id[:8],
+                )
+                return
+
+            # Create pending job row
+            midi_objects = [o for o in objects if _midi_filter(o.path)]
+            job = db.MusehubRenderJob(
+                repo_id=repo_id,
+                commit_id=commit_id,
+                status="rendering",
+                midi_count=len(midi_objects),
+            )
+            session.add(job)
+            await session.flush()  # Obtain PK before proceeding
+
+            logger.info(
+                "✅ Render job created: commit=%s midi_files=%d",
+                commit_id[:8],
+                len(midi_objects),
+            )
+
+            try:
+                result = await _render_commit(
+                    session,
+                    repo_id=repo_id,
+                    commit_id=commit_id,
+                    objects=objects,
+                )
+                job.status = result.status
+                job.mp3_object_ids = result.mp3_object_ids
+                job.image_object_ids = result.image_object_ids
+            except Exception as exc:
+                job.status = "failed"
+                job.error_message = str(exc)
+                logger.error(
+                    "❌ Render pipeline failed for commit=%s: %s",
+                    commit_id[:8],
+                    exc,
+                )
+
+            await session.commit()
+            logger.info(
+                "✅ Render complete: commit=%s status=%s mp3=%d images=%d",
+                commit_id[:8],
+                job.status,
+                len(job.mp3_object_ids or []),
+                len(job.image_object_ids or []),
+            )
+
+    except Exception as exc:
+        logger.error(
+            "❌ Render background task failed for commit=%s: %s",
+            commit_id[:8],
+            exc,
+        )

--- a/maestro/services/musehub_render_pipeline.py
+++ b/maestro/services/musehub_render_pipeline.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 

--- a/tests/test_musehub_render.py
+++ b/tests/test_musehub_render.py
@@ -1,0 +1,683 @@
+"""Tests for the MuseHub render pipeline (issue #214).
+
+Covers the acceptance criteria from the issue:
+  test_push_triggers_render               — Push endpoint triggers render task
+  test_render_creates_mp3_objects         — Render creates MP3 objects in store
+  test_render_creates_piano_roll_images   — Render creates PNG objects in store
+  test_render_idempotent                  — Re-push does not duplicate renders
+  test_render_failure_does_not_block_push — Failed render still allows push to complete
+  test_render_status_endpoint             — Render status queryable by commit SHA
+
+Unit tests (service-level, no HTTP client):
+  test_piano_roll_render_note_events      — Valid MIDI produces non-blank PNG
+  test_piano_roll_render_empty_midi       — Empty/blank MIDI produces stubbed=True result
+  test_piano_roll_render_invalid_bytes    — Garbage bytes produce stubbed=True result
+  test_render_pipeline_midi_filter        — Only .mid/.midi paths are processed
+  test_render_status_not_found            — Missing commit returns not_found status
+
+Integration tests (HTTP client + in-memory SQLite):
+  test_render_status_endpoint_not_found   — Endpoint returns not_found for unknown commit
+  test_render_status_endpoint_complete    — Endpoint returns complete job
+  test_render_status_endpoint_private_repo_no_auth — Private repo returns 401
+"""
+from __future__ import annotations
+
+import base64
+import io
+import struct
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import mido
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import (
+    MusehubBranch,
+    MusehubCommit,
+    MusehubRenderJob,
+    MusehubRepo,
+)
+from maestro.models.musehub import ObjectInput
+from maestro.services.musehub_piano_roll_renderer import (
+    PianoRollRenderResult,
+    render_piano_roll,
+)
+from maestro.services.musehub_render_pipeline import (
+    RenderPipelineResult,
+    _midi_filter,
+    trigger_render_background,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal MIDI construction
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_midi_bytes() -> bytes:
+    """Return bytes for a minimal valid Standard MIDI File with two notes.
+
+    Constructs a type-0 MIDI file using mido in-memory so tests are
+    independent of external fixtures.
+    """
+    mid = mido.MidiFile(type=0)
+    track = mido.MidiTrack()
+    mid.tracks.append(track)
+    track.append(mido.Message("note_on", note=60, velocity=80, time=0))
+    track.append(mido.Message("note_on", note=64, velocity=80, time=100))
+    track.append(mido.Message("note_off", note=60, velocity=0, time=200))
+    track.append(mido.Message("note_off", note=64, velocity=0, time=400))
+    track.append(mido.MetaMessage("end_of_track", time=0))
+
+    buf = io.BytesIO()
+    mid.save(file=buf)
+    return buf.getvalue()
+
+
+def _make_midi_b64() -> str:
+    """Return base64-encoded minimal MIDI."""
+    return base64.b64encode(_make_minimal_midi_bytes()).decode()
+
+
+async def _seed_repo(db_session: AsyncSession) -> tuple[str, str]:
+    """Create a minimal repo + branch and return (repo_id, branch_name)."""
+    repo = MusehubRepo(
+        name="render-test",
+        owner="renderuser",
+        slug="render-test",
+        visibility="private",
+        owner_user_id="test-owner",
+    )
+    db_session.add(repo)
+    await db_session.flush()
+
+    branch = MusehubBranch(repo_id=repo.repo_id, name="main")
+    db_session.add(branch)
+    await db_session.commit()
+
+    return str(repo.repo_id), "main"
+
+
+async def _seed_public_repo(db_session: AsyncSession) -> tuple[str, str]:
+    """Create a minimal public repo + branch and return (repo_id, branch_name)."""
+    repo = MusehubRepo(
+        name="public-render",
+        owner="renderuser",
+        slug="public-render",
+        visibility="public",
+        owner_user_id="test-owner",
+    )
+    db_session.add(repo)
+    await db_session.flush()
+
+    branch = MusehubBranch(repo_id=repo.repo_id, name="main")
+    db_session.add(branch)
+    await db_session.commit()
+
+    return str(repo.repo_id), "main"
+
+
+async def _seed_commit(
+    db_session: AsyncSession, repo_id: str, commit_id: str = "abc123" * 10 + "ab"
+) -> str:
+    """Seed a commit row and return its commit_id."""
+    from datetime import datetime, timezone
+    commit = MusehubCommit(
+        commit_id=commit_id[:64],
+        repo_id=repo_id,
+        branch="main",
+        parent_ids=[],
+        message="test commit",
+        author="tester",
+        timestamp=datetime.now(timezone.utc),
+    )
+    db_session.add(commit)
+    await db_session.commit()
+    return commit.commit_id
+
+
+async def _seed_render_job(
+    db_session: AsyncSession,
+    repo_id: str,
+    commit_id: str,
+    status: str = "complete",
+) -> MusehubRenderJob:
+    """Seed a render job row and return it."""
+    job = MusehubRenderJob(
+        repo_id=repo_id,
+        commit_id=commit_id,
+        status=status,
+        midi_count=1,
+        mp3_object_ids=["sha256:mp3abc"],
+        image_object_ids=["sha256:imgxyz"],
+    )
+    db_session.add(job)
+    await db_session.commit()
+    return job
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — musehub_piano_roll_renderer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_piano_roll_render_note_events() -> None:
+    """Valid MIDI bytes produce a non-blank PNG with stubbed=False."""
+    midi_bytes = _make_minimal_midi_bytes()
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        output_path = Path(f.name)
+
+    result = render_piano_roll(midi_bytes, output_path)
+
+    assert isinstance(result, PianoRollRenderResult)
+    assert result.stubbed is False
+    assert result.note_count > 0
+    assert output_path.exists()
+    # Verify PNG signature
+    png_bytes = output_path.read_bytes()
+    assert png_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+    assert len(png_bytes) > 100
+
+
+@pytest.mark.anyio
+async def test_piano_roll_render_empty_midi() -> None:
+    """A MIDI file with no note events produces a blank canvas (stubbed=True)."""
+    mid = mido.MidiFile(type=0)
+    track = mido.MidiTrack()
+    mid.tracks.append(track)
+    track.append(mido.MetaMessage("end_of_track", time=0))
+    buf = io.BytesIO()
+    mid.save(file=buf)
+    empty_midi = buf.getvalue()
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        output_path = Path(f.name)
+
+    result = render_piano_roll(empty_midi, output_path)
+
+    assert result.stubbed is True
+    assert result.note_count == 0
+    assert output_path.exists()
+    png_bytes = output_path.read_bytes()
+    assert png_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+@pytest.mark.anyio
+async def test_piano_roll_render_invalid_bytes() -> None:
+    """Garbage bytes produce a blank canvas (stubbed=True) without raising."""
+    garbage = b"\x00\x01\x02\x03" * 10
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        output_path = Path(f.name)
+
+    result = render_piano_roll(garbage, output_path)
+
+    assert result.stubbed is True
+    assert output_path.exists()
+    png_bytes = output_path.read_bytes()
+    assert png_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+@pytest.mark.anyio
+async def test_piano_roll_render_output_dimensions() -> None:
+    """Rendered PNG has the correct width and height."""
+    from maestro.services.musehub_piano_roll_renderer import IMAGE_HEIGHT, MAX_WIDTH_PX
+
+    midi_bytes = _make_minimal_midi_bytes()
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        output_path = Path(f.name)
+
+    render_piano_roll(midi_bytes, output_path, target_width=MAX_WIDTH_PX)
+    png_bytes = output_path.read_bytes()
+
+    # PNG IHDR starts at byte 16 (after signature + chunk-length + "IHDR")
+    ihdr_offset = 16
+    width = struct.unpack(">I", png_bytes[ihdr_offset : ihdr_offset + 4])[0]
+    height = struct.unpack(">I", png_bytes[ihdr_offset + 4 : ihdr_offset + 8])[0]
+
+    assert width == MAX_WIDTH_PX
+    assert height == IMAGE_HEIGHT
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — musehub_render_pipeline (service layer, no HTTP)
+# ---------------------------------------------------------------------------
+
+
+def test_render_pipeline_midi_filter() -> None:
+    """Only .mid and .midi paths pass the MIDI filter."""
+    assert _midi_filter("tracks/jazz.mid") is True
+    assert _midi_filter("tracks/JAZZ.MID") is True
+    assert _midi_filter("tracks/bass.midi") is True
+    assert _midi_filter("renders/output.mp3") is False
+    assert _midi_filter("images/piano_roll.png") is False
+    assert _midi_filter("session.json") is False
+
+
+@pytest.mark.anyio
+async def test_render_creates_mp3_objects(
+    db_session: AsyncSession,
+) -> None:
+    """Render pipeline writes MP3 stub objects to the DB for each MIDI file."""
+    repo_id, _ = await _seed_repo(db_session)
+    commit_id = "a" * 64
+
+    objects = [
+        ObjectInput(
+            object_id="sha256:midi001",
+            path="tracks/bass.mid",
+            content_b64=_make_midi_b64(),
+        )
+    ]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("maestro.services.musehub_render_pipeline.settings") as mock_settings:
+            mock_settings.musehub_objects_dir = tmpdir
+            await trigger_render_background(
+                repo_id=repo_id,
+                commit_id=commit_id,
+                objects=objects,
+            )
+
+    from sqlalchemy import select as sa_select
+    from maestro.db.musehub_models import MusehubRenderJob as RJ
+    stmt = sa_select(RJ).where(RJ.repo_id == repo_id, RJ.commit_id == commit_id)
+    job = (await db_session.execute(stmt)).scalar_one_or_none()
+
+    assert job is not None
+    assert job.status == "complete"
+    assert len(job.mp3_object_ids) == 1
+
+
+@pytest.mark.anyio
+async def test_render_creates_piano_roll_images(
+    db_session: AsyncSession,
+) -> None:
+    """Render pipeline writes piano-roll PNG objects to the DB for each MIDI file."""
+    repo_id, _ = await _seed_repo(db_session)
+    commit_id = "b" * 64
+
+    objects = [
+        ObjectInput(
+            object_id="sha256:midi002",
+            path="tracks/keys.mid",
+            content_b64=_make_midi_b64(),
+        )
+    ]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("maestro.services.musehub_render_pipeline.settings") as mock_settings:
+            mock_settings.musehub_objects_dir = tmpdir
+            await trigger_render_background(
+                repo_id=repo_id,
+                commit_id=commit_id,
+                objects=objects,
+            )
+
+    from sqlalchemy import select as sa_select
+    from maestro.db.musehub_models import MusehubRenderJob as RJ
+    stmt = sa_select(RJ).where(RJ.repo_id == repo_id, RJ.commit_id == commit_id)
+    job = (await db_session.execute(stmt)).scalar_one_or_none()
+
+    assert job is not None
+    assert job.status == "complete"
+    assert len(job.image_object_ids) == 1
+
+
+@pytest.mark.anyio
+async def test_render_idempotent(
+    db_session: AsyncSession,
+) -> None:
+    """Re-triggering render for the same commit does not create a second render job."""
+    repo_id, _ = await _seed_repo(db_session)
+    commit_id = "c" * 64
+
+    objects = [
+        ObjectInput(
+            object_id="sha256:midi003",
+            path="tracks/lead.mid",
+            content_b64=_make_midi_b64(),
+        )
+    ]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("maestro.services.musehub_render_pipeline.settings") as mock_settings:
+            mock_settings.musehub_objects_dir = tmpdir
+            # First call
+            await trigger_render_background(
+                repo_id=repo_id,
+                commit_id=commit_id,
+                objects=objects,
+            )
+            # Second call — must be a no-op
+            await trigger_render_background(
+                repo_id=repo_id,
+                commit_id=commit_id,
+                objects=objects,
+            )
+
+    from sqlalchemy import select as sa_select, func
+    from maestro.db.musehub_models import MusehubRenderJob as RJ
+    stmt = sa_select(func.count()).select_from(RJ).where(
+        RJ.repo_id == repo_id, RJ.commit_id == commit_id
+    )
+    count = (await db_session.execute(stmt)).scalar_one()
+    assert count == 1
+
+
+@pytest.mark.anyio
+async def test_render_no_midi_objects(
+    db_session: AsyncSession,
+) -> None:
+    """A push with no MIDI objects creates a render job with midi_count=0 and empty artifacts."""
+    repo_id, _ = await _seed_repo(db_session)
+    commit_id = "d" * 64
+
+    objects = [
+        ObjectInput(
+            object_id="sha256:doc001",
+            path="README.md",
+            content_b64=base64.b64encode(b"# Project").decode(),
+        )
+    ]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("maestro.services.musehub_render_pipeline.settings") as mock_settings:
+            mock_settings.musehub_objects_dir = tmpdir
+            await trigger_render_background(
+                repo_id=repo_id,
+                commit_id=commit_id,
+                objects=objects,
+            )
+
+    from sqlalchemy import select as sa_select
+    from maestro.db.musehub_models import MusehubRenderJob as RJ
+    stmt = sa_select(RJ).where(RJ.repo_id == repo_id, RJ.commit_id == commit_id)
+    job = (await db_session.execute(stmt)).scalar_one_or_none()
+
+    assert job is not None
+    assert job.midi_count == 0
+    assert job.mp3_object_ids == []
+    assert job.image_object_ids == []
+    assert job.status == "complete"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — render-status HTTP endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_render_status_endpoint_not_found(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /repos/{repo_id}/commits/{sha}/render-status returns not_found for unknown commit."""
+    repo_id, _ = await _seed_repo(db_session)
+    commit_id = "e" * 64
+
+    resp = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/commits/{commit_id}/render-status",
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "not_found"
+    assert data["commitId"] == commit_id
+
+
+@pytest.mark.anyio
+async def test_render_status_endpoint_complete(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /repos/{repo_id}/commits/{sha}/render-status returns complete job."""
+    repo_id, _ = await _seed_repo(db_session)
+    commit_id = "f" * 64
+    await _seed_commit(db_session, repo_id, commit_id)
+    job = await _seed_render_job(db_session, repo_id, commit_id, status="complete")
+
+    resp = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/commits/{commit_id}/render-status",
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "complete"
+    assert data["commitId"] == commit_id
+    assert data["midiCount"] == 1
+    assert "sha256:mp3abc" in data["mp3ObjectIds"]
+    assert "sha256:imgxyz" in data["imageObjectIds"]
+
+
+@pytest.mark.anyio
+async def test_render_status_endpoint_pending(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET render-status returns pending status for in-flight jobs."""
+    repo_id, _ = await _seed_repo(db_session)
+    commit_id = "0" * 64
+    await _seed_commit(db_session, repo_id, commit_id)
+    await _seed_render_job(db_session, repo_id, commit_id, status="pending")
+
+    resp = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/commits/{commit_id}/render-status",
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pending"
+
+
+@pytest.mark.anyio
+async def test_render_status_endpoint_private_repo_no_auth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Private repo render-status endpoint requires auth — returns 401 without JWT."""
+    repo_id, _ = await _seed_repo(db_session)
+    commit_id = "1" * 64
+
+    resp = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/commits/{commit_id}/render-status",
+    )
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_render_status_endpoint_public_repo_no_auth(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Public repo render-status endpoint is accessible without JWT."""
+    repo_id, _ = await _seed_public_repo(db_session)
+    commit_id = "2" * 64
+
+    resp = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/commits/{commit_id}/render-status",
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — push endpoint triggers render
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_push_triggers_render(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /repos/{repo_id}/push triggers the render background task."""
+    repo_id, _ = await _seed_repo(db_session)
+
+    trigger_calls: list[dict[str, object]] = []
+
+    async def fake_trigger(
+        *,
+        repo_id: str,
+        commit_id: str,
+        objects: list[ObjectInput],
+    ) -> None:
+        trigger_calls.append(
+            {"repo_id": repo_id, "commit_id": commit_id, "objects": objects}
+        )
+
+    with patch(
+        "maestro.api.routes.musehub.sync.trigger_render_background",
+        side_effect=fake_trigger,
+    ):
+        payload = {
+            "branch": "main",
+            "headCommitId": "a" * 64,
+            "commits": [
+                {
+                    "commitId": "a" * 64,
+                    "branch": "main",
+                    "parentIds": [],
+                    "message": "add bass line",
+                    "author": "testuser",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "snapshotId": None,
+                }
+            ],
+            "objects": [
+                {
+                    "objectId": "sha256:midiobj",
+                    "path": "tracks/bass.mid",
+                    "contentB64": _make_midi_b64(),
+                }
+            ],
+            "force": False,
+        }
+
+        resp = await client.post(
+            f"/api/v1/musehub/repos/{repo_id}/push",
+            json=payload,
+            headers=auth_headers,
+        )
+
+    assert resp.status_code == 200
+    # The trigger must have been called once for this push
+    assert len(trigger_calls) == 1
+    assert trigger_calls[0]["commit_id"] == "a" * 64
+    assert trigger_calls[0]["repo_id"] == repo_id
+
+
+@pytest.mark.anyio
+async def test_render_failure_does_not_block_push(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Push succeeds even when the render background task is a no-op.
+
+    The push HTTP response is returned before background tasks run, so the
+    push is never blocked by render pipeline work.  We verify this by patching
+    ``trigger_render_background`` to a no-op (which never interferes with the
+    HTTP response) and confirming the push still returns 200.
+
+    The internal error-handling contract (render errors logged, not raised) is
+    covered by test_render_pipeline_internal_error_is_logged.
+    """
+    repo_id, _ = await _seed_repo(db_session)
+
+    async def noop_trigger(**kwargs: object) -> None:
+        pass  # Deliberately does nothing — simulates a render that never runs
+
+    with patch(
+        "maestro.api.routes.musehub.sync.trigger_render_background",
+        side_effect=noop_trigger,
+    ):
+        payload = {
+            "branch": "main",
+            "headCommitId": "b" * 64,
+            "commits": [
+                {
+                    "commitId": "b" * 64,
+                    "branch": "main",
+                    "parentIds": [],
+                    "message": "keys riff",
+                    "author": "testuser",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "snapshotId": None,
+                }
+            ],
+            "objects": [],
+            "force": False,
+        }
+
+        resp = await client.post(
+            f"/api/v1/musehub/repos/{repo_id}/push",
+            json=payload,
+            headers=auth_headers,
+        )
+
+    # Push must succeed regardless of what the render task does
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+
+
+@pytest.mark.anyio
+async def test_render_pipeline_internal_error_is_logged(
+    db_session: AsyncSession,
+) -> None:
+    """Render pipeline marks job as failed and logs when _render_commit raises.
+
+    This verifies the contract that render errors never propagate — they are
+    caught inside ``trigger_render_background`` and stored as job.status=failed.
+    """
+    repo_id, _ = await _seed_repo(db_session)
+    commit_id = "e" * 64
+
+    objects = [
+        ObjectInput(
+            object_id="sha256:mididead",
+            path="tracks/broken.mid",
+            # Intentionally bad base64 — _render_commit will log a warning for each
+            # object that fails to decode, but the job itself should still complete
+            content_b64=_make_midi_b64(),
+        )
+    ]
+
+    # Patch _render_commit itself to raise — tests the outer catch
+    from maestro.services import musehub_render_pipeline as pipeline_mod
+
+    async def exploding_render(session: object, **kwargs: object) -> RenderPipelineResult:
+        raise RuntimeError("simulated internal render error")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("maestro.services.musehub_render_pipeline.settings") as mock_settings:
+            mock_settings.musehub_objects_dir = tmpdir
+            with patch.object(pipeline_mod, "_render_commit", side_effect=exploding_render):
+                # Must not raise — errors are swallowed inside trigger_render_background
+                await trigger_render_background(
+                    repo_id=repo_id,
+                    commit_id=commit_id,
+                    objects=objects,
+                )
+
+    from sqlalchemy import select as sa_select
+    from maestro.db.musehub_models import MusehubRenderJob as RJ
+    stmt = sa_select(RJ).where(RJ.repo_id == repo_id, RJ.commit_id == commit_id)
+    job = (await db_session.execute(stmt)).scalar_one_or_none()
+
+    assert job is not None
+    assert job.status == "failed"
+    assert job.error_message is not None
+    assert "simulated internal render error" in job.error_message


### PR DESCRIPTION
## Summary

Closes #214 — Automated render pipeline that generates piano-roll PNG images and MP3 audio stubs on every MuseHub commit push.

## Root Cause / Motivation

MuseHub visualizations depend on rendered artifacts (MP3, piano roll images) being available. Without automation, users must manually run `muse render-preview` before pushing. This PR adds a background pipeline that generates these artifacts automatically on every push.

## Solution

- **`musehub_piano_roll_renderer.py`** — Pure-Python MIDI-to-PNG renderer (mido + stdlib zlib/struct). Zero external image library dependency. Colour-coded by MIDI channel, 128 pitch rows × 2 px per row, up to 1920 px wide.
- **`musehub_render_pipeline.py`** — Background render orchestration triggered after push. Finds MIDI objects, generates piano-roll PNGs and MP3 stubs, stores as `musehub_objects`, updates render job status.
- **`musehub_render_jobs` DB table** — Tracks render status: `pending → rendering → complete | failed`. Unique `(repo_id, commit_id)` constraint enforces idempotency.
- **`GET /api/v1/musehub/repos/{repo_id}/commits/{sha}/render-status`** — Queryable render status endpoint returning `RenderStatusResponse`.
- **Trigger**: `sync.py` `push()` schedules `trigger_render_background` as a `BackgroundTask` after successful push.
- **Idempotent**: re-pushing same commit SHA exits immediately without duplicate render.
- **Failure isolation**: all render errors are caught, logged, stored in `job.error_message`; push is never blocked.

## Layers Affected

- [x] Muse VCS (push flow extended)
- [x] MuseHub (new render pipeline services, status endpoint)
- [x] DB (new `musehub_render_jobs` table in consolidated migration)
- [ ] Intent Engine
- [ ] Pipeline
- [ ] Maestro Handlers
- [ ] Agent Teams
- [ ] Storpheus Client
- [ ] MCP
- [ ] DAW Adapter
- [ ] Auth / Budget
- [ ] RAG
- [ ] Variation
- [ ] SSE Protocol

## Verification

- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (634 files)
- [x] `pytest tests/test_musehub_render.py -v` — 17/17 passed
- [x] Alembic migration applied cleanly
- [x] Docs updated: `muse_vcs.md`, `storpheus.md`, `type_contracts.md`

## Tests Added

- `test_piano_roll_render_note_events` — Valid MIDI → non-blank PNG, stubbed=False
- `test_piano_roll_render_empty_midi` — Empty MIDI → blank canvas, stubbed=True
- `test_piano_roll_render_invalid_bytes` — Garbage bytes → blank canvas, no exception
- `test_piano_roll_render_output_dimensions` — PNG dimensions match MAX_WIDTH_PX × IMAGE_HEIGHT
- `test_render_pipeline_midi_filter` — Only .mid/.midi paths pass filter
- `test_render_creates_mp3_objects` — Render creates MP3 object rows
- `test_render_creates_piano_roll_images` — Render creates PNG object rows
- `test_render_idempotent` — Re-trigger creates exactly 1 job row
- `test_render_no_midi_objects` — Non-MIDI push creates job with midi_count=0
- `test_render_status_endpoint_not_found` — Unknown commit returns status=not_found
- `test_render_status_endpoint_complete` — Complete job returns correct artifact IDs
- `test_render_status_endpoint_pending` — Pending job returns status=pending
- `test_render_status_endpoint_private_repo_no_auth` — Returns 401 without JWT
- `test_render_status_endpoint_public_repo_no_auth` — Public repo accessible without JWT
- `test_push_triggers_render` — Push endpoint calls trigger_render_background
- `test_render_failure_does_not_block_push` — Push returns 200 regardless of render
- `test_render_pipeline_internal_error_is_logged` — Internal error stored as failed status

## Notes

- **WebP**: PNG is emitted instead of WebP because Pillow is not a project dependency. WebP conversion is a planned follow-up (add `Pillow` to requirements.txt and call `Image.open().save(..., format="WEBP")`).
- **MP3**: Storpheus `POST /render` is not yet deployed. MIDI is copied as an MP3 stub. Replace `_make_stub_mp3` in `musehub_render_pipeline.py` when the endpoint ships.