### PR TITLE
feat(musehub): insights dashboard — stars, forks, and watches trend charts

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -7925,3 +7925,42 @@ Pydantic `CamelModel` — Wire representation of a Muse Hub milestone.
 **Produced by:** `maestro.services.musehub_issues.create_milestone()`, `list_milestones()`, `get_milestone()`
 **Consumed by:** `POST /milestones`, `GET /milestones`, `GET /milestones/{number}`
 
+---
+
+### `SocialTrendsDayResult`
+
+**Path:** `maestro/api/routes/musehub/social.py`
+
+Pydantic `BaseModel` — One calendar day of aggregated social engagement counts for a repo. Missing
+days (no activity) are filled with zeros so the chart always spans the full requested window.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `date` | `str` | ISO 8601 calendar date (`YYYY-MM-DD`) |
+| `stars` | `int` | New stars received on this day |
+| `forks` | `int` | New forks created on this day |
+| `watches` | `int` | New watches added on this day |
+
+**Produced by:** `maestro.api.routes.musehub.social.get_social_analytics()`
+**Consumed by:** `GET /api/v1/musehub/repos/{repo_id}/analytics/social` — nested inside `SocialTrendsResult.trend`; insights dashboard SVG multi-line chart
+
+---
+
+### `SocialTrendsResult`
+
+**Path:** `maestro/api/routes/musehub/social.py`
+
+Pydantic `BaseModel` — Top-level response for the social trends analytics endpoint. Bundles
+aggregate totals, a full per-day trend list, and fork-detail records for the insights dashboard.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `star_count` | `int` | Total stars across all time |
+| `fork_count` | `int` | Total forks across all time |
+| `watch_count` | `int` | Total watches across all time |
+| `trend` | `list[SocialTrendsDayResult]` | One entry per calendar day over the requested window (zero-filled) |
+| `forks_detail` | `list[ForkResponse]` | Per-fork records ordered by `created_at` descending, for the "Who forked this" panel |
+
+**Produced by:** `maestro.api.routes.musehub.social.get_social_analytics()`
+**Consumed by:** `GET /api/v1/musehub/repos/{repo_id}/analytics/social` (default window: 90 days, max: 365); insights dashboard Social Trends card and "Who forked this" panel
+

--- a/maestro/templates/musehub/pages/insights.html
+++ b/maestro/templates/musehub/pages/insights.html
@@ -193,6 +193,105 @@ async function loadTrafficChart() {
   } catch (_) {}
 }
 
+function buildSocialTrendsChart(trend) {
+  // Multi-line SVG chart: stars=yellow, forks=blue, watches=purple
+  if (!trend || trend.length === 0)
+    return '<p class="text-muted text-sm">No social trend data yet.</p>';
+
+  // Skip leading zeros — only render from first day with any activity
+  const firstActive = trend.findIndex(d => d.stars > 0 || d.forks > 0 || d.watches > 0);
+  const visible = firstActive >= 0 ? trend.slice(firstActive) : trend.slice(-30);
+  if (visible.length === 0)
+    return '<p class="text-muted text-sm">No social activity in the past 90 days.</p>';
+
+  const W = 600, H = 120, padX = 32, padY = 16;
+  const innerW = W - padX * 2;
+  const innerH = H - padY * 2;
+
+  const maxVal = Math.max(
+    ...visible.map(d => Math.max(d.stars, d.forks, d.watches)), 1
+  );
+
+  function toX(i) { return padX + (i / (visible.length - 1 || 1)) * innerW; }
+  function toY(v) { return padY + innerH - (v / maxVal) * innerH; }
+
+  function polyline(key, color) {
+    const pts = visible.map((d, i) => `${toX(i)},${toY(d[key])}`).join(' ');
+    return `<polyline points="${pts}" fill="none" stroke="${color}" stroke-width="2" opacity="0.85"/>`;
+  }
+
+  function dots(key, color, label) {
+    return visible.map((d, i) =>
+      `<circle cx="${toX(i)}" cy="${toY(d[key])}" r="2.5" fill="${color}">
+        <title>${escHtml(d.date)} — ${d[key]} ${label}</title>
+      </circle>`
+    ).join('');
+  }
+
+  // X-axis: show first and last date labels
+  const firstLabel = visible[0].date.slice(5);  // MM-DD
+  const lastLabel  = visible[visible.length - 1].date.slice(5);
+
+  return `<div style="overflow-x:auto">
+    <svg viewBox="0 0 ${W} ${H}" style="width:100%;max-width:${W}px;height:${H}px">
+      <!-- Grid line at max -->
+      <line x1="${padX}" y1="${padY}" x2="${W - padX}" y2="${padY}"
+            stroke="var(--border-subtle)" stroke-width="1" stroke-dasharray="4,4"/>
+      <!-- Lines -->
+      ${polyline('stars',   '#eab308')}
+      ${polyline('forks',   '#3b82f6')}
+      ${polyline('watches', '#a855f7')}
+      <!-- Dots -->
+      ${dots('stars',   '#eab308', 'stars')}
+      ${dots('forks',   '#3b82f6', 'forks')}
+      ${dots('watches', '#a855f7', 'watches')}
+      <!-- Y axis label -->
+      <text x="${padX - 2}" y="${padY + 4}" font-size="9" fill="var(--text-muted)" text-anchor="end">${maxVal}</text>
+      <text x="${padX - 2}" y="${H - padY + 4}" font-size="9" fill="var(--text-muted)" text-anchor="end">0</text>
+      <!-- X axis labels -->
+      <text x="${padX}" y="${H - 2}" font-size="9" fill="var(--text-muted)" text-anchor="middle">${escHtml(firstLabel)}</text>
+      <text x="${W - padX}" y="${H - 2}" font-size="9" fill="var(--text-muted)" text-anchor="middle">${escHtml(lastLabel)}</text>
+    </svg>
+  </div>
+  <div style="display:flex;gap:var(--space-4);margin-top:6px;font-size:var(--font-size-xs,11px);color:var(--text-muted)">
+    <span><span style="display:inline-block;width:10px;height:3px;background:#eab308;border-radius:2px;vertical-align:middle;margin-right:4px"></span>Stars</span>
+    <span><span style="display:inline-block;width:10px;height:3px;background:#3b82f6;border-radius:2px;vertical-align:middle;margin-right:4px"></span>Forks</span>
+    <span><span style="display:inline-block;width:10px;height:3px;background:#a855f7;border-radius:2px;vertical-align:middle;margin-right:4px"></span>Watches</span>
+  </div>`;
+}
+
+function buildWhoForkedThis(forksDetail) {
+  if (!forksDetail || forksDetail.length === 0)
+    return '<p class="text-muted text-sm">No forks yet.</p>';
+  return forksDetail.slice(0, 20).map(f => {
+    const initial = (f.forked_by || '?')[0].toUpperCase();
+    const hue = ((f.forked_by || '').split('').reduce((acc, c) => acc + c.charCodeAt(0), 0) % 360);
+    return `
+      <div style="display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) 0;border-bottom:1px solid var(--border-subtle)">
+        <div style="width:32px;height:32px;border-radius:50%;background:hsl(${hue},55%,45%);display:flex;align-items:center;justify-content:center;font-size:14px;font-weight:600;color:#fff;flex-shrink:0">${escHtml(initial)}</div>
+        <div>
+          <a href="/musehub/ui/${escHtml(f.forked_by)}" class="text-sm" style="font-weight:500">${escHtml(f.forked_by)}</a>
+          <div class="text-xs text-muted">forked ${fmtRelative(f.created_at)}</div>
+        </div>
+      </div>`;
+  }).join('');
+}
+
+async function loadSocialTrends() {
+  const el = document.getElementById('social-trends-section');
+  if (!el) return;
+  try {
+    const data = await apiFetch('/repos/' + repoId + '/analytics/social?days=90');
+    document.getElementById('stat-stars').textContent   = data.star_count  ?? 0;
+    document.getElementById('stat-forks').textContent   = data.fork_count  ?? 0;
+    document.getElementById('stat-watches').textContent = data.watch_count ?? 0;
+    document.getElementById('social-trend-chart').innerHTML = buildSocialTrendsChart(data.trend || []);
+    document.getElementById('who-forked').innerHTML         = buildWhoForkedThis(data.forks_detail || []);
+  } catch (_) {
+    el.innerHTML = '<p class="text-muted text-sm">Could not load social trends.</p>';
+  }
+}
+
 async function load() {
   initRepoNav(repoId);
   try {
@@ -225,6 +324,7 @@ async function load() {
       if (dls)   dls.textContent   = a.download_count ?? 0;
     }).catch(() => {});
     loadTrafficChart();
+    loadSocialTrends();
 
     // Key signature distribution
     const keyMap = {};
@@ -355,6 +455,29 @@ async function load() {
             <div class="stat-label">Merged PRs</div>
           </div>
         </div>
+      </div>
+
+      <!-- Social Trends -->
+      <div class="card" id="social-trends-section">
+        <h2 style="margin-bottom:var(--space-3)">Social Trends</h2>
+        <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:var(--space-3);margin-bottom:var(--space-4)">
+          <div class="stat-card">
+            <span class="stat-value" id="stat-stars" style="color:#eab308">—</span>
+            <div class="stat-label">⭐ Stars</div>
+          </div>
+          <div class="stat-card">
+            <span class="stat-value" id="stat-watches" style="color:#a855f7">—</span>
+            <div class="stat-label">👁 Watches</div>
+          </div>
+          <div class="stat-card">
+            <span class="stat-value" id="stat-forks" style="color:#3b82f6">—</span>
+            <div class="stat-label">🍴 Forks</div>
+          </div>
+        </div>
+        <p class="text-xs text-muted" style="margin-bottom:var(--space-3)">Past 90 days</p>
+        <div id="social-trend-chart">Loading…</div>
+        <h3 style="margin-top:var(--space-4);margin-bottom:var(--space-2)">Who forked this</h3>
+        <div id="who-forked">Loading…</div>
       </div>
 
       <!-- Recent sessions -->


### PR DESCRIPTION
## Summary
Closes #309 — adds Social Trends charts to the Muse Hub insights dashboard.

## Root Cause / Motivation
The insights dashboard showed star count as a single static number with no trend data. MusehubStar (41 seeded), MusehubFork (2 seeded), and MusehubWatch (22 seeded) all have `created_at` timestamps available for time-series aggregation, but no endpoint existed to surface them.

## Solution

### New endpoint: `GET /repos/{id}/analytics/social`
- Returns `SocialTrendsResult` with `star_count`, `fork_count`, `watch_count` totals and a `trend` list of `SocialTrendsDayResult` (one per calendar day over the window, zeros filled for missing days)
- Also returns `forks_detail` (`list[ForkResponse]`) for the "Who forked this" panel
- Default window: 90 days, max: 365 days
- Uses `func.date()` for day-grouping (compatible with SQLite in tests and PostgreSQL in production — avoids `cast(DateTime, Date)` processor issues in SQLAlchemy's SQLite dialect)
- Visibility guard: public repos open, private repos require auth

### New Pydantic models (inline in `social.py`)
- `SocialTrendsDayResult` — `{date, stars, forks, watches}` per day
- `SocialTrendsResult` — totals + trend + forks_detail

### Updated `insights.html`
- **Social Trends card** with 3 stat cards (⭐ Stars / 👁 Watches / 🍴 Forks), loaded async
- **Multi-line SVG chart** spanning 90 days (stars=yellow `#eab308`, forks=blue `#3b82f6`, watches=purple `#a855f7`) with legend
- **"Who forked this" panel** with avatar circles (HSL color from username hash), forked_by name linked to profile, relative timestamp

## Verification
- [x] `mypy /worktrees/issue-309/maestro/` — clean (408 files)
- [x] `mypy social.py tests/test_musehub_social.py` — clean
- [x] All 63 tests in `test_musehub_social.py` pass (6 new, 57 existing)
- [x] No protocol/SSE changes — no handoff required

## Tests Added
- `test_get_social_analytics_empty_public_repo` — zero totals for new repo
- `test_get_social_analytics_not_found_returns_404` — 404 guard
- `test_get_social_analytics_private_repo_requires_auth` — 401 guard
- `test_get_social_analytics_counts_seeded_rows` — reflects seeded star + watch rows
- `test_get_social_analytics_trend_spans_full_window` — trend has exactly `days` entries
- `test_get_social_analytics_forks_detail_includes_forked_by` — fork detail lists who forked

## Layers Affected
- Routes: `maestro/api/routes/musehub/social.py` — new endpoint + 2 Pydantic models
- Template: `maestro/templates/musehub/pages/insights.html` — Social Trends section
- Tests: `tests/test_musehub_social.py` — 6 new tests

## Handoff
N/A — no SSE/MCP protocol changes.