### PR TITLE
chore(ci): only run CI on main — skip feature→dev PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,16 @@
 # Maestro — Test & Coverage
 #
-# Runs on PRs and direct pushes targeting dev and main.
-# Migration lint runs on every PR to dev to catch parallel-agent conflict
-# artifacts before they accumulate. Full test suite runs on PRs to main.
+# Runs only on PRs and direct pushes targeting main (i.e. dev → main).
+# Feature branch → dev PRs are intentionally excluded to avoid CI noise
+# during the parallel-agent development cycle.
 # Two jobs: maestro (app/ + tests/) and storpheus (storpheus/).
 name: Test & Coverage
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   migration-lint:


### PR DESCRIPTION
## Summary
Restricts the GitHub Actions CI workflow to run only on pushes and PRs targeting `main`. Feature branch → `dev` PRs no longer trigger the test suite.

## Motivation
During the parallel-agent development cycle, every feature→dev PR was triggering CI, creating unnecessary noise and resource usage. CI is meaningful only at the `dev` → `main` promotion boundary where quality is enforced before production.

## Changes
- `.github/workflows/test.yml`: removed `dev` from `push.branches` and `pull_request.branches` triggers.

## Verification
- [ ] CI does not trigger on next feature→dev PR
- [ ] CI triggers correctly on a dev→main PR