### PR TITLE
chore(db): prefix all table names by subsystem (maestro_, muse_, musehub_)

### DIFF
--- a/maestro/db/models.py
+++ b/maestro/db/models.py
@@ -2,12 +2,12 @@
 SQLAlchemy ORM models for Maestro.
 
 Tables:
-- users: User accounts with budget tracking
-- usage_logs: Request history with prompts and costs
-- access_tokens: JWT token tracking for revocation
-- conversations: Conversation threads per user
-- conversation_messages: Messages within conversations
-- message_actions: Actions performed during message execution
+- maestro_users: User accounts with budget tracking
+- maestro_usage_logs: Request history with prompts and costs
+- maestro_access_tokens: JWT token tracking for revocation
+- maestro_conversations: Conversation threads per user
+- maestro_conversation_messages: Messages within conversations
+- maestro_message_actions: Actions performed during message execution
 """
 from __future__ import annotations
 
@@ -52,7 +52,7 @@ class User(Base):
     and as X-Device-ID on asset requests; the JWT sub claim should be this same
     UUID so one identity is used everywhere. Budget is tracked in cents.
     """
-    __tablename__ = "users"
+    __tablename__ = "maestro_users"
 
     # Primary key = device UUID (app-generated, single identifier for this user)
     id: Mapped[str] = mapped_column(
@@ -128,7 +128,7 @@ class UsageLog(Base):
     Prompts are stored for training data unless the user opts out.
     Cost is tracked in cents for precision.
     """
-    __tablename__ = "usage_logs"
+    __tablename__ = "maestro_usage_logs"
     
     id: Mapped[str] = mapped_column(
         String(36),
@@ -139,7 +139,7 @@ class UsageLog(Base):
     # Foreign key to user
     user_id: Mapped[str] = mapped_column(
         String(36),
-        ForeignKey("users.id", ondelete="CASCADE"),
+        ForeignKey("maestro_users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
@@ -204,7 +204,7 @@ class AccessToken(Base):
     
     Stores a hash of the JWT token (not the token itself) for security.
     """
-    __tablename__ = "access_tokens"
+    __tablename__ = "maestro_access_tokens"
     
     id: Mapped[str] = mapped_column(
         String(36),
@@ -215,7 +215,7 @@ class AccessToken(Base):
     # Foreign key to user
     user_id: Mapped[str] = mapped_column(
         String(36),
-        ForeignKey("users.id", ondelete="CASCADE"),
+        ForeignKey("maestro_users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
@@ -261,7 +261,7 @@ class Conversation(Base):
     Each user can have multiple conversations, each containing
     a history of messages with the AI assistant.
     """
-    __tablename__ = "conversations"
+    __tablename__ = "maestro_conversations"
     
     id: Mapped[str] = mapped_column(
         String(36),
@@ -272,7 +272,7 @@ class Conversation(Base):
     # Foreign key to user
     user_id: Mapped[str] = mapped_column(
         String(36),
-        ForeignKey("users.id", ondelete="CASCADE"),
+        ForeignKey("maestro_users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
@@ -338,7 +338,7 @@ class ConversationMessage(Base):
     Stores user prompts and assistant responses, including
     token usage, costs, and tool calls.
     """
-    __tablename__ = "conversation_messages"
+    __tablename__ = "maestro_conversation_messages"
     
     id: Mapped[str] = mapped_column(
         String(36),
@@ -349,7 +349,7 @@ class ConversationMessage(Base):
     # Foreign key to conversation
     conversation_id: Mapped[str] = mapped_column(
         String(36),
-        ForeignKey("conversations.id", ondelete="CASCADE"),
+        ForeignKey("maestro_conversations.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
@@ -438,7 +438,7 @@ class MessageAction(Base):
     Tracks tool calls and their outcomes (track added, region created, etc.)
     for audit trail and potential undo/redo functionality.
     """
-    __tablename__ = "message_actions"
+    __tablename__ = "maestro_message_actions"
     
     id: Mapped[str] = mapped_column(
         String(36),
@@ -449,7 +449,7 @@ class MessageAction(Base):
     # Foreign key to message
     message_id: Mapped[str] = mapped_column(
         String(36),
-        ForeignKey("conversation_messages.id", ondelete="CASCADE"),
+        ForeignKey("maestro_conversation_messages.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )

--- a/maestro/db/muse_models.py
+++ b/maestro/db/muse_models.py
@@ -1,9 +1,9 @@
 """SQLAlchemy ORM models for Muse persistent variation history.
 
 Tables:
-- variations: Top-level variation proposals with lineage tracking
-- phrases: Independently reviewable musical phrases within a variation
-- note_changes: Individual note-level diffs within a phrase
+- muse_variations: Top-level variation proposals with lineage tracking
+- muse_phrases: Independently reviewable musical phrases within a variation
+- muse_note_changes: Individual note-level diffs within a phrase
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ from maestro.db.models import generate_uuid, utc_now
 class Variation(Base):
     """A persisted variation proposal with lineage tracking."""
 
-    __tablename__ = "variations"
+    __tablename__ = "muse_variations"
 
     variation_id: Mapped[str] = mapped_column(String(36), primary_key=True)
     project_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
@@ -38,13 +38,13 @@ class Variation(Base):
     # ── Lineage (Phase 5) ────────────────────────────────────────────
     parent_variation_id: Mapped[str | None] = mapped_column(
         String(36),
-        ForeignKey("variations.variation_id", ondelete="SET NULL"),
+        ForeignKey("muse_variations.variation_id", ondelete="SET NULL"),
         nullable=True,
         index=True,
     )
     parent2_variation_id: Mapped[str | None] = mapped_column(
         String(36),
-        ForeignKey("variations.variation_id", ondelete="SET NULL"),
+        ForeignKey("muse_variations.variation_id", ondelete="SET NULL"),
         nullable=True,
     )
     commit_state_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
@@ -77,12 +77,12 @@ class Variation(Base):
 class Phrase(Base):
     """A persisted musical phrase within a variation."""
 
-    __tablename__ = "phrases"
+    __tablename__ = "muse_phrases"
 
     phrase_id: Mapped[str] = mapped_column(String(36), primary_key=True)
     variation_id: Mapped[str] = mapped_column(
         String(36),
-        ForeignKey("variations.variation_id", ondelete="CASCADE"),
+        ForeignKey("muse_variations.variation_id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
@@ -116,12 +116,12 @@ class Phrase(Base):
 class NoteChange(Base):
     """A persisted note-level diff within a phrase."""
 
-    __tablename__ = "note_changes"
+    __tablename__ = "muse_note_changes"
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
     phrase_id: Mapped[str] = mapped_column(
         String(36),
-        ForeignKey("phrases.phrase_id", ondelete="CASCADE"),
+        ForeignKey("muse_phrases.phrase_id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )

--- a/maestro/muse_cli/models.py
+++ b/maestro/muse_cli/models.py
@@ -1,16 +1,16 @@
-"""SQLAlchemy ORM models for Muse CLI commit history.
+"""SQLAlchemy ORM models for Muse commit history.
 
 Tables:
-- muse_cli_objects: content-addressed file blobs (sha256 keyed)
-- muse_cli_snapshots: snapshot manifests mapping paths to object IDs
-- muse_cli_commits: commit history with parent linkage, branch tracking,
+- muse_objects: content-addressed file blobs (sha256 keyed)
+- muse_snapshots: snapshot manifests mapping paths to object IDs
+- muse_commits: commit history with parent linkage, branch tracking,
   and an extensible ``extra_metadata`` JSON blob for annotations such as
   meter (time signature), tempo, key, and other compositional metadata.
-- muse_cli_tags: music-semantic tags attached to commits
+- muse_tags: music-semantic tags attached to commits
 
 These tables are owned by the Muse CLI (``muse commit``) and are
-distinct from the Muse VCS variation tables (``variations``, ``phrases``,
-``note_changes``) which track DAW-level note editing history.
+distinct from the Muse variation tables (``muse_variations``, ``muse_phrases``,
+``muse_note_changes``) which track DAW-level note editing history.
 
 ``muse_cli_commits.metadata`` is an extensible JSON blob for commit-level
 annotations.  Current keys:
@@ -42,7 +42,7 @@ class MuseCliObject(Base):
     two different branches is stored exactly once.
     """
 
-    __tablename__ = "muse_cli_objects"
+    __tablename__ = "muse_objects"
 
     object_id: Mapped[str] = mapped_column(String(64), primary_key=True)
     size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -61,7 +61,7 @@ class MuseCliSnapshot(Base):
     Content-addressed: two identical working trees produce the same snapshot_id.
     """
 
-    __tablename__ = "muse_cli_snapshots"
+    __tablename__ = "muse_snapshots"
 
     snapshot_id: Mapped[str] = mapped_column(String(64), primary_key=True)
     manifest: Mapped[dict[str, str]] = mapped_column(JSON, nullable=False)
@@ -85,7 +85,7 @@ class MuseCliCommit(Base):
     is the wall-clock DB write time and is non-deterministic.
     """
 
-    __tablename__ = "muse_cli_commits"
+    __tablename__ = "muse_commits"
 
     commit_id: Mapped[str] = mapped_column(String(64), primary_key=True)
     repo_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
@@ -98,7 +98,7 @@ class MuseCliCommit(Base):
     )
     snapshot_id: Mapped[str] = mapped_column(
         String(64),
-        ForeignKey("muse_cli_snapshots.snapshot_id", ondelete="RESTRICT"),
+        ForeignKey("muse_snapshots.snapshot_id", ondelete="RESTRICT"),
         nullable=False,
     )
     message: Mapped[str] = mapped_column(Text, nullable=False)
@@ -135,7 +135,7 @@ class MuseCliTag(Base):
     repo so that different local repos can use independent tag spaces.
     """
 
-    __tablename__ = "muse_cli_tags"
+    __tablename__ = "muse_tags"
 
     tag_id: Mapped[str] = mapped_column(
         String(36), primary_key=True, default=lambda: str(uuid.uuid4())
@@ -143,7 +143,7 @@ class MuseCliTag(Base):
     repo_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
     commit_id: Mapped[str] = mapped_column(
         String(64),
-        ForeignKey("muse_cli_commits.commit_id", ondelete="CASCADE"),
+        ForeignKey("muse_commits.commit_id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )


### PR DESCRIPTION
## Summary

Replaces the inconsistent mix of unprefixed and prefixed table names with a uniform three-namespace scheme:

| Prefix | Subsystem | Tables |
|---|---|---|
| `maestro_` | Auth, usage, conversations | `maestro_users`, `maestro_usage_logs`, `maestro_access_tokens`, `maestro_conversations`, `maestro_conversation_messages`, `maestro_message_actions` |
| `muse_` | Muse (variation history + commit pipeline) | `muse_variations`, `muse_phrases`, `muse_note_changes`, `muse_objects`, `muse_snapshots`, `muse_commits`, `muse_tags` |
| `musehub_` | Muse Hub (remote collaboration) | All `musehub_*` — unchanged |

**Bonus fix:** adds the missing `musehub_pr_comments` table to the migration (it existed in the ORM and routes but was never in `0001_consolidated_schema.py`, which would break a fresh install).

## Verified

```
docker compose build --no-cache
docker compose up -d
alembic current → 0001 (head)
\dt → 39 tables, all correctly prefixed
maestro-app → Up (healthy)
```