### PR TITLE
feat(musehub): comment threads on session detail page

### DIFF
--- a/maestro/templates/musehub/pages/session_detail.html
+++ b/maestro/templates/musehub/pages/session_detail.html
@@ -54,6 +54,76 @@ const repoSlug  = {{ repo_slug | tojson }};
   margin-top: 8px; font-size: 14px; line-height: 1.6;
   color: var(--text-secondary);
 }
+
+/* ── Comment threads ──────────────────────────────────────────────────────── */
+.comment-thread { margin-bottom: var(--space-4); }
+.comment-thread:last-child { margin-bottom: 0; }
+.comment-row {
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+}
+.comment-reply-row { margin-top: var(--space-3); }
+.comment-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  font-size: 13px;
+  font-weight: var(--font-weight-semibold);
+  color: #fff;
+  flex-shrink: 0;
+}
+.comment-body-col { flex: 1; min-width: 0; }
+.comment-meta {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin-bottom: var(--space-1);
+}
+.comment-author {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+}
+.comment-ts {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+.comment-text {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.55;
+}
+.comment-actions {
+  display: flex;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+}
+.comment-delete-btn { color: var(--color-danger, #f87171); }
+.comment-replies {
+  margin-top: var(--space-3);
+  padding-left: var(--space-4);
+  border-left: 2px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.reply-form { margin-top: var(--space-2); }
+.comment-textarea {
+  width: 100%;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-sm);
+}
+.comment-form-actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
 </style>
 {% endblock %}
 
@@ -236,6 +306,23 @@ async function load() {
       </div>
       <div class="card" style="padding:var(--space-3) var(--space-4)">
         <div id="session-reactions"><p class="text-muted text-sm">Loading reactions…</p></div>
+      </div>
+      <div class="card" id="comments-section">
+        <h2 style="margin:0 0 var(--space-3) 0">💬 Discussion</h2>
+        <div id="comments-list"><p class="loading text-sm">Loading comments…</p></div>
+        <div id="new-comment-form" style="display:none;margin-top:var(--space-4)">
+          <div class="comment-row" style="align-items:flex-start">
+            <span class="comment-avatar" id="new-comment-avatar" style="background:var(--bg-overlay);color:var(--text-muted)">?</span>
+            <div style="flex:1">
+              <textarea id="new-comment-body" class="form-input comment-textarea" rows="3"
+                        placeholder="Leave a comment…" style="resize:vertical"></textarea>
+              <div class="comment-form-actions" style="margin-top:var(--space-2)">
+                <button id="comment-submit-btn" class="btn btn-primary btn-sm"
+                        onclick="submitComment(null)">Comment</button>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>`;
 
     // Load rich cards after DOM is set
@@ -284,6 +371,164 @@ async function loadAndMaybePoll() {
   } catch(e) { /* non-fatal */ }
 }
 
+// ── Comment threads ──────────────────────────────────────────────────────────
+
+function currentUsername() {
+  const tok = getToken();
+  if (!tok) return null;
+  try {
+    const payload = JSON.parse(atob(tok.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+    return payload.sub || null;
+  } catch { return null; }
+}
+
+function avatarColor(username) {
+  let hash = 0;
+  for (let i = 0; i < username.length; i++) hash = username.charCodeAt(i) + ((hash << 5) - hash);
+  return `hsl(${Math.abs(hash) % 360},55%,45%)`;
+}
+
+function avatarHtml(username) {
+  const initial = escHtml((username || '?').charAt(0).toUpperCase());
+  const color   = avatarColor(username || '');
+  return `<span class="comment-avatar" style="background:${color}">${initial}</span>`;
+}
+
+function renderComments(comments, me) {
+  const topLevel = comments.filter(c => !c.parent_id);
+  const replies  = comments.filter(c =>  c.parent_id);
+
+  if (topLevel.length === 0 && !me) {
+    return '<p class="text-sm text-muted" style="margin:0">No comments yet.</p>';
+  }
+  if (topLevel.length === 0) {
+    return '<p class="text-sm text-muted" style="margin:0">Be the first to comment.</p>';
+  }
+
+  return topLevel.map(c => commentHtml(c, replies, me)).join('');
+}
+
+function commentHtml(c, allReplies, me) {
+  const isOwn         = me && c.author === me;
+  const threadReplies = allReplies.filter(r => r.parent_id === c.comment_id);
+
+  return `
+<div class="comment-thread" id="comment-${escHtml(c.comment_id)}">
+  <div class="comment-row">
+    ${avatarHtml(c.author)}
+    <div class="comment-body-col">
+      <div class="comment-meta">
+        <a href="/musehub/ui/users/${encodeURIComponent(c.author)}" class="comment-author">${escHtml(c.author)}</a>
+        <span class="comment-ts" title="${escHtml(c.created_at)}">${fmtRelative(c.created_at)}</span>
+      </div>
+      <div class="comment-text">${escHtml(c.body)}</div>
+      <div class="comment-actions">
+        ${me ? `<button class="btn btn-ghost btn-xs" onclick="showReplyForm('${escHtml(c.comment_id)}')">↩ Reply</button>` : ''}
+        ${isOwn ? `<button class="btn btn-ghost btn-xs comment-delete-btn" onclick="deleteComment('${escHtml(c.comment_id)}')">🗑</button>` : ''}
+      </div>
+      <div class="reply-form-slot" id="reply-slot-${escHtml(c.comment_id)}"></div>
+      ${threadReplies.length > 0 ? `<div class="comment-replies">${threadReplies.map(r => replyHtml(r, me)).join('')}</div>` : ''}
+    </div>
+  </div>
+</div>`;
+}
+
+function replyHtml(c, me) {
+  const isOwn = me && c.author === me;
+  return `
+<div class="comment-row comment-reply-row" id="comment-${escHtml(c.comment_id)}">
+  ${avatarHtml(c.author)}
+  <div class="comment-body-col">
+    <div class="comment-meta">
+      <a href="/musehub/ui/users/${encodeURIComponent(c.author)}" class="comment-author">${escHtml(c.author)}</a>
+      <span class="comment-ts" title="${escHtml(c.created_at)}">${fmtRelative(c.created_at)}</span>
+    </div>
+    <div class="comment-text">${escHtml(c.body)}</div>
+    ${isOwn ? `<div class="comment-actions"><button class="btn btn-ghost btn-xs comment-delete-btn" onclick="deleteComment('${escHtml(c.comment_id)}')">🗑</button></div>` : ''}
+  </div>
+</div>`;
+}
+
+async function loadComments() {
+  const el = document.getElementById('comments-section');
+  if (!el) return;
+  try {
+    const comments = await apiFetch(`/repos/${repoId}/comments?target_type=session&target_id=${encodeURIComponent(sessionId)}`);
+    const me = currentUsername();
+    document.getElementById('comments-list').innerHTML = renderComments(comments, me);
+    if (me) {
+      const form   = document.getElementById('new-comment-form');
+      const avatar = document.getElementById('new-comment-avatar');
+      form.style.display = '';
+      if (avatar) {
+        avatar.textContent = me.charAt(0).toUpperCase();
+        avatar.style.background = avatarColor(me);
+        avatar.style.color = '#fff';
+      }
+    }
+  } catch(e) {
+    if (e.message !== 'auth')
+      document.getElementById('comments-list').innerHTML = `<p class="error text-sm">✕ ${escHtml(e.message)}</p>`;
+  }
+}
+
+async function submitComment(parentId) {
+  const textareaId = parentId ? `reply-body-${parentId}` : 'new-comment-body';
+  const textarea   = document.getElementById(textareaId);
+  if (!textarea) return;
+  const body = textarea.value.trim();
+  if (!body) return;
+
+  const btn = parentId
+    ? document.querySelector(`#reply-slot-${parentId} .comment-submit-btn`)
+    : document.getElementById('comment-submit-btn');
+  if (btn) { btn.disabled = true; btn.textContent = 'Posting…'; }
+
+  try {
+    await apiFetch(`/repos/${repoId}/comments`, {
+      method: 'POST',
+      body: JSON.stringify({ target_type: 'session', target_id: sessionId, body, parent_id: parentId || null }),
+    });
+    textarea.value = '';
+    if (parentId) {
+      document.getElementById(`reply-slot-${parentId}`).innerHTML = '';
+    }
+    await loadComments();
+  } catch(e) {
+    if (e.message !== 'auth') alert('Failed to post comment: ' + e.message);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = 'Comment'; }
+  }
+}
+
+async function deleteComment(commentId) {
+  if (!confirm('Delete this comment?')) return;
+  try {
+    await apiFetch(`/repos/${repoId}/comments/${commentId}`, { method: 'DELETE' });
+    await loadComments();
+  } catch(e) {
+    if (e.message !== 'auth') alert('Failed to delete: ' + e.message);
+  }
+}
+
+function showReplyForm(parentId) {
+  const slot = document.getElementById(`reply-slot-${parentId}`);
+  if (!slot) return;
+  if (slot.innerHTML.trim()) { slot.innerHTML = ''; return; }
+  slot.innerHTML = `
+<div class="reply-form">
+  <textarea id="reply-body-${escHtml(parentId)}" class="form-input comment-textarea" rows="2"
+            placeholder="Write a reply…" style="resize:vertical"></textarea>
+  <div class="comment-form-actions">
+    <button class="btn btn-primary btn-sm comment-submit-btn" onclick="submitComment('${escHtml(parentId)}')">Comment</button>
+    <button class="btn btn-ghost btn-sm" onclick="document.getElementById('reply-slot-${escHtml(parentId)}').innerHTML=''">Cancel</button>
+  </div>
+</div>`;
+  const ta = document.getElementById(`reply-body-${parentId}`);
+  if (ta) ta.focus();
+}
+
 loadAndMaybePoll();
+loadComments();
 {% endraw %}
 {% endblock %}

--- a/tests/test_musehub_ui.py
+++ b/tests/test_musehub_ui.py
@@ -2157,6 +2157,96 @@ async def test_session_detail_404_marker(
     # The JS error handler must check for a 404 and render a "not found" message
     assert "Session not found" in body or "404" in body
 
+
+@pytest.mark.anyio
+async def test_session_detail_has_comment_section(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Session detail page must include the Discussion comment section."""
+    await _make_repo(db_session)
+    session_id = "comment-section-session-001"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/sessions/{session_id}")
+    assert response.status_code == 200
+    body = response.text
+    assert "comments-section" in body
+    assert "Discussion" in body
+    assert "comments-list" in body
+
+
+@pytest.mark.anyio
+async def test_session_detail_comment_section_uses_session_target_type(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Session detail comment API calls must use target_type='session'."""
+    await _make_repo(db_session)
+    session_id = "target-type-session-002"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/sessions/{session_id}")
+    assert response.status_code == 200
+    body = response.text
+    assert "target_type: 'session'" in body or "target_type=\"session\"" in body
+
+
+@pytest.mark.anyio
+async def test_session_detail_has_loadcomments_call(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Session detail page must call loadComments() on init."""
+    await _make_repo(db_session)
+    session_id = "load-comments-session-003"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/sessions/{session_id}")
+    assert response.status_code == 200
+    body = response.text
+    assert "loadComments" in body
+
+
+@pytest.mark.anyio
+async def test_session_detail_has_submit_comment_function(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Session detail page must include the submitComment JS function."""
+    await _make_repo(db_session)
+    session_id = "submit-comment-session-004"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/sessions/{session_id}")
+    assert response.status_code == 200
+    body = response.text
+    assert "submitComment" in body
+    assert "deleteComment" in body
+
+
+@pytest.mark.anyio
+async def test_session_detail_has_render_comments_function(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Session detail page must include renderComments() for threaded display."""
+    await _make_repo(db_session)
+    session_id = "render-comments-session-005"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/sessions/{session_id}")
+    assert response.status_code == 200
+    body = response.text
+    assert "renderComments" in body
+
+
+@pytest.mark.anyio
+async def test_session_detail_comment_form_has_new_comment_body(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Session detail page must include the new-comment-body textarea and submit button."""
+    await _make_repo(db_session)
+    session_id = "comment-form-session-006"
+    response = await client.get(f"/musehub/ui/testuser/test-beats/sessions/{session_id}")
+    assert response.status_code == 200
+    body = response.text
+    assert "new-comment-body" in body
+    assert "new-comment-form" in body
+    assert "comment-submit-btn" in body
+
+
 async def _make_session(
     db_session: AsyncSession,
     repo_id: str,


### PR DESCRIPTION
## Summary
Closes #291 — Add threaded comment section to the session detail page.

## Root Cause / Motivation
Session detail page showed participants and commit list only. MusehubComment records with target_type="session" were seeded but had no UI surface. Sessions are collaborative events — comments let participants leave retrospective notes and watchers leave feedback.

## Solution
Reused the existing renderComments(), submitComment(), deleteComment() JS functions already present in commit detail. Wired them to GET /repos/{repo_id}/comments?target_type=session&target_id={session_id} which is already implemented in social.py.

## Changes
- `maestro/templates/musehub/pages/session_detail.html` — added `#comments-section` card with Discussion heading, `#comments-list`, `#new-comment-form`, and all comment thread JS functions (`currentUsername`, `avatarColor`, `avatarHtml`, `renderComments`, `commentHtml`, `replyHtml`, `loadComments`, `submitComment`, `deleteComment`, `showReplyForm`); added comment thread CSS; calls `loadComments()` on page init
- `tests/test_musehub_ui.py` — 6 new regression tests covering: comment section presence, target_type='session' usage, loadComments() call, submitComment/deleteComment presence, renderComments presence, form element IDs

## Verification
- [x] mypy clean
- [x] 30/30 session tests pass (6 new)
- [x] No protocol changes (template-only)