### PR TITLE
refactor(musehub): extract listen-page audio scanning logic to musehub_listen service

### DIFF
--- a/docs/reference/type_contracts.md
+++ b/docs/reference/type_contracts.md
@@ -7849,7 +7849,7 @@ Full emotion map for a Muse repo ref. Returned by `GET /musehub/repos/{repo_id}/
 | `piano_roll_url` | `str \| None` | Absolute URL to the matching piano-roll image, if available |
 | `size_bytes` | `int` | File size in bytes |
 
-**Produced by:** `maestro.api.routes.musehub.repos.list_listen_tracks()` and `maestro.api.routes.musehub.ui.listen_page()`
+**Produced by:** `maestro.services.musehub_listen.build_track_listing()` (canonical). Route handlers `list_listen_tracks()` and `listen_page()` delegate to the service.
 **Consumed by:** MuseHub listen page (`/musehub/ui/{owner}/{repo_slug}/listen/{ref}`); AI agents enumerating audio stems
 
 ---
@@ -7868,7 +7868,7 @@ Full emotion map for a Muse repo ref. Returned by `GET /musehub/repos/{repo_id}/
 | `tracks` | `list[AudioTrackEntry]` | All audio artifacts at this ref, sorted by path |
 | `has_renders` | `bool` | True when at least one audio artifact exists at this ref |
 
-**Produced by:** `maestro.api.routes.musehub.repos.list_listen_tracks()` (`GET /api/v1/musehub/repos/{repo_id}/listen/{ref}/tracks`) and `maestro.api.routes.musehub.ui.listen_page()` (JSON content negotiation)
+**Produced by:** `maestro.services.musehub_listen.build_track_listing()` — the single canonical source of audio scanning logic. Both `maestro.api.routes.musehub.repos.list_listen_tracks()` (`GET /api/v1/musehub/repos/{repo_id}/listen/{ref}/tracks`) and `maestro.api.routes.musehub.ui.listen_page()` (JSON content negotiation) delegate to this service function.
 **Consumed by:** MuseHub listen page JS; AI agents that need to enumerate audio stems without visiting the UI
 
 ---

--- a/maestro/api/routes/musehub/repos.py
+++ b/maestro/api/routes/musehub/repos.py
@@ -70,7 +70,7 @@ from maestro.models.musehub_context import (
     ContextDepth,
     ContextFormat,
 )
-from maestro.services import musehub_analysis, musehub_context, musehub_credits, musehub_divergence, musehub_events, musehub_releases, musehub_repository, musehub_sessions
+from maestro.services import musehub_analysis, musehub_context, musehub_credits, musehub_divergence, musehub_events, musehub_listen, musehub_releases, musehub_repository, musehub_sessions
 from maestro.services.muse_groove_check import (
     DEFAULT_THRESHOLD,
     compute_groove_check,
@@ -999,8 +999,6 @@ async def list_listen_tracks(
     The ``has_renders`` flag distinguishes repos with no audio from repos that
     have audio but no recognised full-mix file.
     """
-    from maestro.services import musehub_listen
-
     repo = await musehub_repository.get_repo(db, repo_id)
     _guard_visibility(repo, claims)
 

--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -89,7 +89,7 @@ from maestro.models.musehub import (
     TagListResponse,
     TagResponse,
 )
-from maestro.services import musehub_divergence, musehub_pull_requests, musehub_releases
+from maestro.services import musehub_divergence, musehub_listen, musehub_pull_requests, musehub_releases
 from maestro.services import musehub_repository
 
 logger = logging.getLogger(__name__)
@@ -771,8 +771,6 @@ async def listen_page(
     action rather than an empty list, so musicians know what to do next.
     No JWT required — the HTML shell's JS handles auth for private repos.
     """
-    from maestro.services import musehub_listen
-
     repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
     json_data = await musehub_listen.build_track_listing(db, repo_id, ref)
 

--- a/maestro/services/musehub_listen.py
+++ b/maestro/services/musehub_listen.py
@@ -1,0 +1,141 @@
+"""Muse Hub listen-page audio scanning service.
+
+Single source of truth for the audio-track scanning and ``TrackListingResponse``
+construction logic shared between:
+
+- ``GET /musehub/repos/{repo_id}/listen/{ref}/tracks``  (repos.py)
+- ``GET /musehub/ui/{owner}/{repo_slug}/listen/{ref}``  (ui.py)
+
+Why this module exists
+----------------------
+Prior to extraction, ``_AUDIO_EXTENSIONS``, ``_IMAGE_EXTENSIONS``,
+``_FULL_MIX_KEYWORDS``, and the ``AudioTrackEntry`` construction loop were
+duplicated between the two handlers.  Any change (e.g. adding ``.aiff`` support)
+had to be made in two places, creating a divergence risk.
+
+This service owns all of that logic.  Both handlers are now thin call-through
+wrappers around ``build_track_listing()``.
+"""
+from __future__ import annotations
+
+import os
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.models.musehub import AudioTrackEntry, TrackListingResponse
+from maestro.services import musehub_repository
+
+# ---------------------------------------------------------------------------
+# Shared constants — single source of truth for all listen-page handlers
+# ---------------------------------------------------------------------------
+
+_AUDIO_EXTENSIONS: frozenset[str] = frozenset({".mp3", ".ogg", ".wav", ".m4a", ".flac"})
+_IMAGE_EXTENSIONS: frozenset[str] = frozenset({".webp", ".png", ".jpg", ".jpeg"})
+_FULL_MIX_KEYWORDS: tuple[str, ...] = ("mix", "full", "master", "bounce")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_audio(path: str) -> bool:
+    """Return True when the path extension is a recognised audio format."""
+    return os.path.splitext(path)[1].lower() in _AUDIO_EXTENSIONS
+
+
+def _piano_roll_url(path: str, object_map: dict[str, str], repo_id: str) -> str | None:
+    """Return an absolute content URL for a matching piano-roll image, or None.
+
+    Looks for an image file (e.g. ``.webp``) whose basename (without extension)
+    matches the audio file's basename — a naming convention produced by the
+    Stori DAW when exporting piano-roll snapshots alongside audio stems.
+    """
+    stem = os.path.splitext(os.path.basename(path))[0]
+    for obj_path, obj_id in object_map.items():
+        ext = os.path.splitext(obj_path)[1].lower()
+        if ext in _IMAGE_EXTENSIONS and os.path.splitext(os.path.basename(obj_path))[0] == stem:
+            return f"/api/v1/musehub/repos/{repo_id}/objects/{obj_id}/content"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public service function
+# ---------------------------------------------------------------------------
+
+
+async def build_track_listing(
+    db: AsyncSession,
+    repo_id: str,
+    ref: str,
+) -> TrackListingResponse:
+    """Scan a repo's stored objects and build the listen-page track listing.
+
+    Fetches all object metadata for ``repo_id`` from the database, filters to
+    audio files, determines a full-mix candidate (preferring files whose
+    basename contains a mix/master keyword, falling back to the first audio
+    file alphabetically), and constructs one ``AudioTrackEntry`` per audio
+    artifact.
+
+    This function performs **no auth or visibility checks** — callers are
+    responsible for guarding access before invoking this service.
+
+    Args:
+        db: Active async database session.
+        repo_id: Internal UUID string for the target repo.
+        ref: Commit ref or branch name being listed (threaded through into
+            the response for client correlation only — not used for filtering).
+
+    Returns:
+        ``TrackListingResponse`` with ``has_renders=False`` when no audio
+        artifacts exist, or a fully-populated listing when audio is present.
+    """
+    objects = await musehub_repository.list_objects(db, repo_id)
+
+    object_map: dict[str, str] = {obj.path: obj.object_id for obj in objects}
+
+    audio_objects = sorted(
+        [obj for obj in objects if _is_audio(obj.path)],
+        key=lambda o: o.path,
+    )
+
+    if not audio_objects:
+        return TrackListingResponse(
+            repo_id=repo_id,
+            ref=ref,
+            full_mix_url=None,
+            tracks=[],
+            has_renders=False,
+        )
+
+    def _audio_url(object_id: str) -> str:
+        return f"/api/v1/musehub/repos/{repo_id}/objects/{object_id}/content"
+
+    full_mix_obj = next(
+        (
+            o
+            for o in audio_objects
+            if any(kw in os.path.basename(o.path).lower() for kw in _FULL_MIX_KEYWORDS)
+        ),
+        audio_objects[0],
+    )
+
+    tracks = [
+        AudioTrackEntry(
+            name=os.path.splitext(os.path.basename(obj.path))[0],
+            path=obj.path,
+            object_id=obj.object_id,
+            audio_url=_audio_url(obj.object_id),
+            piano_roll_url=_piano_roll_url(obj.path, object_map, repo_id),
+            size_bytes=obj.size_bytes,
+        )
+        for obj in audio_objects
+    ]
+
+    return TrackListingResponse(
+        repo_id=repo_id,
+        ref=ref,
+        full_mix_url=_audio_url(full_mix_obj.object_id),
+        tracks=tracks,
+        has_renders=True,
+    )

--- a/tests/test_musehub_ui.py
+++ b/tests/test_musehub_ui.py
@@ -4584,6 +4584,140 @@ async def test_listen_page_json_response(
     assert isinstance(body["tracks"], list)
 
 
+# ---------------------------------------------------------------------------
+# Issue #366 — musehub_listen service function (direct unit tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_track_listing_returns_full_mix_and_tracks(
+    db_session: AsyncSession,
+) -> None:
+    """build_track_listing() returns a populated TrackListingResponse with mix + stems."""
+    from maestro.services.musehub_listen import build_track_listing
+
+    repo = MusehubRepo(
+        name="svc-listen-test",
+        owner="svcuser",
+        slug="svc-listen-test",
+        visibility="public",
+        owner_user_id="svc-owner",
+    )
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    repo_id = str(repo.repo_id)
+
+    for path, size in [
+        ("mix/full_mix.mp3", 204800),
+        ("tracks/bass.mp3", 51200),
+        ("tracks/keys.mp3", 61440),
+        ("tracks/bass.webp", 8192),
+    ]:
+        obj = MusehubObject(
+            object_id=f"sha256:svc_{path.replace('/', '_')}",
+            repo_id=repo_id,
+            path=path,
+            size_bytes=size,
+            disk_path=f"/tmp/svc_{path.replace('/', '_')}",
+        )
+        db_session.add(obj)
+    await db_session.commit()
+
+    result = await build_track_listing(db_session, repo_id, "main")
+
+    assert result.has_renders is True
+    assert result.repo_id == repo_id
+    assert result.ref == "main"
+    # full-mix URL points to the mix file (contains "mix" keyword)
+    assert result.full_mix_url is not None
+    assert "full_mix" in result.full_mix_url or "mix" in result.full_mix_url
+    # Two audio tracks (bass.mp3 + keys.mp3); bass.webp is not audio
+    assert len(result.tracks) == 3  # mix/full_mix.mp3, tracks/bass.mp3, tracks/keys.mp3
+    track_paths = {t.path for t in result.tracks}
+    assert "tracks/bass.mp3" in track_paths
+    assert "tracks/keys.mp3" in track_paths
+    # Piano-roll URL attached to bass.mp3 (matching bass.webp exists)
+    bass_track = next(t for t in result.tracks if t.path == "tracks/bass.mp3")
+    assert bass_track.piano_roll_url is not None
+
+
+@pytest.mark.anyio
+async def test_build_track_listing_no_audio_returns_empty(
+    db_session: AsyncSession,
+) -> None:
+    """build_track_listing() returns has_renders=False when no audio objects exist."""
+    from maestro.services.musehub_listen import build_track_listing
+
+    repo = MusehubRepo(
+        name="svc-silent-test",
+        owner="svcuser",
+        slug="svc-silent-test",
+        visibility="public",
+        owner_user_id="svc-owner",
+    )
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    repo_id = str(repo.repo_id)
+
+    # Only a non-audio object
+    obj = MusehubObject(
+        object_id="sha256:svc_midi",
+        repo_id=repo_id,
+        path="tracks/bass.mid",
+        size_bytes=1024,
+        disk_path="/tmp/svc_bass.mid",
+    )
+    db_session.add(obj)
+    await db_session.commit()
+
+    result = await build_track_listing(db_session, repo_id, "dev")
+
+    assert result.has_renders is False
+    assert result.full_mix_url is None
+    assert result.tracks == []
+
+
+@pytest.mark.anyio
+async def test_build_track_listing_no_mix_keyword_uses_first_alphabetically(
+    db_session: AsyncSession,
+) -> None:
+    """When no file matches _FULL_MIX_KEYWORDS, the first audio file (by path) is used."""
+    from maestro.services.musehub_listen import build_track_listing
+
+    repo = MusehubRepo(
+        name="svc-nomix-test",
+        owner="svcuser",
+        slug="svc-nomix-test",
+        visibility="public",
+        owner_user_id="svc-owner",
+    )
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    repo_id = str(repo.repo_id)
+
+    for path, size in [
+        ("tracks/bass.mp3", 51200),
+        ("tracks/drums.mp3", 61440),
+    ]:
+        obj = MusehubObject(
+            object_id=f"sha256:svc_nomix_{path.replace('/', '_')}",
+            repo_id=repo_id,
+            path=path,
+            size_bytes=size,
+            disk_path=f"/tmp/svc_nomix_{path.replace('/', '_')}",
+        )
+        db_session.add(obj)
+    await db_session.commit()
+
+    result = await build_track_listing(db_session, repo_id, "main")
+
+    assert result.has_renders is True
+    # 'tracks/bass.mp3' sorts before 'tracks/drums.mp3'
+    assert result.full_mix_url is not None
+    assert "bass" in result.full_mix_url
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes #366 — extracts duplicated audio track scanning logic into a shared service function.

## Root Cause / Motivation
Follow-up from PR #356 (grade B). `_AUDIO_EXTENSIONS`, `_IMAGE_EXTENSIONS`, `_FULL_MIX_KEYWORDS` and the `AudioTrackEntry` construction loop were duplicated between `repos.py` and `ui.py`. Any future change (e.g. adding `.aiff` support) required two edits.

## Solution
- **New** `maestro/services/musehub_listen.py` with shared constants and `build_track_listing(db, repo_id, ref) → TrackListingResponse`
- `list_listen_tracks()` in `repos.py` is now a thin wrapper: guards visibility, then calls the service
- `listen_page()` in `ui.py` is now a thin wrapper: resolves `repo_id`, then calls the service
- `AudioTrackEntry` and `TrackListingResponse` docs in `type_contracts.md` updated to reference the canonical service

## Layers Affected
- [x] Services (`maestro/services/musehub_listen.py` — new)
- [x] Routes (`maestro/api/routes/musehub/repos.py`, `ui.py` — refactored, no contract change)

## Verification
- [x] `mypy` clean (pre-existing 2 errors in unrelated test files unchanged)
- [x] All 16 existing listen-page tests pass
- [x] 3 new direct service function tests added and passing

## Tests Added
- `test_build_track_listing_returns_full_mix_and_tracks` — happy path: mix keyword detected, piano-roll URL matched
- `test_build_track_listing_no_audio_returns_empty` — has_renders=False when no audio objects
- `test_build_track_listing_no_mix_keyword_uses_first_alphabetically` — fallback to first-by-path when no mix keyword

## Handoff
N/A — no SSE/MCP protocol change. No API contract change. Route signatures and response shapes unchanged.