### PR TITLE
feat(db): add musehub_labels, musehub_issue_labels, and musehub_pr_labels tables

### DIFF
--- a/alembic/versions/0003_labels.py
+++ b/alembic/versions/0003_labels.py
@@ -1,0 +1,100 @@
+"""Add musehub_labels, musehub_issue_labels, and musehub_pr_labels tables.
+
+Revision ID: 0003_labels
+Revises: 0002_milestones
+Create Date: 2026-02-28 00:00:00.000000
+
+Adds coloured label tags that can be applied to issues and pull requests
+for categorisation. Three tables:
+
+  musehub_labels           — label definitions per repo (name, hex colour)
+  musehub_issue_labels     — many-to-many join: issues ↔ labels
+  musehub_pr_labels        — many-to-many join: pull requests ↔ labels
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0003_labels"
+down_revision = "0002_milestones"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "musehub_labels",
+        sa.Column("id", sa.String(36), nullable=False),
+        sa.Column("repo_id", sa.String(36), nullable=False),
+        sa.Column("name", sa.String(50), nullable=False),
+        sa.Column("color", sa.String(7), nullable=False),
+        sa.Column("description", sa.String(200), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["repo_id"],
+            ["musehub_repos.repo_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("repo_id", "name", name="uq_musehub_labels_repo_name"),
+    )
+    op.create_index("ix_musehub_labels_repo_id", "musehub_labels", ["repo_id"])
+
+    op.create_table(
+        "musehub_issue_labels",
+        sa.Column("issue_id", sa.String(36), nullable=False),
+        sa.Column("label_id", sa.String(36), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["issue_id"],
+            ["musehub_issues.issue_id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["label_id"],
+            ["musehub_labels.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("issue_id", "label_id"),
+    )
+    op.create_index(
+        "ix_musehub_issue_labels_label_id", "musehub_issue_labels", ["label_id"]
+    )
+
+    op.create_table(
+        "musehub_pr_labels",
+        sa.Column("pr_id", sa.String(36), nullable=False),
+        sa.Column("label_id", sa.String(36), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["pr_id"],
+            ["musehub_pull_requests.pr_id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["label_id"],
+            ["musehub_labels.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("pr_id", "label_id"),
+    )
+    op.create_index(
+        "ix_musehub_pr_labels_label_id", "musehub_pr_labels", ["label_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_musehub_pr_labels_label_id", table_name="musehub_pr_labels")
+    op.drop_table("musehub_pr_labels")
+
+    op.drop_index(
+        "ix_musehub_issue_labels_label_id", table_name="musehub_issue_labels"
+    )
+    op.drop_table("musehub_issue_labels")
+
+    op.drop_index("ix_musehub_labels_repo_id", table_name="musehub_labels")
+    op.drop_table("musehub_labels")

--- a/maestro/db/musehub_label_models.py
+++ b/maestro/db/musehub_label_models.py
@@ -1,0 +1,116 @@
+"""SQLAlchemy ORM models for Muse Hub label tables.
+
+Tables:
+- musehub_labels: Coloured label definitions scoped to a repo
+- musehub_issue_labels: Many-to-many join between issues and labels
+- musehub_pr_labels: Many-to-many join between pull requests and labels
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from maestro.db.database import Base
+
+
+def _new_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+class MusehubLabel(Base):
+    """A coloured label tag that can be applied to issues and pull requests.
+
+    Labels are scoped to a repo — the same name may exist across repos with
+    different colours. The UNIQUE(repo_id, name) constraint enforces uniqueness
+    within a repo. ``color`` stores a hex string like ``#d73a4a``.
+    """
+
+    __tablename__ = "musehub_labels"
+    __table_args__ = (
+        UniqueConstraint("repo_id", "name", name="uq_musehub_labels_repo_name"),
+        Index("ix_musehub_labels_repo_id", "repo_id"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    repo_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("musehub_repos.repo_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(50), nullable=False)
+    # Hex colour string, e.g. "#d73a4a"
+    color: Mapped[str] = mapped_column(String(7), nullable=False)
+    description: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utc_now
+    )
+
+    issue_labels: Mapped[list[MusehubIssueLabel]] = relationship(
+        "MusehubIssueLabel", back_populates="label", cascade="all, delete-orphan"
+    )
+    pr_labels: Mapped[list[MusehubPRLabel]] = relationship(
+        "MusehubPRLabel", back_populates="label", cascade="all, delete-orphan"
+    )
+
+
+class MusehubIssueLabel(Base):
+    """Join table linking issues to labels.
+
+    Composite primary key on (issue_id, label_id). Both sides cascade-delete
+    so removing an issue or a label automatically cleans up the association.
+    """
+
+    __tablename__ = "musehub_issue_labels"
+    __table_args__ = (
+        Index("ix_musehub_issue_labels_label_id", "label_id"),
+    )
+
+    issue_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("musehub_issues.issue_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    label_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("musehub_labels.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+    label: Mapped[MusehubLabel] = relationship(
+        "MusehubLabel", back_populates="issue_labels"
+    )
+
+
+class MusehubPRLabel(Base):
+    """Join table linking pull requests to labels.
+
+    Composite primary key on (pr_id, label_id). Both sides cascade-delete
+    so removing a PR or a label automatically cleans up the association.
+    """
+
+    __tablename__ = "musehub_pr_labels"
+    __table_args__ = (
+        Index("ix_musehub_pr_labels_label_id", "label_id"),
+    )
+
+    pr_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("musehub_pull_requests.pr_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    label_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("musehub_labels.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+    label: Mapped[MusehubLabel] = relationship(
+        "MusehubLabel", back_populates="pr_labels"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,5 +79,11 @@ ignore_missing_imports = true
 module = ["boto3", "botocore.*", "gradio_client", "mido", "yaml"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+# lint_migration and stress_test are injected via sys.path at test-time (tools/ and scripts/e2e/).
+# They are not importable at mypy's analysis phase, so suppress the missing-import error.
+module = ["lint_migration", "stress_test"]
+ignore_missing_imports = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["maestro"]


### PR DESCRIPTION
## Summary
Closes #403 — adds Alembic migration and SQLAlchemy ORM models for musehub_labels, musehub_issue_labels, and musehub_pr_labels.

## Changes
- `alembic/versions/0003_labels.py` — new migration, down_revision = 0002_milestones
- `maestro/db/musehub_label_models.py` — MusehubLabel, MusehubIssueLabel, MusehubPRLabel ORM models

## Merge order dependency
This migration depends on #402 (0002_milestones). Merge #402 first.

## Verification
- [ ] mypy clean
- [ ] Migration upgrade/downgrade reviewed