### PR TITLE
feat(musehub): release list page enrichment — download buttons, body preview, download count

### DIFF
--- a/maestro/templates/musehub/pages/release_list.html
+++ b/maestro/templates/musehub/pages/release_list.html
@@ -6,6 +6,66 @@
 {% endblock %}
 {% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
 
+{% block extra_css %}
+<style>
+.release-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border, #30363d);
+}
+.release-row:last-child { border-bottom: none; }
+.release-meta { font-size: 12px; color: var(--text-muted, #8b949e); margin-top: 4px; }
+.release-body-preview {
+  font-size: 13px;
+  color: var(--text-secondary, #c9d1d9);
+  margin-top: 6px;
+  line-height: 1.5;
+}
+.release-downloads {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+.dl-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  text-decoration: none;
+  border: 1px solid var(--border, #30363d);
+  background: var(--bg-overlay, #161b22);
+  color: var(--text-primary, #c9d1d9);
+  transition: border-color 0.15s, background 0.15s;
+}
+.dl-btn:hover { border-color: var(--accent, #58a6ff); color: var(--accent, #58a6ff); }
+.dl-btn.disabled {
+  opacity: 0.4;
+  pointer-events: none;
+  cursor: default;
+}
+.download-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--text-muted, #8b949e);
+  padding: 2px 7px;
+  border-radius: 10px;
+  background: var(--bg-overlay, #161b22);
+  border: 1px solid var(--border, #30363d);
+}
+/* Tag colour-coding: green = stable (v1+), yellow = pre-release (v0.x) */
+.tag-stable   { background: rgba(63,185,80,0.15); color: #3fb950; border-color: rgba(63,185,80,0.4); }
+.tag-prerelease { background: rgba(210,153,34,0.15); color: #d2991a; border-color: rgba(210,153,34,0.4); }
+</style>
+{% endblock %}
+
 {% block page_data %}
 const repoId = {{ repo_id | tojson }};
 const base   = {{ base_url | tojson }};
@@ -13,32 +73,116 @@ const base   = {{ base_url | tojson }};
 
 {% block page_script %}
 {% raw %}
+/**
+ * Strip basic Markdown syntax from a string so it can be shown as plain text.
+ * Handles: headers (#), bold/italic (*_), links, code, blockquotes, and list markers.
+ */
+function stripMarkdown(md) {
+  return md
+    .replace(/^#{1,6}\s+/gm, '')          // headers
+    .replace(/(\*\*|__)(.*?)\1/g, '$2')   // bold
+    .replace(/(\*|_)(.*?)\1/g, '$2')      // italic
+    .replace(/`{1,3}[^`]*`{1,3}/g, '')   // code spans
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links → label
+    .replace(/^>\s+/gm, '')               // blockquotes
+    .replace(/^[-*+]\s+/gm, '')           // list bullets
+    .replace(/\n+/g, ' ')                 // collapse newlines
+    .trim();
+}
+
+/**
+ * Return the first non-empty paragraph from a markdown string, stripped of
+ * markdown syntax and truncated to maxLen characters (ellipsis appended when
+ * truncated). Returns empty string when body is blank.
+ */
+function bodyPreview(md, maxLen) {
+  if (!md) return '';
+  const firstPara = md.split(/\n\n+/)[0] || md;
+  const plain = stripMarkdown(firstPara);
+  if (!plain) return '';
+  return plain.length > maxLen ? plain.substring(0, maxLen).trimEnd() + '…' : plain;
+}
+
+/**
+ * Derive the CSS class for the release badge based on its semver tag.
+ * v1.x and above are considered stable (green); v0.x are pre-releases (yellow).
+ * Falls back to the default badge-release style for unrecognised patterns.
+ */
+function tagBadgeClass(tag) {
+  const m = tag.match(/^v?(\d+)/);
+  if (!m) return 'badge badge-release';
+  return parseInt(m[1], 10) >= 1
+    ? 'badge badge-release tag-stable'
+    : 'badge badge-release tag-prerelease';
+}
+
+/**
+ * Build the inline download icon button row for a release.
+ * Each button links to the corresponding download URL; disabled (greyed out)
+ * when the URL is absent.
+ */
+function downloadButtons(dl) {
+  const pkgs = [
+    { icon: '🎹', label: 'MIDI',     url: dl.midiBundle },
+    { icon: '🎛️', label: 'Stems',    url: dl.stems      },
+    { icon: '🎵', label: 'MP3',      url: dl.mp3        },
+    { icon: '📄', label: 'MusicXML', url: dl.musicxml   },
+  ];
+  return pkgs.map(p =>
+    p.url
+      ? `<a class="dl-btn" href="${escHtml(p.url)}" download title="Download ${p.label}">${p.icon} ${p.label}</a>`
+      : `<span class="dl-btn disabled" title="${p.label} not available">${p.icon} ${p.label}</span>`
+  ).join('');
+}
+
 async function load() {
   initRepoNav(repoId);
   try {
-    const data     = await apiFetch('/repos/' + repoId + '/releases');
-    const releases = data.releases || [];
+    const [data, analytics] = await Promise.all([
+      apiFetch('/repos/' + repoId + '/releases'),
+      apiFetch('/repos/' + repoId + '/analytics').catch(() => null),
+    ]);
+    const releases     = data.releases || [];
+    const downloadCount = analytics ? (analytics.downloadCount ?? 0) : 0;
+
+    const statsBar = `
+      <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;font-size:13px;color:var(--text-muted,#8b949e)">
+        <span>${releases.length} release${releases.length !== 1 ? 's' : ''}</span>
+        <span class="download-badge">&#11015; ${downloadCount} download${downloadCount !== 1 ? 's' : ''}</span>
+      </div>`;
 
     const rows = releases.length === 0
       ? '<p class="loading">No releases published yet.</p>'
-      : releases.map(r => `
+      : releases.map(r => {
+          const dl      = r.downloadUrls || {};
+          const preview = bodyPreview(r.body || '', 150);
+          const shortSha = r.commitId ? r.commitId.substring(0, 8) : null;
+          return `
         <div class="release-row">
-          <span class="badge badge-release">${escHtml(r.tag)}</span>
-          <div style="flex:1">
-            <a href="${base}/releases/${encodeURIComponent(r.tag)}">${escHtml(r.title)}</a>
-            <div style="font-size:12px;color:#8b949e;margin-top:2px">
+          <div style="padding-top:2px">
+            <span class="${tagBadgeClass(r.tag)}">${escHtml(r.tag)}</span>
+          </div>
+          <div style="flex:1;min-width:0">
+            <a href="${base}/releases/${encodeURIComponent(r.tag)}" style="font-weight:600">${escHtml(r.title)}</a>
+            <div class="release-meta">
               Released ${fmtDate(r.createdAt)}
-              ${r.commitId ? ' &bull; commit <span style="font-family:monospace">' + r.commitId.substring(0,8) + '</span>' : ''}
+              ${shortSha ? ` &bull; commit <a href="${base}/commits/${r.commitId}" style="font-family:monospace">${shortSha}</a>` : ''}
+            </div>
+            ${preview ? `<div class="release-body-preview">${escHtml(preview)}</div>` : ''}
+            <div class="release-downloads">
+              ${downloadButtons(dl)}
             </div>
           </div>
-        </div>`).join('');
+        </div>`;
+        }).join('');
 
     document.getElementById('content').innerHTML = `
       <div style="margin-bottom:12px">
         <a href="${base}">&larr; Back to repo</a>
       </div>
       <div class="card">
-        <h1 style="margin-bottom:16px">Releases</h1>
+        <h1 style="margin-bottom:12px">Releases</h1>
+        ${statsBar}
         ${rows}
       </div>`;
   } catch(e) {

--- a/tests/test_musehub_ui.py
+++ b/tests/test_musehub_ui.py
@@ -401,6 +401,89 @@ async def test_ui_release_list_page_returns_200(
 
 
 @pytest.mark.anyio
+async def test_ui_release_list_page_has_download_buttons(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Release list page template includes inline download icon buttons for all package types."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/releases")
+    assert response.status_code == 200
+    body = response.text
+    # All four download package types must appear in the JS template source.
+    assert "MIDI" in body
+    assert "Stems" in body
+    assert "MP3" in body
+    assert "MusicXML" in body
+    # The helper function that builds download buttons must be present.
+    assert "downloadButtons" in body
+
+
+@pytest.mark.anyio
+async def test_ui_release_list_page_has_body_preview(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Release list page template includes body preview logic (stripMarkdown / bodyPreview)."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/releases")
+    assert response.status_code == 200
+    body = response.text
+    assert "stripMarkdown" in body
+    assert "bodyPreview" in body
+
+
+@pytest.mark.anyio
+async def test_ui_release_list_page_has_download_count_badge(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Release list page fetches the analytics endpoint to show a download count badge."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/releases")
+    assert response.status_code == 200
+    body = response.text
+    # The page must fetch analytics to populate the download count.
+    assert "/analytics" in body
+    assert "downloadCount" in body
+    assert "download-badge" in body
+
+
+@pytest.mark.anyio
+async def test_ui_release_list_page_has_commit_link(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Release list page links each release's commit_id to the commit detail page."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/releases")
+    assert response.status_code == 200
+    body = response.text
+    # Commit link renders first 8 chars of commit_id via substring(0, 8).
+    assert "commitId" in body
+    assert "substring(0, 8)" in body or "substring(0,8)" in body
+    # Commit detail URL pattern must be embedded in the JS template.
+    assert "/commits/" in body
+
+
+@pytest.mark.anyio
+async def test_ui_release_list_page_has_tag_colour_coding(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Release list page colour-codes tags: v1.x = green (stable), v0.x = yellow (pre-release)."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/releases")
+    assert response.status_code == 200
+    body = response.text
+    # CSS classes for stable and pre-release tags must be present.
+    assert "tag-stable" in body
+    assert "tag-prerelease" in body
+    # The JS function that assigns these classes must be present.
+    assert "tagBadgeClass" in body
+
+
+@pytest.mark.anyio
 async def test_ui_release_detail_page_returns_200(
     client: AsyncClient,
     db_session: AsyncSession,


### PR DESCRIPTION
## Summary
Closes #301 — Enriches the release list page with body preview, download buttons, download count badge, commit link, and tag colour-coding.

## Root Cause / Motivation
The release list page showed only tag, title, and date with no way to download packages or see more details.

## Solution
- Added first paragraph of body preview (markdown stripped, max 150 chars)
- Added inline download icon buttons: 🎹 MIDI | 🎛️ Stems | 🎵 MP3 | 📄 MusicXML (disabled if absent)
- Added download count badge from analytics endpoint
- Added commit link: short SHA (first 8 chars) of commit_id linking to commit detail page
- Added tag colour-coding: v1.x = green (stable), v0.x = yellow (pre-release)

## Verification
- [x] mypy clean (638 source files, no issues)
- [x] Tests pass (6 targeted release_list tests, all green)
- [x] Docs updated (inline JSDoc on all new JS helpers)