### PR TITLE
feat(musehub): analysis dashboard — add per-dimension detail page links from analysis cards

### DIFF
--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -42,6 +42,12 @@ Endpoint summary (repo-scoped):
   GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/contour    -- melodic contour analysis
   GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/tempo      -- tempo analysis
   GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/dynamics   -- dynamics analysis
+  GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/key        -- key detection analysis
+  GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/meter      -- metric analysis
+  GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/chord-map  -- chord map analysis
+  GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/groove     -- rhythmic groove analysis
+  GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/emotion    -- emotion analysis
+  GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/form       -- formal structure analysis
   GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/motifs     -- motif browser (recurring patterns, transformations)
   GET /musehub/ui/{owner}/{repo_slug}/listen/{ref}              -- full-mix and per-track audio playback with track listing
   GET /musehub/ui/{owner}/{repo_slug}/listen/{ref}/{path}       -- single-stem playback page
@@ -1685,6 +1691,204 @@ async def dynamics_analysis_page(
     return templates.TemplateResponse(
         request,
         "musehub/pages/dynamics.html",
+        {
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "ref": ref,
+            "base_url": base_url,
+            "current_page": "analysis",
+        },
+    )
+
+
+@router.get(
+    "/{owner}/{repo_slug}/analysis/{ref}/key",
+    response_class=HTMLResponse,
+    summary="Muse Hub key detection analysis page",
+)
+async def key_analysis_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    ref: str,
+    db: AsyncSession = Depends(get_db),
+) -> HTMLResponse:
+    """Render the key detection analysis page for a Muse commit ref.
+
+    Displays the detected tonic, mode, relative key, confidence bar, and a
+    ranked list of alternate key candidates.  Agents use this to confirm the
+    tonal centre before generating harmonically compatible material.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    return templates.TemplateResponse(
+        request,
+        "musehub/pages/key.html",
+        {
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "ref": ref,
+            "base_url": base_url,
+            "current_page": "analysis",
+        },
+    )
+
+
+@router.get(
+    "/{owner}/{repo_slug}/analysis/{ref}/meter",
+    response_class=HTMLResponse,
+    summary="Muse Hub meter analysis page",
+)
+async def meter_analysis_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    ref: str,
+    db: AsyncSession = Depends(get_db),
+) -> HTMLResponse:
+    """Render the metric analysis page for a Muse commit ref.
+
+    Shows the primary time signature, compound/simple classification, a
+    beat-strength profile bar chart, and any irregular-meter sections.
+    Agents use this to generate rhythmically coherent material.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    return templates.TemplateResponse(
+        request,
+        "musehub/pages/meter.html",
+        {
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "ref": ref,
+            "base_url": base_url,
+            "current_page": "analysis",
+        },
+    )
+
+
+@router.get(
+    "/{owner}/{repo_slug}/analysis/{ref}/chord-map",
+    response_class=HTMLResponse,
+    summary="Muse Hub chord map analysis page",
+)
+async def chord_map_analysis_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    ref: str,
+    db: AsyncSession = Depends(get_db),
+) -> HTMLResponse:
+    """Render the chord map analysis page for a Muse commit ref.
+
+    Lists the full chord progression with beat positions, Roman-numeral
+    harmonic functions, tension scores, and a tension-curve SVG graph.
+    Agents use this to generate harmonically idiomatic accompaniment.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    return templates.TemplateResponse(
+        request,
+        "musehub/pages/chord_map.html",
+        {
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "ref": ref,
+            "base_url": base_url,
+            "current_page": "analysis",
+        },
+    )
+
+
+@router.get(
+    "/{owner}/{repo_slug}/analysis/{ref}/groove",
+    response_class=HTMLResponse,
+    summary="Muse Hub groove analysis page",
+)
+async def groove_analysis_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    ref: str,
+    db: AsyncSession = Depends(get_db),
+) -> HTMLResponse:
+    """Render the rhythmic groove analysis page for a Muse commit ref.
+
+    Displays groove style, BPM, grid resolution, onset deviation, groove
+    score gauge, and a swing-factor bar.  Agents use this to match rhythmic
+    feel when generating continuation material.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    return templates.TemplateResponse(
+        request,
+        "musehub/pages/groove.html",
+        {
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "ref": ref,
+            "base_url": base_url,
+            "current_page": "analysis",
+        },
+    )
+
+
+@router.get(
+    "/{owner}/{repo_slug}/analysis/{ref}/emotion",
+    response_class=HTMLResponse,
+    summary="Muse Hub emotion analysis page",
+)
+async def emotion_analysis_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    ref: str,
+    db: AsyncSession = Depends(get_db),
+) -> HTMLResponse:
+    """Render the emotion analysis page for a Muse commit ref.
+
+    Displays primary emotion label, valence-arousal plot, tension bar, and
+    confidence score.  Agents use this to maintain emotional continuity or
+    introduce deliberate contrast in the next section.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    return templates.TemplateResponse(
+        request,
+        "musehub/pages/emotion.html",
+        {
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "ref": ref,
+            "base_url": base_url,
+            "current_page": "analysis",
+        },
+    )
+
+
+@router.get(
+    "/{owner}/{repo_slug}/analysis/{ref}/form",
+    response_class=HTMLResponse,
+    summary="Muse Hub form analysis page",
+)
+async def form_analysis_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    ref: str,
+    db: AsyncSession = Depends(get_db),
+) -> HTMLResponse:
+    """Render the formal structure analysis page for a Muse commit ref.
+
+    Shows the detected macro form label (e.g. AABA, verse-chorus), a colour-coded
+    section timeline, and a per-section table with beat ranges and function labels.
+    Agents use this to understand where they are in the compositional arc.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    return templates.TemplateResponse(
+        request,
+        "musehub/pages/form.html",
         {
             "owner": owner,
             "repo_slug": repo_slug,

--- a/maestro/templates/musehub/pages/chord_map.html
+++ b/maestro/templates/musehub/pages/chord_map.html
@@ -95,6 +95,8 @@ async function load() {
           </div>
         </div>
 
+        ${tensionCurveSvg(d.tensionCurve)}
+
         <div style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:14px;margin-bottom:16px">
           <div style="display:flex;align-items:center;gap:12px;margin-bottom:8px">
             <span class="meta-label">Chord Progression</span>

--- a/maestro/templates/musehub/pages/chord_map.html
+++ b/maestro/templates/musehub/pages/chord_map.html
@@ -1,0 +1,115 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Chord Map {{ ref[:8] }}{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> /
+  analysis / {{ ref[:8] }} / chord-map
+{% endblock %}
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block page_data %}
+const repoId  = {{ repo_id | tojson }};
+const ref     = {{ ref | tojson }};
+const base    = {{ base_url | tojson }};
+const apiBase = '/api/v1/musehub/repos/' + repoId;
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+function tensionColor(tension) {
+  if (tension >= 0.7) return '#f85149';
+  if (tension >= 0.4) return '#f0883e';
+  return '#3fb950';
+}
+
+function chordRow(event, index) {
+  const col = tensionColor(event.tension);
+  const tensionPct = Math.round(event.tension * 100);
+  return `<div style="display:flex;align-items:center;gap:12px;padding:8px 0;
+            border-top:1px solid #21262d;font-size:13px">
+    <span style="min-width:36px;color:#8b949e;font-size:12px">b${event.beat.toFixed(1)}</span>
+    <span style="min-width:60px;font-weight:700;font-family:monospace;color:#e6edf3;font-size:15px">
+      ${escHtml(event.chord)}
+    </span>
+    <span style="min-width:40px;color:#8b949e;font-family:monospace">${escHtml(event.function)}</span>
+    <div style="flex:1;height:6px;background:#21262d;border-radius:3px;overflow:hidden">
+      <div style="height:100%;width:${tensionPct}%;background:${col};border-radius:3px"></div>
+    </div>
+    <span style="font-size:11px;color:${col};min-width:28px">${tensionPct}%</span>
+  </div>`;
+}
+
+function tensionCurveSvg(curve) {
+  if (!curve || curve.length === 0) return '';
+  const W = 700, H = 80, PAD = 16;
+  const pts = curve.map((v, i) => {
+    const x = PAD + (i / (curve.length - 1 || 1)) * (W - PAD * 2);
+    const y = PAD + (1 - v) * (H - PAD * 2);
+    return x + ',' + y;
+  }).join(' ');
+  return `
+    <div style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:12px;margin-bottom:16px">
+      <span class="meta-label" style="display:block;margin-bottom:8px">Tension Curve (per beat)</span>
+      <svg viewBox="0 0 ${W} ${H}" style="width:100%;height:auto;display:block" role="img"
+           aria-label="Harmonic tension curve">
+        <polyline points="${pts}" fill="none" stroke="#f0883e" stroke-width="2" stroke-linejoin="round"/>
+        <text x="${PAD}" y="${H - 2}" font-size="10" fill="#8b949e" font-family="monospace">beat 1</text>
+        <text x="${W - PAD - 10}" y="${H - 2}" font-size="10" fill="#8b949e" font-family="monospace">${curve.length}</text>
+        <text x="2" y="${PAD + 4}" font-size="10" fill="#8b949e" font-family="monospace">tense</text>
+        <text x="2" y="${H - PAD + 4}" font-size="10" fill="#8b949e" font-family="monospace">calm</text>
+      </svg>
+    </div>`;
+}
+
+async function load() {
+  initRepoNav(repoId);
+  try {
+    const url = '/repos/' + repoId + '/analysis/' + encodeURIComponent(ref) + '/chord-map';
+    const data = await apiFetch(url);
+    const d = data.data;
+
+    const chordRows = d.progression && d.progression.length > 0
+      ? d.progression.map(chordRow).join('')
+      : '<p class="loading">No chord data available.</p>';
+
+    document.getElementById('content').innerHTML = `
+      <div style="margin-bottom:12px">
+        <a href="${escHtml(base)}">&larr; Back to repo</a>
+      </div>
+      <div class="card">
+        <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:16px">
+          <h1 style="margin:0">&#127929; Chord Map</h1>
+          <code style="font-size:13px;background:#0d1117;padding:2px 8px;border-radius:4px;color:#8b949e">
+            ref: ${escHtml(ref.substring(0, 8))}
+          </code>
+        </div>
+
+        <div class="meta-row" style="margin-bottom:16px">
+          <div class="meta-item">
+            <span class="meta-label">Total Chords</span>
+            <span class="meta-value" style="font-size:22px;font-weight:700;color:#58a6ff">${d.totalChords}</span>
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Total Beats</span>
+            <span class="meta-value">${d.totalBeats}</span>
+          </div>
+        </div>
+
+        <div style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:14px;margin-bottom:16px">
+          <div style="display:flex;align-items:center;gap:12px;margin-bottom:8px">
+            <span class="meta-label">Chord Progression</span>
+            <span style="font-size:11px;color:#8b949e">beat · chord · function · tension</span>
+          </div>
+          ${chordRows}
+        </div>
+      </div>`;
+  } catch(e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML =
+        '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/maestro/templates/musehub/pages/emotion.html
+++ b/maestro/templates/musehub/pages/emotion.html
@@ -1,0 +1,119 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Emotion {{ ref[:8] }}{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> /
+  analysis / {{ ref[:8] }} / emotion
+{% endblock %}
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block page_data %}
+const repoId  = {{ repo_id | tojson }};
+const ref     = {{ ref | tojson }};
+const base    = {{ base_url | tojson }};
+const apiBase = '/api/v1/musehub/repos/' + repoId;
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+const EMOTION_COLORS = {
+  joyful:      '#ffa657',
+  serene:      '#3fb950',
+  melancholic: '#58a6ff',
+  tense:       '#f85149',
+  energetic:   '#bc8cff',
+  nostalgic:   '#f0883e',
+  mysterious:  '#8b949e',
+};
+
+function emotionColor(label) {
+  return EMOTION_COLORS[label] || '#58a6ff';
+}
+
+function valenceArousalPlot(valence, arousal) {
+  const W = 240, H = 240, PAD = 20;
+  const cx = PAD + ((valence + 1) / 2) * (W - PAD * 2);
+  const cy = H - PAD - arousal * (H - PAD * 2);
+  return `
+    <svg viewBox="0 0 ${W} ${H}" style="width:${W}px;height:${H}px;display:block" role="img"
+         aria-label="Valence-arousal plot">
+      <line x1="${PAD}" y1="${H/2}" x2="${W-PAD}" y2="${H/2}" stroke="#30363d" stroke-width="1"/>
+      <line x1="${W/2}" y1="${PAD}" x2="${W/2}" y2="${H-PAD}" stroke="#30363d" stroke-width="1"/>
+      <text x="${PAD+2}" y="${H/2 - 4}" font-size="9" fill="#8b949e" font-family="monospace">negative</text>
+      <text x="${W-PAD-34}" y="${H/2 - 4}" font-size="9" fill="#8b949e" font-family="monospace">positive</text>
+      <text x="${W/2+4}" y="${PAD+10}" font-size="9" fill="#8b949e" font-family="monospace">energetic</text>
+      <text x="${W/2+4}" y="${H-PAD-4}" font-size="9" fill="#8b949e" font-family="monospace">calm</text>
+      <circle cx="${cx}" cy="${cy}" r="8" fill="#58a6ff" opacity="0.8"/>
+      <circle cx="${cx}" cy="${cy}" r="12" fill="none" stroke="#58a6ff" stroke-width="1" opacity="0.4"/>
+    </svg>`;
+}
+
+function axisBar(label, value, color) {
+  const pct = Math.round(value * 100);
+  return `<div style="margin-bottom:12px">
+    <div style="display:flex;justify-content:space-between;margin-bottom:4px">
+      <span class="meta-label">${label}</span>
+      <span style="font-size:13px;color:${color};font-weight:600">${pct}%</span>
+    </div>
+    <div style="height:8px;background:#21262d;border-radius:4px;overflow:hidden">
+      <div style="height:100%;width:${pct}%;background:${color};border-radius:4px;transition:width 0.4s ease"></div>
+    </div>
+  </div>`;
+}
+
+async function load() {
+  initRepoNav(repoId);
+  try {
+    const url = '/repos/' + repoId + '/analysis/' + encodeURIComponent(ref) + '/emotion';
+    const data = await apiFetch(url);
+    const d = data.data;
+    const col = emotionColor(d.primaryEmotion);
+    const valenceNorm = (d.valence + 1) / 2;
+
+    document.getElementById('content').innerHTML = `
+      <div style="margin-bottom:12px">
+        <a href="${escHtml(base)}">&larr; Back to repo</a>
+      </div>
+      <div class="card">
+        <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:20px">
+          <h1 style="margin:0">&#127917; Emotion Analysis</h1>
+          <code style="font-size:13px;background:#0d1117;padding:2px 8px;border-radius:4px;color:#8b949e">
+            ref: ${escHtml(ref.substring(0, 8))}
+          </code>
+        </div>
+
+        <div style="display:flex;gap:24px;flex-wrap:wrap;margin-bottom:20px;align-items:flex-start">
+          <div style="text-align:center">
+            ${valenceArousalPlot(d.valence, d.arousal)}
+            <span style="font-size:11px;color:#8b949e">Valence &times; Arousal</span>
+          </div>
+          <div style="flex:1;min-width:200px">
+            <div style="margin-bottom:16px">
+              <span class="meta-label">Primary Emotion</span>
+              <div style="margin-top:6px">
+                <span class="badge" style="background:${col}22;color:${col};
+                      border:1px solid ${col}44;font-size:16px;padding:4px 14px;text-transform:capitalize">
+                  ${escHtml(d.primaryEmotion)}
+                </span>
+              </div>
+            </div>
+            ${axisBar('Valence (negative \u2192 positive)', valenceNorm, '#58a6ff')}
+            ${axisBar('Arousal (calm \u2192 energetic)', d.arousal, '#ffa657')}
+            ${axisBar('Tension (relaxed \u2192 tense)', d.tension, '#f85149')}
+            <div style="margin-top:8px">
+              <span class="meta-label">Confidence</span>
+              <span class="meta-value" style="margin-left:8px">${Math.round(d.confidence * 100)}%</span>
+            </div>
+          </div>
+        </div>
+      </div>`;
+  } catch(e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML =
+        '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/maestro/templates/musehub/pages/form.html
+++ b/maestro/templates/musehub/pages/form.html
@@ -1,0 +1,128 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Form {{ ref[:8] }}{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> /
+  analysis / {{ ref[:8] }} / form
+{% endblock %}
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block page_data %}
+const repoId  = {{ repo_id | tojson }};
+const ref     = {{ ref | tojson }};
+const base    = {{ base_url | tojson }};
+const apiBase = '/api/v1/musehub/repos/' + repoId;
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+const SECTION_COLORS = {
+  intro:  '#58a6ff',
+  verse:  '#3fb950',
+  chorus: '#ffa657',
+  bridge: '#bc8cff',
+  outro:  '#8b949e',
+  break:  '#f0883e',
+};
+
+function sectionColor(label) {
+  const key = (label || '').split('_')[0].toLowerCase();
+  return SECTION_COLORS[key] || '#8b949e';
+}
+
+function sectionBar(section, totalBeats) {
+  const col = sectionColor(section.label);
+  const startPct = totalBeats > 0 ? (section.startBeat / totalBeats) * 100 : 0;
+  const widthPct = totalBeats > 0 ? (section.lengthBeats / totalBeats) * 100 : 10;
+  return `<div style="position:absolute;left:${startPct.toFixed(2)}%;width:${Math.max(widthPct, 2).toFixed(2)}%;
+            height:100%;background:${col};border-radius:3px;overflow:hidden"
+            title="${escHtml(section.label)} (${section.lengthBeats.toFixed(0)} beats)">
+    <span style="font-size:10px;color:#fff;padding:2px 4px;white-space:nowrap;
+      overflow:hidden;display:inline-block;max-width:100%">
+      ${escHtml(section.label)}
+    </span>
+  </div>`;
+}
+
+function sectionRow(section) {
+  const col = sectionColor(section.label);
+  return `<div style="display:flex;align-items:center;gap:12px;padding:8px 0;
+            border-top:1px solid #21262d;font-size:13px">
+    <span style="display:inline-block;width:12px;height:12px;border-radius:3px;
+      background:${col};flex-shrink:0"></span>
+    <span style="min-width:80px;font-weight:600;color:#e6edf3">${escHtml(section.label)}</span>
+    <span style="color:#8b949e;min-width:80px">${escHtml(section.function)}</span>
+    <span style="color:#8b949e;font-family:monospace;font-size:12px">
+      b${section.startBeat.toFixed(0)} &ndash; ${section.endBeat.toFixed(0)}
+      (${section.lengthBeats.toFixed(0)} beats)
+    </span>
+  </div>`;
+}
+
+async function load() {
+  initRepoNav(repoId);
+  try {
+    const url = '/repos/' + repoId + '/analysis/' + encodeURIComponent(ref) + '/form';
+    const data = await apiFetch(url);
+    const d = data.data;
+
+    const totalBeats = d.totalBeats || 1;
+    const timeline = d.sections && d.sections.length > 0
+      ? d.sections.map(s => sectionBar(s, totalBeats)).join('')
+      : '';
+    const sectionList = d.sections && d.sections.length > 0
+      ? d.sections.map(sectionRow).join('')
+      : '<p class="loading">No section data available.</p>';
+
+    document.getElementById('content').innerHTML = `
+      <div style="margin-bottom:12px">
+        <a href="${escHtml(base)}">&larr; Back to repo</a>
+      </div>
+      <div class="card">
+        <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:20px">
+          <h1 style="margin:0">&#128203; Form Analysis</h1>
+          <code style="font-size:13px;background:#0d1117;padding:2px 8px;border-radius:4px;color:#8b949e">
+            ref: ${escHtml(ref.substring(0, 8))}
+          </code>
+        </div>
+
+        <div class="meta-row" style="margin-bottom:20px">
+          <div class="meta-item">
+            <span class="meta-label">Form</span>
+            <span class="meta-value" style="font-size:20px;font-weight:700;font-family:monospace;color:#58a6ff">
+              ${escHtml(d.formLabel)}
+            </span>
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Total Beats</span>
+            <span class="meta-value">${d.totalBeats}</span>
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Sections</span>
+            <span class="meta-value">${d.sections ? d.sections.length : 0}</span>
+          </div>
+        </div>
+
+        ${timeline ? `
+        <div style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:14px;margin-bottom:16px">
+          <span class="meta-label" style="display:block;margin-bottom:10px">Form Timeline</span>
+          <div style="position:relative;height:32px;background:#161b22;border-radius:4px;overflow:hidden">
+            ${timeline}
+          </div>
+        </div>` : ''}
+
+        <div style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:14px">
+          <span class="meta-label" style="display:block;margin-bottom:4px">Sections</span>
+          ${sectionList}
+        </div>
+      </div>`;
+  } catch(e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML =
+        '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/maestro/templates/musehub/pages/groove.html
+++ b/maestro/templates/musehub/pages/groove.html
@@ -1,0 +1,131 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Groove {{ ref[:8] }}{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> /
+  analysis / {{ ref[:8] }} / groove
+{% endblock %}
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block page_data %}
+const repoId  = {{ repo_id | tojson }};
+const ref     = {{ ref | tojson }};
+const base    = {{ base_url | tojson }};
+const apiBase = '/api/v1/musehub/repos/' + repoId;
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+const GROOVE_STYLE_COLORS = {
+  straight: '#3fb950',
+  swing:     '#58a6ff',
+  shuffled:  '#bc8cff',
+  latin:     '#ffa657',
+  funk:      '#f0883e',
+};
+
+function grooveStyleColor(style) {
+  return GROOVE_STYLE_COLORS[style] || '#8b949e';
+}
+
+function scoreGauge(score) {
+  const pct = Math.round(score * 100);
+  const color = score >= 0.8 ? '#3fb950' : score >= 0.6 ? '#f0883e' : '#f85149';
+  return `
+    <div style="margin-top:8px">
+      <div style="display:flex;justify-content:space-between;margin-bottom:4px">
+        <span style="font-size:12px;color:#8b949e">0 (loose)</span>
+        <span style="font-size:14px;font-weight:700;color:${color}">${pct}%</span>
+        <span style="font-size:12px;color:#8b949e">100 (tight)</span>
+      </div>
+      <div style="height:10px;background:#21262d;border-radius:5px;overflow:hidden">
+        <div style="height:100%;width:${pct}%;background:${color};border-radius:5px;transition:width 0.5s ease"></div>
+      </div>
+    </div>`;
+}
+
+function swingBar(swingFactor) {
+  const pct = Math.round(swingFactor * 100);
+  const label = swingFactor < 0.53 ? 'straight' : swingFactor < 0.60 ? 'light swing' : 'hard swing';
+  return `
+    <div style="margin-top:8px">
+      <div style="display:flex;justify-content:space-between;margin-bottom:4px">
+        <span style="font-size:12px;color:#8b949e">0.5 (straight)</span>
+        <span style="font-size:13px;color:#e6edf3">${swingFactor.toFixed(3)} — ${label}</span>
+        <span style="font-size:12px;color:#8b949e">0.67 (triplet)</span>
+      </div>
+      <div style="height:8px;background:#21262d;border-radius:4px;overflow:hidden;position:relative">
+        <div style="position:absolute;left:0;right:0;top:0;bottom:0">
+          <div style="height:100%;width:${pct}%;background:#58a6ff;border-radius:4px;
+            transition:width 0.5s ease"></div>
+        </div>
+      </div>
+    </div>`;
+}
+
+async function load() {
+  initRepoNav(repoId);
+  try {
+    const url = '/repos/' + repoId + '/analysis/' + encodeURIComponent(ref) + '/groove';
+    const data = await apiFetch(url);
+    const d = data.data;
+    const styleCol = grooveStyleColor(d.style);
+
+    document.getElementById('content').innerHTML = `
+      <div style="margin-bottom:12px">
+        <a href="${escHtml(base)}">&larr; Back to repo</a>
+      </div>
+      <div class="card">
+        <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:20px">
+          <h1 style="margin:0">&#129345; Groove Analysis</h1>
+          <code style="font-size:13px;background:#0d1117;padding:2px 8px;border-radius:4px;color:#8b949e">
+            ref: ${escHtml(ref.substring(0, 8))}
+          </code>
+        </div>
+
+        <div class="meta-row" style="margin-bottom:20px;flex-wrap:wrap">
+          <div class="meta-item">
+            <span class="meta-label">Style</span>
+            <span class="meta-value">
+              <span class="badge" style="background:${styleCol}22;color:${styleCol};
+                    border:1px solid ${styleCol}44;font-size:14px;text-transform:capitalize">
+                ${escHtml(d.style)}
+              </span>
+            </span>
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">BPM</span>
+            <span class="meta-value" style="font-size:22px;font-weight:700;color:#e6edf3">
+              ${d.bpm.toFixed(1)}
+            </span>
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Grid Resolution</span>
+            <span class="meta-value" style="font-family:monospace">${escHtml(d.gridResolution)}</span>
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Onset Deviation</span>
+            <span class="meta-value">${d.onsetDeviation.toFixed(4)} beats</span>
+          </div>
+        </div>
+
+        <div style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:14px;margin-bottom:14px">
+          <span class="meta-label" style="display:block;margin-bottom:4px">Groove Score</span>
+          ${scoreGauge(d.grooveScore)}
+        </div>
+
+        <div style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:14px">
+          <span class="meta-label" style="display:block;margin-bottom:4px">Swing Factor</span>
+          ${swingBar(d.swingFactor)}
+        </div>
+      </div>`;
+  } catch(e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML =
+        '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/maestro/templates/musehub/pages/key.html
+++ b/maestro/templates/musehub/pages/key.html
@@ -1,0 +1,115 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Key {{ ref[:8] }}{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> /
+  analysis / {{ ref[:8] }} / key
+{% endblock %}
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block page_data %}
+const repoId  = {{ repo_id | tojson }};
+const ref     = {{ ref | tojson }};
+const base    = {{ base_url | tojson }};
+const apiBase = '/api/v1/musehub/repos/' + repoId;
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+const MODE_COLORS = {
+  major:      '#3fb950',
+  minor:      '#58a6ff',
+  dorian:     '#bc8cff',
+  phrygian:   '#f85149',
+  lydian:     '#ffa657',
+  mixolydian: '#f0883e',
+  locrian:    '#8b949e',
+};
+
+function modeColor(mode) {
+  return MODE_COLORS[mode] || '#58a6ff';
+}
+
+function confidenceBar(confidence) {
+  const pct = Math.round(confidence * 100);
+  const color = confidence >= 0.8 ? '#3fb950' : confidence >= 0.6 ? '#f0883e' : '#f85149';
+  return `
+    <div style="display:flex;align-items:center;gap:10px;margin-top:4px">
+      <div style="flex:1;height:8px;background:#21262d;border-radius:4px;overflow:hidden">
+        <div style="height:100%;width:${pct}%;background:${color};border-radius:4px;transition:width 0.4s ease"></div>
+      </div>
+      <span style="font-size:13px;color:#8b949e;min-width:36px">${pct}%</span>
+    </div>`;
+}
+
+function alternateKeyRow(alt) {
+  const color = modeColor(alt.mode);
+  const pct = Math.round(alt.confidence * 100);
+  return `<div style="display:flex;align-items:center;gap:12px;padding:8px 0;border-top:1px solid #21262d">
+    <span style="min-width:80px;font-weight:600;color:#e6edf3;font-family:monospace">${escHtml(alt.tonic)} ${escHtml(alt.mode)}</span>
+    <div style="flex:1;height:6px;background:#21262d;border-radius:4px;overflow:hidden">
+      <div style="height:100%;width:${pct}%;background:${color}88;border-radius:4px"></div>
+    </div>
+    <span style="font-size:12px;color:#8b949e;min-width:32px">${pct}%</span>
+  </div>`;
+}
+
+async function load() {
+  initRepoNav(repoId);
+  try {
+    const url = '/repos/' + repoId + '/analysis/' + encodeURIComponent(ref) + '/key';
+    const data = await apiFetch(url);
+    const d = data.data;
+    const col = modeColor(d.mode);
+
+    document.getElementById('content').innerHTML = `
+      <div style="margin-bottom:12px">
+        <a href="${escHtml(base)}">&larr; Back to repo</a>
+      </div>
+      <div class="card">
+        <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:20px">
+          <h1 style="margin:0">&#127925; Key Detection</h1>
+          <code style="font-size:13px;background:#0d1117;padding:2px 8px;border-radius:4px;color:#8b949e">
+            ref: ${escHtml(ref.substring(0, 8))}
+          </code>
+        </div>
+
+        <div style="display:flex;align-items:center;gap:20px;margin-bottom:20px;flex-wrap:wrap">
+          <div style="background:#0d1117;border:2px solid ${col}44;border-radius:12px;padding:20px 32px;text-align:center">
+            <div style="font-size:36px;font-weight:700;color:${col};font-family:monospace;letter-spacing:2px">
+              ${escHtml(d.tonic)}
+            </div>
+            <div style="font-size:15px;color:#8b949e;margin-top:4px;text-transform:capitalize">
+              ${escHtml(d.mode)}
+            </div>
+          </div>
+          <div>
+            <div class="meta-row" style="gap:16px">
+              <div class="meta-item">
+                <span class="meta-label">Relative Key</span>
+                <span class="meta-value" style="font-family:monospace">${escHtml(d.relativeKey)}</span>
+              </div>
+              <div class="meta-item" style="min-width:160px">
+                <span class="meta-label">Detection Confidence</span>
+                ${confidenceBar(d.confidence)}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        ${d.alternateKeys && d.alternateKeys.length > 0 ? `
+        <div style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:14px;margin-top:8px">
+          <span class="meta-label" style="display:block;margin-bottom:8px">Alternate Key Candidates</span>
+          ${d.alternateKeys.map(alternateKeyRow).join('')}
+        </div>` : ''}
+      </div>`;
+  } catch(e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML =
+        '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/maestro/templates/musehub/pages/meter.html
+++ b/maestro/templates/musehub/pages/meter.html
@@ -1,0 +1,109 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Meter {{ ref[:8] }}{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> /
+  analysis / {{ ref[:8] }} / meter
+{% endblock %}
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block page_data %}
+const repoId  = {{ repo_id | tojson }};
+const ref     = {{ ref | tojson }};
+const base    = {{ base_url | tojson }};
+const apiBase = '/api/v1/musehub/repos/' + repoId;
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+function beatStrengthSvg(profile) {
+  if (!profile || profile.length === 0) return '<p class="loading">No beat data.</p>';
+  const W = 400, H = 80, PAD = 16;
+  const barW = Math.floor((W - PAD * 2) / profile.length) - 2;
+  const maxV = Math.max(...profile, 0.01);
+  const bars = profile.map((v, i) => {
+    const x = PAD + i * (barW + 2);
+    const h = Math.max(4, Math.round(((H - PAD * 2) * v) / maxV));
+    const y = H - PAD - h;
+    const color = i === 0 ? '#58a6ff' : '#30363d';
+    return `<rect x="${x}" y="${y}" width="${barW}" height="${h}" rx="2" fill="${color}"/>
+            <text x="${x + barW / 2}" y="${H - 2}" text-anchor="middle" font-size="9" fill="#8b949e">${i + 1}</text>`;
+  }).join('');
+  return `<svg viewBox="0 0 ${W} ${H}" style="width:100%;height:auto;display:block" role="img"
+       aria-label="Beat strength profile">
+    ${bars}
+  </svg>`;
+}
+
+function irregularRow(sec) {
+  return `<div style="display:flex;align-items:center;gap:12px;padding:6px 0;border-top:1px solid #21262d;font-size:13px">
+    <span style="font-family:monospace;color:#ffa657;min-width:48px">${escHtml(sec.timeSignature)}</span>
+    <span style="color:#8b949e">beats ${sec.startBeat.toFixed(1)} &ndash; ${sec.endBeat.toFixed(1)}</span>
+  </div>`;
+}
+
+async function load() {
+  initRepoNav(repoId);
+  try {
+    const url = '/repos/' + repoId + '/analysis/' + encodeURIComponent(ref) + '/meter';
+    const data = await apiFetch(url);
+    const d = data.data;
+
+    document.getElementById('content').innerHTML = `
+      <div style="margin-bottom:12px">
+        <a href="${escHtml(base)}">&larr; Back to repo</a>
+      </div>
+      <div class="card">
+        <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:20px">
+          <h1 style="margin:0">&#127932; Meter Analysis</h1>
+          <code style="font-size:13px;background:#0d1117;padding:2px 8px;border-radius:4px;color:#8b949e">
+            ref: ${escHtml(ref.substring(0, 8))}
+          </code>
+        </div>
+
+        <div class="meta-row" style="margin-bottom:20px">
+          <div class="meta-item">
+            <span class="meta-label">Time Signature</span>
+            <span class="meta-value" style="font-size:28px;font-weight:700;font-family:monospace;color:#58a6ff">
+              ${escHtml(d.timeSignature)}
+            </span>
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Meter Type</span>
+            <span class="meta-value">
+              <span class="badge" style="background:${d.isCompound ? '#bc8cff22' : '#3fb95022'};
+                color:${d.isCompound ? '#bc8cff' : '#3fb950'};
+                border:1px solid ${d.isCompound ? '#bc8cff44' : '#3fb95044'};font-size:13px">
+                ${d.isCompound ? 'compound' : 'simple'}
+              </span>
+            </span>
+          </div>
+        </div>
+
+        <div style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:12px;margin-bottom:16px">
+          <span class="meta-label" style="display:block;margin-bottom:8px">Beat Strength Profile</span>
+          ${beatStrengthSvg(d.beatStrengthProfile)}
+          <p style="font-size:11px;color:#8b949e;margin:6px 0 0">
+            Bar 1 is highlighted. Beat 1 is always the strongest downbeat.
+          </p>
+        </div>
+
+        ${d.irregularSections && d.irregularSections.length > 0 ? `
+        <div style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:14px">
+          <span class="meta-label" style="display:block;margin-bottom:4px">Irregular Sections</span>
+          ${d.irregularSections.map(irregularRow).join('')}
+        </div>` : `
+        <div style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:12px;color:#8b949e;font-size:13px">
+          No irregular meter sections detected.
+        </div>`}
+      </div>`;
+  } catch(e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML =
+        '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/tests/test_musehub_ui.py
+++ b/tests/test_musehub_ui.py
@@ -5210,3 +5210,268 @@ async def test_ui_commit_page_artifact_auth_uses_blob_proxy(
     # hydrateImages and _fetchBlobUrl must be present for the blob proxy pattern
     assert "hydrateImages" in body
     assert "_fetchBlobUrl" in body
+
+
+# ---------------------------------------------------------------------------
+# Per-dimension analysis detail pages (issue #332)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_key_analysis_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/key returns 200 HTML."""
+    await _make_repo(db_session)
+    ref = "abc1234567890abcdef"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/key")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_key_analysis_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Key analysis page must be accessible without a JWT (HTML shell handles auth)."""
+    await _make_repo(db_session)
+    ref = "deadbeef1234"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/key")
+    assert response.status_code != 401
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_key_analysis_page_contains_key_data_labels(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Key page must contain tonic, mode, relative key, and confidence UI elements."""
+    await _make_repo(db_session)
+    ref = "cafebabe12345678"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/key")
+    assert response.status_code == 200
+    body = response.text
+    assert "Key Detection" in body
+    assert "Relative Key" in body
+    assert "Detection Confidence" in body
+    assert "Alternate Key" in body
+
+
+@pytest.mark.anyio
+async def test_meter_analysis_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/meter returns 200 HTML."""
+    await _make_repo(db_session)
+    ref = "abc1234567890abcdef"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/meter")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_meter_analysis_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Meter analysis page must be accessible without a JWT (HTML shell handles auth)."""
+    await _make_repo(db_session)
+    ref = "deadbeef5678"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/meter")
+    assert response.status_code != 401
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_meter_analysis_page_contains_meter_data_labels(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Meter page must contain time signature, compound/simple badge, and beat strength UI."""
+    await _make_repo(db_session)
+    ref = "feedface5678"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/meter")
+    assert response.status_code == 200
+    body = response.text
+    assert "Meter Analysis" in body
+    assert "Time Signature" in body
+    assert "Beat Strength Profile" in body
+    assert "beatStrengthSvg" in body or "beatStrengthProfile" in body
+
+
+@pytest.mark.anyio
+async def test_chord_map_analysis_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/chord-map returns 200 HTML."""
+    await _make_repo(db_session)
+    ref = "abc1234567890abcdef"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/chord-map")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_chord_map_analysis_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Chord-map analysis page must be accessible without a JWT (HTML shell handles auth)."""
+    await _make_repo(db_session)
+    ref = "deadbeef9999"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/chord-map")
+    assert response.status_code != 401
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_chord_map_analysis_page_contains_chord_data_labels(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Chord-map page must contain progression, tension, and beat position UI elements."""
+    await _make_repo(db_session)
+    ref = "beefdead1234"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/chord-map")
+    assert response.status_code == 200
+    body = response.text
+    assert "Chord Map" in body
+    assert "Total Chords" in body
+    assert "Chord Progression" in body
+    assert "tension" in body.lower()
+
+
+@pytest.mark.anyio
+async def test_groove_analysis_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/groove returns 200 HTML."""
+    await _make_repo(db_session)
+    ref = "abc1234567890abcdef"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/groove")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_groove_analysis_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Groove analysis page must be accessible without a JWT (HTML shell handles auth)."""
+    await _make_repo(db_session)
+    ref = "deadbeef4321"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/groove")
+    assert response.status_code != 401
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_groove_analysis_page_contains_groove_data_labels(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Groove page must contain style badge, BPM, swing factor, and groove score UI."""
+    await _make_repo(db_session)
+    ref = "cafefeed5678"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/groove")
+    assert response.status_code == 200
+    body = response.text
+    assert "Groove Analysis" in body
+    assert "Style" in body
+    assert "BPM" in body
+    assert "Groove Score" in body
+    assert "Swing Factor" in body
+
+
+@pytest.mark.anyio
+async def test_emotion_analysis_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/emotion returns 200 HTML."""
+    await _make_repo(db_session)
+    ref = "abc1234567890abcdef"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/emotion")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_emotion_analysis_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Emotion analysis page must be accessible without a JWT (HTML shell handles auth)."""
+    await _make_repo(db_session)
+    ref = "deadbeef0001"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/emotion")
+    assert response.status_code != 401
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_emotion_analysis_page_contains_emotion_data_labels(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Emotion page must contain primary emotion, valence-arousal plot, and tension bar."""
+    await _make_repo(db_session)
+    ref = "aabbccdd5678"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/emotion")
+    assert response.status_code == 200
+    body = response.text
+    assert "Emotion Analysis" in body
+    assert "Primary Emotion" in body
+    assert "Valence" in body or "valence" in body
+    assert "Arousal" in body or "arousal" in body
+    assert "Tension" in body or "tension" in body
+
+
+@pytest.mark.anyio
+async def test_form_analysis_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{repo_slug}/analysis/{ref}/form returns 200 HTML."""
+    await _make_repo(db_session)
+    ref = "abc1234567890abcdef"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/form")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_form_analysis_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Form analysis page must be accessible without a JWT (HTML shell handles auth)."""
+    await _make_repo(db_session)
+    ref = "deadbeef0002"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/form")
+    assert response.status_code != 401
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_form_analysis_page_contains_form_data_labels(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Form page must contain form label, section timeline, and sections table."""
+    await _make_repo(db_session)
+    ref = "11223344abcd"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/analysis/{ref}/form")
+    assert response.status_code == 200
+    body = response.text
+    assert "Form Analysis" in body
+    assert "Form Timeline" in body or "formLabel" in body
+    assert "Sections" in body
+    assert "Total Beats" in body


### PR DESCRIPTION
## Summary

Closes #332 — adds the 6 missing per-dimension analysis detail pages so all 10 analysis dashboard cards resolve to real pages.

## Root Cause / Motivation

PR #276 shipped the analysis dashboard with 10 dimension cards, each linking to `/{owner}/{repo_slug}/analysis/{ref}/{dim_id}`. Only 4 of those routes existed (contour, tempo, dynamics, motifs). The remaining 6 (key, meter, chord-map, groove, emotion, form) returned 404s when a user clicked a card.

## Solution

Added 6 route handlers in `maestro/api/routes/musehub/ui.py` and 6 Jinja2 templates in `maestro/templates/musehub/pages/` following the exact pattern of `contour.html`:

| Dimension | Route | Template |
|-----------|-------|----------|
| key | `/{owner}/{repo_slug}/analysis/{ref}/key` | `key.html` |
| meter | `/{owner}/{repo_slug}/analysis/{ref}/meter` | `meter.html` |
| chord-map | `/{owner}/{repo_slug}/analysis/{ref}/chord-map` | `chord_map.html` |
| groove | `/{owner}/{repo_slug}/analysis/{ref}/groove` | `groove.html` |
| emotion | `/{owner}/{repo_slug}/analysis/{ref}/emotion` | `emotion.html` |
| form | `/{owner}/{repo_slug}/analysis/{ref}/form` | `form.html` |

Each template:
- Extends `musehub/base.html`
- Uses `{% block page_data %}` for server-side Jinja vars (repoId, ref, base, apiBase)
- Uses `{% block page_script %}` for client-side fetch/render (no JWT on HTML shell)
- Renders typed fields from `AnalysisResponse.data` with relevant visualisations:
  - **key**: confidence bar + alternate key candidate list
  - **meter**: beat-strength profile SVG bar chart + irregular sections table
  - **chord-map**: chord progression table with tension colour-coding per row
  - **groove**: groove score gauge + swing factor bar
  - **emotion**: valence-arousal 2D plot + axis bars (valence, arousal, tension)
  - **form**: colour-coded form timeline SVG + sections table

## Verification

- [x] mypy clean (`maestro/api/routes/musehub/ui.py` + `tests/test_musehub_ui.py`)
- [x] 18 new tests pass (3 per dimension: renders 200, no auth required, contains key data labels)
- [x] Docs updated (`docs/architecture/muse_vcs.md` — new "Muse Hub — Per-Dimension Analysis Detail Pages" section)