### PR TITLE
chore: fix agent command policy and parallel prompts

### DIFF
--- a/.cursor/AGENT_COMMAND_POLICY.md
+++ b/.cursor/AGENT_COMMAND_POLICY.md
@@ -70,7 +70,7 @@ Clear the existing allowlist entirely, then paste the block below into
 > commands in kickoff prompts must be written as single lines.
 
 ```
-ls, ls -la, ls -lah, ls -l, pwd, cat, head, tail, echo, wc, file, which, date, basename, dirname, printf, jq, sort, uniq, tr, awk, sed, cut, xargs, tee, rg, grep, find, mkdir -p, cp, mv, touch, ln -s, cd, sleep, python3 -c, REPO=, WTNAME=, DEV_SHA=, WT=, NUM=, TITLE=, BRANCH=, PRTREES=, WORKTREE=, ENTRY=, FOLLOW_UP_URL=, ISSUE_URL=, declare -a, declare -a ISSUES=, declare -a PRS=, for entry in, for NUM in, for WT in, git status, git log, git diff, git show, git branch, git fetch, git fetch origin, git pull, git pull origin, git pull origin dev, git stash list, git worktree list, git ls-remote, git rev-parse, git ls-files, git merge-base, git describe, git cat-file, git -C, git -C /Users, git worktree list --porcelain, git bisect, git bisect start, git bisect bad, git bisect good, git bisect log, git bisect reset, git checkout -b, git checkout, git add, git add -A, git commit, git merge origin/dev, git merge, git stash, git stash pop, git stash apply, git restore, git restore --staged, git push origin, git push origin --delete, git worktree add, git worktree add --detach, git worktree remove --force, git worktree prune, docker compose ps, docker compose logs, docker compose config, docker compose -f, docker ps, docker inspect, docker compose exec maestro mypy, docker compose exec maestro pytest, docker compose exec maestro sh -c, docker compose exec maestro python -m coverage, docker compose exec maestro python -c, docker compose exec maestro ls, docker compose exec maestro cat, docker compose exec maestro rg, docker compose exec maestro grep, docker compose exec maestro find, docker compose exec maestro alembic history, docker compose exec maestro alembic current, docker compose exec maestro alembic heads, docker compose exec maestro alembic upgrade head, docker compose exec maestro python3, docker compose exec storpheus mypy, docker compose exec storpheus pytest, docker compose exec storpheus sh -c, docker compose exec storpheus ls, docker compose exec storpheus cat, docker compose exec storpheus rg, docker compose exec storpheus grep, docker compose exec storpheus python3, docker compose exec postgres psql, gh auth status, gh repo view, gh pr view, gh pr list, gh pr diff, gh pr create, gh pr checkout, gh pr merge, gh pr comment, gh pr review, gh issue view, gh issue list, gh issue create, gh issue close, gh issue comment, gh issue edit, gh label list, gh run list, gh run view, gh release list, gh release view, gh api, ps aux, ps -ef, pgrep, nc -z, curl, REPO=$(git, WTNAME=$(basename, DEV_SHA=$(git, WT=$HOME, BRANCH=$(git
+ls, ls -la, ls -lah, ls -l, pwd, cat, head, tail, echo, wc, file, which, date, basename, dirname, printf, jq, sort, uniq, tr, awk, sed, cut, xargs, tee, rg, grep, find, mkdir -p, cp, mv, touch, ln -s, cd, sleep, python3 -c, python3 -m, REPO=, WTNAME=, DEV_SHA=, WT=, NUM=, TITLE=, BRANCH=, PRTREES=, WORKTREE=, ENTRY=, FOLLOW_UP_URL=, ISSUE_URL=, GH_REPO=, export GH_REPO=, declare -a, declare -a ISSUES=, declare -a PRS=, for entry in, for NUM in, for WT in, git status, git log, git diff, git show, git branch, git fetch, git fetch origin, git pull, git pull origin, git pull origin dev, git stash list, git worktree list, git ls-remote, git rev-parse, git ls-files, git merge-base, git describe, git cat-file, git config rerere.enabled, git -C, git -C /Users, git worktree list --porcelain, git bisect, git bisect start, git bisect bad, git bisect good, git bisect log, git bisect reset, git checkout -b, git checkout, git add, git add -A, git commit, git merge origin/dev, git merge, git stash, git stash pop, git stash apply, git restore, git restore --staged, git push origin, git push -u origin, git push origin --delete, git worktree add, git worktree add --detach, git worktree remove --force, git worktree prune, docker compose ps, docker compose logs, docker compose config, docker compose -f, docker ps, docker inspect, docker compose exec maestro mypy, docker compose exec maestro pytest, docker compose exec maestro sh -c, docker compose exec maestro python -m coverage, docker compose exec maestro python -c, docker compose exec maestro python3 -m, docker compose exec maestro ps, docker compose exec maestro ls, docker compose exec maestro cat, docker compose exec maestro rg, docker compose exec maestro grep, docker compose exec maestro find, docker compose exec maestro alembic history, docker compose exec maestro alembic current, docker compose exec maestro alembic heads, docker compose exec maestro alembic upgrade head, docker compose exec maestro python3, docker compose exec storpheus mypy, docker compose exec storpheus pytest, docker compose exec storpheus sh -c, docker compose exec storpheus ls, docker compose exec storpheus cat, docker compose exec storpheus rg, docker compose exec storpheus grep, docker compose exec storpheus python3, docker compose exec postgres psql, gh auth status, gh repo view, gh pr view, gh pr list, gh pr diff, gh pr create, gh pr checkout, gh pr merge, gh pr comment, gh pr review, gh issue view, gh issue list, gh issue create, gh issue close, gh issue comment, gh issue edit, gh label list, gh run list, gh run view, gh release list, gh release view, gh api, ps aux, ps -ef, pgrep, nc -z, curl, REPO=$(git, WTNAME=$(basename, DEV_SHA=$(git, WT=$HOME, BRANCH=$(git
 ```
 
 ---
@@ -105,6 +105,8 @@ WORKTREE=<path>               ← variable assignment
 ENTRY=<value>                 ← variable assignment
 FOLLOW_UP_URL=<value>         ← B-grade follow-up issue URL
 ISSUE_URL=<value>             ← captured issue URL in scripts
+GH_REPO=cgcardona/maestro     ← hardcoded repo slug — NEVER derive from local path
+export GH_REPO=cgcardona/maestro
 ```
 
 ### Shell — Text Processing (read-only transforms)
@@ -169,6 +171,13 @@ git bisect log
 git bisect reset
 ```
 
+### Git — Config (rerere only — limited to this one safe key)
+```
+git config rerere.enabled true   ← coordinator setup only; enables conflict-resolution cache
+                                  ← must be on the allowlist so it runs outside sandbox
+                                  ← ALL other git config writes are Yellow tier
+```
+
 ### Git — Safe Writes (worktree scope only — never touching dev/main directly)
 ```
 git checkout -b <feature-branch>   ← creating new branches
@@ -191,6 +200,8 @@ git worktree prune                       ← pruning stale worktree refs
 ### Git — Push (feature branches only)
 ```
 git push origin <feature-branch>          ← non-main, non-dev branches ONLY
+git push -u origin <feature-branch>       ← same as above with upstream tracking; -u writes to .git/config
+                                           ← must be on the allowlist so it runs outside sandbox
 git push origin --delete <feature-branch> ← remote branch cleanup after PR merge
 ```
 
@@ -246,6 +257,8 @@ docker compose exec maestro pytest <file> -v [flags]
 docker compose exec maestro sh -c "<any command>"
 docker compose exec maestro python -m coverage run ...
 docker compose exec maestro python -m coverage report ...
+docker compose exec maestro python3 -m <module>       ← stdlib modules inside container
+docker compose exec maestro ps aux                    ← process inspection inside container
 docker compose exec maestro ls <path>
 docker compose exec maestro cat <file>
 docker compose exec maestro rg <pattern>
@@ -289,6 +302,8 @@ pgrep <name>
 python3 -c "<one-liner>"      ← JSON parsing, string manipulation of gh/git output ONLY
                                ← No file writes, no imports beyond stdlib, no network calls
                                ← Longer scripts or any I/O must use docker compose exec
+python3 -m json.tool           ← pretty-printing JSON output from curl or gh commands
+python3 -m <stdlib-module>     ← stdlib modules only (json, base64, hashlib, etc.)
 ```
 
 ### Network — Read-only probes
@@ -425,3 +440,24 @@ gh pr merge <N>   ← without having first output "Grade: X" and "Approved for m
 
 6. **When in doubt, stop and ask.** Explain exactly what you need and why.
    A paused agent is infinitely better than a destructive one.
+
+7. **Never use `while read` in pipelines for issue/PR data.** Use `xargs` instead — it is on
+   the allowlist and avoids the sandbox prompt that `read` (a shell builtin) triggers.
+   ```bash
+   # ✅ Correct — uses xargs (allowlisted, no prompt):
+   gh pr view <N> --json body --jq '.body' \
+     | grep -oE '[Cc]loses?\s+#[0-9]+' \
+     | grep -oE '[0-9]+' \
+     | xargs -I{} gh issue close {} --comment "Fixed by PR #<N>." --repo "$GH_REPO"
+
+   # ❌ Wrong — while read triggers a sandbox prompt:
+   | while read ISSUE_NUM; do gh issue close "$ISSUE_NUM" ...; done
+   ```
+
+8. **`GH_REPO` is always `cgcardona/maestro` — hardcoded, never derived.**
+   The local path (`/Users/gabriel/dev/tellurstori/maestro`) contains `tellurstori` which is
+   NOT the GitHub org. Using `gh` without `--repo "$GH_REPO"` or with a derived slug causes
+   "Forbidden" / "Repository not found" errors.
+   ```bash
+   export GH_REPO=cgcardona/maestro   # always set this first; all gh commands inherit it
+   ```

--- a/.github/PR_REVIEW_PROMPT.md
+++ b/.github/PR_REVIEW_PROMPT.md
@@ -459,11 +459,9 @@ Only after you have output the grade and **"Approved for merge"**, do the follow
    gh pr view <pr-number> --json body --jq '.body' \
      | grep -oE '[Cc]loses?\s+#[0-9]+' \
      | grep -oE '[0-9]+' \
-     | while read ISSUE_NUM; do
-         gh issue close "$ISSUE_NUM" \
-           --comment "Fixed by PR #<pr-number>." \
-           --repo "$GH_REPO"
-       done
+     | xargs -I{} gh issue close {} \
+         --comment "Fixed by PR #<pr-number>." \
+         --repo "$GH_REPO"
    ```
    ⚠️ Do NOT use `grep -o '#[0-9]*'` — it matches any `#N` in the body (commit hashes, mentions, etc.)
    and silently closes the wrong issue. Always match `Closes #N` explicitly.
@@ -472,7 +470,7 @@ Only after you have output the grade and **"Approved for merge"**, do the follow
    ```bash
    git fetch --prune
    git checkout dev
-   git pull origin dev
+   git fetch origin && git merge origin/dev
    git branch -d "$BRANCH"
    ```
    This leaves the working tree on a clean, up-to-date `dev` — ready for the next task.


### PR DESCRIPTION
## Summary

Fixes all the command-prompt friction observed during multi-agent PR review runs.

## Root Cause / Motivation

Several shell commands were triggering Cursor confirmation dialogs or sandbox errors because they were missing from the allowlist or were using patterns the sandbox blocks.

## What Changed

### AGENT_COMMAND_POLICY.md
- Added to allowlist string: `git push -u origin`, `git config rerere.enabled`, `docker compose exec maestro ps`, `python3 -m`, `export GH_REPO=`
- Added documentation sections: Git Config (rerere only), docker exec maestro ps, python3 -m stdlib modules
- Added Hard Rule 7: use `xargs` instead of `while read` in pipelines (read builtin triggers sandbox prompt)
- Added Hard Rule 8: GH_REPO is always `cgcardona/maestro` — never derived

### PARALLEL_PR_REVIEW.md
- Replaced `while read ISSUE_NUM; do ...` with `xargs -I{}` in issue-closing command
- Replaced `git pull origin dev` with `git fetch origin && git merge origin/dev` in coordinator pre-flight (both Step 2 and After-agents section) — `git pull --rebase` fails with unstaged changes; `pull` also blocks on sandbox .git/config writes
- Added GH_REPO validation step (`gh repo view "$GH_REPO"`) to Kickoff Prompt STEP 1

### PARALLEL_ISSUE_TO_PR.md
- Same `git fetch + merge` fix in coordinator Step C pre-flight
- Added GH_REPO validation step to Kickoff Prompt STEP 1

## Verification

All changes are to `.cursor/` prompt files — no Python code changed, no mypy/pytest needed.