### PR TITLE
fix(agents): squash merge conflict time-sink — universal triage, pre-dispatch overlap check, rerere

### DIFF
--- a/.github/PR_REVIEW_PROMPT.md
+++ b/.github/PR_REVIEW_PROMPT.md
@@ -92,7 +92,39 @@ git status | grep "^UU"                     # list conflicted files
 grep -c "^<<<<<" <file>                     # count blocks in a specific file
 ```
 
-**STEP B — Apply the rule for each file:**
+**STEP A.5 — Universal triage (do this for every conflict before STEP B):**
+
+For each conflicted file, check the conflict shape first:
+```bash
+git diff --diff-filter=U -- <file> | grep -A6 "^<<<<<<<"
+```
+
+Apply the **first matching rule** — stop as soon as one matches:
+
+**RULE 0 — ONE SIDE EMPTY** (most common in parallel batches — no judgment needed):
+```
+<<<<<<< HEAD
+(blank / whitespace only)       ← this side is empty
+=======
+<real content>                  ← this side has content
+>>>>>>> origin/dev
+```
+OR the reverse (HEAD has content, origin/dev is blank/stub).
+**Action: take the non-empty side. Remove markers. Done.**
+This is always safe. The empty side is a base-file placeholder, not intentionally deleted content.
+Do NOT open the file to "verify" — just take the non-empty side and move on.
+
+**RULE 1 — BOTH SIDES IDENTICAL:** Keep either side, remove markers. Done.
+
+**RULE 2 — KNOWN ADDITIVE FILE:** Apply the file-specific rule in STEP B.
+Files: `muse_cli/app.py` · `muse_vcs.md` · `type_contracts.md`
+
+**RULE 3 — ALL OTHER FILES (judgment conflict):** Preserve dev's version plus this PR's additions.
+If semantically incompatible → stop, leave PR open, report ambiguity to user. Never guess.
+
+---
+
+**STEP B — Apply the file-specific rule (only for files not resolved by STEP A.5):**
 
 `maestro/muse_cli/app.py`
 - Each parallel agent adds one `app.add_typer()` line.


### PR DESCRIPTION
## Summary
Closes the recurring merge conflict time-sink that was burning 30%+ of parallel agent cycles.

Three root causes addressed:

**1. No universal first-pass rule for the most common conflict pattern**
Every parallel batch produces conflicts where one side is blank (base-file placeholder) and the other has real content. There was no rule that said "take the non-empty side immediately" — agents would open files, read both sides, and loop trying to figure out which to keep. Fixed by inserting **STEP A.5 — Universal Triage** before the file-specific rules in all three prompt documents. RULE 0 is explicit: blank side = take the non-empty side, 5 seconds, no judgment.

**2. No pre-dispatch file overlap detection**
Coordinators had no tooling to verify that 20 parallel issues wouldn't stomp each other's files before worktrees were created. Fixed by adding a `gh pr diff --name-only` loop to the "Before launching" section of both PARALLEL_* docs. Any shared file = serialize those issues into sequential batches.

**3. No conflict resolution caching**
When one agent correctly resolves a `muse_vcs.md` conflict, the next agent hitting the same conflict starts from scratch. Fixed by adding `git config rerere.enabled true` to both setup scripts. Git's rerere mechanism records resolutions in `.git/rr-cache/` and reapplies them automatically on identical future conflicts.

## Files Changed
- `.cursor/PARALLEL_ISSUE_TO_PR.md` — universal triage, pre-check script, rerere setup, sequential batching guidance
- `.cursor/PARALLEL_PR_REVIEW.md` — universal triage, pre-check script, rerere setup
- `.github/PR_REVIEW_PROMPT.md` — universal triage between STEP A and STEP B

## Verification
- [x] All three documents read correctly — no markers, no broken formatting
- [x] mypy N/A (markdown/docs only)
- [x] No protocol changes — doc-only fix