### PR TITLE
feat(musehub): profile page — starred repos tab

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -1694,6 +1694,33 @@ forked, newest first.
 | `forks` | `list[UserForkedRepoEntry]` | Repos forked by this user |
 | `total` | `int` | Total number of forked repos |
 
+#### `UserStarredRepoEntry`
+
+**Path:** `maestro/models/musehub.py`
+**Endpoint:** `GET /api/v1/musehub/users/{username}/starred`
+
+A single starred-repo entry shown on a user's profile Starred tab. Combines
+the starred repo's full metadata with the star timestamp.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `star_id` | `str` | Internal UUID of the star relationship record |
+| `repo` | `RepoResponse` | Full metadata of the starred repo |
+| `starred_at` | `datetime` | ISO-8601 UTC timestamp when the user starred the repo |
+
+#### `UserStarredResponse`
+
+**Path:** `maestro/models/musehub.py`
+**Endpoint:** `GET /api/v1/musehub/users/{username}/starred`
+
+Returned by the public starred endpoint. Lists all repos that a given user has
+starred, newest first.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `starred` | `list[UserStarredRepoEntry]` | Repos starred by this user |
+| `total` | `int` | Total number of starred repos |
+
 #### `FollowResponse`
 
 **Path:** `maestro/api/routes/musehub/social.py`

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -1989,6 +1989,29 @@ class UserForksResponse(CamelModel):
     total: int = Field(..., description="Total number of forked repos")
 
 
+class UserStarredRepoEntry(CamelModel):
+    """A single starred-repo entry shown on a user's profile Starred tab.
+
+    Combines the starred repo's full metadata with the star timestamp so the
+    profile page can render the repo card with owner/slug linked and
+    "starred at {timestamp}" context.
+    """
+
+    star_id: str = Field(..., description="Internal UUID of the star relationship record")
+    repo: RepoResponse = Field(..., description="Full metadata of the starred repo")
+    starred_at: datetime = Field(..., description="Timestamp when the user starred the repo (ISO-8601 UTC)")
+
+
+class UserStarredResponse(CamelModel):
+    """Paginated list of repos starred by a user.
+
+    Returned by ``GET /api/v1/musehub/users/{username}/starred``.
+    """
+
+    starred: list[UserStarredRepoEntry] = Field(..., description="Repos starred by this user")
+    total: int = Field(..., description="Total number of starred repos")
+
+
 # ── Render pipeline ────────────────────────────────────────────────────────
 
 

--- a/maestro/templates/musehub/pages/profile.html
+++ b/maestro/templates/musehub/pages/profile.html
@@ -7,6 +7,7 @@
 const username        = {{ username | tojson }};
 const API_PROFILE     = '/api/v1/musehub/users/' + username;
 const API_FORKS       = '/api/v1/musehub/users/' + username + '/forks';
+const API_STARRED     = '/api/v1/musehub/users/' + username + '/starred';
 const API_FOLLOWERS   = '/api/v1/musehub/users/' + username + '/followers-list';
 const API_FOLLOWING   = '/api/v1/musehub/users/' + username + '/following-list';
 {% endblock %}
@@ -67,6 +68,43 @@ function forkedRepoCardHtml(entry) {
       &bull; forked from <a href="${sourceLink}">${escHtml(entry.sourceOwner)}/${escHtml(entry.sourceSlug)}</a>
     </div>
   </div>`;
+}
+
+function starredRepoCardHtml(entry) {
+  const r = entry.repo;
+  const key = r.keySignature ? escHtml(r.keySignature) : null;
+  const bpm = r.tempoBpm ? r.tempoBpm + ' BPM' : null;
+  const meta = [key, bpm].filter(Boolean).join(' &bull; ');
+  const starCount = typeof r.starCount !== 'undefined' ? r.starCount : '';
+  return `<div class="repo-card">
+    <h3><a href="/musehub/ui/${escHtml(r.owner)}/${escHtml(r.slug)}">${escHtml(r.owner)}/${escHtml(r.name)}</a></h3>
+    ${r.description ? `<p style="font-size:13px;color:var(--fg-muted);margin:4px 0">${escHtml(r.description)}</p>` : ''}
+    <div class="repo-meta">
+      <span class="badge badge-${r.visibility}">${r.visibility}</span>
+      ${meta ? '&bull; ' + meta : ''}
+      ${typeof starCount === 'number' ? `&bull; &#11088; ${starCount}` : ''}
+    </div>
+  </div>`;
+}
+
+async function loadStarredRepos() {
+  try {
+    const data = await fetch(API_STARRED).then(r => r.json());
+    const starred = data.starred || [];
+    const section = document.getElementById('starred-section');
+    if (!section) return;
+    if (starred.length === 0) {
+      section.innerHTML = '<div class="card"><p class="loading">No starred repositories yet.</p></div>';
+      return;
+    }
+    section.innerHTML = `<div class="card">
+      <h2 style="margin-bottom:12px">&#11088; Starred Repositories (${starred.length})</h2>
+      <div class="repo-grid">${starred.map(starredRepoCardHtml).join('')}</div>
+    </div>`;
+  } catch(e) {
+    const section = document.getElementById('starred-section');
+    if (section) section.innerHTML = '';
+  }
 }
 
 async function loadForkedRepos() {
@@ -263,8 +301,10 @@ async function load() {
     ${graphSection}
     ${reposSection}
     <div id="forked-section"></div>
+    <div id="starred-section"></div>
   `;
   loadForkedRepos();
+  loadStarredRepos();
 }
 
 // Style active social tab button via JS since we're in a raw-string context


### PR DESCRIPTION
## Summary
Closes #297 — adds a Starred tab to the profile page showing repos the user has starred.

## Root Cause / Motivation
MusehubStar (41 seeded rows) tracks user_id → repo_id but there was no UI or API to surface starred repos on the profile page.

## Solution
- New `GET /users/{username}/starred` endpoint returning `UserStarredResponse`
- `get_user_starred()` service function in `musehub_repository.py` (DB join: MusehubStar → MusehubRepo, newest first)
- `starred-section` div and `loadStarredRepos()` JS added to `profile.html` with repo cards matching the explore page style (owner/name linked, description, key, BPM, star count)
- `UserStarredRepoEntry` and `UserStarredResponse` registered in `docs/reference/type_contracts.md`

## Layers Affected
- [x] Muse Hub routes (`maestro/api/routes/musehub/users.py`)
- [x] Muse Hub services (`maestro/services/musehub_repository.py`)
- [x] Pydantic models (`maestro/models/musehub.py`)
- [x] Profile template (`maestro/templates/musehub/pages/profile.html`)

## Verification
- [x] `docker compose exec maestro mypy maestro/models/musehub.py maestro/services/musehub_repository.py maestro/api/routes/musehub/users.py` — clean
- [x] 6 targeted tests pass: `pytest tests/test_musehub_ui.py -k 'starred'`
- [x] Docs updated (`docs/reference/type_contracts.md`)

## Tests Added
- `test_profile_starred_repos_empty_list` — empty list when user has no stars
- `test_profile_starred_repos_returns_starred` — returns starred repos with full metadata
- `test_profile_starred_repos_404_for_unknown_user` — 404 for unknown user
- `test_profile_starred_repos_no_auth_required` — publicly accessible without JWT
- `test_profile_starred_repos_ordered_newest_first` — ordering newest first
- `test_profile_page_has_starred_section_js` — profile HTML includes starred JS and DOM elements

## Handoff
N/A — no SSE/MCP protocol change