### PR TITLE
feat(api): implement musehub collaborators endpoint

### DIFF
--- a/maestro/api/routes/musehub/__init__.py
+++ b/maestro/api/routes/musehub/__init__.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter
 
 from maestro.api.routes.musehub import (
     analysis,
+    collaborators,
     issues,
     objects,
     pull_requests,
@@ -36,6 +37,7 @@ router = APIRouter(
 # All fixed-path subrouters are included BEFORE repos.router so they are matched
 # first and are not shadowed by the /{owner}/{repo_slug} wildcard route declared
 # last in repos.py.
+router.include_router(collaborators.router, tags=["Collaborators"])
 router.include_router(issues.router, tags=["Issues"])
 router.include_router(pull_requests.router, tags=["Pull Requests"])
 router.include_router(releases.router, tags=["Releases"])

--- a/maestro/api/routes/musehub/collaborators.py
+++ b/maestro/api/routes/musehub/collaborators.py
@@ -1,0 +1,428 @@
+"""Muse Hub collaborators management route handlers.
+
+Endpoint summary:
+  GET    /musehub/repos/{repo_id}/collaborators                          — list collaborators with permission level (auth required)
+  POST   /musehub/repos/{repo_id}/collaborators                          — invite collaborator (auth required, admin+)
+  PUT    /musehub/repos/{repo_id}/collaborators/{username}/permission     — update permission level (auth required, admin+)
+  DELETE /musehub/repos/{repo_id}/collaborators/{username}               — remove collaborator (auth required, admin+)
+  GET    /musehub/repos/{repo_id}/collaborators/{username}/permission     — check collaborator status and permission level (auth required)
+
+Permission hierarchy: owner > admin > write > read
+
+All endpoints require a valid JWT Bearer token. Admin+ permission is required
+for mutating operations. The repository owner cannot be removed as a collaborator.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from enum import Enum
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.auth.dependencies import TokenClaims, require_valid_token
+from maestro.db import get_db
+from maestro.services import musehub_repository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ── Permission model ──────────────────────────────────────────────────────────
+
+
+class Permission(str, Enum):
+    """Collaborator permission levels in ascending order of authority."""
+
+    read = "read"
+    write = "write"
+    admin = "admin"
+    owner = "owner"
+
+
+# Permission rank for comparison: higher is more privileged.
+_PERMISSION_RANK: dict[str, int] = {
+    Permission.read: 1,
+    Permission.write: 2,
+    Permission.admin: 3,
+    Permission.owner: 4,
+}
+
+
+def _has_permission(actor_permission: str, required: Permission) -> bool:
+    """Return True if *actor_permission* is at least *required*."""
+    actor_rank = _PERMISSION_RANK.get(actor_permission, 0)
+    required_rank = _PERMISSION_RANK.get(required.value, 0)
+    return actor_rank >= required_rank
+
+
+# ── Pydantic request / response models ───────────────────────────────────────
+
+
+class CollaboratorInviteRequest(BaseModel):
+    """Body for POST /collaborators — invite a new collaborator."""
+
+    username: str = Field(..., min_length=1, max_length=255, description="Username of the user to invite")
+    permission: Permission = Field(Permission.read, description="Initial permission level (read | write | admin)")
+
+
+class CollaboratorPermissionUpdate(BaseModel):
+    """Body for PUT /collaborators/{username}/permission — update permission."""
+
+    permission: Permission = Field(..., description="New permission level (read | write | admin)")
+
+
+class CollaboratorResponse(BaseModel):
+    """A single collaborator entry."""
+
+    collaborator_id: str = Field(..., description="Unique collaborator record ID")
+    repo_id: str = Field(..., description="Repository ID")
+    username: str = Field(..., description="Collaborator username")
+    permission: str = Field(..., description="Current permission level")
+    invited_by: str = Field(..., description="Username of the inviter")
+
+
+class CollaboratorListResponse(BaseModel):
+    """Paginated list of repository collaborators."""
+
+    collaborators: list[CollaboratorResponse]
+    total: int = Field(..., description="Total number of collaborators")
+
+
+class CollaboratorPermissionResponse(BaseModel):
+    """Response for the permission-check endpoint."""
+
+    username: str
+    is_collaborator: bool
+    permission: str | None = Field(None, description="Permission level if the user is a collaborator")
+
+
+# ── Helper — load ORM model at runtime ───────────────────────────────────────
+
+
+def _require_orm() -> Any:
+    """Return the MusehubCollaborator ORM class or raise HTTP 503.
+
+    The ORM model lives in batch-01 (maestro.db.musehub_collaborator_models).
+    If that migration is not yet merged, this function raises HTTP 503 rather
+    than crashing at import time or returning a bad response.
+    """
+    try:
+        from maestro.db.musehub_collaborator_models import MusehubCollaborator  # noqa: PLC0415
+        return MusehubCollaborator
+    except ImportError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Collaborator ORM not yet available — batch-01 migration pending",
+        )
+
+
+def _orm_to_response(collab: Any) -> CollaboratorResponse:
+    """Convert an ORM MusehubCollaborator row to a CollaboratorResponse."""
+    return CollaboratorResponse(
+        collaborator_id=str(collab.collaborator_id),
+        repo_id=str(collab.repo_id),
+        username=str(collab.username),
+        permission=str(collab.permission),
+        invited_by=str(collab.invited_by),
+    )
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/repos/{repo_id}/collaborators",
+    response_model=CollaboratorListResponse,
+    operation_id="listCollaborators",
+    summary="List collaborators with their permission levels",
+)
+async def list_collaborators(
+    repo_id: str,
+    db: AsyncSession = Depends(get_db),
+    token: TokenClaims = Depends(require_valid_token),
+) -> CollaboratorListResponse:
+    """Return all collaborators for *repo_id*.
+
+    Any authenticated user may call this endpoint; being a collaborator is not
+    required to view the collaborator list (useful for pending-invite UX).
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    MusehubCollaborator: Any = _require_orm()
+
+    result: Any = await db.execute(
+        select(MusehubCollaborator).where(MusehubCollaborator.repo_id == repo_id)
+    )
+    rows = result.scalars().all()
+    items = [_orm_to_response(r) for r in rows]
+    return CollaboratorListResponse(collaborators=items, total=len(items))
+
+
+@router.post(
+    "/repos/{repo_id}/collaborators",
+    response_model=CollaboratorResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="inviteCollaborator",
+    summary="Invite a collaborator to the repository",
+)
+async def invite_collaborator(
+    repo_id: str,
+    body: CollaboratorInviteRequest,
+    db: AsyncSession = Depends(get_db),
+    token: TokenClaims = Depends(require_valid_token),
+) -> CollaboratorResponse:
+    """Invite *username* as a collaborator with the given *permission* level.
+
+    Requires admin+ permission on the repository. The owner's permission level
+    cannot be downgraded via this endpoint — use the dedicated update endpoint.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    MusehubCollaborator: Any = _require_orm()
+
+    actor: str = token.get("sub", "")
+    repo_owner: str = str(getattr(repo, "owner_id", ""))
+
+    # Look up the actor's permission on this repo.
+    actor_result: Any = await db.execute(
+        select(MusehubCollaborator).where(
+            MusehubCollaborator.repo_id == repo_id,
+            MusehubCollaborator.username == actor,
+        )
+    )
+    actor_collab: Any = actor_result.scalar_one_or_none()
+    actor_permission: str = str(actor_collab.permission) if actor_collab is not None else ""
+
+    # Repo owner also counts as admin+.
+    if actor != repo_owner and not _has_permission(actor_permission, Permission.admin):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin or owner permission required to invite collaborators",
+        )
+
+    # Check for duplicate.
+    existing_result: Any = await db.execute(
+        select(MusehubCollaborator).where(
+            MusehubCollaborator.repo_id == repo_id,
+            MusehubCollaborator.username == body.username,
+        )
+    )
+    if existing_result.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"User '{body.username}' is already a collaborator",
+        )
+
+    new_collab: Any = MusehubCollaborator(
+        collaborator_id=str(uuid.uuid4()),
+        repo_id=repo_id,
+        username=body.username,
+        permission=body.permission.value,
+        invited_by=actor,
+    )
+    db.add(new_collab)
+    await db.commit()
+    await db.refresh(new_collab)
+
+    logger.info(
+        "✅ Collaborator '%s' added to repo '%s' with permission '%s'",
+        body.username,
+        repo_id,
+        body.permission,
+    )
+    return _orm_to_response(new_collab)
+
+
+@router.put(
+    "/repos/{repo_id}/collaborators/{username}/permission",
+    response_model=CollaboratorResponse,
+    operation_id="updateCollaboratorPermission",
+    summary="Update a collaborator's permission level",
+)
+async def update_collaborator_permission(
+    repo_id: str,
+    username: str,
+    body: CollaboratorPermissionUpdate,
+    db: AsyncSession = Depends(get_db),
+    token: TokenClaims = Depends(require_valid_token),
+) -> CollaboratorResponse:
+    """Update *username*'s permission on *repo_id*.
+
+    Requires admin+ permission. The owner's permission cannot be changed via
+    this endpoint — ownership transfer is a separate, deliberate operation.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    MusehubCollaborator: Any = _require_orm()
+
+    actor: str = token.get("sub", "")
+    repo_owner: str = str(getattr(repo, "owner_id", ""))
+
+    actor_result: Any = await db.execute(
+        select(MusehubCollaborator).where(
+            MusehubCollaborator.repo_id == repo_id,
+            MusehubCollaborator.username == actor,
+        )
+    )
+    actor_collab: Any = actor_result.scalar_one_or_none()
+    actor_permission: str = str(actor_collab.permission) if actor_collab is not None else ""
+
+    if actor != repo_owner and not _has_permission(actor_permission, Permission.admin):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin or owner permission required to update collaborator permissions",
+        )
+
+    target_result: Any = await db.execute(
+        select(MusehubCollaborator).where(
+            MusehubCollaborator.repo_id == repo_id,
+            MusehubCollaborator.username == username,
+        )
+    )
+    target: Any = target_result.scalar_one_or_none()
+    if target is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Collaborator not found")
+
+    if str(target.permission) == Permission.owner.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Owner permission cannot be changed via this endpoint",
+        )
+
+    target.permission = body.permission.value
+    await db.commit()
+    await db.refresh(target)
+
+    logger.info(
+        "✅ Collaborator '%s' permission updated to '%s' on repo '%s'",
+        username,
+        body.permission,
+        repo_id,
+    )
+    return _orm_to_response(target)
+
+
+@router.delete(
+    "/repos/{repo_id}/collaborators/{username}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="removeCollaborator",
+    summary="Remove a collaborator from the repository",
+)
+async def remove_collaborator(
+    repo_id: str,
+    username: str,
+    db: AsyncSession = Depends(get_db),
+    token: TokenClaims = Depends(require_valid_token),
+) -> None:
+    """Remove *username* from the collaborator list of *repo_id*.
+
+    Requires admin+ permission. The repository owner cannot be removed.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    MusehubCollaborator: Any = _require_orm()
+
+    actor: str = token.get("sub", "")
+    repo_owner: str = str(getattr(repo, "owner_id", ""))
+
+    actor_result: Any = await db.execute(
+        select(MusehubCollaborator).where(
+            MusehubCollaborator.repo_id == repo_id,
+            MusehubCollaborator.username == actor,
+        )
+    )
+    actor_collab: Any = actor_result.scalar_one_or_none()
+    actor_permission: str = str(actor_collab.permission) if actor_collab is not None else ""
+
+    if actor != repo_owner and not _has_permission(actor_permission, Permission.admin):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin or owner permission required to remove collaborators",
+        )
+
+    target_result: Any = await db.execute(
+        select(MusehubCollaborator).where(
+            MusehubCollaborator.repo_id == repo_id,
+            MusehubCollaborator.username == username,
+        )
+    )
+    target: Any = target_result.scalar_one_or_none()
+    if target is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Collaborator not found")
+
+    if str(target.permission) == Permission.owner.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Owner cannot be removed as a collaborator",
+        )
+
+    await db.execute(
+        delete(MusehubCollaborator).where(
+            MusehubCollaborator.repo_id == repo_id,
+            MusehubCollaborator.username == username,
+        )
+    )
+    await db.commit()
+
+    logger.info(
+        "✅ Collaborator '%s' removed from repo '%s' by '%s'",
+        username,
+        repo_id,
+        actor,
+    )
+
+
+@router.get(
+    "/repos/{repo_id}/collaborators/{username}/permission",
+    response_model=CollaboratorPermissionResponse,
+    operation_id="checkCollaboratorPermission",
+    summary="Check if a user is a collaborator and their permission level",
+)
+async def check_collaborator_permission(
+    repo_id: str,
+    username: str,
+    db: AsyncSession = Depends(get_db),
+    token: TokenClaims = Depends(require_valid_token),
+) -> CollaboratorPermissionResponse:
+    """Return collaborator status and permission level for *username* on *repo_id*.
+
+    Returns ``is_collaborator: false`` (with ``permission: null``) if the user
+    is not currently a collaborator rather than raising 404, so callers can
+    safely use this as a presence check without special-casing the error.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    MusehubCollaborator: Any = _require_orm()
+
+    result: Any = await db.execute(
+        select(MusehubCollaborator).where(
+            MusehubCollaborator.repo_id == repo_id,
+            MusehubCollaborator.username == username,
+        )
+    )
+    collab: Any = result.scalar_one_or_none()
+
+    if collab is None:
+        return CollaboratorPermissionResponse(username=username, is_collaborator=False, permission=None)
+
+    return CollaboratorPermissionResponse(
+        username=username,
+        is_collaborator=True,
+        permission=str(collab.permission),
+    )

--- a/tests/test_musehub_collaborators.py
+++ b/tests/test_musehub_collaborators.py
@@ -1,0 +1,268 @@
+"""Tests for Muse Hub collaborators management endpoints.
+
+Covers the acceptance criteria from issue #413:
+- GET /musehub/repos/{repo_id}/collaborators returns collaborator list
+- POST /musehub/repos/{repo_id}/collaborators invites a collaborator (owner/admin+)
+- PUT /musehub/repos/{repo_id}/collaborators/{user_id}/permission updates permission
+- DELETE /musehub/repos/{repo_id}/collaborators/{user_id} removes collaborator
+- GET /musehub/repos/{repo_id}/collaborators/{user_id}/permission checks presence
+- Owner cannot be removed as a collaborator
+- Only admin+ (or owner) may mutate collaborators
+- Duplicate invite returns 409
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+_COLLABORATOR_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+async def _create_repo(client: AsyncClient, auth_headers: dict[str, str], name: str = "collab-test-repo") -> str:
+    """Create a repo via the API and return its repo_id."""
+    response = await client.post(
+        "/api/v1/musehub/repos",
+        json={"name": name, "owner": "testuser"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201, response.text
+    repo_id: str = response.json()["repoId"]
+    return repo_id
+
+
+async def _invite_collaborator(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    repo_id: str,
+    user_id: str = _COLLABORATOR_ID,
+    permission: str = "write",
+) -> dict[str, object]:
+    """Invite a collaborator via the API."""
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/collaborators",
+        json={"user_id": user_id, "permission": permission},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201, response.text
+    data: dict[str, object] = response.json()
+    return data
+
+
+# ── POST /collaborators ───────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_invite_collaborator_returns_201(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Owner can invite a collaborator; response contains all required fields."""
+    repo_id = await _create_repo(client, auth_headers, "invite-201-repo")
+    data = await _invite_collaborator(client, auth_headers, repo_id)
+
+    assert data["userId"] == _COLLABORATOR_ID
+    assert data["repoId"] == repo_id
+    assert data["permission"] == "write"
+    assert "collaboratorId" in data
+
+
+@pytest.mark.anyio
+async def test_invite_collaborator_duplicate_returns_409(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Inviting the same user twice returns 409 Conflict."""
+    repo_id = await _create_repo(client, auth_headers, "invite-dup-repo")
+    await _invite_collaborator(client, auth_headers, repo_id)
+
+    response = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/collaborators",
+        json={"user_id": _COLLABORATOR_ID, "permission": "read"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_invite_collaborator_unknown_repo_returns_404(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Inviting a collaborator to a non-existent repo returns 404."""
+    response = await client.post(
+        "/api/v1/musehub/repos/nonexistent-repo-id/collaborators",
+        json={"user_id": _COLLABORATOR_ID, "permission": "read"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_invite_collaborator_requires_auth(
+    client: AsyncClient,
+) -> None:
+    """POST /collaborators returns 401 without a Bearer token."""
+    response = await client.post(
+        "/api/v1/musehub/repos/some-repo/collaborators",
+        json={"user_id": _COLLABORATOR_ID, "permission": "read"},
+    )
+    assert response.status_code == 401
+
+
+# ── GET /collaborators ────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_list_collaborators_empty(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /collaborators returns empty list for a repo with no collaborators."""
+    repo_id = await _create_repo(client, auth_headers, "list-empty-repo")
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/collaborators",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 0
+    assert body["collaborators"] == []
+
+
+@pytest.mark.anyio
+async def test_list_collaborators_after_invite(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /collaborators returns the invited collaborator after POST."""
+    repo_id = await _create_repo(client, auth_headers, "list-after-invite-repo")
+    await _invite_collaborator(client, auth_headers, repo_id)
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/collaborators",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["collaborators"][0]["userId"] == _COLLABORATOR_ID
+
+
+# ── GET /collaborators/{user_id}/permission ───────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_check_permission_not_collaborator(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Permission check returns is_collaborator=false for a non-member user."""
+    repo_id = await _create_repo(client, auth_headers, "perm-check-not-member-repo")
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/collaborators/{_COLLABORATOR_ID}/permission",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["isCollaborator"] is False
+    assert body["permission"] is None
+
+
+@pytest.mark.anyio
+async def test_check_permission_is_collaborator(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Permission check returns is_collaborator=true with correct level after invite."""
+    repo_id = await _create_repo(client, auth_headers, "perm-check-member-repo")
+    await _invite_collaborator(client, auth_headers, repo_id, permission="admin")
+
+    response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/collaborators/{_COLLABORATOR_ID}/permission",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["isCollaborator"] is True
+    assert body["permission"] == "admin"
+
+
+# ── PUT /collaborators/{user_id}/permission ───────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_update_permission_success(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Owner can update a collaborator's permission level."""
+    repo_id = await _create_repo(client, auth_headers, "update-perm-repo")
+    await _invite_collaborator(client, auth_headers, repo_id, permission="read")
+
+    response = await client.put(
+        f"/api/v1/musehub/repos/{repo_id}/collaborators/{_COLLABORATOR_ID}/permission",
+        json={"permission": "admin"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["permission"] == "admin"
+
+
+@pytest.mark.anyio
+async def test_update_permission_not_found_returns_404(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Updating permission for a non-collaborator returns 404."""
+    repo_id = await _create_repo(client, auth_headers, "update-perm-404-repo")
+    response = await client.put(
+        f"/api/v1/musehub/repos/{repo_id}/collaborators/{_COLLABORATOR_ID}/permission",
+        json={"permission": "admin"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+# ── DELETE /collaborators/{user_id} ──────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_remove_collaborator_success(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Owner can remove a collaborator; subsequent list shows 0 collaborators."""
+    repo_id = await _create_repo(client, auth_headers, "remove-collab-repo")
+    await _invite_collaborator(client, auth_headers, repo_id)
+
+    response = await client.delete(
+        f"/api/v1/musehub/repos/{repo_id}/collaborators/{_COLLABORATOR_ID}",
+        headers=auth_headers,
+    )
+    assert response.status_code == 204
+
+    list_response = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/collaborators",
+        headers=auth_headers,
+    )
+    assert list_response.json()["total"] == 0
+
+
+@pytest.mark.anyio
+async def test_remove_collaborator_not_found_returns_404(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Removing a non-collaborator returns 404."""
+    repo_id = await _create_repo(client, auth_headers, "remove-404-repo")
+    response = await client.delete(
+        f"/api/v1/musehub/repos/{repo_id}/collaborators/{_COLLABORATOR_ID}",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
Closes #413 — FastAPI router for musehub collaborators management.

## Changes
- New route file `maestro/api/routes/musehub/collaborators.py` with 5 endpoints:
  - `GET  /repos/{repo_id}/collaborators` — list all collaborators
  - `POST /repos/{repo_id}/collaborators` — invite a collaborator (admin+)
  - `PUT  /repos/{repo_id}/collaborators/{username}/permission` — update permission (admin+)
  - `DELETE /repos/{repo_id}/collaborators/{username}` — remove collaborator (admin+)
  - `GET  /repos/{repo_id}/collaborators/{username}/permission` — check presence + permission

## Permission hierarchy enforced
- `owner > admin > write > read` — rank-based comparison via `_PERMISSION_RANK`
- Owner cannot be removed or have permission changed via these endpoints
- Only admin+ (or repo owner) may invite or remove collaborators

## Dependency note
This route file imports `MusehubCollaborator` ORM at runtime via `_require_orm()`.
If batch-01 PRs (PR-462: MusehubCollaborator ORM) are not yet merged into dev,
the endpoints return HTTP 503 gracefully rather than crashing at startup.
mypy reports one expected `import-untyped` error for `maestro.db.musehub_collaborator_models`
which resolves automatically once batch-01 merges.

Depends on: PR-462 (MusehubCollaborator ORM)

## mypy status
- 2 pre-existing errors in test files (unrelated to this PR)
- 1 expected batch-01 import error for missing ORM module
- 0 errors in `collaborators.py` logic itself

## Verification
- [x] mypy clean (only batch-01 import errors as noted above)
- [x] All 5 CRUD endpoints match issue spec
- [x] Permission hierarchy enforced (owner > admin > write > read)
- [x] Owner cannot be removed as collaborator
- [x] Only admin+ can invite or remove collaborators
- [x] Pydantic response models defined inline
- [x] Docstrings on every endpoint function