### PR TITLE
feat(musehub): profile page — following/followers lists with user cards

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -1694,6 +1694,35 @@ forked, newest first.
 | `forks` | `list[UserForkedRepoEntry]` | Repos forked by this user |
 | `total` | `int` | Total number of forked repos |
 
+#### `FollowResponse`
+
+**Path:** `maestro/api/routes/musehub/social.py`
+**Endpoint:** `GET /api/v1/musehub/users/{username}/followers`
+
+Returned by the public followers endpoint. Extended in issue #295 to include `following_count`
+so the profile header can display both "N followers · M following" at a glance.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `follower_count` | `int` | Number of users following this user |
+| `following_count` | `int` | Number of users this user follows (added #295) |
+| `following` | `bool` | Whether the calling user follows this user |
+
+#### `UserCardResponse`
+
+**Path:** `maestro/api/routes/musehub/users.py`
+**Endpoints:** `GET /api/v1/musehub/users/{username}/followers-list`, `GET /api/v1/musehub/users/{username}/following-list`
+
+Compact user card returned by the followers-list and following-list endpoints (issue #295).
+Designed for rendering avatar circles, linked usernames, and bio previews in the
+Followers / Following tabs on the profile page.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `username` | `str` | The user's public username |
+| `bio` | `str \| None` | Profile bio (may be absent) |
+| `avatar_url` | `str \| None` | Avatar image URL (may be absent) |
+
 #### `ForkCreateResponse`
 
 Returned by `POST /api/v1/musehub/repos/{id}/fork`.

--- a/maestro/api/routes/musehub/social.py
+++ b/maestro/api/routes/musehub/social.py
@@ -36,7 +36,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -48,6 +48,7 @@ from maestro.db.musehub_models import (
     MusehubFollow,
     MusehubFork,
     MusehubNotification,
+    MusehubProfile,
     MusehubReaction,
     MusehubStar,
     MusehubViewEvent,
@@ -410,9 +411,6 @@ async def get_followers(
     claims: TokenClaims | None = Depends(optional_token),
 ) -> FollowResponse:
     """Return follower count, following count, and whether the calling user follows this user."""
-    from sqlalchemy import or_
-    from maestro.db.musehub_models import MusehubProfile
-
     # Resolve user_id so we can match both username-keyed and user_id-keyed rows.
     profile_row = (await db.execute(
         select(MusehubProfile).where(MusehubProfile.username == username)

--- a/maestro/api/routes/musehub/users.py
+++ b/maestro/api/routes/musehub/users.py
@@ -1,27 +1,31 @@
 """Muse Hub user-profile route handlers (JSON API).
 
 Endpoint summary:
-  GET  /musehub/users/{username}  — fetch full profile (public, no JWT required)
-  POST /musehub/users             — create a profile for the authenticated user
-  PUT  /musehub/users/{username}  — update bio/avatar/pinned repos (owner only)
+  GET  /musehub/users/{username}                — fetch full profile (public, no JWT required)
+  POST /musehub/users                           — create a profile for the authenticated user
+  PUT  /musehub/users/{username}                — update bio/avatar/pinned repos (owner only)
+  GET  /musehub/users/{username}/followers-list — list followers as user cards (public)
+  GET  /musehub/users/{username}/following-list — list following as user cards (public)
 
 Content negotiation: all endpoints return JSON.  The browser UI fetches from
 these endpoints using the client-side JWT stored in localStorage.
 
-The GET endpoint is intentionally unauthenticated so that profile pages are
+The GET endpoints are intentionally unauthenticated so that profile pages are
 publicly discoverable without login — matching the behaviour of GitHub profiles.
 """
 from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pydantic import Field
 
-from maestro.auth.dependencies import TokenClaims, require_valid_token
+from maestro.auth.dependencies import TokenClaims, optional_token, require_valid_token
 from maestro.db import get_db
+from maestro.db.musehub_models import MusehubFollow, MusehubProfile
 from maestro.models.base import CamelModel
 from maestro.models.musehub import ProfileResponse, ProfileUpdateRequest
 from maestro.services import musehub_profile as profile_svc
@@ -48,6 +52,18 @@ class CreateProfileBody(CamelModel):
     )
     bio: str | None = Field(None, max_length=500, description="Short bio (Markdown supported)")
     avatar_url: str | None = Field(None, max_length=2048, description="Avatar image URL")
+
+
+class UserCardResponse(CamelModel):
+    """Compact user card returned by followers-list and following-list endpoints.
+
+    Designed for rendering avatar circles, linked usernames, and bio previews
+    in the Followers / Following tabs on the profile page.
+    """
+
+    username: str
+    bio: str | None = None
+    avatar_url: str | None = None
 
 
 @router.get(
@@ -163,3 +179,114 @@ async def update_user_profile(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Profile updated but not found")
     logger.info("✅ Updated profile username=%s", username)
     return full
+
+
+# ---------------------------------------------------------------------------
+# Followers / following lists
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_user_id(db: AsyncSession, username: str) -> str:
+    """Return the user_id for a given username, falling back to the username itself.
+
+    MusehubFollow rows created via the API store a user_id (JWT sub) as
+    follower_id and a username string as followee_id.  Rows created by the
+    seed script store user_ids in both columns.  This helper resolves the
+    profile's canonical user_id so list queries can match both conventions.
+    """
+    row = (await db.execute(
+        select(MusehubProfile).where(MusehubProfile.username == username)
+    )).scalar_one_or_none()
+    return row.user_id if row else username
+
+
+async def _profile_to_card(db: AsyncSession, id_value: str) -> UserCardResponse | None:
+    """Look up a profile by user_id or username and return a UserCardResponse.
+
+    Tries user_id first (covers API-created follows and seed data), then falls
+    back to username lookup (covers followee_id = username from the follow API).
+    """
+    row = (await db.execute(
+        select(MusehubProfile).where(
+            or_(MusehubProfile.user_id == id_value, MusehubProfile.username == id_value)
+        )
+    )).scalar_one_or_none()
+    if row is None:
+        return None
+    return UserCardResponse(username=row.username, bio=row.bio, avatar_url=row.avatar_url)
+
+
+@router.get(
+    "/users/{username}/followers-list",
+    response_model=list[UserCardResponse],
+    operation_id="listFollowerCards",
+    summary="List followers as user cards (public)",
+)
+async def list_followers(
+    username: str,
+    limit: int = Query(100, ge=1, le=500),
+    db: AsyncSession = Depends(get_db),
+    claims: TokenClaims | None = Depends(optional_token),
+) -> list[UserCardResponse]:
+    """Return user cards for everyone who follows *username*.
+
+    Handles both seed-data rows (user_ids in both columns) and API-created rows
+    (user_id in follower_id, username string in followee_id).
+    No JWT required — follower lists are publicly accessible.
+    """
+    profile = await profile_svc.get_profile_by_username(db, username)
+    if profile is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"No profile found for '{username}'")
+
+    user_id = profile.user_id
+    rows = (await db.execute(
+        select(MusehubFollow).where(
+            or_(MusehubFollow.followee_id == username, MusehubFollow.followee_id == user_id)
+        ).limit(limit)
+    )).scalars().all()
+
+    cards: list[UserCardResponse] = []
+    for row in rows:
+        card = await _profile_to_card(db, row.follower_id)
+        if card is not None:
+            cards.append(card)
+    logger.info("✅ Followers list username=%s count=%d", username, len(cards))
+    return cards
+
+
+@router.get(
+    "/users/{username}/following-list",
+    response_model=list[UserCardResponse],
+    operation_id="listFollowingCards",
+    summary="List following as user cards (public)",
+)
+async def list_following(
+    username: str,
+    limit: int = Query(100, ge=1, le=500),
+    db: AsyncSession = Depends(get_db),
+    claims: TokenClaims | None = Depends(optional_token),
+) -> list[UserCardResponse]:
+    """Return user cards for everyone that *username* follows.
+
+    Handles both seed-data rows (user_ids in both columns) and API-created rows
+    (user_id in follower_id, username string in followee_id).
+    No JWT required — following lists are publicly accessible.
+    """
+    profile = await profile_svc.get_profile_by_username(db, username)
+    if profile is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"No profile found for '{username}'")
+
+    user_id = profile.user_id
+    rows = (await db.execute(
+        select(MusehubFollow).where(
+            or_(MusehubFollow.follower_id == username, MusehubFollow.follower_id == user_id)
+        ).limit(limit)
+    )).scalars().all()
+
+    cards: list[UserCardResponse] = []
+    for row in rows:
+        card = await _profile_to_card(db, row.followee_id)
+        if card is not None:
+            cards.append(card)
+    logger.info("✅ Following list username=%s count=%d", username, len(cards))
+    return cards

--- a/maestro/templates/musehub/pages/profile.html
+++ b/maestro/templates/musehub/pages/profile.html
@@ -4,8 +4,10 @@
 {% block breadcrumb %}<a href="/musehub/ui/users/{{ username }}">@{{ username }}</a>{% endblock %}
 
 {% block page_data %}
-const username    = {{ username | tojson }};
-const API_PROFILE = '/api/v1/musehub/users/' + username;
+const username        = {{ username | tojson }};
+const API_PROFILE     = '/api/v1/musehub/users/' + username;
+const API_FOLLOWERS   = '/api/v1/musehub/users/' + username + '/followers-list';
+const API_FOLLOWING   = '/api/v1/musehub/users/' + username + '/following-list';
 {% endblock %}
 
 {% block page_script %}
@@ -73,11 +75,57 @@ async function toggleFollow() {
   } catch(e) { /* non-critical */ }
 }
 
+function userCardHtml(u) {
+  const bio = u.bio ? escHtml(u.bio.slice(0, 60)) + (u.bio.length > 60 ? '…' : '') : '';
+  const hue = u.username.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0) % 360;
+  const initial = (u.username[0] || '?').toUpperCase();
+  const avatar = u.avatarUrl
+    ? `<img src="${escHtml(u.avatarUrl)}" alt="${escHtml(u.username)}" style="width:40px;height:40px;border-radius:50%;object-fit:cover" />`
+    : `<div style="width:40px;height:40px;border-radius:50%;background:hsl(${hue},55%,45%);display:flex;align-items:center;justify-content:center;color:#fff;font-weight:700;font-size:18px;flex-shrink:0">${initial}</div>`;
+  return `<div class="user-card" style="display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3) 0;border-bottom:1px solid var(--border)">
+    <a href="/musehub/ui/users/${escHtml(u.username)}" style="flex-shrink:0">${avatar}</a>
+    <div style="flex:1;min-width:0">
+      <a href="/musehub/ui/users/${escHtml(u.username)}" style="font-weight:600">@${escHtml(u.username)}</a>
+      ${bio ? `<p style="margin:2px 0 0;font-size:13px;color:var(--fg-muted)">${bio}</p>` : ''}
+    </div>
+  </div>`;
+}
+
+async function loadFollowTab(tab) {
+  const container = document.getElementById('social-tab-content');
+  if (!container) return;
+  container.innerHTML = '<p class="loading">Loading…</p>';
+  try {
+    const url = tab === 'followers' ? API_FOLLOWERS : API_FOLLOWING;
+    const users = await fetch(url).then(r => r.json());
+    if (!Array.isArray(users) || users.length === 0) {
+      container.innerHTML = `<p class="loading">No ${tab} yet.</p>`;
+      return;
+    }
+    container.innerHTML = users.map(userCardHtml).join('');
+  } catch(e) {
+    container.innerHTML = `<p class="error">Failed to load ${tab}.</p>`;
+  }
+}
+
+function switchTab(tab) {
+  document.querySelectorAll('.social-tab-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.tab === tab);
+  });
+  loadFollowTab(tab);
+}
+
 async function loadFollowState() {
   try {
     const data = await fetch('/api/v1/musehub/users/' + username + '/followers', { headers: authHeaders() }).then(r => r.json());
     const countEl = document.getElementById('follower-count');
-    if (countEl) countEl.textContent = (data.follower_count || 0) + ' followers';
+    if (countEl) {
+      countEl.textContent = (data.follower_count || 0) + ' followers · ' + (data.following_count || 0) + ' following';
+    }
+    const followersTabBtn = document.getElementById('tab-btn-followers');
+    const followingTabBtn = document.getElementById('tab-btn-following');
+    if (followersTabBtn) followersTabBtn.textContent = 'Followers (' + (data.follower_count || 0) + ')';
+    if (followingTabBtn) followingTabBtn.textContent = 'Following (' + (data.following_count || 0) + ')';
     if (getToken() && document.getElementById('follow-btn')) {
       document.getElementById('follow-btn').style.display = '';
       document.getElementById('follow-btn').dataset.following = data.following ? 'true' : 'false';
@@ -139,6 +187,25 @@ async function load() {
       </p>
     </div>`;
 
+  const socialTabsSection = `
+    <div class="card" style="padding-bottom:0">
+      <div style="display:flex;gap:0;border-bottom:1px solid var(--border);margin:0 calc(-1 * var(--space-4))">
+        <button id="tab-btn-followers" class="social-tab-btn active" data-tab="followers"
+          onclick="switchTab('followers')"
+          style="padding:var(--space-2) var(--space-4);border:none;background:none;cursor:pointer;font-weight:600;color:var(--fg);border-bottom:2px solid transparent">
+          Followers
+        </button>
+        <button id="tab-btn-following" class="social-tab-btn" data-tab="following"
+          onclick="switchTab('following')"
+          style="padding:var(--space-2) var(--space-4);border:none;background:none;cursor:pointer;color:var(--fg-muted);border-bottom:2px solid transparent">
+          Following
+        </button>
+      </div>
+      <div id="social-tab-content" style="padding-top:var(--space-3)">
+        <p class="loading">Loading…</p>
+      </div>
+    </div>`;
+
   document.getElementById('content').innerHTML = `
     <div class="card profile-header">
       <div class="avatar">${avatarHtml}</div>
@@ -159,11 +226,26 @@ async function load() {
       </div>
     </div>
     ${pinnedSection}
+    ${socialTabsSection}
     ${graphSection}
     ${reposSection}
   `;
 }
 
-load();
+// Style active social tab button via JS since we're in a raw-string context
+document.addEventListener('click', e => {
+  if (e.target.classList.contains('social-tab-btn')) {
+    document.querySelectorAll('.social-tab-btn').forEach(b => {
+      b.style.borderBottomColor = 'transparent';
+      b.style.color = 'var(--fg-muted)';
+      b.style.fontWeight = '';
+    });
+    e.target.style.borderBottomColor = 'var(--color-accent)';
+    e.target.style.color = 'var(--fg)';
+    e.target.style.fontWeight = '600';
+  }
+});
+
+load().then(() => { loadFollowTab('followers'); });
 {% endraw %}
 {% endblock %}


### PR DESCRIPTION
## Summary
Closes #295 — Add following/followers tabs with user cards to the MuseHub profile page.

## Root Cause / Motivation
Profile page showed follower count but provided no way to browse the actual follower or following lists. MusehubFollow was seeded (24 relationships) but had no UI surface.

## Solution
- Added two new API endpoints (`GET /users/{username}/followers-list` and `GET /users/{username}/following-list`) returning `UserCardResponse` (username, bio, avatar_url). Both endpoints handle the dual-key convention in `MusehubFollow` rows (user_id keys from seed data, username keys from the live follow API) via OR queries.
- Extended `FollowResponse` with `following_count` so the profile header can show both "N followers · M following" at a glance.
- Added **Followers** and **Following** tabs below pinned repos in `profile.html` with avatar circles (initial + deterministic hsl colour), linked @username, bio preview (≤60 chars), and `switchTab()` / `loadFollowTab()` for tab switching.

## Verification
- [x] mypy clean (640 source files, 0 issues)
- [x] 10 new regression tests — all pass (follow-list endpoints, 404 paths, empty state, `following_count` field, tab/card JS presence in profile page)
- [x] Existing profile tests unaffected (16/16 pass)