### PR TITLE
feat(db): add musehub_collaborators table for repo access control

### DIFF
--- a/alembic/versions/0004_collaborators.py
+++ b/alembic/versions/0004_collaborators.py
@@ -1,0 +1,55 @@
+"""Add musehub_collaborators table for repo access control.
+
+Revision ID: 0004_collaborators
+Revises: 0003_labels
+Create Date: 2026-02-28 00:00:00.000000
+
+Creates the musehub_collaborators table which tracks users granted explicit
+push/admin access to a repo beyond the owner.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0004_collaborators"
+down_revision = "0003_labels"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "musehub_collaborators",
+        sa.Column("id", sa.String(36), nullable=False),
+        sa.Column("repo_id", sa.String(36), nullable=False),
+        sa.Column("user_id", sa.String(36), nullable=False),
+        sa.Column("permission", sa.String(20), nullable=False, server_default="write"),
+        sa.Column("invited_by", sa.String(36), nullable=True),
+        sa.Column(
+            "invited_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("accepted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["repo_id"], ["musehub_repos.repo_id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["maestro_users.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["invited_by"], ["maestro_users.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("repo_id", "user_id", name="uq_musehub_collaborators_repo_user"),
+    )
+    op.create_index("ix_musehub_collaborators_repo_id", "musehub_collaborators", ["repo_id"])
+    op.create_index("ix_musehub_collaborators_user_id", "musehub_collaborators", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_musehub_collaborators_user_id", table_name="musehub_collaborators")
+    op.drop_index("ix_musehub_collaborators_repo_id", table_name="musehub_collaborators")
+    op.drop_table("musehub_collaborators")

--- a/maestro/db/musehub_collaborator_models.py
+++ b/maestro/db/musehub_collaborator_models.py
@@ -1,0 +1,65 @@
+"""SQLAlchemy ORM model for Muse Hub collaborators.
+
+Collaborators are users granted explicit push/admin access to a repo beyond
+the owner. Permission levels: read | write | admin (default: write).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from maestro.db.database import Base
+
+
+def _new_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+class MusehubCollaborator(Base):
+    """A collaborator record granting a user explicit access to a repo.
+
+    ``permission`` is one of "read" | "write" | "admin"; defaults to "write".
+    ``invited_by`` references the user who extended the invitation (nullable —
+    some collaborators may be added programmatically without an inviter).
+    ``accepted_at`` is null until the invited user explicitly accepts.
+    """
+
+    __tablename__ = "musehub_collaborators"
+    __table_args__ = (
+        UniqueConstraint("repo_id", "user_id", name="uq_musehub_collaborators_repo_user"),
+        Index("ix_musehub_collaborators_repo_id", "repo_id"),
+        Index("ix_musehub_collaborators_user_id", "user_id"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    repo_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("musehub_repos.repo_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("maestro_users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # Permission level: "read" | "write" | "admin"
+    permission: Mapped[str] = mapped_column(String(20), nullable=False, default="write")
+    invited_by: Mapped[str | None] = mapped_column(
+        String(36),
+        ForeignKey("maestro_users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    invited_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+    # Null until the invited user accepts the invitation
+    accepted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )


### PR DESCRIPTION
## Summary
Closes #407 — adds Alembic migration and SQLAlchemy ORM model for musehub_collaborators.

## Changes
- `alembic/versions/0004_collaborators.py` — new migration, down_revision = 0003_labels
- `maestro/db/musehub_collaborator_models.py` — MusehubCollaborator ORM model

## Merge order dependency
This migration depends on #403 (0003_labels). Merge in order: #402 → #403 → #407.

## Verification
- [ ] mypy clean
- [ ] Migration upgrade/downgrade reviewed