### PR TITLE
chore(agents): pull dev in main repo after each PR review merge

### DIFF
--- a/.cursor/PARALLEL_PR_REVIEW.md
+++ b/.cursor/PARALLEL_PR_REVIEW.md
@@ -582,6 +582,13 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
       gh attempts to checkout dev locally to delete the feature branch, but dev
       is already checked out in the main worktree and git will refuse.
 
+  # 8. Pull the merge into the main repo's local dev — so the coordinator's
+  #    working copy reflects reality and the next batch starts from the true tip.
+  #    This is the step that prevents "relation does not exist" DB errors when the
+  #    coordinator tries to apply migrations before fetching.
+  git -C "$REPO" fetch origin
+  git -C "$REPO" merge origin/dev
+
 STEP 7 — SELF-DESTRUCT (always run this, merge or not, early stop or not):
   WORKTREE=$(pwd)
   cd "$REPO"


### PR DESCRIPTION
## Summary
Adds step 6.8 to the PR review agent cleanup protocol in \`.cursor/PARALLEL_PR_REVIEW.md\`.

## Root Cause / Motivation
After squash-merging a PR, the agent deletes the feature branch and closes the issue but never updates the main repo's local \`dev\` checkout. The coordinator's \`dev\` ref drifts behind origin/dev, which causes errors (e.g. \`relation "musehub_repos" does not exist\`) when the coordinator tries to apply migrations before running \`git fetch\`. This was a silent gap: everything on GitHub was correct but the local disk was stale.

## Solution
Added a single \`git -C "$REPO" fetch origin && git -C "$REPO" merge origin/dev\` block as step 6.8 — runs immediately after issue closure, before self-destruct. The coordinator's working tree now always reflects the true dev tip after each agent cycle completes.