### PR TITLE
feat(musehub): enhanced issue detail — discussion threads, assignees, milestones, and musical context links

### DIFF
--- a/docs/architecture/muse_vcs.md
+++ b/docs/architecture/muse_vcs.md
@@ -8317,3 +8317,66 @@ something meaningful.
 | Tests (UI) | `tests/test_musehub_ui.py` — `test_score_*` (9 tests) |
 
 ---
+
+## Issue Tracker Enhancements (Phase 9 — Issue #218)
+
+### Overview
+
+The Muse Hub issue tracker supports full collaborative workflows beyond the initial title/body/close MVP. This section documents the enhanced issue detail capabilities added in phase 9.
+
+### Features
+
+**Threaded Discussion**
+
+Issues support threaded comments via `POST /issues/{number}/comments`. Top-level comments have `parentId: null`; replies set `parentId` to the target comment UUID. The UI builds the thread tree client-side from the flat chronological list.
+
+**Musical Context Linking**
+
+Comment bodies are scanned at write time for musical context references using the pattern `type:value`:
+
+| Syntax | Type | Example |
+|--------|------|---------|
+| `track:bass` | track | References the bass track |
+| `section:chorus` | section | References the chorus section |
+| `beats:16-24` | beats | References a beat range |
+
+Parsed refs are stored in `musehub_issue_comments.musical_refs` (JSON array) and returned in `IssueCommentResponse.musicalRefs`. The issue detail UI renders them as coloured badges.
+
+**Assignees**
+
+A single collaborator can be assigned per issue via `POST /issues/{number}/assign`. The `assignee` field is a free-form display name. Pass `"assignee": null` to unassign.
+
+**Milestones**
+
+Milestones group issues into named goals (e.g. "Album v1.0"). Create milestones at `POST /milestones`, then link issues via `POST /issues/{number}/milestone?milestone_id=<uuid>`. Each milestone response includes live `openIssues` and `closedIssues` counts computed from the current state of linked issues.
+
+**State Transitions**
+
+Issues may be reopened after closing: `POST /issues/{number}/reopen`. Both close and reopen fire webhook events with `action: "opened"/"closed"`.
+
+**Edit Capability**
+
+`PATCH /issues/{number}` allows partial updates to title, body, and labels.
+
+### Database Schema
+
+| Table | Purpose |
+|-------|---------|
+| `musehub_milestones` | Per-repo milestone definitions |
+| `musehub_issues` | Extended with `assignee`, `milestone_id`, `updated_at` |
+| `musehub_issue_comments` | Threaded comments with `parent_id` and `musical_refs` |
+
+### Implementation
+
+| Layer | File |
+|-------|------|
+| DB models | `maestro/db/musehub_models.py` — `MusehubMilestone`, `MusehubIssueComment`, extended `MusehubIssue` |
+| Pydantic models | `maestro/models/musehub.py` — `MilestoneCreate/Response`, `IssueCommentCreate/Response`, `IssueUpdate`, `IssueAssignRequest`, `MusicalRef` |
+| Service | `maestro/services/musehub_issues.py` — comment CRUD, milestone CRUD, assign, reopen, update |
+| Routes | `maestro/api/routes/musehub/issues.py` — 12 endpoints |
+| UI template | `maestro/templates/musehub/pages/issue_detail.html` — threaded UI |
+| Migration | `alembic/versions/0001_consolidated_schema.py` — new tables and columns |
+| Tests | `tests/test_musehub_issues.py` — 12 new tests covering all acceptance criteria |
+
+---
+

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1175,11 +1175,124 @@ Get a single issue by its per-repo sequential number.
 
 **Response (200):** Full issue object (same shape as above). Returns **404** if the issue number does not exist.
 
+### PATCH /api/v1/musehub/repos/{repo_id}/issues/{issue_number}
+
+Partially update an issue's title, body, and/or labels. Only fields present in the body are modified.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `title` | string | — | Updated title (1–500 chars) |
+| `body` | string | — | Updated Markdown body |
+| `labels` | string[] | — | Replacement label list |
+
+**Response (200):** Updated issue object.
+
 ### POST /api/v1/musehub/repos/{repo_id}/issues/{issue_number}/close
 
 Close an issue (set `state` → `"closed"`).
 
 **Response (200):** Updated issue object with `"state": "closed"`. Returns **404** if the issue number does not exist.
+
+### POST /api/v1/musehub/repos/{repo_id}/issues/{issue_number}/reopen
+
+Reopen a closed issue (set `state` → `"open"`).
+
+**Response (200):** Updated issue object with `"state": "open"`. Returns **404** if not found.
+
+### POST /api/v1/musehub/repos/{repo_id}/issues/{issue_number}/assign
+
+Assign or unassign a collaborator. Pass `"assignee": null` to unassign.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `assignee` | string\|null | yes | Collaborator display name; null to unassign |
+
+**Response (200):** Updated issue object with `assignee` field set.
+
+### POST /api/v1/musehub/repos/{repo_id}/issues/{issue_number}/milestone
+
+Assign or remove a milestone. Query param `?milestone_id=<uuid>` to assign; omit to remove.
+
+**Response (200):** Updated issue object with `milestoneId` and `milestoneTitle` set.
+
+### GET /api/v1/musehub/repos/{repo_id}/issues/{issue_number}/comments
+
+List all non-deleted comments on an issue, ordered chronologically (oldest first).
+
+**Response (200):**
+```json
+{
+  "comments": [
+    {
+      "commentId": "uuid",
+      "issueId": "uuid",
+      "author": "miles_davis",
+      "body": "The section:chorus beats:16-24 has a frequency clash with track:bass.",
+      "parentId": null,
+      "musicalRefs": [
+        {"type": "section", "value": "chorus", "raw": "section:chorus"},
+        {"type": "beats", "value": "16-24", "raw": "beats:16-24"},
+        {"type": "track", "value": "bass", "raw": "track:bass"}
+      ],
+      "isDeleted": false,
+      "createdAt": "2026-02-28T12:00:00Z",
+      "updatedAt": "2026-02-28T12:00:00Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+### POST /api/v1/musehub/repos/{repo_id}/issues/{issue_number}/comments
+
+Create a comment on an issue. Supports threaded replies via `parentId`.
+
+Musical context references (`track:bass`, `section:chorus`, `beats:16-24`) are parsed automatically and returned in `musicalRefs`.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `body` | string | yes | Markdown comment body |
+| `parentId` | string | — | Parent comment UUID for threaded replies |
+
+**Response (201):** Full updated comment list (`IssueCommentListResponse`).
+
+### DELETE /api/v1/musehub/repos/{repo_id}/issues/{issue_number}/comments/{comment_id}
+
+Soft-delete a comment (excluded from future list results).
+
+**Response (204):** No content. Returns **404** if not found.
+
+---
+
+## Muse Hub Milestones API
+
+Group issues into milestones (e.g. "Album v1.0", "Mix Session 3"). All endpoints are under `/api/v1/musehub/repos/{repo_id}/milestones/`.
+
+### GET /api/v1/musehub/repos/{repo_id}/milestones
+
+List milestones. Optional `?state=open|closed|all` (default `open`).
+
+**Response (200):** `{ "milestones": [MilestoneResponse, ...] }`
+
+Each milestone includes `openIssues` and `closedIssues` counts.
+
+### POST /api/v1/musehub/repos/{repo_id}/milestones
+
+Create a milestone.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `title` | string | yes | Milestone title (1–255 chars) |
+| `description` | string | — | Markdown description |
+| `dueOn` | string | — | ISO-8601 due date |
+
+**Response (201):** `MilestoneResponse`
+
+### GET /api/v1/musehub/repos/{repo_id}/milestones/{milestone_number}
+
+Get a single milestone by its per-repo sequential number.
+
+**Response (200):** `MilestoneResponse`. Returns **404** if not found.
 
 ---
 

--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -7814,3 +7814,69 @@ as JSON by `GET /api/v1/musehub/repos/{repo_id}/objects/{object_id}/parse-midi`.
 
 **Produced by:** `maestro.services.musehub_midi_parser.parse_midi_bytes()`
 **Consumed by:** `maestro.api.routes.musehub.objects.parse_midi_object()`; MuseHub piano roll JavaScript renderer (`piano-roll.js`)
+
+
+---
+
+### `IssueCommentResponse`
+
+**Path:** `maestro/models/musehub.py`
+
+Pydantic `CamelModel` — Wire representation of a single threaded comment on a Muse Hub issue.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `comment_id` | `str` | Internal UUID for this comment |
+| `issue_id` | `str` | UUID of the parent issue |
+| `author` | `str` | Display name of the comment author |
+| `body` | `str` | Markdown comment body |
+| `parent_id` | `str \| None` | Parent comment UUID; null for top-level comments |
+| `musical_refs` | `list[MusicalRef]` | Parsed musical context references |
+| `is_deleted` | `bool` | True when soft-deleted |
+| `created_at` | `datetime` | Comment creation timestamp |
+| `updated_at` | `datetime` | Last edit timestamp |
+
+**Produced by:** `maestro.services.musehub_issues.create_comment()`, `list_comments()`
+**Consumed by:** `POST /issues/{number}/comments`, `GET /issues/{number}/comments`
+
+---
+
+### `MusicalRef`
+
+**Path:** `maestro/models/musehub.py`
+
+Pydantic `CamelModel` — A parsed musical context reference extracted from a comment body.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `str` | Reference type: `"track"` \| `"section"` \| `"beats"` |
+| `value` | `str` | The referenced value, e.g. `"bass"`, `"chorus"`, `"16-24"` |
+| `raw` | `str` | Original raw token from the comment body, e.g. `"track:bass"` |
+
+**Produced by:** `maestro.services.musehub_issues._parse_musical_refs()`
+**Consumed by:** `IssueCommentResponse.musical_refs`; issue detail UI rendering
+
+---
+
+### `MilestoneResponse`
+
+**Path:** `maestro/models/musehub.py`
+
+Pydantic `CamelModel` — Wire representation of a Muse Hub milestone.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `milestone_id` | `str` | Internal UUID |
+| `number` | `int` | Per-repo sequential milestone number |
+| `title` | `str` | Milestone title |
+| `description` | `str` | Markdown description |
+| `state` | `str` | `"open"` or `"closed"` |
+| `author` | `str` | Creator display name |
+| `due_on` | `datetime \| None` | Optional due date |
+| `open_issues` | `int` | Number of open issues linked to this milestone |
+| `closed_issues` | `int` | Number of closed issues linked to this milestone |
+| `created_at` | `datetime` | Creation timestamp |
+
+**Produced by:** `maestro.services.musehub_issues.create_milestone()`, `list_milestones()`, `get_milestone()`
+**Consumed by:** `POST /milestones`, `GET /milestones`, `GET /milestones/{number}`
+

--- a/maestro/db/musehub_models.py
+++ b/maestro/db/musehub_models.py
@@ -5,6 +5,8 @@ Tables:
 - musehub_branches: Named branch pointers inside a repo
 - musehub_commits: Remote commit records pushed from CLI clients
 - musehub_issues: Issue tracker entries per repo
+- musehub_issue_comments: Threaded comments on issues
+- musehub_milestones: Milestone groupings for issues
 - musehub_pull_requests: Pull requests proposing branch merges
 - musehub_objects: Content-addressed binary artifact storage
 - musehub_releases: Tagged releases
@@ -81,6 +83,10 @@ class MusehubRepo(Base):
     )
     issues: Mapped[list[MusehubIssue]] = relationship(
         "MusehubIssue", back_populates="repo", cascade="all, delete-orphan"
+    )
+    milestones: Mapped[list[MusehubMilestone]] = relationship(
+        "MusehubMilestone", back_populates="repo", cascade="all, delete-orphan",
+        foreign_keys="[MusehubMilestone.repo_id]",
     )
     pull_requests: Mapped[list[MusehubPullRequest]] = relationship(
         "MusehubPullRequest", back_populates="repo", cascade="all, delete-orphan"
@@ -178,12 +184,58 @@ class MusehubObject(Base):
 
     repo: Mapped[MusehubRepo] = relationship("MusehubRepo", back_populates="objects")
 
+class MusehubMilestone(Base):
+    """A milestone that groups issues within a repo.
+
+    Milestones give musicians a way to track progress toward goals like
+    "Album v1.0" or "Mix Session 3". Issues are linked via milestone_id.
+
+    ``number`` is sequential per repo (1-based), mirroring the issue numbering
+    convention so users can reference milestones as "Milestone #1".
+    """
+
+    __tablename__ = "musehub_milestones"
+
+    milestone_id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    repo_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("musehub_repos.repo_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Sequential per-repo milestone number (1, 2, 3…)
+    number: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    # Lifecycle: open → closed
+    state: Mapped[str] = mapped_column(String(20), nullable=False, default="open", index=True)
+    # Display name of the user who created the milestone
+    author: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    # Optional due date for the milestone
+    due_on: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    repo: Mapped[MusehubRepo] = relationship(
+        "MusehubRepo", back_populates="milestones", foreign_keys=[repo_id]
+    )
+    issues: Mapped[list[MusehubIssue]] = relationship(
+        "MusehubIssue", back_populates="milestone", foreign_keys="[MusehubIssue.milestone_id]"
+    )
+
+
 class MusehubIssue(Base):
     """An issue opened against a Muse Hub repo.
 
     ``number`` is auto-incremented per repo starting at 1 so musicians can
     reference issues as ``#1``, ``#2``, etc., independently of the global PK.
     ``labels`` is a JSON list of free-form strings (no validation at MVP).
+    ``assignee`` is the display name or identifier of the user assigned to this issue.
+    ``milestone_id`` links the issue to a MusehubMilestone for progress tracking.
     """
 
     __tablename__ = "musehub_issues"
@@ -204,11 +256,76 @@ class MusehubIssue(Base):
     labels: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
     # Display name or identifier of the user who opened this issue
     author: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    # Display name or user ID of the collaborator assigned to resolve this issue
+    assignee: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # FK to musehub_milestones — null when the issue is not part of a milestone
+    milestone_id: Mapped[str | None] = mapped_column(
+        String(36),
+        ForeignKey("musehub_milestones.milestone_id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_utc_now
     )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
 
     repo: Mapped[MusehubRepo] = relationship("MusehubRepo", back_populates="issues")
+    milestone: Mapped[MusehubMilestone | None] = relationship(
+        "MusehubMilestone", back_populates="issues", foreign_keys=[milestone_id]
+    )
+    comments: Mapped[list[MusehubIssueComment]] = relationship(
+        "MusehubIssueComment", back_populates="issue", cascade="all, delete-orphan",
+        order_by="MusehubIssueComment.created_at",
+    )
+
+
+class MusehubIssueComment(Base):
+    """A comment in a threaded discussion on a Muse Hub issue.
+
+    Comments support threaded replies via ``parent_id``. Top-level comments
+    have ``parent_id=None``. Markdown body is stored verbatim; rendering
+    happens client-side.
+
+    ``musical_refs`` is a JSON list of parsed musical context references
+    extracted from the body (e.g. ``track:bass``, ``section:chorus``,
+    ``beats:16-24``). Parsing is done at write time so reads are fast.
+    """
+
+    __tablename__ = "musehub_issue_comments"
+
+    comment_id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    issue_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("musehub_issues.issue_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    repo_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("musehub_repos.repo_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Display name or user ID of the comment author
+    author: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    # Markdown comment body
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    # Parent comment ID for threaded replies; null for top-level comments
+    parent_id: Mapped[str | None] = mapped_column(String(36), nullable=True, index=True)
+    # JSON list of parsed musical context dicts: {"type": "track"|"section"|"beats", "value": "..."}
+    musical_refs: Mapped[list[dict[str, str]]] = mapped_column(JSON, nullable=False, default=list)
+    is_deleted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, index=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now
+    )
+
+    issue: Mapped[MusehubIssue] = relationship("MusehubIssue", back_populates="comments")
 
 class MusehubPullRequest(Base):
     """A pull request proposing to merge one branch into another.

--- a/maestro/services/musehub_issues.py
+++ b/maestro/services/musehub_issues.py
@@ -1,6 +1,7 @@
 """Muse Hub issue persistence adapter — single point of DB access for issues.
 
-This module is the ONLY place that touches the ``musehub_issues`` table.
+This module is the ONLY place that touches the ``musehub_issues``,
+``musehub_issue_comments``, and ``musehub_milestones`` tables.
 Route handlers delegate here; no business logic lives in routes.
 
 Boundary rules:
@@ -12,17 +13,52 @@ Boundary rules:
 from __future__ import annotations
 
 import logging
+import re
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from maestro.db import musehub_models as db
-from maestro.models.musehub import IssueResponse
+from maestro.models.musehub import (
+    IssueCommentListResponse,
+    IssueCommentResponse,
+    IssueResponse,
+    MilestoneListResponse,
+    MilestoneResponse,
+    MusicalRef,
+)
 
 logger = logging.getLogger(__name__)
 
+# Regex to parse musical context references: track:bass, section:chorus, beats:16-24
+_MUSICAL_REF_RE = re.compile(
+    r"\b(track|section|beats):([A-Za-z0-9_\-]+(?:-[A-Za-z0-9_\-]+)*)\b"
+)
 
-def _to_issue_response(row: db.MusehubIssue) -> IssueResponse:
+
+def _parse_musical_refs(body: str) -> list[dict[str, str]]:
+    """Extract musical context references from comment body text.
+
+    Returns a list of dicts with keys ``type``, ``value``, and ``raw`` so
+    they can be stored in the JSON ``musical_refs`` column and round-tripped
+    without re-parsing on every read.
+    """
+    refs: list[dict[str, str]] = []
+    for m in _MUSICAL_REF_RE.finditer(body):
+        refs.append({"type": m.group(1), "value": m.group(2), "raw": m.group(0)})
+    return refs
+
+
+def _to_issue_response(row: db.MusehubIssue, comment_count: int = 0) -> IssueResponse:
+    """Convert a DB row to an IssueResponse wire model.
+
+    ``comment_count`` must be passed in by the caller — it requires a separate
+    aggregate query so we avoid N+1 loads on list endpoints.
+    """
+    milestone_title: str | None = None
+    if row.milestone is not None:
+        milestone_title = row.milestone.title
     return IssueResponse(
         issue_id=row.issue_id,
         number=row.number,
@@ -31,6 +67,48 @@ def _to_issue_response(row: db.MusehubIssue) -> IssueResponse:
         state=row.state,
         labels=list(row.labels or []),
         author=row.author,
+        assignee=row.assignee,
+        milestone_id=row.milestone_id,
+        milestone_title=milestone_title,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        comment_count=comment_count,
+    )
+
+
+def _to_comment_response(row: db.MusehubIssueComment) -> IssueCommentResponse:
+    """Convert a DB comment row to the wire representation."""
+    musical_refs = [
+        MusicalRef(type=r["type"], value=r["value"], raw=r["raw"])
+        for r in (row.musical_refs or [])
+    ]
+    return IssueCommentResponse(
+        comment_id=row.comment_id,
+        issue_id=row.issue_id,
+        author=row.author,
+        body=row.body,
+        parent_id=row.parent_id,
+        musical_refs=musical_refs,
+        is_deleted=row.is_deleted,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _to_milestone_response(
+    row: db.MusehubMilestone, open_count: int = 0, closed_count: int = 0
+) -> MilestoneResponse:
+    """Convert a DB milestone row to the wire representation."""
+    return MilestoneResponse(
+        milestone_id=row.milestone_id,
+        number=row.number,
+        title=row.title,
+        description=row.description,
+        state=row.state,
+        author=row.author,
+        due_on=row.due_on,
+        open_issues=open_count,
+        closed_issues=closed_count,
         created_at=row.created_at,
     )
 
@@ -42,6 +120,25 @@ async def _next_issue_number(session: AsyncSession, repo_id: str) -> int:
     )
     current_max: int | None = (await session.execute(stmt)).scalar_one_or_none()
     return (current_max or 0) + 1
+
+
+async def _next_milestone_number(session: AsyncSession, repo_id: str) -> int:
+    """Return the next sequential milestone number for the given repo (1-based)."""
+    stmt = select(func.max(db.MusehubMilestone.number)).where(
+        db.MusehubMilestone.repo_id == repo_id
+    )
+    current_max: int | None = (await session.execute(stmt)).scalar_one_or_none()
+    return (current_max or 0) + 1
+
+
+async def _count_comments(session: AsyncSession, issue_id: str) -> int:
+    """Return the non-deleted comment count for a single issue."""
+    stmt = select(func.count(db.MusehubIssueComment.comment_id)).where(
+        db.MusehubIssueComment.issue_id == issue_id,
+        db.MusehubIssueComment.is_deleted.is_(False),
+    )
+    count: int = (await session.execute(stmt)).scalar_one()
+    return count
 
 
 async def create_issue(
@@ -81,22 +178,34 @@ async def list_issues(
     *,
     state: str = "open",
     label: str | None = None,
+    milestone_id: str | None = None,
 ) -> list[IssueResponse]:
-    """Return issues for a repo, filtered by state and/or label.
+    """Return issues for a repo, filtered by state, label, and/or milestone.
 
     ``state`` may be ``"open"``, ``"closed"``, or ``"all"``.
     ``label`` filters to issues whose labels list contains the given string.
+    ``milestone_id`` filters to issues assigned to that milestone.
     Results are ordered by issue number ascending.
     """
-    stmt = select(db.MusehubIssue).where(db.MusehubIssue.repo_id == repo_id)
+    stmt = (
+        select(db.MusehubIssue)
+        .options(selectinload(db.MusehubIssue.milestone))
+        .where(db.MusehubIssue.repo_id == repo_id)
+    )
 
     if state != "all":
         stmt = stmt.where(db.MusehubIssue.state == state)
 
+    if milestone_id is not None:
+        stmt = stmt.where(db.MusehubIssue.milestone_id == milestone_id)
+
     stmt = stmt.order_by(db.MusehubIssue.number)
     rows = (await session.execute(stmt)).scalars().all()
 
-    results = [_to_issue_response(r) for r in rows]
+    results: list[IssueResponse] = []
+    for r in rows:
+        count = await _count_comments(session, r.issue_id)
+        results.append(_to_issue_response(r, count))
 
     if label is not None:
         results = [r for r in results if label in r.labels]
@@ -110,14 +219,32 @@ async def get_issue(
     issue_number: int,
 ) -> IssueResponse | None:
     """Return a single issue by its per-repo number, or None if not found."""
-    stmt = select(db.MusehubIssue).where(
-        db.MusehubIssue.repo_id == repo_id,
-        db.MusehubIssue.number == issue_number,
+    stmt = (
+        select(db.MusehubIssue)
+        .options(selectinload(db.MusehubIssue.milestone))
+        .where(
+            db.MusehubIssue.repo_id == repo_id,
+            db.MusehubIssue.number == issue_number,
+        )
     )
     row = (await session.execute(stmt)).scalar_one_or_none()
     if row is None:
         return None
-    return _to_issue_response(row)
+    count = await _count_comments(session, row.issue_id)
+    return _to_issue_response(row, count)
+
+
+async def get_issue_by_id(
+    session: AsyncSession,
+    issue_id: str,
+) -> db.MusehubIssue | None:
+    """Return the raw ORM row for an issue by its UUID primary key."""
+    stmt = (
+        select(db.MusehubIssue)
+        .options(selectinload(db.MusehubIssue.milestone))
+        .where(db.MusehubIssue.issue_id == issue_id)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
 
 
 async def close_issue(
@@ -126,9 +253,13 @@ async def close_issue(
     issue_number: int,
 ) -> IssueResponse | None:
     """Set the issue state to ``closed``. Returns None if the issue does not exist."""
-    stmt = select(db.MusehubIssue).where(
-        db.MusehubIssue.repo_id == repo_id,
-        db.MusehubIssue.number == issue_number,
+    stmt = (
+        select(db.MusehubIssue)
+        .options(selectinload(db.MusehubIssue.milestone))
+        .where(
+            db.MusehubIssue.repo_id == repo_id,
+            db.MusehubIssue.number == issue_number,
+        )
     )
     row = (await session.execute(stmt)).scalar_one_or_none()
     if row is None:
@@ -137,4 +268,317 @@ async def close_issue(
     await session.flush()
     await session.refresh(row)
     logger.info("✅ Closed issue #%d for repo %s", issue_number, repo_id)
-    return _to_issue_response(row)
+    count = await _count_comments(session, row.issue_id)
+    return _to_issue_response(row, count)
+
+
+async def reopen_issue(
+    session: AsyncSession,
+    repo_id: str,
+    issue_number: int,
+) -> IssueResponse | None:
+    """Set the issue state back to ``open``. Returns None if the issue does not exist."""
+    stmt = (
+        select(db.MusehubIssue)
+        .options(selectinload(db.MusehubIssue.milestone))
+        .where(
+            db.MusehubIssue.repo_id == repo_id,
+            db.MusehubIssue.number == issue_number,
+        )
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return None
+    row.state = "open"
+    await session.flush()
+    await session.refresh(row)
+    logger.info("✅ Reopened issue #%d for repo %s", issue_number, repo_id)
+    count = await _count_comments(session, row.issue_id)
+    return _to_issue_response(row, count)
+
+
+async def update_issue(
+    session: AsyncSession,
+    repo_id: str,
+    issue_number: int,
+    *,
+    title: str | None = None,
+    body: str | None = None,
+    labels: list[str] | None = None,
+) -> IssueResponse | None:
+    """Partially update an issue's title, body, and/or labels.
+
+    Only non-None arguments are applied. Returns None if the issue is not found.
+    """
+    stmt = (
+        select(db.MusehubIssue)
+        .options(selectinload(db.MusehubIssue.milestone))
+        .where(
+            db.MusehubIssue.repo_id == repo_id,
+            db.MusehubIssue.number == issue_number,
+        )
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return None
+    if title is not None:
+        row.title = title
+    if body is not None:
+        row.body = body
+    if labels is not None:
+        row.labels = labels
+    await session.flush()
+    await session.refresh(row)
+    count = await _count_comments(session, row.issue_id)
+    return _to_issue_response(row, count)
+
+
+async def assign_issue(
+    session: AsyncSession,
+    repo_id: str,
+    issue_number: int,
+    *,
+    assignee: str | None,
+) -> IssueResponse | None:
+    """Set or clear the assignee on an issue.
+
+    Pass ``assignee=None`` to unassign. Returns None if the issue is not found.
+    """
+    stmt = (
+        select(db.MusehubIssue)
+        .options(selectinload(db.MusehubIssue.milestone))
+        .where(
+            db.MusehubIssue.repo_id == repo_id,
+            db.MusehubIssue.number == issue_number,
+        )
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return None
+    row.assignee = assignee
+    await session.flush()
+    await session.refresh(row)
+    logger.info(
+        "✅ %s issue #%d for repo %s",
+        f"Assigned {assignee} to" if assignee else "Unassigned",
+        issue_number,
+        repo_id,
+    )
+    count = await _count_comments(session, row.issue_id)
+    return _to_issue_response(row, count)
+
+
+async def set_issue_milestone(
+    session: AsyncSession,
+    repo_id: str,
+    issue_number: int,
+    *,
+    milestone_id: str | None,
+) -> IssueResponse | None:
+    """Assign or remove a milestone from an issue.
+
+    Pass ``milestone_id=None`` to remove the milestone.
+    Returns None if the issue is not found.
+    Raises ValueError if the milestone_id does not belong to the same repo.
+    """
+    stmt = (
+        select(db.MusehubIssue)
+        .options(selectinload(db.MusehubIssue.milestone))
+        .where(
+            db.MusehubIssue.repo_id == repo_id,
+            db.MusehubIssue.number == issue_number,
+        )
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return None
+
+    if milestone_id is not None:
+        ms_stmt = select(db.MusehubMilestone).where(
+            db.MusehubMilestone.milestone_id == milestone_id,
+            db.MusehubMilestone.repo_id == repo_id,
+        )
+        ms_row = (await session.execute(ms_stmt)).scalar_one_or_none()
+        if ms_row is None:
+            raise ValueError(f"Milestone {milestone_id!r} not found in repo {repo_id!r}")
+
+    row.milestone_id = milestone_id
+    await session.flush()
+    await session.refresh(row)
+    count = await _count_comments(session, row.issue_id)
+    return _to_issue_response(row, count)
+
+
+# ── Issue comment operations ───────────────────────────────────────────────────
+
+
+async def create_comment(
+    session: AsyncSession,
+    *,
+    issue_id: str,
+    repo_id: str,
+    body: str,
+    author: str,
+    parent_id: str | None = None,
+) -> IssueCommentResponse:
+    """Create a new comment on an issue.
+
+    Musical context references (``track:bass``, ``section:chorus``,
+    ``beats:16-24``) are parsed from ``body`` at write time and persisted in
+    the ``musical_refs`` JSON column for fast retrieval.
+    """
+    if parent_id is not None:
+        parent_stmt = select(db.MusehubIssueComment).where(
+            db.MusehubIssueComment.comment_id == parent_id,
+            db.MusehubIssueComment.issue_id == issue_id,
+        )
+        parent_row = (await session.execute(parent_stmt)).scalar_one_or_none()
+        if parent_row is None:
+            raise ValueError(f"Parent comment {parent_id!r} not found on issue {issue_id!r}")
+
+    musical_refs = _parse_musical_refs(body)
+    comment = db.MusehubIssueComment(
+        issue_id=issue_id,
+        repo_id=repo_id,
+        author=author,
+        body=body,
+        parent_id=parent_id,
+        musical_refs=musical_refs,
+    )
+    session.add(comment)
+    await session.flush()
+    await session.refresh(comment)
+    logger.info("✅ Created comment %s on issue %s by %s", comment.comment_id, issue_id, author)
+    return _to_comment_response(comment)
+
+
+async def list_comments(
+    session: AsyncSession,
+    issue_id: str,
+    *,
+    include_deleted: bool = False,
+) -> IssueCommentListResponse:
+    """Return all comments on an issue, ordered chronologically.
+
+    Deleted comments are omitted by default; pass ``include_deleted=True``
+    to include them (e.g. for moderation views).
+    """
+    stmt = select(db.MusehubIssueComment).where(
+        db.MusehubIssueComment.issue_id == issue_id
+    )
+    if not include_deleted:
+        stmt = stmt.where(db.MusehubIssueComment.is_deleted.is_(False))
+    stmt = stmt.order_by(db.MusehubIssueComment.created_at)
+    rows = (await session.execute(stmt)).scalars().all()
+    comments = [_to_comment_response(r) for r in rows]
+    return IssueCommentListResponse(comments=comments, total=len(comments))
+
+
+async def delete_comment(
+    session: AsyncSession,
+    comment_id: str,
+    issue_id: str,
+) -> bool:
+    """Soft-delete a comment. Returns True if the comment existed and was deleted."""
+    stmt = select(db.MusehubIssueComment).where(
+        db.MusehubIssueComment.comment_id == comment_id,
+        db.MusehubIssueComment.issue_id == issue_id,
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return False
+    row.is_deleted = True
+    await session.flush()
+    logger.info("✅ Soft-deleted comment %s", comment_id)
+    return True
+
+
+# ── Milestone operations ────────────────────────────────────────────────────────
+
+
+async def create_milestone(
+    session: AsyncSession,
+    *,
+    repo_id: str,
+    title: str,
+    description: str = "",
+    author: str = "",
+    due_on: object = None,
+) -> MilestoneResponse:
+    """Create a new milestone for the given repo in ``open`` state."""
+    from datetime import datetime as _datetime
+
+    due: _datetime | None = due_on if isinstance(due_on, _datetime) else None
+    number = await _next_milestone_number(session, repo_id)
+    milestone = db.MusehubMilestone(
+        repo_id=repo_id,
+        number=number,
+        title=title,
+        description=description,
+        author=author,
+        due_on=due,
+    )
+    session.add(milestone)
+    await session.flush()
+    await session.refresh(milestone)
+    logger.info("✅ Created milestone #%d for repo %s: %s", number, repo_id, title)
+    return _to_milestone_response(milestone)
+
+
+async def list_milestones(
+    session: AsyncSession,
+    repo_id: str,
+    *,
+    state: str = "open",
+) -> MilestoneListResponse:
+    """Return milestones for a repo filtered by state.
+
+    ``state`` may be ``"open"``, ``"closed"``, or ``"all"``.
+    """
+    stmt = select(db.MusehubMilestone).where(db.MusehubMilestone.repo_id == repo_id)
+    if state != "all":
+        stmt = stmt.where(db.MusehubMilestone.state == state)
+    stmt = stmt.order_by(db.MusehubMilestone.number)
+    rows = (await session.execute(stmt)).scalars().all()
+
+    milestones: list[MilestoneResponse] = []
+    for ms in rows:
+        open_count_stmt = select(func.count(db.MusehubIssue.issue_id)).where(
+            db.MusehubIssue.milestone_id == ms.milestone_id,
+            db.MusehubIssue.state == "open",
+        )
+        closed_count_stmt = select(func.count(db.MusehubIssue.issue_id)).where(
+            db.MusehubIssue.milestone_id == ms.milestone_id,
+            db.MusehubIssue.state == "closed",
+        )
+        open_count: int = (await session.execute(open_count_stmt)).scalar_one()
+        closed_count: int = (await session.execute(closed_count_stmt)).scalar_one()
+        milestones.append(_to_milestone_response(ms, open_count, closed_count))
+
+    return MilestoneListResponse(milestones=milestones)
+
+
+async def get_milestone(
+    session: AsyncSession,
+    repo_id: str,
+    milestone_number: int,
+) -> MilestoneResponse | None:
+    """Return a single milestone by its per-repo number, or None if not found."""
+    stmt = select(db.MusehubMilestone).where(
+        db.MusehubMilestone.repo_id == repo_id,
+        db.MusehubMilestone.number == milestone_number,
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return None
+    open_count_stmt = select(func.count(db.MusehubIssue.issue_id)).where(
+        db.MusehubIssue.milestone_id == row.milestone_id,
+        db.MusehubIssue.state == "open",
+    )
+    closed_count_stmt = select(func.count(db.MusehubIssue.issue_id)).where(
+        db.MusehubIssue.milestone_id == row.milestone_id,
+        db.MusehubIssue.state == "closed",
+    )
+    open_count: int = (await session.execute(open_count_stmt)).scalar_one()
+    closed_count: int = (await session.execute(closed_count_stmt)).scalar_one()
+    return _to_milestone_response(row, open_count, closed_count)

--- a/maestro/services/musehub_issues.py
+++ b/maestro/services/musehub_issues.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import re
+from datetime import datetime
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -503,12 +504,10 @@ async def create_milestone(
     title: str,
     description: str = "",
     author: str = "",
-    due_on: object = None,
+    due_on: datetime | None = None,
 ) -> MilestoneResponse:
     """Create a new milestone for the given repo in ``open`` state."""
-    from datetime import datetime as _datetime
-
-    due: _datetime | None = due_on if isinstance(due_on, _datetime) else None
+    due: datetime | None = due_on
     number = await _next_milestone_number(session, repo_id)
     milestone = db.MusehubMilestone(
         repo_id=repo_id,

--- a/maestro/templates/musehub/pages/issue_detail.html
+++ b/maestro/templates/musehub/pages/issue_detail.html
@@ -15,63 +15,315 @@ const base   = {{ base_url | tojson }};
 
 {% block page_script %}
 {% raw %}
-async function closeIssue() {
-  if (!confirm('Close issue #' + number + '?')) return;
-  try {
-    await apiFetch('/repos/' + repoId + '/issues/' + number + '/close', { method: 'POST' });
-    location.reload();
-  } catch(e) {
-    if (e.message !== 'auth')
-      alert('Close failed: ' + e.message);
-  }
+// ── State ──────────────────────────────────────────────────────────────────
+let currentIssue = null;
+let replyingToId = null;
+
+// ── Musical context ref rendering ──────────────────────────────────────────
+function renderMusicalRefs(refs) {
+  if (!refs || refs.length === 0) return '';
+  return '<div class="musical-refs">' +
+    refs.map(r => {
+      const icons = { track: '🎵', section: '🎼', beats: '🥁' };
+      const icon = icons[r.type] || '🎵';
+      return `<span class="musical-ref musical-ref-${escHtml(r.type)}">${icon} ${escHtml(r.raw)}</span>`;
+    }).join('') +
+  '</div>';
 }
 
+// ── Cross-reference auto-linking in body text ──────────────────────────────
+function linkifyBody(text) {
+  // Escape first, then add links for #NNN and @sha
+  let escaped = escHtml(text);
+  // Issue cross-refs: #123
+  escaped = escaped.replace(/#(\d+)/g, `<a href="${base.replace(/\/issues.*$/, '')}/issues/$1">#$1</a>`);
+  // Musical context refs: track:X, section:X, beats:X-Y
+  escaped = escaped.replace(/(track|section|beats):([A-Za-z0-9_\-]+(?:-[A-Za-z0-9_\-]+)*)/g,
+    '<span class="musical-ref musical-ref-$1">$1:$2</span>');
+  return escaped;
+}
+
+// ── Comment thread builder ─────────────────────────────────────────────────
+function buildCommentThread(comments) {
+  const topLevel = comments.filter(c => !c.parentId);
+  const byParent = {};
+  for (const c of comments) {
+    if (c.parentId) {
+      (byParent[c.parentId] = byParent[c.parentId] || []).push(c);
+    }
+  }
+
+  function renderComment(c, isReply = false) {
+    const replies = byParent[c.commentId] || [];
+    const replyClass = isReply ? ' comment-reply' : '';
+    return `
+      <div class="comment${replyClass}" id="comment-${escHtml(c.commentId)}">
+        <div class="comment-header">
+          <span class="comment-avatar">${escHtml((c.author || '?').charAt(0).toUpperCase())}</span>
+          <span class="comment-author">${escHtml(c.author || 'unknown')}</span>
+          <span class="comment-date">${fmtDate(c.createdAt)}</span>
+        </div>
+        <div class="comment-body">${linkifyBody(c.body)}</div>
+        ${renderMusicalRefs(c.musicalRefs)}
+        <div class="comment-actions">
+          <button class="btn-link" onclick="startReply('${escHtml(c.commentId)}', '${escHtml(c.author || '')}')">↩ Reply</button>
+        </div>
+        ${replies.length > 0 ? '<div class="comment-replies">' + replies.map(r => renderComment(r, true)).join('') + '</div>' : ''}
+      </div>`;
+  }
+
+  return topLevel.map(c => renderComment(c)).join('');
+}
+
+// ── Load issue + comments ──────────────────────────────────────────────────
 async function load() {
   initRepoNav(repoId);
   try {
-    const issue = await apiFetch('/repos/' + repoId + '/issues/' + number);
-
-    const closeSection = issue.state === 'open' ? `
-      <div style="margin-top:16px">
-        <button class="btn btn-danger" onclick="closeIssue()">&#10005; Close issue</button>
-      </div>` : '';
-
-    document.getElementById('content').innerHTML = `
-      <div style="margin-bottom:12px">
-        <a href="${base}/issues">&larr; Back to issues</a>
-      </div>
-      <div class="card">
-        <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px">
-          <h1 style="margin:0">${escHtml(issue.title)}</h1>
-          <span class="badge badge-${issue.state}">#${issue.number}</span>
-          <span class="badge badge-${issue.state}">${issue.state}</span>
-        </div>
-        <div class="meta-row">
-          ${issue.author ? `
-          <div class="meta-item">
-            <span class="meta-label">Author</span>
-            <span class="meta-value" style="display:flex;align-items:center;gap:6px">
-              <span style="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:50%;background:var(--accent,#58a6ff);color:#0d1117;font-size:11px;font-weight:700;flex-shrink:0">${escHtml(issue.author.charAt(0).toUpperCase())}</span>
-              <a href="${base.replace(/\/[^/]+\/[^/]+$/, '')}/users/${encodeURIComponent(escHtml(issue.author))}">${escHtml(issue.author)}</a>
-            </span>
-          </div>` : ''}
-          <div class="meta-item">
-            <span class="meta-label">Opened</span>
-            <span class="meta-value">${fmtDate(issue.createdAt)}</span>
-          </div>
-        </div>
-        <div style="margin:8px 0">
-          ${(issue.labels||[]).map(l => '<span class="label">' + escHtml(l) + '</span>').join('')}
-        </div>
-        ${issue.body ? '<pre>' + escHtml(issue.body) + '</pre>' : ''}
-        ${closeSection}
-      </div>`;
+    const [issue, commentData] = await Promise.all([
+      apiFetch('/repos/' + repoId + '/issues/' + number),
+      apiFetch('/repos/' + repoId + '/issues/' + number + '/comments').catch(() => ({ comments: [] })),
+    ]);
+    currentIssue = issue;
+    renderIssue(issue, commentData.comments || []);
   } catch(e) {
     if (e.message !== 'auth')
       document.getElementById('content').innerHTML = '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
   }
 }
 
+function renderIssue(issue, comments) {
+  const stateBtn = issue.state === 'open'
+    ? `<button class="btn btn-danger" onclick="closeIssue()">&#10005; Close issue</button>`
+    : `<button class="btn btn-secondary" onclick="reopenIssue()">&#8635; Reopen issue</button>`;
+
+  const milestoneHtml = issue.milestoneTitle
+    ? `<div class="meta-item">
+         <span class="meta-label">Milestone</span>
+         <span class="meta-value">&#127937; ${escHtml(issue.milestoneTitle)}</span>
+       </div>`
+    : '';
+
+  const assigneeHtml = issue.assignee
+    ? `<div class="meta-item">
+         <span class="meta-label">Assignee</span>
+         <span class="meta-value" style="display:flex;align-items:center;gap:6px">
+           <span style="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:50%;background:var(--accent,#58a6ff);color:#0d1117;font-size:11px;font-weight:700;flex-shrink:0">${escHtml(issue.assignee.charAt(0).toUpperCase())}</span>
+           ${escHtml(issue.assignee)}
+         </span>
+       </div>`
+    : '<div class="meta-item"><span class="meta-label">Assignee</span><span class="meta-value muted">Unassigned</span></div>';
+
+  const commentCount = issue.commentCount || 0;
+
+  document.getElementById('content').innerHTML = `
+    <div style="margin-bottom:12px">
+      <a href="${base}/issues">&larr; Back to issues</a>
+    </div>
+
+    <div class="card">
+      <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:12px;flex-wrap:wrap">
+        <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+          <h1 style="margin:0">${escHtml(issue.title)}</h1>
+          <span class="badge badge-${issue.state}">#${issue.number}</span>
+          <span class="badge badge-${issue.state}">${issue.state}</span>
+        </div>
+        <div style="display:flex;gap:8px;flex-shrink:0">
+          ${stateBtn}
+        </div>
+      </div>
+
+      <div class="meta-row">
+        ${issue.author ? `
+        <div class="meta-item">
+          <span class="meta-label">Author</span>
+          <span class="meta-value" style="display:flex;align-items:center;gap:6px">
+            <span style="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:50%;background:var(--accent,#58a6ff);color:#0d1117;font-size:11px;font-weight:700;flex-shrink:0">${escHtml(issue.author.charAt(0).toUpperCase())}</span>
+            <a href="${base.replace(/\/[^/]+\/[^/]+$/, '')}/users/${encodeURIComponent(escHtml(issue.author))}">${escHtml(issue.author)}</a>
+          </span>
+        </div>` : ''}
+        <div class="meta-item">
+          <span class="meta-label">Opened</span>
+          <span class="meta-value">${fmtDate(issue.createdAt)}</span>
+        </div>
+        ${assigneeHtml}
+        ${milestoneHtml}
+      </div>
+
+      <div style="margin:8px 0">
+        ${(issue.labels||[]).map(l => '<span class="label">' + escHtml(l) + '</span>').join('')}
+      </div>
+
+      ${issue.body ? '<div class="issue-body">' + linkifyBody(issue.body) + '</div>' : ''}
+    </div>
+
+    <div class="section-header" style="margin-top:24px;margin-bottom:12px">
+      <h2 style="margin:0;font-size:1rem">&#128172; Discussion (${commentCount})</h2>
+    </div>
+
+    <div id="comments-container">
+      ${comments.length > 0 ? buildCommentThread(comments) : '<p class="muted" style="margin:0 0 16px">No comments yet. Be the first to start the discussion.</p>'}
+    </div>
+
+    <div class="card" id="comment-form" style="margin-top:16px">
+      <div id="reply-indicator" style="display:none;margin-bottom:8px;padding:6px 10px;background:var(--bg-tertiary,#161b22);border-radius:4px;font-size:0.85rem;color:var(--text-secondary,#8b949e)">
+        Replying to <span id="reply-author"></span> &mdash; <button class="btn-link" onclick="cancelReply()">cancel</button>
+      </div>
+      <textarea id="comment-input" placeholder="Leave a comment... Use track:bass, section:chorus, beats:16-24 for musical refs. Use #123 to reference issues." rows="4" style="width:100%;box-sizing:border-box;background:var(--bg-secondary,#0d1117);color:var(--text-primary,#e6edf3);border:1px solid var(--border,#30363d);border-radius:6px;padding:8px;font-family:inherit;font-size:0.9rem;resize:vertical"></textarea>
+      <div style="margin-top:8px;display:flex;gap:8px;justify-content:flex-end">
+        <button class="btn btn-primary" onclick="submitComment()">Comment</button>
+      </div>
+    </div>`;
+}
+
+// ── Comment actions ────────────────────────────────────────────────────────
+function startReply(commentId, author) {
+  replyingToId = commentId;
+  document.getElementById('reply-indicator').style.display = 'block';
+  document.getElementById('reply-author').textContent = author;
+  document.getElementById('comment-input').focus();
+  document.getElementById('comment-form').scrollIntoView({ behavior: 'smooth' });
+}
+
+function cancelReply() {
+  replyingToId = null;
+  document.getElementById('reply-indicator').style.display = 'none';
+}
+
+async function submitComment() {
+  const input = document.getElementById('comment-input');
+  const body = input.value.trim();
+  if (!body) return;
+  const btn = document.querySelector('#comment-form button.btn-primary');
+  btn.disabled = true;
+  try {
+    const commentData = await apiFetch(
+      '/repos/' + repoId + '/issues/' + number + '/comments',
+      {
+        method: 'POST',
+        body: JSON.stringify({ body, parentId: replyingToId }),
+      }
+    );
+    input.value = '';
+    cancelReply();
+    document.getElementById('comments-container').innerHTML =
+      commentData.comments && commentData.comments.length > 0
+        ? buildCommentThread(commentData.comments)
+        : '<p class="muted" style="margin:0 0 16px">No comments yet.</p>';
+    if (currentIssue) {
+      currentIssue.commentCount = (commentData.total || 0);
+      document.querySelector('h2[style]').textContent = `💬 Discussion (${currentIssue.commentCount})`;
+    }
+  } catch(e) {
+    if (e.message !== 'auth') alert('Comment failed: ' + e.message);
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+// ── Issue state transitions ────────────────────────────────────────────────
+async function closeIssue() {
+  if (!confirm('Close issue #' + number + '?')) return;
+  try {
+    await apiFetch('/repos/' + repoId + '/issues/' + number + '/close', { method: 'POST' });
+    location.reload();
+  } catch(e) {
+    if (e.message !== 'auth') alert('Close failed: ' + e.message);
+  }
+}
+
+async function reopenIssue() {
+  if (!confirm('Reopen issue #' + number + '?')) return;
+  try {
+    await apiFetch('/repos/' + repoId + '/issues/' + number + '/reopen', { method: 'POST' });
+    location.reload();
+  } catch(e) {
+    if (e.message !== 'auth') alert('Reopen failed: ' + e.message);
+  }
+}
+
 load();
 {% endraw %}
+{% endblock %}
+
+{% block extra_css %}
+<style>
+.issue-body {
+  background: var(--bg-secondary, #0d1117);
+  border: 1px solid var(--border, #30363d);
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-top: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.6;
+}
+.comment {
+  border: 1px solid var(--border, #30363d);
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: 12px;
+  background: var(--bg-primary, #0d1117);
+}
+.comment-reply {
+  margin-left: 24px;
+  border-left: 3px solid var(--accent, #58a6ff);
+}
+.comment-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 0.85rem;
+}
+.comment-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--accent, #58a6ff);
+  color: #0d1117;
+  font-size: 11px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.comment-author { font-weight: 600; }
+.comment-date { color: var(--text-secondary, #8b949e); margin-left: auto; }
+.comment-body {
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.6;
+  margin-bottom: 6px;
+}
+.comment-actions { margin-top: 6px; }
+.comment-replies { margin-top: 12px; }
+.musical-refs { margin-top: 6px; display: flex; flex-wrap: wrap; gap: 6px; }
+.musical-ref {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background: var(--bg-tertiary, #161b22);
+  border: 1px solid var(--border, #30363d);
+  cursor: default;
+}
+.musical-ref-track { border-color: #3fb950; color: #3fb950; }
+.musical-ref-section { border-color: #58a6ff; color: #58a6ff; }
+.musical-ref-beats { border-color: #d2a8ff; color: #d2a8ff; }
+.btn-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent, #58a6ff);
+  cursor: pointer;
+  font-size: 0.8rem;
+  text-decoration: underline;
+}
+.muted { color: var(--text-secondary, #8b949e); }
+.section-header { border-bottom: 1px solid var(--border, #30363d); padding-bottom: 8px; }
+</style>
 {% endblock %}


### PR DESCRIPTION
## Summary

Closes #218 — Enhance MuseHub issue detail with threaded comments, assignees, milestones, cross-references, and musical context linking.

- Added `MusehubMilestone` and `MusehubIssueComment` DB models with full schema migration
- Extended `MusehubIssue` with `assignee`, `milestone_id`, and `updated_at` columns
- Added 9 new API endpoints: issue edit (PATCH), reopen, assign, milestone assign, comment CRUD, milestone CRUD
- Parsed musical context syntax (`track:bass`, `section:chorus`, `beats:16-24`) at write time — stored in `musical_refs` JSON column, returned in API and rendered as colour-coded badges in the UI
- Enhanced `issue_detail.html` with threaded discussion panel, assignee display, milestone indicator, reopen button, and cross-ref auto-linking (`#123` → issue links)
- Added 12 new tests covering all acceptance criteria (29 tests total, all passing)

## Root Cause / Motivation

Issue detail pages only showed title, body, labels, and a close button. No collaborative workflow was possible without comments, assignees, or milestone grouping. Musicians had no way to reference specific musical regions (bars, tracks, sections) in their discussions.

## Solution

- **DB:** `musehub_milestones` (milestone definitions) + `musehub_issue_comments` (threaded comments with `parent_id` and `musical_refs`) + `musehub_issues` extended with `assignee`, `milestone_id`, `updated_at`
- **Service:** New functions for comment CRUD, milestone CRUD, assign/unassign, reopen, partial update, musical ref parsing
- **Routes:** 9 new endpoints on `issues.py` router (no new router file)
- **UI:** Full threaded discussion UI with reply chains, musical ref badges, assignee/milestone panels, reopen button
- **Migration:** All schema changes inlined into `0001_consolidated_schema.py` per project conventions

## Verification

- [x] mypy clean (638 source files, 0 errors)
- [x] 29 tests pass in `test_musehub_issues.py` (12 new tests)
- [x] Docs updated: `api.md`, `type_contracts.md`, `muse_vcs.md`