### PR TITLE
feat(musehub): mark-as-read UX in activity feed

### DIFF
--- a/maestro/templates/musehub/pages/feed.html
+++ b/maestro/templates/musehub/pages/feed.html
@@ -58,8 +58,9 @@ const EVENT_META = {
 /**
  * Render a single notification as a rich event card.
  *
- * Each card carries a `data-notif-id` attribute so issue #293 (mark-as-read
- * UX) can attach action buttons without restructuring the DOM.
+ * Unread cards include a "Mark read" button (✓) that calls
+ * POST /notifications/{notif_id}/read and applies the read style in-place
+ * without a full page reload.
  */
 function eventCard(item) {
   const meta      = EVENT_META[item.event_type] || { icon: '•', sentence: (a) => actorLink(a) };
@@ -72,18 +73,97 @@ function eventCard(item) {
     ? 'border-left:3px solid var(--color-accent);padding-left:calc(var(--space-3) - 3px);'
     : 'border-left:3px solid transparent;padding-left:calc(var(--space-3) - 3px);opacity:0.75;';
 
+  const markReadBtn = isUnread
+    ? `<button
+         class="mark-read-btn"
+         data-notif-id="${escHtml(item.notif_id)}"
+         onclick="markOneRead(this)"
+         title="Mark as read"
+         style="background:none;border:1px solid var(--border-color);border-radius:50%;width:22px;height:22px;cursor:pointer;color:var(--text-muted);font-size:12px;line-height:1;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;margin-left:var(--space-2)"
+       >&#10003;</button>`
+    : '';
+
   return `
     <div class="comment-item" data-notif-id="${escHtml(item.notif_id)}" style="${unreadStyle}">
       ${actorAvatar(item.actor)}
-      <div class="comment-body">
+      <div class="comment-body" style="flex:1;min-width:0">
         <div class="comment-meta" style="display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap">
           <span style="font-size:16px;line-height:1">${icon}</span>
           <span>${sentence}</span>
-          <span style="margin-left:auto;white-space:nowrap">${escHtml(timestamp)}</span>
+          <span style="margin-left:auto;white-space:nowrap;display:flex;align-items:center;gap:var(--space-2)">
+            ${escHtml(timestamp)}
+            ${markReadBtn}
+          </span>
         </div>
-        ${isUnread ? '<div style="width:6px;height:6px;border-radius:50%;background:var(--color-accent);display:inline-block;margin-top:var(--space-1)"></div>' : ''}
+        ${isUnread ? '<div class="unread-dot" style="width:6px;height:6px;border-radius:50%;background:var(--color-accent);display:inline-block;margin-top:var(--space-1)"></div>' : ''}
       </div>
     </div>`;
+}
+
+/**
+ * Mark a single notification as read via POST /notifications/{notif_id}/read.
+ * Updates the card styling and nav badge count in-place on success.
+ */
+async function markOneRead(btn) {
+  const notifId = btn.dataset.notifId;
+  if (!notifId) return;
+  try {
+    await apiFetch('/notifications/' + encodeURIComponent(notifId) + '/read', { method: 'POST' });
+    const card = document.querySelector('.comment-item[data-notif-id="' + CSS.escape(notifId) + '"]');
+    if (card) {
+      card.style.borderLeft = '3px solid transparent';
+      card.style.opacity    = '0.75';
+      const dot = card.querySelector('.unread-dot');
+      if (dot) dot.remove();
+    }
+    btn.remove();
+    decrementNavBadge();
+  } catch (e) {
+    if (e.message !== 'auth') btn.style.color = 'var(--color-danger)';
+  }
+}
+
+/**
+ * Mark all notifications as read via POST /notifications/read-all.
+ * Applies read styling to every card and resets the nav badge to 0.
+ */
+async function markAllRead() {
+  const markAllBtn = document.getElementById('mark-all-read-btn');
+  if (markAllBtn) markAllBtn.disabled = true;
+  try {
+    await apiFetch('/notifications/read-all', { method: 'POST' });
+    document.querySelectorAll('.comment-item').forEach(card => {
+      card.style.borderLeft = '3px solid transparent';
+      card.style.opacity    = '0.75';
+      const dot = card.querySelector('.unread-dot');
+      if (dot) dot.remove();
+      const btn = card.querySelector('.mark-read-btn');
+      if (btn) btn.remove();
+    });
+    const badge = document.getElementById('nav-notif-badge');
+    if (badge) badge.style.display = 'none';
+    if (markAllBtn) markAllBtn.remove();
+  } catch (e) {
+    if (markAllBtn) markAllBtn.disabled = false;
+    if (e.message !== 'auth') {
+      const err = document.getElementById('feed-error');
+      if (err) err.textContent = 'Could not mark all as read: ' + e.message;
+    }
+  }
+}
+
+/**
+ * Decrement the nav badge count by 1; hide it when it reaches 0.
+ */
+function decrementNavBadge() {
+  const badge = document.getElementById('nav-notif-badge');
+  if (!badge) return;
+  const current = parseInt(badge.textContent, 10);
+  if (isNaN(current) || current <= 1) {
+    badge.style.display = 'none';
+  } else {
+    badge.textContent = String(current - 1);
+  }
 }
 
 async function load() {
@@ -101,8 +181,22 @@ async function load() {
       return;
     }
 
+    const hasUnread = items.some(item => !item.is_read);
+    const markAllHtml = hasUnread && getToken()
+      ? `<button
+           id="mark-all-read-btn"
+           onclick="markAllRead()"
+           class="btn btn-secondary"
+           style="font-size:12px;padding:4px 10px"
+         >&#10003; Mark all as read</button>`
+      : '';
+
     document.getElementById('content').innerHTML = `
-      <h1 style="margin-bottom:var(--space-4)">Activity Feed</h1>
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4)">
+        <h1 style="margin:0">Activity Feed</h1>
+        ${markAllHtml}
+      </div>
+      <p id="feed-error" style="color:var(--color-danger);font-size:13px"></p>
       <div class="card" style="padding:0">
         ${items.map(eventCard).join('')}
       </div>`;

--- a/tests/test_musehub_ui.py
+++ b/tests/test_musehub_ui.py
@@ -84,6 +84,15 @@ Covers issue #292 (rich event cards in activity feed):
 - test_feed_page_has_actor_avatar_logic      — actorAvatar / actorHsl helper present
 - test_feed_page_has_relative_timestamp      — fmtRelative called in card rendering
 
+Covers issue #293 (mark-as-read UX in activity feed):
+- test_feed_page_has_mark_one_read_function          — markOneRead() defined for per-card action
+- test_feed_page_has_mark_all_read_function          — markAllRead() defined for bulk action
+- test_feed_page_has_decrement_nav_badge_function    — decrementNavBadge() keeps badge in sync
+- test_feed_page_mark_read_btn_targets_notification_endpoint — calls POST /notifications/{id}/read
+- test_feed_page_mark_all_btn_targets_read_all_endpoint      — calls POST /notifications/read-all
+- test_feed_page_mark_all_btn_present_in_template    — mark-all-read-btn element in page HTML
+- test_feed_page_mark_read_updates_nav_badge         — nav-notif-badge updated after mark-all
+
 UI routes require no JWT auth (they return HTML shells whose JS handles auth).
 The HTML content tests assert structural markers present in every rendered page.
 
@@ -6213,6 +6222,92 @@ async def test_feed_page_has_relative_timestamp(
     response = await client.get("/musehub/ui/feed")
     assert response.status_code == 200
     assert "fmtRelative" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Mark-as-read UX tests — issue #293
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_feed_page_has_mark_one_read_function(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Feed page must define markOneRead() for per-notification mark-as-read."""
+    response = await client.get("/musehub/ui/feed")
+    assert response.status_code == 200
+    assert "markOneRead" in response.text
+
+
+@pytest.mark.anyio
+async def test_feed_page_has_mark_all_read_function(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Feed page must define markAllRead() for bulk mark-as-read."""
+    response = await client.get("/musehub/ui/feed")
+    assert response.status_code == 200
+    assert "markAllRead" in response.text
+
+
+@pytest.mark.anyio
+async def test_feed_page_has_decrement_nav_badge_function(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Feed page must define decrementNavBadge() to keep the nav badge in sync."""
+    response = await client.get("/musehub/ui/feed")
+    assert response.status_code == 200
+    assert "decrementNavBadge" in response.text
+
+
+@pytest.mark.anyio
+async def test_feed_page_mark_read_btn_targets_notification_endpoint(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """markOneRead() must call POST /notifications/{notif_id}/read."""
+    response = await client.get("/musehub/ui/feed")
+    assert response.status_code == 200
+    body = response.text
+    assert "/notifications/" in body
+    assert "mark-read-btn" in body
+
+
+@pytest.mark.anyio
+async def test_feed_page_mark_all_btn_targets_read_all_endpoint(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """markAllRead() must call POST /notifications/read-all."""
+    response = await client.get("/musehub/ui/feed")
+    assert response.status_code == 200
+    assert "read-all" in response.text
+
+
+@pytest.mark.anyio
+async def test_feed_page_mark_all_btn_present_in_template(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Feed page must render a 'Mark all as read' button element."""
+    response = await client.get("/musehub/ui/feed")
+    assert response.status_code == 200
+    assert "mark-all-read-btn" in response.text
+
+
+@pytest.mark.anyio
+async def test_feed_page_mark_read_updates_nav_badge(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """After marking all as read, page logic must update nav-notif-badge to hidden."""
+    response = await client.get("/musehub/ui/feed")
+    assert response.status_code == 200
+    body = response.text
+    assert "nav-notif-badge" in body
+    assert "decrementNavBadge" in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes #293 — adds per-notification and bulk mark-as-read actions to the MuseHub activity feed.

## Root Cause / Motivation
The feed page had no way to mark notifications as read, leaving the nav badge permanently elevated even after the user viewed their feed.

## Solution
- Added `markOneRead(btn)` — per-card checkmark button (✓) calls `POST /notifications/{notif_id}/read`; removes the unread highlight and dot in-place, then decrements the nav badge via `decrementNavBadge()`
- Added `markAllRead()` — "Mark all as read" button in the feed header calls `POST /notifications/read-all`; applies read styling to every card and hides the nav badge
- Added `decrementNavBadge()` helper to keep the badge count in sync after single-card actions without a full notification refetch
- `eventCard()` now renders the per-card mark-read button only for unread items; existing `data-notif-id` attribute (from PR #375) used as the selector anchor

## Verification
- [x] mypy clean (640 source files, 0 issues)
- [x] 14 tests pass (7 existing feed tests + 7 new mark-as-read tests)
- [x] No API contract changes (uses existing `POST /notifications/{notif_id}/read` and `POST /notifications/read-all` endpoints)