### PR TITLE
feat(agents): conductor prompt, pipeline state labels, anti-loop guards, feedback loop

### DIFF
--- a/.cursor/AGENT_COMMAND_POLICY.md
+++ b/.cursor/AGENT_COMMAND_POLICY.md
@@ -70,7 +70,7 @@ Clear the existing allowlist entirely, then paste the block below into
 > commands in kickoff prompts must be written as single lines.
 
 ```
-ls, ls -la, ls -lah, ls -l, pwd, cat, head, tail, echo, true, false, wc, file, which, date, basename, dirname, printf, jq, sort, uniq, tr, awk, sed, cut, xargs, tee, rg, grep, find, mkdir, cp, mv, touch, ln -s, cd, sleep, continue, python3 -c, python3 -m, REPO=, WTNAME=, DEV_SHA=, WT=, NUM=, TITLE=, BRANCH=, PRTREES=, WORKTREE=, ENTRY=, FOLLOW_UP_URL=, ISSUE_URL=, GH_REPO=, export GH_REPO=, declare -a, declare -a ISSUES=, declare -a PRS=, for entry in, for NUM in, for WT in, git status, git log, git diff, git show, git branch, git fetch, git fetch origin, git pull, git pull origin, git pull origin dev, git stash list, git worktree list, git ls-remote, git rev-parse, git ls-files, git merge-base, git describe, git cat-file, git config rerere.enabled, git -C, git -C /Users, git worktree list --porcelain, git bisect, git bisect start, git bisect bad, git bisect good, git bisect log, git bisect reset, git checkout -b, git checkout, git add, git add -A, git commit, git merge origin/dev, git merge, git stash, git stash pop, git stash apply, git restore, git restore --staged, git push origin, git push -u origin, git push origin --delete, git worktree add, git worktree add --detach, git worktree remove --force, git worktree prune, docker compose ps, docker compose logs, docker compose config, docker compose -f, docker ps, docker inspect, docker compose exec maestro mypy, docker compose exec maestro pytest, docker compose exec maestro sh -c, docker compose exec maestro python -m coverage, docker compose exec maestro python -c, docker compose exec maestro python3 -m, docker compose exec maestro ps, docker compose exec maestro ls, docker compose exec maestro cat, docker compose exec maestro rg, docker compose exec maestro grep, docker compose exec maestro find, docker compose exec maestro alembic history, docker compose exec maestro alembic current, docker compose exec maestro alembic heads, docker compose exec maestro alembic upgrade head, docker compose exec maestro python3, docker compose exec storpheus mypy, docker compose exec storpheus pytest, docker compose exec storpheus sh -c, docker compose exec storpheus ls, docker compose exec storpheus cat, docker compose exec storpheus rg, docker compose exec storpheus grep, docker compose exec storpheus python3, docker compose exec postgres psql, gh auth status, gh repo view, gh pr view, gh pr list, gh pr diff, gh pr create, gh pr edit, gh pr checkout, gh pr merge, gh pr comment, gh pr review, gh issue view, gh issue list, gh issue create, gh issue close, gh issue comment, gh issue edit, gh label list, gh run list, gh run view, gh release list, gh release view, gh api, ps aux, ps -ef, pgrep, nc -z, curl, REPO=$(git, WTNAME=$(basename, DEV_SHA=$(git, WT=$HOME, BRANCH=$(git
+ls, ls -la, ls -lah, ls -l, pwd, cat, head, tail, echo, true, false, seq, wc, file, which, date, basename, dirname, printf, jq, sort, uniq, tr, awk, sed, cut, xargs, tee, rg, grep, find, mkdir, cp, mv, touch, ln -s, cd, sleep, break, continue, exit, exit 0, exit 1, mapfile, IFS=, python3 -c, python3 -m, REPO=, WTNAME=, DEV_SHA=, WT=, NUM=, TITLE=, BRANCH=, PRTREES=, WORKTREE=, ENTRY=, FOLLOW_UP_URL=, ISSUE_URL=, GH_REPO=, export GH_REPO=, declare -a, declare -A, declare -a ISSUES=, declare -a PRS=, for entry in, for NUM in, for WT in, for i in, for label in, for n in, N=$(grep, N=$(printf, BRANCH=$(grep, MERGE_AFTER=$(grep, LABELS_TO_APPLY=$(grep, CLOSES_ISSUES=$(grep, STATE=$(gh, PR_BRANCH=$(gh, PR_FILES=$(gh, CLOSES_ISSUE=$(gh, OPEN_PRS=$(gh, REMAINING=$(gh, NUM=$(echo, TITLE=$(echo, LABELS=$(echo, PHASE=$(echo, BATCH=$(echo, SHORT=$(grep, git status, git log, git diff, git show, git branch, git branch -D, git fetch, git fetch origin, git pull, git pull origin, git pull origin dev, git stash list, git worktree list, git ls-remote, git rev-parse, git ls-files, git merge-base, git describe, git cat-file, git config rerere.enabled, git -C, git -C /Users, git worktree list --porcelain, git bisect, git bisect start, git bisect bad, git bisect good, git bisect log, git bisect reset, git checkout -b, git checkout, git add, git add -A, git commit, git merge origin/dev, git merge, git stash, git stash pop, git stash apply, git restore, git restore --staged, git push origin, git push -u origin, git push origin --delete, git worktree add, git worktree add --detach, git worktree remove --force, git worktree prune, docker compose ps, docker compose logs, docker compose config, docker compose -f, docker ps, docker inspect, docker compose exec maestro mypy, docker compose exec maestro pytest, docker compose exec maestro sh -c, docker compose exec maestro python -m coverage, docker compose exec maestro python -c, docker compose exec maestro python3 -m, docker compose exec maestro ps, docker compose exec maestro ls, docker compose exec maestro cat, docker compose exec maestro rg, docker compose exec maestro grep, docker compose exec maestro find, docker compose exec maestro alembic history, docker compose exec maestro alembic current, docker compose exec maestro alembic heads, docker compose exec maestro alembic upgrade head, docker compose exec maestro python3, docker compose exec storpheus mypy, docker compose exec storpheus pytest, docker compose exec storpheus sh -c, docker compose exec storpheus ls, docker compose exec storpheus cat, docker compose exec storpheus rg, docker compose exec storpheus grep, docker compose exec storpheus python3, docker compose exec postgres psql, gh auth status, gh repo view, gh pr view, gh pr list, gh pr diff, gh pr create, gh pr edit, gh pr checkout, gh pr merge, gh pr comment, gh pr review, gh issue view, gh issue list, gh issue create, gh issue close, gh issue comment, gh issue edit, gh label list, gh label create, gh label delete, gh label edit, gh run list, gh run view, gh release list, gh release view, gh api, ps aux, ps -ef, pgrep, nc -z, curl, REPO=$(git, WTNAME=$(basename, DEV_SHA=$(git, WT=$HOME, BRANCH=$(git
 ```
 
 ---
@@ -87,7 +87,7 @@ tail -n N <file>              ← file inspection ONLY (never to filter test out
 echo
 true                          ← null-op; used as || true for safe error suppression in scripts
 false                         ← null-op complement; used in boolean control flow
-continue                      ← bash loop control (skip to next iteration); used in for loops
+seq <N>                       ← integer sequence; used in merge-gate polling loops: for i in $(seq 1 15)
 wc / wc -l
 file <path>
 which <cmd>
@@ -98,11 +98,21 @@ jq <filter> <file>            ← JSON parsing
 sleep <N>                     ← harmless pause; agents use between push and gh pr create
 ```
 
-### Shell — Bash control flow (coordinator setup scripts)
+### Shell — Bash control flow (coordinator setup scripts and polling loops)
 ```
-declare -a ISSUES=(...)       ← array declaration in coordinator setup scripts
-declare -a PRS=(...)          ← array declaration in coordinator setup scripts
-for entry in "${ARRAY[@]}"    ← iteration in coordinator setup scripts
+break                         ← bash loop exit; used in merge-gate polling loops
+continue                      ← bash loop skip; used in for loops
+exit / exit 0 / exit 1        ← script exit; used in merge-gate escalation and idempotency gates
+mapfile -t <ARRAY> < <(...)   ← bash builtin for reading command output into an array
+IFS=',' read -ra <ARRAY> <<< ← bash IFS-split; used to iterate LABELS_TO_APPLY and similar CSV fields
+declare -a ISSUES=(...)       ← indexed array declaration in coordinator setup scripts
+declare -a PRS=(...)          ← indexed array declaration in coordinator setup scripts
+declare -A <MAP>=(...)        ← associative array declaration; used in coordinator setup scripts
+for entry in "${ARRAY[@]}"    ← iteration over indexed arrays
+for i in $(seq 1 <N>)        ← counted loop; used in merge-gate polling
+for label in "${LABELS[@]}"  ← iteration over label arrays (label pre-flight scripts)
+for NUM in <list>             ← iteration over explicit issue/PR number lists
+for n in <list>               ← iteration over explicit number lists
 PRTREES=<path>                ← variable assignment
 WORKTREE=<path>               ← variable assignment
 ENTRY=<value>                 ← variable assignment
@@ -110,6 +120,30 @@ FOLLOW_UP_URL=<value>         ← B-grade follow-up issue URL
 ISSUE_URL=<value>             ← captured issue URL in scripts
 GH_REPO=cgcardona/maestro     ← hardcoded repo slug — NEVER derive from local path
 export GH_REPO=cgcardona/maestro
+```
+
+### Shell — Variable assignments from command substitution (task-file parsing)
+These patterns appear in every agent kickoff when parsing `.agent-task` KEY=value fields.
+Cursor treats each `VAR=$(cmd)` prefix as a command token — all must be on the allowlist.
+```
+N=$(grep                      ← parse PR_NUMBER / ISSUE_NUMBER from .agent-task
+N=$(printf                    ← zero-pad batch number: N=$(printf "%02d" $i)
+BRANCH=$(grep                 ← parse PR_BRANCH from .agent-task
+MERGE_AFTER=$(grep            ← parse MERGE_AFTER gate from .agent-task
+LABELS_TO_APPLY=$(grep        ← parse comma-separated label list from .agent-task
+CLOSES_ISSUES=$(grep          ← parse linked issue numbers from .agent-task
+STATE=$(gh                    ← capture live PR/issue state: STATE=$(gh pr view ...)
+PR_BRANCH=$(gh                ← fetch PR branch name from GitHub
+PR_FILES=$(gh                 ← fetch PR file list from GitHub
+CLOSES_ISSUE=$(gh             ← fetch close-links from PR body
+OPEN_PRS=$(gh                 ← list open PRs for overlap check
+REMAINING=$(gh                ← count remaining open issues in phase closure audit
+NUM=$(echo                    ← extract issue/PR number from pipe: NUM="${entry%%|*}"
+TITLE=$(echo                  ← extract title from pipe: TITLE="${entry##*|}"
+LABELS=$(echo                 ← extract label string from pipe output
+PHASE=$(echo                  ← extract phase label from comma-separated labels
+BATCH=$(echo                  ← extract batch label from comma-separated labels
+SHORT=$(grep                  ← extract short slug for branch naming
 ```
 
 ### Shell — Text Processing (read-only transforms)
@@ -210,6 +244,8 @@ git push origin <feature-branch>          ← non-main, non-dev branches ONLY
 git push -u origin <feature-branch>       ← same as above with upstream tracking; -u writes to .git/config
                                            ← must be on the allowlist so it runs outside sandbox
 git push origin --delete <feature-branch> ← remote branch cleanup after PR merge
+git branch -D <feature-branch>            ← delete LOCAL branch ref after PR squash-merge
+                                           ← worktree remove destroys the directory but NOT the local ref
 ```
 
 ### GitHub CLI — Read Only
@@ -227,6 +263,15 @@ gh run view <id>
 gh release list
 gh release view [<tag>]
 gh api <GET-endpoint>              ← read-only API calls only
+```
+
+### GitHub CLI — Label Management (Label Pre-flight scripts)
+```
+gh label create <name> --color <hex> --description "..."  ← idempotent; pre-flight before any batch
+gh label delete <name> --yes                              ← removes stale/conflicting labels
+gh label edit <name> --color <hex> --description "..."    ← updates existing label metadata
+# ⚠️  Label pre-flight MUST run before worktrees are created for any batch.
+#    Without it, gh issue edit --add-label fails silently and issues are mislabeled.
 ```
 
 ### GitHub CLI — Safe Writes

--- a/.cursor/PARALLEL_BUGS_TO_ISSUES.md
+++ b/.cursor/PARALLEL_BUGS_TO_ISSUES.md
@@ -5,50 +5,245 @@
 > If you are an AI agent reading this document, your role is **coordinator only**.
 >
 > **Your job — the full list, nothing more:**
-> 1. Fill in the bug descriptions in each `.agent-task` file (or confirm the user has done so).
-> 2. Run the Setup script below to create one worktree per batch.
-> 3. Launch one sub-agent per worktree by pasting the Kickoff Prompt (found at the bottom of this document) into a separate Cursor composer window rooted in that worktree.
-> 4. Report back once all sub-agents have been launched.
+> 1. Run the **Label Pre-flight** script to create required labels and delete stale ones.
+> 2. Fill in the bug descriptions in each `.agent-task` file (or confirm the user has done so), including the label fields.
+> 3. Run the **Setup** script to create one worktree per batch.
+> 4. Launch one sub-agent per worktree using the Task tool (or Cursor composer window). Each sub-agent reads its own `.agent-task` — you do not need to pass context manually.
+> 5. Report back once all sub-agents have been launched.
 >
 > **You do NOT:**
 > - Draft or create any GitHub issues yourself.
 > - Read bug reports and analyze them yourself.
 > - Run `gh issue create` yourself.
+> - Apply labels yourself.
 >
 > The **Kickoff Prompt** at the bottom of this document is for the sub-agents, not for you.
-> Copy it verbatim into each sub-agent's window. Do not follow it yourself.
+> Do not follow it yourself.
 
 ---
 
-Each sub-agent gets its own ephemeral worktree. Worktrees are created at kickoff,
-named by batch number, and **deleted by the sub-agent when its job is done**.
-No branch, no Docker — pure `gh issue create`.
+## Why `.agent-task` files unlock more than 4 parallel agents
+
+When a coordinator manages parallel work by holding all task details in its own
+context window, it is limited to ~4 concurrent agents before context overhead
+becomes a bottleneck.
+
+**`.agent-task` files break this limit** by externalising all task state into
+the filesystem. The coordinator writes every task file upfront — one per batch
+or per issue — and then launches agents without needing to hold any task content
+itself. Each agent is fully self-sufficient: it reads its `.agent-task` file on
+startup and knows exactly what to do.
+
+This also enables **nested orchestration**: a "sub-coordinator" agent can read
+its task file, discover it has sub-tasks to delegate, write sub-task files, and
+launch its own leaf agents — creating a tree of unlimited depth.
+
+```
+Coordinator
+  ├── writes batch-1/.agent-task  (SPAWN_SUB_AGENTS=true, 4 issues)
+  ├── writes batch-2/.agent-task  (SPAWN_SUB_AGENTS=true, 4 issues)
+  ├── writes batch-3/.agent-task  (SPAWN_SUB_AGENTS=true, 4 issues)
+  └── launches 3 sub-coordinators simultaneously
+
+Sub-coordinator (batch-1)
+  ├── reads batch-1/.agent-task
+  ├── writes issue-A/.agent-task
+  ├── writes issue-B/.agent-task
+  ├── writes issue-C/.agent-task
+  ├── writes issue-D/.agent-task
+  └── launches 4 leaf agents
+
+Leaf agent (issue-A)
+  └── reads issue-A/.agent-task → creates issue → self-destructs
+```
+
+With 3 sub-coordinators × 4 leaf agents = **12 agents from a single coordinator call**.
+Scale by adding more batches, not by holding more context.
+
+---
+
+## Agent Task File Reference
+
+Everything an agent needs to know goes in its `.agent-task` file.
+The file is plain text; fields are `KEY=value` lines followed by free-form content.
+Agents parse what they need and ignore fields they don't recognise.
+
+### All supported fields
+
+```
+# ── Identity ──────────────────────────────────────────────────────────────────
+WORKFLOW=bugs-to-issues          # bugs-to-issues | issue-to-pr | pr-review
+BATCH_NUM=3                      # batch number (used in worktree name)
+
+# ── GitHub Labels ─────────────────────────────────────────────────────────────
+# Labels MUST exist on GitHub before agents try to apply them.
+# Run the Label Pre-flight script (below) before creating worktrees.
+PHASE_LABEL=phase-2/core-api           # phase label (parent category)
+BATCH_LABEL=batch-03                   # batch label (child category)
+LABELS_TO_APPLY=enhancement,muse-hub,phase-2/core-api,batch-03
+# ↑ Comma-separated. Each applied individually (|| true) so one failure
+#   never blocks the others. Add domain labels here too (muse-cli, etc.).
+
+# ── File Ownership (conflict avoidance) ───────────────────────────────────────
+# Declare which files/dirs this batch exclusively owns.
+# Used by the coordinator to verify no two batches share a file.
+FILE_OWNERSHIP=maestro/api/routes/musehub/milestones.py,maestro/db/musehub_milestone_models.py
+
+# ── Dependencies ──────────────────────────────────────────────────────────────
+# Do not implement until these batch numbers or issue numbers are merged.
+DEPENDS_ON=batch-01,batch-02
+
+# ── Sub-agent Orchestration ───────────────────────────────────────────────────
+# Set to true to make this agent act as a sub-coordinator that spawns
+# its own leaf agents rather than doing the work directly.
+SPAWN_SUB_AGENTS=false
+# If SPAWN_SUB_AGENTS=true, list the sub-task worktree paths to create:
+# SUB_TASK_PATHS=/path/to/sub1,/path/to/sub2
+
+# ── Output Contract ───────────────────────────────────────────────────────────
+# What the agent must produce and report back.
+# For bugs-to-issues: a list of created issue URLs.
+REQUIRED_OUTPUT=issue_urls
+
+# ── Escalation ────────────────────────────────────────────────────────────────
+# If the agent is blocked (e.g. gh auth fails, API errors), what to do.
+# stop = self-destruct and report. retry = try once more. escalate = notify coordinator.
+ON_BLOCK=stop
+
+# ── Environment hints ─────────────────────────────────────────────────────────
+GH_REPO=cgcardona/maestro        # always hardcoded, never derived from local path
+```
+
+### Free-form content (after the key=value header)
+
+Below the key=value block, the file contains the actual task content.
+For `bugs-to-issues`, this is the list of bug descriptions — one `## Issue N` section per issue.
+
+### Nested sub-coordinator example
+
+If `SPAWN_SUB_AGENTS=true`, the agent's task file looks like this:
+
+```
+WORKFLOW=bugs-to-issues
+BATCH_NUM=1
+SPAWN_SUB_AGENTS=true
+PHASE_LABEL=phase-1/db-schema
+BATCH_LABEL=batch-01
+LABELS_TO_APPLY=enhancement,muse-hub,phase-1/db-schema,batch-01
+
+SUB_TASKS:
+## Sub-task A
+ISSUE_TITLE=[DB] Add musehub_milestones table
+ISSUE_BODY=...full description...
+
+## Sub-task B
+ISSUE_TITLE=[DB] Add musehub_labels table
+ISSUE_BODY=...full description...
+```
+
+The sub-coordinator agent:
+1. Reads the task file and discovers `SPAWN_SUB_AGENTS=true`
+2. Creates sub-worktrees (e.g. `batch-1a`, `batch-1b`)
+3. Writes a `.agent-task` file into each with `SPAWN_SUB_AGENTS=false`
+4. Launches one leaf agent per sub-worktree
+5. Collects leaf agent reports and self-destructs
 
 ---
 
 ## Architecture
 
 ```
-Kickoff (coordinator)
-  └─ for each batch of bugs:
+Coordinator
+  └─ Label Pre-flight (create/delete labels on GitHub)
+  └─ for each batch:
        DEV_SHA=$(git rev-parse dev)
-       git worktree add --detach .../batch-<N> "$DEV_SHA"  ← detached HEAD at dev tip
-       write .agent-task into it                            ← bug assignments, no guessing
+       git worktree add --detach .../batch-<N> "$DEV_SHA"
+       write .agent-task into it   ← ALL context the agent needs, incl. labels
        launch agent in that directory
 
 Agent (per worktree)
-  └─ cat .agent-task                         ← reads its bug batch
-  └─ for each bug: draft → gh issue create
-  └─ git worktree remove --force <path>      ← self-destructs when done
-  └─ git -C <main-repo> worktree prune       ← cleans up the ref
+  └─ cat .agent-task               ← reads LABELS_TO_APPLY and all other fields
+  └─ for each bug: draft → gh issue create (no --label)
+  └─ for each label in LABELS_TO_APPLY: gh issue edit --add-label || true
+  └─ git worktree remove --force   ← self-destructs when done
+  └─ git worktree prune
 ```
-
-Worktrees are **not** kept around between cycles. If an agent crashes before
-cleanup, run `git worktree prune` from the main repo.
 
 ---
 
-## Setup — run this before launching agents
+## Step 0 — Label Pre-flight (run ONCE before creating worktrees)
+
+Run this before the Setup script. It ensures every label in every
+`LABELS_TO_APPLY` field exists on GitHub — and deletes any stale labels from
+previous naming schemes that would pollute autocomplete.
+
+```bash
+export GH_REPO=cgcardona/maestro
+
+# ── 1. Identify stale labels to delete ────────────────────────────────────────
+# List all phase/batch labels currently on GitHub so you can spot obsolete ones.
+echo "=== Current phase/batch labels ==="
+gh label list --repo "$GH_REPO" --limit 100 | grep -E "^(phase|batch)" | sort
+
+# Delete stale labels (edit this list to match what's actually stale):
+# for label in phase-1 phase-2 batch-1 batch-2; do
+#   gh label delete "$label" --repo "$GH_REPO" --yes 2>/dev/null || true
+# done
+
+# ── 2. Create/update phase labels ─────────────────────────────────────────────
+# Add any phase labels needed for this run. gh label create fails silently if
+# the label already exists with the correct colour — use --force to update colour/desc.
+declare -A PHASE_LABELS=(
+  ["phase-1/db-schema"]="0052cc|Phase 1 · DB Schema: new Alembic migrations + ORM models"
+  ["phase-2/core-api"]="0075ca|Phase 2 · Core API: brand-new FastAPI route files"
+  ["phase-3/api-extensions"]="0e8a16|Phase 3 · API Extensions: new endpoints on existing route files"
+  ["phase-4/new-ui-pages"]="006b75|Phase 4 · New UI Pages: brand-new page route files"
+  ["phase-5/ui-enhancements"]="5319e7|Phase 5 · UI Enhancements: improvements to existing pages"
+  ["phase-6/seed-data"]="b60205|Phase 6 · Seed Data: 10x seed script, CC MIDI, narratives"
+  ["phase-7/machine-access"]="e4e669|Phase 7 · Machine Access: JSON alternates, oEmbed, JSON-LD, RSS"
+)
+for label in "${!PHASE_LABELS[@]}"; do
+  IFS='|' read -r color desc <<< "${PHASE_LABELS[$label]}"
+  gh label create "$label" --repo "$GH_REPO" --color "$color" --description "$desc" 2>/dev/null \
+    || gh label edit "$label" --repo "$GH_REPO" --color "$color" --description "$desc" 2>/dev/null \
+    || true
+  echo "✅ phase label: $label"
+done
+
+# ── 3. Create/update status labels (pipeline state — used by conductor) ───────
+declare -A STATUS_LABELS=(
+  ["status/ready"]="0e8a16|Issue is open and ready for an ISSUE_TO_PR agent"
+  ["status/in-progress"]="e4e669|ISSUE_TO_PR agent currently working on this issue"
+  ["status/pr-open"]="d93f0b|PR created, awaiting PR_REVIEW agent"
+  ["status/merged"]="6f42c1|PR merged and issue closed"
+  ["conductor-reminder"]="e4e669|Open: pipeline incomplete — re-run PARALLEL_CONDUCTOR.md"
+)
+for label in "${!STATUS_LABELS[@]}"; do
+  IFS='|' read -r color desc <<< "${STATUS_LABELS[$label]}"
+  gh label create "$label" --repo "$GH_REPO" --color "$color" --description "$desc" 2>/dev/null \
+    || gh label edit "$label" --repo "$GH_REPO" --color "$color" --description "$desc" 2>/dev/null \
+    || true
+  echo "✅ status label: $label"
+done
+
+# ── 4. Create/update batch labels ─────────────────────────────────────────────
+for i in $(seq 1 15); do
+  N=$(printf "%02d" $i)
+  gh label create "batch-$N" --repo "$GH_REPO" \
+    --color "f4a261" \
+    --description "Batch $N · 4 parallel issues guaranteed no file conflicts" \
+    2>/dev/null || true
+done
+echo "✅ batch labels 01-15 ready"
+
+# ── 4. Verify all required labels exist ───────────────────────────────────────
+echo "=== All phase/batch labels after pre-flight ==="
+gh label list --repo "$GH_REPO" --limit 100 | grep -E "^(phase|batch)" | sort
+```
+
+---
+
+## Setup — run this after the Label Pre-flight
 
 Run from anywhere inside the main repo. Paths are derived automatically.
 **Fill in the bug descriptions in each `.agent-task` before launching agents.**
@@ -60,43 +255,73 @@ Run from anywhere inside the main repo. Paths are derived automatically.
 ```bash
 REPO=$(git rev-parse --show-toplevel)
 PRTREES="$HOME/.cursor/worktrees/$(basename "$REPO")"
+mkdir -p "$PRTREES"
 cd "$REPO"
 
-# Number of agents (one per batch)
-NUM_AGENTS=3
+GH_REPO=cgcardona/maestro
+NUM_BATCHES=3   # one worktree per batch
 
 DEV_SHA=$(git rev-parse dev)
 
-for i in $(seq 1 $NUM_AGENTS); do
+for i in $(seq 1 $NUM_BATCHES); do
   WT="$PRTREES/batch-$i"
   if [ -d "$WT" ]; then
     echo "⚠️  worktree batch-$i already exists, skipping"
     continue
   fi
   git worktree add --detach "$WT" "$DEV_SHA"
-  cat > "$WT/.agent-task" <<EOF
+
+  # ── Write the task file ───────────────────────────────────────────────────
+  # Edit: PHASE_LABEL, BATCH_LABEL, LABELS_TO_APPLY, FILE_OWNERSHIP per batch.
+  # Then add the bug descriptions under BUGS:.
+  cat > "$WT/.agent-task" << TASKEOF
 WORKFLOW=bugs-to-issues
 BATCH_NUM=$i
+GH_REPO=$GH_REPO
+
+PHASE_LABEL=phase-X/name-here
+BATCH_LABEL=batch-$(printf "%02d" $i)
+LABELS_TO_APPLY=enhancement,muse-hub,phase-X/name-here,batch-$(printf "%02d" $i)
+
+FILE_OWNERSHIP=
+DEPENDS_ON=
+SPAWN_SUB_AGENTS=false
+ATTEMPT_N=0
+REQUIRED_OUTPUT=issue_urls
+ON_BLOCK=stop
 
 BUGS:
 # Paste bug descriptions for batch $i below, one per section.
-# Each bug becomes one GitHub issue.
+# Each ## Issue N block becomes one GitHub issue.
 
-## Bug 1
+## Issue 1
+<title>
 <description>
 
-## Bug 2
+## Issue 2
+<title>
 <description>
-EOF
-  echo "✅ worktree batch-$i ready — fill in .agent-task"
+TASKEOF
+
+  echo "✅ worktree batch-$i ready — fill in PHASE_LABEL, BATCH_LABEL, LABELS_TO_APPLY, and BUGS"
 done
 
 git worktree list
 ```
 
-After filling in each `.agent-task`, open one Cursor composer window per
-worktree, each rooted in its `batch-<N>` directory, and paste the Kickoff
-Prompt below.
+After filling in each `.agent-task`, launch one agent per worktree using the
+Task tool (recommended — allows more than 4 simultaneous agents) or by pasting
+the Kickoff Prompt into a Cursor composer window rooted in that worktree.
+
+**Using the Task tool (preferred):** you can launch all batches simultaneously
+in a single message because each agent reads its own task file independently:
+
+```python
+# Launch all 3 batch agents in one message — they run fully in parallel
+Task(worktree="/path/to/batch-1", prompt=KICKOFF_PROMPT)
+Task(worktree="/path/to/batch-2", prompt=KICKOFF_PROMPT)
+Task(worktree="/path/to/batch-3", prompt=KICKOFF_PROMPT)
+```
 
 ---
 
@@ -108,16 +333,17 @@ Prompt below.
 # Derive main repo path if needed
 REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only
 
-# GitHub repo slug — HARDCODED. NEVER derive from local path or directory name.
-# The local path is /Users/gabriel/dev/tellurstori/maestro — "tellurstori" is NOT the GitHub org.
-export GH_REPO=cgcardona/maestro
+# GitHub repo slug — read from .agent-task GH_REPO field, or use hardcoded default.
+# NEVER derive from local path or directory name.
+export GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
+export GH_REPO=${GH_REPO:-cgcardona/maestro}   # fallback
 ```
 
 | Item | Value |
 |------|-------|
 | Your worktree root | current directory (contains `.agent-task`) |
 | Main repo (local path) | first entry of `git worktree list` |
-| GitHub repo slug | `cgcardona/maestro` — always hardcoded, never derived |
+| GitHub repo slug | read from `.agent-task` GH_REPO field — always `cgcardona/maestro` |
 | GitHub CLI | `gh` — already authenticated |
 
 **No Docker needed.** Issues are created via `gh issue create` — no code
@@ -130,59 +356,111 @@ changes, no mypy, no tests.
 ```
 PARALLEL AGENT COORDINATION — BUGS TO ISSUES
 
-STEP 0 — READ YOUR TASK:
+STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
-  This file contains your batch of bug reports to convert into GitHub issues.
 
-STEP 1 — SET GITHUB REPO AND VERIFY AUTH:
-  # GitHub repo slug — ALWAYS hardcoded. NEVER derive from directory name or local path.
-  # The local path contains "tellurstori" but the GitHub org is "cgcardona".
-  export GH_REPO=cgcardona/maestro
-  # All gh commands pick this up automatically. You may also pass --repo "$GH_REPO" explicitly.
+  Parse these fields from the header (KEY=value lines):
+    WORKFLOW        — must be "bugs-to-issues"
+    BATCH_NUM       — your batch number
+    GH_REPO         — GitHub repo slug (hardcoded: cgcardona/maestro)
+    PHASE_LABEL     — the phase label to apply to every issue (e.g. phase-2/core-api)
+    BATCH_LABEL     — the batch label (e.g. batch-03)
+    LABELS_TO_APPLY — comma-separated list of ALL labels to apply to every issue
+    FILE_OWNERSHIP  — which files this batch owns (for your awareness, not action needed)
+    DEPENDS_ON      — batch/issue numbers that must be merged before you run
+    SPAWN_SUB_AGENTS — if true, follow the sub-coordinator path instead of this path
 
+  Export for use in all subsequent commands:
+    export GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
+    export GH_REPO=${GH_REPO:-cgcardona/maestro}
+
+    PHASE_LABEL=$(grep "^PHASE_LABEL=" .agent-task | cut -d= -f2)
+    BATCH_LABEL=$(grep "^BATCH_LABEL=" .agent-task | cut -d= -f2)
+    LABELS_TO_APPLY=$(grep "^LABELS_TO_APPLY=" .agent-task | cut -d= -f2)
+    ATTEMPT_N=$(grep "^ATTEMPT_N=" .agent-task | cut -d= -f2)
+
+  ⚠️  ANTI-LOOP GUARD: if ATTEMPT_N > 2 → STOP immediately.
+    You have retried this task 3+ times. Continuing is almost certainly wrong.
+    Self-destruct and escalate: report the exact failure from your last attempt
+    so a human can diagnose the root cause. Never loop blindly.
+
+  ⚠️  RETRY-WITHOUT-STRATEGY-MUTATION: if a command fails twice in a row with
+    the same error, you MUST change strategy — not retry with minor parameter tweaks.
+    Two identical failures = the approach is wrong. Stop. Redesign. Or escalate.
+
+  If SPAWN_SUB_AGENTS=true → follow the sub-coordinator path:
+    1. For each sub-task in the file, create a sub-worktree with its own .agent-task
+    2. Launch one leaf agent per sub-worktree (Task tool or Cursor composer)
+    3. Collect leaf reports and self-destruct
+    (This enables nested orchestration — see Agent Task File Reference in the main doc)
+
+STEP 1 — VERIFY AUTH AND LABELS EXIST:
   gh auth status
+  # Verify every label in LABELS_TO_APPLY exists on GitHub:
+  IFS=',' read -ra LABELS <<< "$LABELS_TO_APPLY"
+  for label in "${LABELS[@]}"; do
+    FOUND=$(gh label list --repo "$GH_REPO" --search "$label" --json name --jq '.[].name' 2>/dev/null)
+    if [ -z "$FOUND" ]; then
+      echo "❌ Label '$label' does not exist on GitHub. Run the Label Pre-flight script."
+      echo "   Continuing — label application will use || true so this is non-fatal."
+    fi
+  done
 
 STEP 2 — CREATE ISSUES:
-  Read and follow every step in .github/CREATE_ISSUES_PROMPT.md exactly.
-  For each bug in your batch:
-  1. Analyze the bug using the domain context in CREATE_ISSUES_PROMPT.md
-  2. Check for an existing issue BEFORE creating a new one (idempotency gate):
-       gh issue list --search "Fix: <short description>" --state all --json number,title,url
-     If a matching open or closed issue already exists → skip creation, record the existing URL.
-  3. Draft the full issue body (description, user journey, location, fix shape, tests, docs, labels)
-  4. Create the issue (only if step 2 found nothing) using the TWO-STEP PATTERN:
+  For each ## Issue N section in the BUGS: block of .agent-task:
 
-     ── LABEL REFERENCE (only use labels from this list) ──────────────────────
-     │ bug              documentation     duplicate         enhancement        │
-     │ good first issue help wanted       invalid           question           │
-     │ wontfix          multimodal        performance       ai-pipeline        │
-     │ muse             muse-cli          muse-hub          storpheus          │
-     │ maestro-integration  mypy          cli               testing            │
-     │ weekend-mvp      muse-music-extensions                                  │
-     │                                                                         │
-     │ ⚠️  Never invent labels (e.g. "tech-debt", "mcp", "budget",            │
-     │    "security" do NOT exist). Using a missing label causes               │
-     │    gh issue create to fail entirely.                                    │
-     └─────────────────────────────────────────────────────────────────────────
+  1. Check for an existing issue first (idempotency gate):
+       gh issue list --repo "$GH_REPO" --search "<title>" --state all --json number,title,url | head -3
+     If a matching issue already exists → skip creation, record the existing URL.
 
-     ── TWO-STEP PATTERN ──────────────────────────────────────────────────────
-     │ Step 1: create without --label (never fails due to labels)             │
-     │ Step 2: apply labels with gh issue edit || true (non-fatal per label)  │
-     └─────────────────────────────────────────────────────────────────────────
+  2. Create the issue WITHOUT --label (the two-step pattern prevents label failures
+     from blocking issue creation):
 
-       ISSUE_URL=$(gh issue create \
-         --title "Fix: <short description>" \
-         --body "$(cat <<'EOF'
-<full issue body>
+     ISSUE_URL=$(gh issue create \
+       --repo "$GH_REPO" \
+       --title "<title from task file>" \
+       --body "$(cat <<'EOF'
+<full body from task file — include Phase, Batch, File Ownership, Depends On,
+ and all technical spec details>
 EOF
 )")
-       # Apply each label on its own line from the LABEL REFERENCE above.
-       gh issue edit "$ISSUE_URL" --add-label "bug" 2>/dev/null || true
-       # gh issue edit "$ISSUE_URL" --add-label "<second-label>" 2>/dev/null || true
 
-  5. Record the created issue URL ($ISSUE_URL).
-     ⚠️  If gh issue create fails twice for the same bug, skip it and report the failure —
-     do NOT loop endlessly. Change strategy or escalate.
+  3. Apply EVERY label from LABELS_TO_APPLY individually (|| true = non-fatal):
+     IFS=',' read -ra LABELS <<< "$LABELS_TO_APPLY"
+     for label in "${LABELS[@]}"; do
+       gh issue edit "$ISSUE_URL" --repo "$GH_REPO" --add-label "$label" 2>/dev/null || true
+     done
+
+     # Also apply any domain-specific labels listed in the issue section itself:
+     # (e.g. muse-cli for commands that map to CLI commands)
+     # gh issue edit "$ISSUE_URL" --repo "$GH_REPO" --add-label "muse-cli" 2>/dev/null || true
+
+  4. Record the created issue URL.
+     ⚠️  If gh issue create fails twice for the same issue, skip it and report
+     the failure — do NOT loop endlessly.
+
+  ── VALID LABEL REFERENCE ────────────────────────────────────────────────────
+  │ Standard labels (always exist):                                            │
+  │   bug             documentation   duplicate        enhancement             │
+  │   good first issue  help wanted   invalid          question                │
+  │   wontfix         multimodal      performance      ai-pipeline             │
+  │   muse            muse-cli        muse-hub         storpheus               │
+  │   maestro-integration  mypy       cli              testing                 │
+  │   weekend-mvp     muse-music-extensions                                    │
+  │                                                                            │
+  │ Phase labels (created by Label Pre-flight):                                │
+  │   phase-1/db-schema      phase-2/core-api      phase-3/api-extensions     │
+  │   phase-4/new-ui-pages   phase-5/ui-enhancements  phase-6/seed-data       │
+  │   phase-7/machine-access                                                   │
+  │                                                                            │
+  │ Batch labels (created by Label Pre-flight):                                │
+  │   batch-01  batch-02  batch-03  batch-04  batch-05  batch-06  batch-07    │
+  │   batch-08  batch-09  batch-10  batch-11  batch-12  batch-13  batch-14    │
+  │   batch-15                                                                 │
+  │                                                                            │
+  │ ⚠️  Never invent labels. A missing label causes gh issue edit to fail     │
+  │    (non-fatal with || true), but leaves the issue mislabeled.             │
+  └────────────────────────────────────────────────────────────────────────────
 
 STEP 3 — SELF-DESTRUCT (always run this when done):
   REPO=$(git worktree list | head -1 | awk '{print $1}')
@@ -191,28 +469,37 @@ STEP 3 — SELF-DESTRUCT (always run this when done):
   git worktree remove --force "$WORKTREE"
   git worktree prune
 
-Report: batch number, explicit list of created issue URLs with titles.
-⚠️  An empty URL list is a failure — "Done" is not an acceptable report without artifact proof.
+Report: batch number, PHASE_LABEL, BATCH_LABEL, and the explicit list of
+created issue URLs with titles. ⚠️  An empty URL list is a failure — "Done"
+without artifact proof is not acceptable.
 ```
 
 ---
 
 ## Before launching
 
-1. Create worktrees with the setup script above.
-2. Fill in `.agent-task` bug descriptions in each worktree.
+1. Run the **Label Pre-flight** script above.
+2. Run the **Setup** script and fill in `.agent-task` files (PHASE_LABEL, BATCH_LABEL, LABELS_TO_APPLY, BUGS).
 3. Confirm `gh` is authenticated: `gh auth status`
-4. Confirm issues will land in the right repo: `gh repo view`
+4. Confirm issues will land in the right repo: `gh repo view cgcardona/maestro`
 
 ---
 
 ## After agents complete
 
-- Review created issues on GitHub for accuracy and completeness.
-- Add any `blocks #N` / `related to #N` cross-references if needed.
+- Review created issues on GitHub for accuracy and label correctness.
+- Verify every issue has: phase label + batch label + domain labels.
+  ```bash
+  gh issue list --repo cgcardona/maestro --label "batch-01" --json number,title,labels
+  ```
+- Add `blocks #N` / `related to #N` cross-references if needed.
 - Verify no stale worktrees remain: `git worktree list` — should show only the main repo.
   If any linger (agent crashed before cleanup):
   ```bash
   git -C "$(git rev-parse --show-toplevel)" worktree prune
   ```
 - Issues are immediately available for the **PARALLEL_ISSUE_TO_PR.md** workflow.
+  To dispatch the next wave, select issues by batch label:
+  ```bash
+  gh issue list --repo cgcardona/maestro --label "batch-01" --state open --json number,title,url
+  ```

--- a/.cursor/PARALLEL_CONDUCTOR.md
+++ b/.cursor/PARALLEL_CONDUCTOR.md
@@ -1,0 +1,513 @@
+# Parallel Agent Conductor — Full Pipeline Orchestration
+
+> ## YOU ARE THE META-ORCHESTRATOR
+>
+> If you are an AI agent reading this document, your role is **conductor only**.
+>
+> **Your job — the full list, nothing more:**
+> 1. Close any stale `conductor-reminder` issues from the previous run.
+> 2. Clean up orphaned worktrees left by crashed agents.
+> 3. Query GitHub to reconstruct full pipeline state from labels and PR status.
+> 4. Resolve the dependency graph — determine which batches can advance right now.
+> 5. Dispatch the correct canonical coordinator for each ready batch, simultaneously.
+> 6. Collect coordinator reports and verify artifact proof.
+> 7. Create a `conductor-reminder` issue if the pipeline is not idle.
+>
+> **You do NOT:**
+> - Implement any feature yourself.
+> - Review any PR yourself.
+> - Create any GitHub issue yourself (other than the reminder).
+> - Run mypy or pytest yourself.
+> - Hardcode batch or issue numbers — **GitHub label state is the single source of truth**.
+>
+> The coordinators you dispatch read their own canonical prompts.
+> You do not rewrite those prompts or duplicate their logic.
+
+---
+
+## Why the conductor exists
+
+The three canonical prompts (BUGS_TO_ISSUES, ISSUE_TO_PR, PR_REVIEW) are stage-specific.
+Each requires a human to decide when to run it, which batch to target, and whether
+dependencies are met. The conductor removes that human bottleneck.
+
+A single conductor invocation:
+1. Reads all pipeline state from GitHub labels.
+2. Determines which batches are ready (dependencies satisfied).
+3. Dispatches ISSUE_TO_PR and PR_REVIEW coordinators **simultaneously** for all ready batches.
+4. Leaves a reminder if work remains so the next run is obvious.
+
+The conductor does not loop — it makes one full pass, then creates a reminder.
+Re-run it once per development session or whenever a human decides to advance the pipeline.
+
+---
+
+## Pipeline State Model
+
+Pipeline state lives entirely in GitHub. No external database, no sidecar files.
+
+### Source of truth signals
+
+| Signal | How to read it |
+|--------|---------------|
+| Open issues with `batch-NN` label | Issues not yet implemented — ready for ISSUE_TO_PR |
+| Open PRs linked to `batch-NN` issues | PRs awaiting review — ready for PR_REVIEW |
+| Closed issues | Implemented and merged |
+| Open issues with `status/in-progress` | ISSUE_TO_PR agent currently working |
+| Open PRs with `status/pr-open` | PR_REVIEW agent dispatched but not yet merged |
+| `conductor-reminder` issue open | Pipeline was incomplete on last conductor run |
+
+### Phase dependency order
+
+Phases must be completed in order. Within a phase, all batches run in parallel.
+
+```
+phase-1/db-schema      →  phase-2/core-api      →  phase-3/api-extensions
+phase-4/new-ui-pages   →  phase-5/ui-enhancements
+phase-6/seed-data      →  phase-7/machine-access
+```
+
+A batch is "ready" if:
+- Its phase's predecessor phase has all issues closed (merged), AND
+- It has open issues (ISSUE_TO_PR) or open PRs (PR_REVIEW).
+
+⚠️  **Human approval gates** — these batches require explicit human sign-off before dispatch:
+- Any batch in `phase-1/db-schema` containing an Alembic migration — migration chains
+  must be audited for MERGE_AFTER ordering before parallel review.
+- Any issue or PR labeled `security`.
+- Any PR that modifies `maestro/protocol/events.py` (SSE contract — Swift frontend impact).
+
+---
+
+## Setup — run this once to create the conductor worktree
+
+```bash
+REPO=$(git rev-parse --show-toplevel)
+PRTREES="$HOME/.cursor/worktrees/$(basename "$REPO")"
+mkdir -p "$PRTREES"
+cd "$REPO"
+
+export GH_REPO=cgcardona/maestro
+
+# Snapshot dev tip
+DEV_SHA=$(git rev-parse dev)
+
+WT="$PRTREES/conductor"
+if [ -d "$WT" ]; then
+  echo "⚠️  conductor worktree already exists — remove it first or re-use:"
+  echo "    git worktree remove --force $WT && git worktree prune"
+  exit 1
+fi
+git worktree add --detach "$WT" "$DEV_SHA"
+
+# Write the conductor task file.
+# PHASE_FILTER: leave empty to run the full pipeline, or set to a single phase
+# label (e.g. phase-3/api-extensions) to limit scope to one phase.
+cat > "$WT/.agent-task" << TASKEOF
+WORKFLOW=conductor
+GH_REPO=$GH_REPO
+PHASE_FILTER=
+MAX_ISSUES_PER_DISPATCH=12
+MAX_PRS_PER_DISPATCH=12
+ATTEMPT_N=0
+REQUIRED_OUTPUT=pipeline_status_report
+ON_BLOCK=escalate
+TASKEOF
+
+echo "✅ conductor worktree ready: $WT"
+git worktree list
+```
+
+After running, launch the conductor agent with the **Kickoff Prompt** below.
+
+---
+
+## Kickoff Prompt
+
+```
+PARALLEL AGENT COORDINATION — PIPELINE CONDUCTOR
+
+Read .cursor/AGENT_COMMAND_POLICY.md before issuing any shell commands.
+Green-tier commands run without confirmation. Yellow = check scope first.
+Red = never, ask the user instead.
+
+STEP 0 — READ YOUR TASK FILE:
+  cat .agent-task
+
+  Parse all KEY=value fields:
+    GH_REPO                → GitHub repo slug (always cgcardona/maestro)
+    PHASE_FILTER           → restrict to one phase, or empty for all
+    MAX_ISSUES_PER_DISPATCH → cap on parallel ISSUE_TO_PR agents (safety valve)
+    MAX_PRS_PER_DISPATCH   → cap on parallel PR_REVIEW agents (safety valve)
+    ATTEMPT_N              → how many times conductor has run without progress
+
+  Export:
+    export GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
+    export GH_REPO=${GH_REPO:-cgcardona/maestro}
+    PHASE_FILTER=$(grep "^PHASE_FILTER=" .agent-task | cut -d= -f2)
+    ATTEMPT_N=$(grep "^ATTEMPT_N=" .agent-task | cut -d= -f2)
+
+  ⚠️  ANTI-LOOP GUARD: if ATTEMPT_N > 3 → STOP.
+    This conductor has run 4+ times without advancing the pipeline.
+    Something is systematically wrong (label misconfiguration, GitHub API failure,
+    all remaining issues blocked on human-gated dependencies, etc.).
+    Create a GitHub issue:
+      gh issue create --repo "$GH_REPO" \
+        --title "⚠️ Conductor stuck: ATTEMPT_N=$ATTEMPT_N — needs human intervention" \
+        --body "The pipeline conductor has run $(( ATTEMPT_N )) times without advancing.
+  Possible causes:
+  - All remaining batches have unresolved DEPENDS_ON dependencies
+  - All remaining PRs are in D/F grade rejection state
+  - Label misconfiguration (phase/batch labels missing or wrong)
+  - GitHub API failures
+  
+  Run: gh issue list --repo $GH_REPO --label 'conductor-reminder' --state open
+  "
+    Then self-destruct and escalate to the user.
+
+STEP 1 — STALE STATE CLEANUP (always run first):
+  # 1a. Close stale conductor-reminder issues (they're outdated by this new run)
+  STALE_REMINDERS=$(gh issue list --repo "$GH_REPO" \
+    --label "conductor-reminder" --state open --json number --jq '.[].number' 2>/dev/null)
+  if [ -n "$STALE_REMINDERS" ]; then
+    echo "$STALE_REMINDERS" | tr ',' '\n' | xargs -I{} gh issue close {} \
+      --comment "Superseded by new conductor run. New reminder will be created if pipeline is still incomplete." \
+      --repo "$GH_REPO" 2>/dev/null || true
+    echo "✅ Closed stale reminder issues: $STALE_REMINDERS"
+  fi
+
+  # 1b. Clean up orphaned worktrees from crashed previous runs
+  REPO=$(git worktree list | head -1 | awk '{print $1}')
+  PRTREES="$HOME/.cursor/worktrees/$(basename "$REPO")"
+  STALE_WT=$(git worktree list --porcelain \
+    | grep "^worktree " | awk '{print $2}' \
+    | grep -v "^$REPO$" \
+    | grep "$PRTREES" \
+    | grep -v "conductor")
+  if [ -n "$STALE_WT" ]; then
+    echo "⚠️  Orphaned worktrees detected:"
+    echo "$STALE_WT"
+    echo "$STALE_WT" | xargs -I{} git -C "$REPO" worktree remove --force {} 2>/dev/null || true
+    git -C "$REPO" worktree prune
+    echo "✅ Orphaned worktrees cleaned up"
+  fi
+
+STEP 2 — QUERY GITHUB PIPELINE STATE:
+  # Build a complete picture of the pipeline from GitHub labels.
+  # Do not assume — derive everything from live GitHub state.
+
+  echo "=== OPEN ISSUES BY PHASE/BATCH ==="
+  if [ -n "$PHASE_FILTER" ]; then
+    gh issue list --repo "$GH_REPO" --label "$PHASE_FILTER" --state open \
+      --json number,title,labels --limit 100
+  else
+    # Query all phase labels in priority order
+    for phase in "phase-1/db-schema" "phase-2/core-api" "phase-3/api-extensions" \
+                 "phase-4/new-ui-pages" "phase-5/ui-enhancements" \
+                 "phase-6/seed-data" "phase-7/machine-access"; do
+      COUNT=$(gh issue list --repo "$GH_REPO" --label "$phase" --state open \
+        --json number --jq 'length' 2>/dev/null || echo 0)
+      if [ "$COUNT" -gt 0 ]; then
+        echo ""
+        echo "── $phase ($COUNT open issues) ──"
+        gh issue list --repo "$GH_REPO" --label "$phase" --state open \
+          --json number,title,labels --jq \
+          '.[] | "\(.number) | \(.title) | \(.labels | map(.name) | join(","))"'
+      fi
+    done
+  fi
+
+  echo ""
+  echo "=== OPEN PRs ==="
+  gh pr list --repo "$GH_REPO" --state open --limit 50 \
+    --json number,title,headRefName,labels --jq \
+    '.[] | "#\(.number) | \(.title) | \(.headRefName)"'
+
+STEP 3 — RESOLVE DEPENDENCY GRAPH:
+  # Determine which phases are fully merged (all issues closed) and which have work.
+  # This drives the "ready" determination for each batch.
+
+  # For each phase, count open issues:
+  declare -A PHASE_OPEN=()
+  for phase in "phase-1/db-schema" "phase-2/core-api" "phase-3/api-extensions" \
+               "phase-4/new-ui-pages" "phase-5/ui-enhancements" \
+               "phase-6/seed-data" "phase-7/machine-access"; do
+    COUNT=$(gh issue list --repo "$GH_REPO" --label "$phase" --state open \
+      --json number --jq 'length' 2>/dev/null || echo 0)
+    PHASE_OPEN[$phase]=$COUNT
+    echo "  $phase: $COUNT open issues"
+  done
+
+  # Phase ordering groups (a group must fully close before the next group starts):
+  # Group A: phase-1 → phase-2 → phase-3
+  # Group B: phase-4 → phase-5
+  # Group C: phase-6 → phase-7
+  #
+  # The ACTIVE phase in each group is the lowest-numbered phase with open issues.
+  # Within a phase, all batches with open issues run in parallel.
+
+  # Determine active phases:
+  ACTIVE_PHASES=()
+  # Group A
+  if [ "${PHASE_OPEN[phase-1/db-schema]:-0}" -gt 0 ]; then
+    ACTIVE_PHASES+=("phase-1/db-schema")
+  elif [ "${PHASE_OPEN[phase-2/core-api]:-0}" -gt 0 ]; then
+    ACTIVE_PHASES+=("phase-2/core-api")
+  elif [ "${PHASE_OPEN[phase-3/api-extensions]:-0}" -gt 0 ]; then
+    ACTIVE_PHASES+=("phase-3/api-extensions")
+  fi
+  # Group B
+  if [ "${PHASE_OPEN[phase-4/new-ui-pages]:-0}" -gt 0 ]; then
+    ACTIVE_PHASES+=("phase-4/new-ui-pages")
+  elif [ "${PHASE_OPEN[phase-5/ui-enhancements]:-0}" -gt 0 ]; then
+    ACTIVE_PHASES+=("phase-5/ui-enhancements")
+  fi
+  # Group C
+  if [ "${PHASE_OPEN[phase-6/seed-data]:-0}" -gt 0 ]; then
+    ACTIVE_PHASES+=("phase-6/seed-data")
+  elif [ "${PHASE_OPEN[phase-7/machine-access]:-0}" -gt 0 ]; then
+    ACTIVE_PHASES+=("phase-7/machine-access")
+  fi
+
+  echo "Active phases: ${ACTIVE_PHASES[*]}"
+
+  # Collect ready issues (no PR yet) and ready PRs (open, not merged) from active phases
+  READY_ISSUES=()
+  READY_PRS=()
+  for phase in "${ACTIVE_PHASES[@]}"; do
+    # Issues with no associated PR → ready for ISSUE_TO_PR
+    PHASE_ISSUES=$(gh issue list --repo "$GH_REPO" --label "$phase" --state open \
+      --json number,title --jq '.[] | "\(.number)|\(.title)"' 2>/dev/null)
+    while IFS= read -r issue_entry; do
+      [ -z "$issue_entry" ] && continue
+      ISSUE_NUM="${issue_entry%%|*}"
+      # Check if a PR already exists for this issue
+      EXISTING_PR=$(gh pr list --repo "$GH_REPO" --state open \
+        --search "closes #$ISSUE_NUM" --json number --jq '.[0].number' 2>/dev/null)
+      if [ -z "$EXISTING_PR" ]; then
+        READY_ISSUES+=("$issue_entry")
+      fi
+    done <<< "$PHASE_ISSUES"
+
+    # PRs linked to this phase's issues → ready for PR_REVIEW
+    PHASE_PRS=$(gh pr list --repo "$GH_REPO" --state open --limit 50 \
+      --json number,title,labels --jq \
+      ".[] | select(.labels | map(.name) | any(. == \"$phase\")) | \"\(.number)|\(.title)\"" 2>/dev/null)
+    while IFS= read -r pr_entry; do
+      [ -z "$pr_entry" ] && continue
+      READY_PRS+=("$pr_entry")
+    done <<< "$PHASE_PRS"
+  done
+
+  echo ""
+  echo "=== READY FOR ISSUE_TO_PR (${#READY_ISSUES[@]} issues) ==="
+  for i in "${READY_ISSUES[@]}"; do echo "  #${i%%|*}: ${i##*|}"; done
+  echo ""
+  echo "=== READY FOR PR_REVIEW (${#READY_PRS[@]} PRs) ==="
+  for i in "${READY_PRS[@]}"; do echo "  #${i%%|*}: ${i##*|}"; done
+
+STEP 4 — HUMAN APPROVAL GATE:
+  # Check for gated items before dispatching.
+  # Gated items must NOT be dispatched without explicit human sign-off.
+
+  GATED=false
+
+  # Check for phase-1 (DB schema / Alembic migrations)
+  for issue_entry in "${READY_ISSUES[@]}"; do
+    ISSUE_NUM="${issue_entry%%|*}"
+    LABELS=$(gh issue view "$ISSUE_NUM" --repo "$GH_REPO" --json labels \
+      --jq '.labels | map(.name) | join(",")' 2>/dev/null)
+    if echo "$LABELS" | grep -q "phase-1/db-schema"; then
+      echo "⚠️  HUMAN GATE: Issue #$ISSUE_NUM is in phase-1/db-schema (Alembic migration)."
+      echo "   Verify MERGE_AFTER chain before dispatching. Requires human sign-off."
+      GATED=true
+    fi
+    if echo "$LABELS" | grep -q "security"; then
+      echo "⚠️  HUMAN GATE: Issue #$ISSUE_NUM has 'security' label. Requires human sign-off."
+      GATED=true
+    fi
+  done
+
+  if [ "$GATED" = true ]; then
+    echo ""
+    echo "⚠️  Gated items found. Dispatching all non-gated items first."
+    echo "   Review gated items manually, then re-run the conductor."
+  fi
+
+STEP 5 — DISPATCH COORDINATORS:
+  # Dispatch ISSUE_TO_PR and PR_REVIEW coordinators SIMULTANEOUSLY.
+  # Use the Task tool to launch them in parallel — no need to wait for one before
+  # starting the other.
+
+  # ── ISSUE_TO_PR: dispatch if there are ready issues ──────────────────────────
+  if [ "${#READY_ISSUES[@]}" -gt 0 ]; then
+    echo ""
+    echo "Dispatching ISSUE_TO_PR coordinator for ${#READY_ISSUES[@]} issues..."
+    echo ""
+    echo "Read .cursor/PARALLEL_ISSUE_TO_PR.md and follow the COORDINATOR ROLE exactly."
+    echo "Target issues (pre-screened for file isolation within their phase):"
+    for i in "${READY_ISSUES[@]}"; do echo "  #${i%%|*}: ${i##*|}"; done
+    echo ""
+    echo "The coordinator query: gh issue list --repo $GH_REPO --label <active_phase> --state open"
+    echo "Match these issue numbers to confirm the set before creating worktrees."
+    echo ""
+    echo "Coordinator constraint: MAX_ISSUES_PER_DISPATCH=$(grep "^MAX_ISSUES_PER_DISPATCH=" .agent-task | cut -d= -f2)"
+    echo "If more issues exist than the limit, prioritize by batch label (lowest batch-NN first)."
+    # LAUNCH: use the Task tool to spawn the coordinator agent.
+    # The coordinator reads PARALLEL_ISSUE_TO_PR.md and follows its coordinator role.
+  fi
+
+  # ── PR_REVIEW: dispatch if there are ready PRs ───────────────────────────────
+  if [ "${#READY_PRS[@]}" -gt 0 ]; then
+    echo ""
+    echo "Dispatching PR_REVIEW coordinator for ${#READY_PRS[@]} PRs..."
+    echo ""
+    echo "Read .cursor/PARALLEL_PR_REVIEW.md and follow the COORDINATOR ROLE exactly."
+    echo "Target PRs:"
+    for i in "${READY_PRS[@]}"; do echo "  #${i%%|*}: ${i##*|}"; done
+    echo ""
+    echo "Coordinator constraint: MAX_PRS_PER_DISPATCH=$(grep "^MAX_PRS_PER_DISPATCH=" .agent-task | cut -d= -f2)"
+    echo "If more PRs exist than the limit, prioritize by batch label (lowest batch-NN first)."
+    # LAUNCH: use the Task tool to spawn the coordinator agent.
+    # The coordinator reads PARALLEL_PR_REVIEW.md and follows its coordinator role.
+  fi
+
+  # ── IDLE: nothing to dispatch ─────────────────────────────────────────────────
+  if [ "${#READY_ISSUES[@]}" -eq 0 ] && [ "${#READY_PRS[@]}" -eq 0 ]; then
+    echo ""
+    echo "✅ Pipeline is idle. No open issues or PRs in any active phase."
+    echo "   Either all work is done, or all remaining batches are gated."
+    echo "   Push new GitHub issues with phase/batch labels to continue."
+  fi
+
+STEP 6 — COLLECT COORDINATOR REPORTS:
+  # Wait for all dispatched coordinators to report back.
+  # Each coordinator must provide artifact proof:
+  #   ISSUE_TO_PR: list of PR URLs created
+  #   PR_REVIEW:   list of PRs merged + grades
+
+  # Verify no coordinator reported an empty artifact list.
+  # "Done" without PR URLs or merge status = failure.
+
+  # If a coordinator self-destructed with a D/F grade report:
+  #   - Note the failed PR URL in this conductor's report.
+  #   - Do NOT block the pipeline on it — other batches continue.
+  #   - The rejected PR stays open; note it in the reminder issue.
+
+STEP 7 — REMINDER GATE:
+  # After collecting all reports, determine if work remains.
+
+  REMAINING_ISSUES=$(gh issue list --repo "$GH_REPO" --state open \
+    --json labels --jq '[.[] | select(.labels | map(.name) | any(startswith("phase-")))] | length' \
+    2>/dev/null || echo 0)
+  REMAINING_PRS=$(gh pr list --repo "$GH_REPO" --state open --limit 100 \
+    --json number --jq 'length' 2>/dev/null || echo 0)
+
+  if [ "$REMAINING_ISSUES" -gt 0 ] || [ "$REMAINING_PRS" -gt 0 ]; then
+    echo ""
+    echo "Pipeline is NOT idle. Creating conductor-reminder issue..."
+
+    # Build a pipeline status summary for the reminder body
+    STATUS_BODY="## Pipeline Status — $(date -u '+%Y-%m-%d %H:%M UTC')
+
+**Open issues:** $REMAINING_ISSUES
+**Open PRs:** $REMAINING_PRS
+**Conductor run:** attempt $(( ATTEMPT_N + 1 ))
+
+### What to do next
+Re-run the conductor by pasting the kickoff prompt from \`.cursor/PARALLEL_CONDUCTOR.md\`
+into a new Cursor composer window rooted in the conductor worktree.
+
+### Open issues by phase
+$(for phase in "phase-1/db-schema" "phase-2/core-api" "phase-3/api-extensions" \
+     "phase-4/new-ui-pages" "phase-5/ui-enhancements" \
+     "phase-6/seed-data" "phase-7/machine-access"; do
+  COUNT=$(gh issue list --repo "$GH_REPO" --label "$phase" --state open \
+    --json number --jq 'length' 2>/dev/null || echo 0)
+  [ "$COUNT" -gt 0 ] && echo "- $phase: $COUNT open issues"
+done)
+
+### Gated items (require human sign-off before conductor can proceed)
+$(gh issue list --repo "$GH_REPO" --label "phase-1/db-schema" --state open \
+  --json number,title --jq '.[] | "- Issue #\(.number): \(.title)"' 2>/dev/null || true)
+
+### Failed PRs (D/F grade — not merged, needs human review)
+$(gh pr list --repo "$GH_REPO" --state open \
+  --json number,title --jq '.[] | "- PR #\(.number): \(.title)"' 2>/dev/null | head -5 || true)
+"
+
+    REMINDER_URL=$(gh issue create \
+      --repo "$GH_REPO" \
+      --title "⏰ Conductor reminder — pipeline incomplete ($(date -u '+%Y-%m-%d'))" \
+      --body "$STATUS_BODY")
+    gh issue edit "$REMINDER_URL" --add-label "conductor-reminder" 2>/dev/null || true
+    echo "✅ Reminder created: $REMINDER_URL"
+    echo "   Re-run the conductor when coordinators have completed their work."
+  else
+    echo ""
+    echo "✅ Pipeline is fully idle. No open issues or PRs with phase labels."
+    echo "   All batches are implemented and merged. Well done."
+    echo "   Push new GitHub issues with phase/batch labels to start the next development cycle."
+  fi
+
+STEP 8 — SELF-DESTRUCT:
+  REPO=$(git worktree list | head -1 | awk '{print $1}')
+  WORKTREE=$(pwd)
+  cd "$REPO"
+  git worktree remove --force "$WORKTREE"
+  git worktree prune
+
+Report: pipeline state table (open issues by phase, open PRs, reminder URL if created).
+⚠️  "Done" without the pipeline state table is not acceptable.
+```
+
+---
+
+## Label Pre-flight (add conductor-reminder label once)
+
+Run this once to add the `conductor-reminder` label before the first conductor run.
+
+```bash
+export GH_REPO=cgcardona/maestro
+
+gh label create "conductor-reminder" \
+  --repo "$GH_REPO" \
+  --color "e4e669" \
+  --description "Open: pipeline incomplete — re-run PARALLEL_CONDUCTOR.md" \
+  2>/dev/null || true
+
+echo "✅ conductor-reminder label ready"
+```
+
+---
+
+## Taxonomy of failure modes this conductor guards against
+
+These are patterns from real multi-agent systems. The conductor addresses each:
+
+| Failure Mode | Guard |
+|---|---|
+| Orphaned subagent (child spins, parent unaware) | STEP 1: orphan worktree cleanup before every run |
+| Recursive thinking loop (plan, never execute) | STEP 0: ATTEMPT_N > 3 → abort and escalate |
+| Spec drift (parent updates, child continues old spec) | Conductor reads canonical prompts by file path — always current |
+| Semantic telephone (intent mutates across hops) | `.agent-task` is the spec; coordinators read it directly — no retelling |
+| False completion ("Done" with no artifact) | STEP 6: coordinator reports must include PR URLs or merge status |
+| Context drift after summarization | Conductor re-reads `.agent-task` at each STEP (no state in memory) |
+| Watchdog chain paradox (who watches the watchdog?) | Conductor reminder issue is the external signal; human is the top watchdog |
+| Cross-agent race conditions | Phase ordering + FILE_OWNERSHIP in task files — same as before |
+| Gated dependency deadlock | STEP 4: human approval gate surfaces gated items explicitly |
+
+---
+
+## After agents complete
+
+1. Pull dev and confirm it reflects the merged PRs.
+2. Check `git worktree list` — should show only the main repo.
+3. Check for `conductor-reminder` issues. If one exists, re-run the conductor.
+
+```bash
+REPO=$(git rev-parse --show-toplevel)
+git -C "$REPO" fetch origin && git -C "$REPO" merge origin/dev
+git worktree list
+gh issue list --repo cgcardona/maestro --label "conductor-reminder" --state open
+```

--- a/.cursor/PARALLEL_ISSUE_TO_PR.md
+++ b/.cursor/PARALLEL_ISSUE_TO_PR.md
@@ -5,10 +5,10 @@
 > If you are an AI agent reading this document, your role is **coordinator only**.
 >
 > **Your job — the full list, nothing more:**
-> 1. Query GitHub for the current phase label to get your canonical batch — **never use a hardcoded list**.
+> 1. Query GitHub for the current batch label to get your canonical issue set — **never use a hardcoded list**.
 > 2. Pull `dev` to confirm it is up to date.
-> 3. Run the Setup script below to create one worktree per issue.
-> 4. Launch one sub-agent per worktree by pasting the Kickoff Prompt (found at the bottom of this document) into a separate Cursor composer window rooted in that worktree.
+> 3. Run the Setup script below to create one worktree per issue and write a `.agent-task` file into each.
+> 4. Launch one sub-agent per worktree using the **Task tool** (preferred — allows unlimited parallel agents) or a Cursor composer window rooted in that worktree.
 > 5. Report back once all sub-agents have been launched.
 >
 > **You do NOT:**
@@ -16,10 +16,37 @@
 > - Run mypy or pytest yourself.
 > - Create PRs yourself.
 > - Read issue bodies or study code yourself.
-> - Hardcode issue numbers — **the GitHub label is the single source of truth**.
+> - Hardcode issue numbers — **the GitHub batch label is the single source of truth**.
 >
 > The **Kickoff Prompt** at the bottom of this document is for the sub-agents, not for you.
-> Copy it verbatim into each sub-agent's window. Do not follow it yourself.
+> Do not follow it yourself.
+
+---
+
+## Why `.agent-task` files unlock more than 4 parallel agents
+
+The Task tool can launch multiple agents from a single coordinator message.
+Each agent reads its own `.agent-task` file, so the coordinator does not
+need to pass any content as prompt text — just the worktree path and the
+kickoff prompt. This means you can launch 10, 20, or 50 agents in one message:
+
+```python
+# All launched simultaneously — no 4-agent limit
+Task(worktree="/path/to/issue-402", prompt=KICKOFF_PROMPT)
+Task(worktree="/path/to/issue-403", prompt=KICKOFF_PROMPT)
+Task(worktree="/path/to/issue-407", prompt=KICKOFF_PROMPT)
+Task(worktree="/path/to/issue-411", prompt=KICKOFF_PROMPT)
+Task(worktree="/path/to/issue-405", prompt=KICKOFF_PROMPT)
+# ... as many as you have worktrees
+```
+
+**Nested orchestration:** An agent whose `.agent-task` contains
+`SPAWN_SUB_AGENTS=true` acts as a sub-coordinator: it creates its own
+sub-worktrees with sub-task files and launches leaf agents. This creates
+a tree of unlimited depth and width.
+
+See `PARALLEL_BUGS_TO_ISSUES.md` → "Agent Task File Reference" for the
+full field reference including nested orchestration patterns.
 
 ---
 
@@ -139,60 +166,47 @@ PRTREES="$HOME/.cursor/worktrees/$(basename "$REPO")"
 mkdir -p "$PRTREES"
 cd "$REPO"
 
-# GitHub repo slug — hardcoded. NEVER derive from local path.
 GH_REPO=cgcardona/maestro
 
-# Enable rerere so git caches conflict resolutions across agents.
-# When multiple agents resolve the same conflict (e.g. muse_vcs.md), rerere
-# automatically reuses the recorded resolution — no manual work needed.
-# || true: the sandbox blocks .git/config writes (EPERM) when this runs as
-# part of a multi-statement block. rerere is an optimization, not critical.
 git config rerere.enabled true || true
 
-# ── PHASE LABEL ─────────────────────────────────────────────────────────────
-# Change this to the current phase label. This is the ONLY value you update.
-PHASE_LABEL="phase-1"
+# ── BATCH LABEL ─────────────────────────────────────────────────────────────
+# Set this to the batch label to implement. The batch label is the ONLY
+# value you change between runs.  Example: "batch-01", "batch-02", ...
+# This is more precise than a phase label when issues are pre-grouped.
+BATCH_LABEL="batch-01"
 
-# ── DERIVE BATCH FROM GITHUB — never hardcode issue numbers ─────────────────
-# The label on GitHub is the single source of truth. If an issue is labeled
-# phase-1 but not in this list, it WILL be skipped and the phase will appear
-# complete when it isn't. Always derive from the label.
-echo "📋 Querying GitHub for open '$PHASE_LABEL' issues..."
+# ── DERIVE ISSUES FROM GITHUB — never hardcode issue numbers ─────────────────
+echo "📋 Querying GitHub for open '$BATCH_LABEL' issues..."
 mapfile -t RAW_ISSUES < <(
   gh issue list \
     --repo "$GH_REPO" \
-    --label "$PHASE_LABEL" \
+    --label "$BATCH_LABEL" \
     --state open \
-    --json number,title \
-    --jq '.[] | "\(.number)|\(.title)"'
+    --json number,title,labels \
+    --jq '.[] | "\(.number)|\(.title)|\(.labels | map(.name) | join(","))"'
 )
 
 if [ ${#RAW_ISSUES[@]} -eq 0 ]; then
-  echo "✅ No open issues with label '$PHASE_LABEL'. Phase is complete."
+  echo "✅ No open issues with label '$BATCH_LABEL'. Batch is complete."
   exit 0
 fi
 
 echo "Found ${#RAW_ISSUES[@]} open issue(s):"
 for entry in "${RAW_ISSUES[@]}"; do
-  echo "  #${entry%%|*}: ${entry##*|}"
+  echo "  #${entry%%|*}: $(echo "$entry" | cut -d'|' -f2)"
 done
 
 # ── ISSUE SELECTION (coordinator applies both criteria before proceeding) ────
-# From RAW_ISSUES, select up to 4 that satisfy:
-#   Criterion 1 — Foundational first (see Issue selection section above)
-#   Criterion 2 — Zero file overlap between any two selected issues
+# Issues in the same batch label are pre-screened for file isolation,
+# so you can usually select all of them. Verify with the file-overlap check
+# in "Before launching" below before finalising.
 #
-# Document your selection and rationale in the comments below, then populate
-# SELECTED_ISSUES. Do NOT skip this review — blindly passing all RAW_ISSUES
-# to agents causes merge conflicts when issues share files.
-#
-# Example (replace with your actual selection):
-#   #NNN → files: maestro/foo.py, tests/test_foo.py
-#   #MMM → files: maestro/bar.py, tests/test_bar.py
-#   Load-bearing order: #NNN (shared fixture) → #MMM (consumer)
+# Load-bearing order: within a batch, issues are numbered by implementation
+# priority (1→2→3→4). If issue B's body says "Depends on #A", serialize them.
 declare -a SELECTED_ISSUES=(
-  # Paste selected entries from RAW_ISSUES here, one per line:
-  # "NNN|title of issue NNN"
+  # Paste selected entries from RAW_ISSUES here:
+  # "NNN|Issue title|label1,label2,..."
 )
 
 if [ ${#SELECTED_ISSUES[@]} -eq 0 ]; then
@@ -200,29 +214,62 @@ if [ ${#SELECTED_ISSUES[@]} -eq 0 ]; then
   exit 1
 fi
 
-# ── SNAPSHOT DEV TIP — all worktrees start here ──────────────────────────────
+# ── SNAPSHOT DEV TIP ─────────────────────────────────────────────────────────
 DEV_SHA=$(git rev-parse dev)
 
-# ── CREATE WORKTREES + TASK FILES ────────────────────────────────────────────
+# ── CREATE WORKTREES + AGENT TASK FILES ──────────────────────────────────────
 for entry in "${SELECTED_ISSUES[@]}"; do
-  NUM="${entry%%|*}"
-  TITLE="${entry##*|}"
+  NUM=$(echo "$entry" | cut -d'|' -f1)
+  TITLE=$(echo "$entry" | cut -d'|' -f2)
+  LABELS=$(echo "$entry" | cut -d'|' -f3)
+  # Derive phase label from the issue's labels (first label matching phase-*)
+  PHASE=$(echo "$LABELS" | tr ',' '\n' | grep "^phase-" | head -1)
+  BATCH=$(echo "$LABELS" | tr ',' '\n' | grep "^batch-" | head -1)
+
   WT="$PRTREES/issue-$NUM"
   if [ -d "$WT" ]; then
     echo "⚠️  worktree issue-$NUM already exists, skipping"
     continue
   fi
   git worktree add --detach "$WT" "$DEV_SHA"
-  printf "WORKFLOW=issue-to-pr\nISSUE_NUMBER=%s\nISSUE_TITLE=%s\nISSUE_URL=https://github.com/%s/issues/%s\nPHASE_LABEL=%s\n" \
-    "$NUM" "$TITLE" "$GH_REPO" "$NUM" "$PHASE_LABEL" > "$WT/.agent-task"
-  echo "✅ worktree issue-$NUM ready"
+
+  # Write rich .agent-task — agent reads ALL context from this file
+  # Extract DEPENDS_ON from issue body (looks for "Depends on #NNN" patterns)
+  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  DEPENDS_ON=$(echo "$ISSUE_BODY" | grep -oE 'Depends on #[0-9]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
+  [ -z "$DEPENDS_ON" ] && DEPENDS_ON=none
+
+  # FILE_OWNERSHIP: coordinator should fill this in manually from the taxonomy
+  # to prevent agents from stepping on each other. Format: comma-separated paths.
+  # Leave as "tbd" if unknown — agent will document its actual files in the PR body.
+  FILE_OWNERSHIP_VALUE="${FILE_OWNERSHIP:-tbd}"
+
+  cat > "$WT/.agent-task" << TASKEOF
+WORKFLOW=issue-to-pr
+GH_REPO=$GH_REPO
+ISSUE_NUMBER=$NUM
+ISSUE_TITLE=$TITLE
+ISSUE_URL=https://github.com/$GH_REPO/issues/$NUM
+PHASE_LABEL=$PHASE
+BATCH_LABEL=$BATCH
+ALL_ISSUE_LABELS=$LABELS
+DEPENDS_ON=$DEPENDS_ON
+FILE_OWNERSHIP=$FILE_OWNERSHIP_VALUE
+SPAWN_SUB_AGENTS=false
+ATTEMPT_N=0
+REQUIRED_OUTPUT=pr_url
+ON_BLOCK=stop
+TASKEOF
+
+  echo "✅ worktree issue-$NUM ready (.agent-task written)"
 done
 
 git worktree list
 ```
 
-After running this, open one Cursor composer window per worktree, each rooted
-in its `issue-<N>` directory, and paste the Kickoff Prompt below.
+After running this, launch one agent per worktree using the **Task tool**
+(preferred — no limit on simultaneous agents) or a Cursor composer window
+rooted in each `issue-<N>` directory.
 
 ---
 
@@ -296,10 +343,37 @@ Read .cursor/AGENT_COMMAND_POLICY.md before issuing any shell commands.
 Green-tier commands run without confirmation. Yellow = check scope first.
 Red = never, ask the user instead.
 
-STEP 0 — READ YOUR TASK:
+STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
-  This file tells you your issue number, title, and URL. Substitute your actual
-  issue number wherever you see <N> below.
+
+  Parse all KEY=value fields from the header:
+    GH_REPO          → GitHub repo slug (export immediately)
+    ISSUE_NUMBER     → your issue number (substitute for <N> throughout)
+    ISSUE_TITLE      → issue title
+    ISSUE_URL        → full GitHub URL for reference
+    PHASE_LABEL      → phase label already applied on GitHub
+    BATCH_LABEL      → batch label already applied on GitHub
+    SPAWN_SUB_AGENTS → if true, act as sub-coordinator (spawn leaf agents
+                       from sub-task sections in this file, then self-destruct)
+
+  Export for all subsequent commands:
+    export GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
+    export GH_REPO=${GH_REPO:-cgcardona/maestro}
+    N=$(grep "^ISSUE_NUMBER=" .agent-task | cut -d= -f2)
+    ATTEMPT_N=$(grep "^ATTEMPT_N=" .agent-task | cut -d= -f2)
+
+  ⚠️  ANTI-LOOP GUARD: if ATTEMPT_N > 2 → STOP immediately.
+    You have retried this task 3+ times. Self-destruct and escalate with the
+    exact last failure so a human can diagnose. Never loop blindly.
+
+  ⚠️  RETRY-WITHOUT-STRATEGY-MUTATION: if any command fails twice with the same
+    error → change strategy entirely. Two identical failures = wrong approach.
+    Stop. Redesign. Or escalate. Do NOT tweak parameters and retry.
+
+  ⚠️  SURGICAL UNDO ONLY: never run git reset --hard or git restore .
+    to undo your own changes. Use git restore -p <file> (patch mode) or
+    git restore --staged <file> for staged undo. Broad undo destroys
+    unrelated work. When in doubt: commit, then fix forward.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only
@@ -323,6 +397,9 @@ STEP 1 — DERIVE PATHS:
 STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
   you have confirmed no prior work exists. This is the idempotency gate.
+
+  # Mark issue as in-progress so the conductor and other agents see it's claimed.
+  gh issue edit <N> --repo "$GH_REPO" --add-label "status/in-progress" 2>/dev/null || true
 
   # 0. Is the issue itself already closed? (fastest exit — check this FIRST)
   ISSUE_STATE=$(gh issue view <N> --json state --jq '.state')
@@ -360,32 +437,108 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
 
 STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   Read and follow every step in .github/CREATE_PR_PROMPT.md exactly.
-  Steps: issue analysis → branch (from dev) → implement → mypy → tests → commit → docs → PR.
+  Steps: baseline → branch → implement → mypy → tests → commit → docs → PR.
 
-  # Create your feature branch from current HEAD (already at dev tip)
+  # ── STEP 3.0 — DEPENDENCY GATE ────────────────────────────────────────────
+  # Read DEPENDS_ON from .agent-task. If set, verify those PRs/issues are merged
+  # before implementing — your code may import from them at runtime.
+  DEPENDS_ON=$(grep "^DEPENDS_ON=" .agent-task | cut -d= -f2)
+  if [ -n "$DEPENDS_ON" ] && [ "$DEPENDS_ON" != "none" ]; then
+    echo "ℹ️  DEPENDS_ON: $DEPENDS_ON"
+    echo "   Checking whether dependencies are already on dev..."
+    # For each PR number listed, verify it is MERGED. If not, note it in the PR body
+    # so reviewers know to merge dependencies first. Do NOT block implementation —
+    # implement against dev and note the dependency clearly in the PR description.
+    # If the dependency is a missing ORM model or missing module, use TYPE_CHECKING
+    # guard for the import so mypy passes on the current dev state.
+  fi
+
+  # ── STEP 3.1 — BASELINE HEALTH SNAPSHOT (before touching any code) ────────
+  # Record the pre-existing state of dev SO YOU KNOW what errors are yours vs.
+  # what was already broken. This baseline is your contract with the next agent.
+  echo "=== PRE-EXISTING MYPY BASELINE (dev, before any changes) ==="
+  cd "$REPO" && docker compose exec maestro sh -c \
+    "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/" \
+    2>&1 | tail -5
+  # Record the error count. After implementation, the error count must not increase.
+  # Errors you did NOT introduce: fix them if they are in files you are touching.
+  # Errors in files you are NOT touching: file a follow-up GitHub issue and note it.
+
+  echo "=== PRE-EXISTING TEST BASELINE (targeted files) ==="
+  # Run targeted tests BEFORE branching to capture baseline failures.
+  # Any test that fails before your change is pre-existing — you own fixing it.
+  FILE_OWNERSHIP=$(grep "^FILE_OWNERSHIP=" .agent-task | cut -d= -f2)
+  # (Run targeted tests for the module you're about to modify)
+
+  # ── STEP 3.2 — CREATE BRANCH ──────────────────────────────────────────────
   git checkout -b feat/<short-description>
 
-  mypy (run BEFORE tests — fix all type errors first):
-    cd "$REPO" && docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/"
+  # ── STEP 3.3 — IMPLEMENT ──────────────────────────────────────────────────
+  # (implement the feature per the issue spec)
 
-  ⚠️  TYPE-SYSTEM RULES — mypy must be fixed correctly, not worked around:
-    - No cast() at call sites — fix the callee's return type, not the caller.
-    - No Any. Use TypeAlias, TypeVar, Protocol, Union, or typed wrappers at 3rd-party edges.
+  # ── STEP 3.4 — MYPY (FULL CODEBASE — not just your files) ─────────────────
+  # Run mypy across the ENTIRE codebase, not just your worktree files.
+  # This catches errors in other files that your changes may expose.
+  cd "$REPO" && docker compose exec maestro sh -c \
+    "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/"
+
+  ⚠️  MYPY RULES — fix correctly, never work around:
+    - No cast() at call sites — fix the callee's return type.
+    - No Any in return types, parameters, or TypedDict fields.
     - No `object` as a type annotation — be specific.
-    - No naked collections at boundaries: dict[str, Any], list[dict], bare tuples = code smell.
-      Wrap in a named entity. Convention: <Domain><Concept>Result (DynamicsResult, SwingAnalysis).
-    - No # type: ignore without an inline comment citing the specific 3rd-party issue.
-    - No non-ASCII characters inside b"..." bytes literals — mypy rejects them with
-      "Bytes can only contain ASCII literal characters". Use only plain ASCII in byte
-      strings; encode Unicode values explicitly (e.g. "MIDI v2 \u2014 newer".encode()).
-    - Two failed fix attempts = stop and redesign — never loop with incremental tweaks.
-    - Every public function signature is a contract. Register new result types in docs/reference/type_contracts.md.
+    - No naked collections crossing module boundaries (dict[str, Any], list[dict],
+      bare tuples) — wrap in a named entity: <Domain><Concept>Result.
+    - No # type: ignore without an inline comment naming the specific 3rd-party issue.
+    - No non-ASCII characters inside b"..." — encode explicitly.
+    - Two failed fix attempts = stop and redesign.
+    - Every new public function signature is a contract — register result types in
+      docs/reference/type_contracts.md.
 
-  pytest — TARGETED TESTS ONLY (never the full suite):
-    cd "$REPO" && docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME pytest /worktrees/$WTNAME/tests/path/to/test_file.py -v"
+  ⚠️  PRE-EXISTING MYPY ERRORS — you own them if they are in files you touch:
+    - If an error was already present on dev (confirmed by STEP 3.1 baseline) AND
+      is in a file your PR modifies → fix it in the same commit.
+    - If it is in a file you do NOT touch → file a GitHub issue, note it in your
+      PR description, and do NOT block your PR on it.
+    - NEVER leave a file you modified in a worse mypy state than you found it.
 
-  The full suite takes several minutes and is the responsibility of developers/CI,
-  not parallel agents. Run only the test files directly related to your changes.
+  # ── STEP 3.5 — ALEMBIC CHAIN VALIDATION (migrations only) ────────────────
+  # If your implementation adds an Alembic migration, validate the revision chain.
+  # This prevents two agents creating migrations with the same revision ID or
+  # the same down_revision, which breaks alembic upgrade head.
+  #
+  # 1. Find the current head revision on dev:
+  cd "$REPO" && docker compose exec maestro alembic heads
+  #
+  # 2. Your new migration's down_revision MUST equal that head.
+  # 3. Your new migration's revision MUST be unique (not used by any existing file).
+  # 4. If two agents created migrations with the same revision number (e.g. both
+  #    named 0006_*), the second must be renumbered (e.g. 0007_*) and its
+  #    down_revision updated to point to the first.
+  #
+  # grep -r "^revision" alembic/versions/   ← list all revision IDs
+  # grep -r "^down_revision" alembic/versions/  ← verify no two share a down_revision
+
+  # ── STEP 3.6 — TESTS ──────────────────────────────────────────────────────
+  # Run targeted tests for the module you modified + any test file that imports it.
+  cd "$REPO" && docker compose exec maestro sh -c \
+    "PYTHONPATH=/worktrees/$WTNAME pytest /worktrees/$WTNAME/tests/path/to/test_file.py -v"
+
+  ⚠️  NEVER pipe mypy or pytest output through grep/head/tail — full output only.
+
+  After tests pass — cascading failure scan:
+    Search for similar assertions or fixtures across other test files before declaring
+    complete. A fix that changes a constant, model field, or shared contract likely
+    affects more than one test file. Find and fix all of them in the same commit.
+
+  ⚠️  PRE-EXISTING BROKEN TESTS — you own them:
+    If a test was ALREADY failing before your change (confirmed by STEP 3.1 baseline):
+    - Fix it unconditionally. Do not leave it for the next agent.
+    - Commit the fix separately: "fix: repair pre-existing broken test <name>"
+    - Note every pre-existing fix in your PR description.
+    If you cannot fix a pre-existing failure without a major refactor:
+    - File a GitHub issue describing the failure exactly.
+    - Add a pytest.mark.skip with a comment referencing the issue number.
+    - Include the skip commit in your PR. Never leave a red test silently.
 
   DOCS — non-negotiable, same commit as code:
     - Docstrings on every new module, class, and public function (why + contract, not what)
@@ -393,17 +546,6 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
         purpose, flags table, output example, result type, agent use case
     - Register new named result types in docs/reference/type_contracts.md
     - Docs are written for AI agent consumers — explain the contract and when to call this
-
-  After tests pass — cascading failure scan:
-    Search for similar assertions or fixtures across other test files before declaring complete.
-    A fix that changes a constant, model field, or shared contract likely affects more than one
-    test file. Find and fix all of them in the same commit.
-
-  Broken tests from other agents — fix them anyway:
-    If you encounter a failing test that your implementation did NOT introduce,
-    fix it before opening your PR. Include the fix in your branch with message:
-    "fix: repair broken test <name> (pre-existing failure from dev)"
-    Note it in your PR description. Never leave a broken test for the next agent.
 
 STEP 4 — PRE-PUSH SYNC (critical — always run before pushing):
   ⚠️  Other agents may have merged PRs while you were implementing. Sync with dev
@@ -548,6 +690,12 @@ STEP 5 — PUSH & CREATE PR:
   - [ ] Docs updated
   EOF
   )"
+
+  # Transition status label: in-progress → pr-open
+  gh issue edit <N> --repo "$GH_REPO" \
+    --remove-label "status/in-progress" 2>/dev/null || true
+  gh issue edit <N> --repo "$GH_REPO" \
+    --add-label "status/pr-open" 2>/dev/null || true
 
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — run immediately after gh pr create:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"

--- a/alembic/versions/0003_labels.py
+++ b/alembic/versions/0003_labels.py
@@ -1,7 +1,7 @@
 """Add musehub_labels, musehub_issue_labels, and musehub_pr_labels tables.
 
 Revision ID: 0003_labels
-Revises: 0002_milestones
+Revises: 0001
 Create Date: 2026-02-28 00:00:00.000000
 
 Adds coloured label tags that can be applied to issues and pull requests
@@ -10,6 +10,9 @@ for categorisation. Three tables:
   musehub_labels           — label definitions per repo (name, hex colour)
   musehub_issue_labels     — many-to-many join: issues ↔ labels
   musehub_pr_labels        — many-to-many join: pull requests ↔ labels
+
+Note: 0002_milestones was folded into 0001_consolidated_schema (commit 82d7a8b).
+This migration chains directly from 0001.
 """
 from __future__ import annotations
 
@@ -17,7 +20,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "0003_labels"
-down_revision = "0002_milestones"
+down_revision = "0001"
 branch_labels = None
 depends_on = None
 

--- a/docs/roadmaps/musehub-taxonomy.md
+++ b/docs/roadmaps/musehub-taxonomy.md
@@ -1,0 +1,958 @@
+# MuseHub Complete Taxonomy
+## Muse Protocol · MuseHub URL Structure · Page Feature Matrix · Seed Data Blueprint
+
+> **Status:** Living document — each section generates a batch of GitHub issues.
+> **Audience:** Agents, engineers, and product stakeholders.
+
+---
+
+## TABLE OF CONTENTS
+
+1. [Muse CLI Command Index](#1-muse-cli-command-index)
+2. [MuseHub URL Taxonomy — Current vs Missing](#2-musehub-url-taxonomy)
+3. [Per-Page Feature Matrix](#3-per-page-feature-matrix)
+4. [Seed Data Blueprint](#4-seed-data-blueprint)
+5. [GitHub Issue Backlog](#5-github-issue-backlog)
+
+---
+
+## 1. MUSE CLI COMMAND INDEX
+
+> Muse is Git for music. Every command maps to a musical dimension.
+> **Porcelain** = human-facing composites. **Plumbing** = low-level primitives.
+
+### 1.1 Porcelain — Repository Lifecycle
+
+| Command | Key Flags | Musical Meaning | MuseHub URL Exposed? |
+|---|---|---|---|
+| `muse init` | `--bare`, `--template` | Create a new Muse repo locally | POST `/repos` |
+| `muse clone` | `--branch`, `--depth`, `--bare` | Clone from MuseHub remote | POST via sync |
+| `muse commit` | `-m`, `--amend`, `--no-verify`, `--allow-empty` | Snapshot current DAW state | POST `/sync/push` |
+| `muse amend` | `--no-edit`, `-m` | Rewrite the last commit message/contents | ❌ Missing UI |
+| `muse push` | `--force`, `--tags`, `--set-upstream` | Upload commits to MuseHub | POST `/sync/push` |
+| `muse pull` | `--rebase`, `--ff-only`, `--no-commit` | Download + integrate remote changes | POST `/sync/pull` |
+| `muse fetch` | `--all`, `--tags`, `--prune` | Download refs without integrating | ❌ Missing API |
+| `muse status` | `--short`, `--branch`, `--porcelain` | Show working-tree status | GET `/repos/{id}/status` |
+| `muse log` | `--oneline`, `--graph`, `--since`, `--until`, `--author`, `--grep`, `--follow`, `-p` | Commit history | `/commits` page + graph |
+| `muse show` | `--stat`, `--format`, `--name-only` | Inspect a single commit | `/commits/{id}` page |
+| `muse diff` | `--stat`, `--cached`, `--word-diff`, `--name-only` | Multi-dimensional musical diff | `/compare/base...head` |
+| `muse checkout` | `-b`, `--detach`, `--orphan`, `--track` | Switch branches / restore files | ❌ Missing UI |
+| `muse restore` | `--staged`, `--source`, `--patch` | Discard working-tree changes | ❌ Missing UI |
+| `muse reset` | `--soft`, `--mixed`, `--hard`, `--keep` | Move HEAD, optionally reset index | ❌ Missing UI |
+| `muse revert` | `-n`, `--no-edit`, `--mainline` | Create inverse commit | ❌ Missing UI |
+| `muse merge` | `--no-ff`, `--squash`, `--abort`, `--strategy` | Combine two branches | POST `/pull-requests/{id}/merge` |
+| `muse rebase` | `-i`, `--onto`, `--abort`, `--continue`, `--exec` | Linearize commit history | ❌ Missing UI |
+| `muse cherry-pick` | `-n`, `--continue`, `--abort`, `--edit` | Apply specific commit to current branch | ❌ Missing UI |
+| `muse stash` | `push`, `pop`, `apply`, `drop`, `list`, `show` | Temporarily shelve changes | ❌ Missing API + UI |
+| `muse tag` | `-a`, `-d`, `-l`, `--sort`, `-m`, `-f` | Semantic version milestones | GET/POST `/releases` |
+| `muse remote` | `add`, `remove`, `set-url`, `-v`, `rename` | Manage remotes | ❌ Missing UI |
+| `muse worktree` | `add`, `list`, `remove`, `prune` | Parallel branch workspaces | ❌ Missing UI |
+| `muse bisect` | `start`, `good`, `bad`, `reset`, `log`, `replay` | Binary search through history for a change | ❌ Missing UI |
+
+### 1.2 Porcelain — Musical Analysis (Muse-Native)
+
+| Command | Key Flags | Musical Meaning | MuseHub URL Exposed? |
+|---|---|---|---|
+| `muse arrange` | `--ref`, `--format` | Section × instrument density matrix | `/arrange/{ref}` ✅ |
+| `muse ask` | `--ref`, `--model`, `--stream` | AI Q&A about a commit | `/context/{ref}` ✅ |
+| `muse blame` | `--ref`, `--track`, `--region`, `--beat-range` | Who wrote which notes, when | ❌ Missing UI |
+| `muse chord-map` | `--ref`, `--window`, `--resolution` | Chord progression over time | `/analysis/{ref}/chord-map` ✅ |
+| `muse contour` | `--ref`, `--track`, `--smooth` | Melodic contour visualization | `/analysis/{ref}/contour` ✅ |
+| `muse describe` | `--ref`, `--long`, `--abbrev` | Human-readable musical summary | ❌ Missing standalone UI |
+| `muse dynamics` | `--ref`, `--track`, `--window` | Velocity/dynamics envelope | `/analysis/{ref}/dynamics` ✅ |
+| `muse emotion-diff` | `--base`, `--head`, `--dimensions` | Emotional shift between two commits | ❌ Missing UI (analysis diff) |
+| `muse form` | `--ref`, `--sections`, `--labels` | Formal structure (verse/chorus/bridge) | `/analysis/{ref}/form` ✅ |
+| `muse groove-check` | `--ref`, `--track`, `--window` | Rhythmic groove analysis (swing ratio, microtiming) | `/analysis/{ref}/groove` ✅ |
+| `muse harmony` | `--ref`, `--key`, `--mode` | Harmonic analysis (Roman numerals, cadences) | ❌ Missing standalone UI |
+| `muse humanize` | `--amount`, `--velocity`, `--timing`, `--ref` | Add human-feel microtiming to a commit | ❌ Missing UI |
+| `muse inspect` | `--ref`, `--track`, `--region`, `--verbose` | Deep inspection of a specific object | ❌ Missing UI |
+| `muse key` | `--ref`, `--confidence`, `--algorithm` | Key detection + modulation map | `/analysis/{ref}/key` ✅ |
+| `muse meter` | `--ref`, `--set`, `--detect` | Time signature detection + annotation | `/analysis/{ref}/meter` ✅ |
+| `muse motif` | `--ref`, `--min-length`, `--threshold`, `--track` | Recurring motif browser | `/analysis/{ref}/motifs` ✅ |
+| `muse play` | `--ref`, `--track`, `--loop`, `--from`, `--to` | Playback a commit | `/listen/{ref}` ✅ |
+| `muse recall` | `--query`, `--k`, `--ref` | Semantic memory search over history | ❌ Missing UI |
+| `muse render-preview` | `--ref`, `--track`, `--format`, `--stem` | Render audio preview | `/listen/{ref}/{path}` ✅ |
+| `muse session` | `start`, `end`, `log`, `annotate` | Recording session lifecycle | `/sessions` ✅ |
+| `muse similarity` | `--base`, `--head`, `--dimensions`, `--threshold` | Cross-commit musical similarity score | ❌ Missing UI |
+| `muse swing` | `--ref`, `--track`, `--amount`, `--style` | Quantize swing ratio analysis | `/analysis/{ref}/groove` (partial) |
+| `muse tempo` | `--ref`, `--set`, `--detect`, `--scale` | Tempo detection + annotation | `/analysis/{ref}/tempo` ✅ |
+| `muse tempo-scale` | `--factor`, `--ref`, `--preserve-feel` | Time-stretch a commit | ❌ Missing UI |
+| `muse timeline` | `--ref`, `--branches`, `--tags`, `--since`, `--until` | Chronological SVG timeline | `/timeline` ✅ |
+| `muse transpose` | `--semitones`, `--key`, `--ref`, `--track` | Pitch transposition with key annotation | ❌ Missing UI |
+| `muse validate` | `--ref`, `--strict`, `--schema` | Validate MIDI structure | ❌ Missing UI |
+
+### 1.3 Plumbing — Content-Addressed Store
+
+| Command | Key Flags | Description | MuseHub Exposed? |
+|---|---|---|---|
+| `muse hash-object` | `-w`, `-t`, `--stdin` | Write blob to object store | POST `/objects` |
+| `muse cat-object` | `-p`, `-t`, `-s`, `--batch` | Read object by hash | GET `/objects/{hash}` ✅ |
+| `muse commit-tree` | `-p`, `-m`, `--no-gpg-sign` | Create commit from a tree | ❌ Plumbing only |
+| `muse write-tree` | `--missing-ok`, `--prefix` | Write working tree to object store | ❌ Plumbing only |
+| `muse read-tree` | `-m`, `--reset`, `-u` | Read a tree object into the index | ❌ Plumbing only |
+| `muse rev-parse` | `--verify`, `--abbrev-ref`, `--symbolic` | Resolve refs to object hashes | GET `/repos/{id}/resolve/{ref}` |
+| `muse symbolic-ref` | `--delete`, `-q`, `--short` | Read/write symbolic HEAD ref | ❌ Plumbing only |
+| `muse update-ref` | `-d`, `--no-deref`, `--stdin` | Safely update a ref | ❌ Plumbing only |
+
+### 1.4 Plumbing — Querying & Analysis
+
+| Command | Key Flags | Description | MuseHub Exposed? |
+|---|---|---|---|
+| `muse context` | `--ref`, `--tokens`, `--format` | Generate AI context blob | GET `/analysis/{ref}/context` |
+| `muse divergence` | `--base`, `--head`, `--dimensions` | Compute branch divergence scores | `/divergence` ✅ |
+| `muse find` | `--commit`, `--tag`, `--branch`, `--pattern` | Search refs/objects by pattern | GET `/search` ✅ |
+| `muse grep` | `--ref`, `--track`, `--pattern`, `--note`, `--pitch` | Search musical content | GET `/search?mode=musical` ✅ |
+| `muse export` | `--format`, `--ref`, `--track`, `--stems` | Export to MIDI/MusicXML/stems | GET `/releases/{tag}` (partial) |
+| `muse import` | `--format`, `--branch`, `--message` | Import external MIDI into Muse | ❌ Missing UI |
+| `muse open` | `--commit`, `--ref` | Open in DAW | ❌ macOS DAW only |
+| `muse resolve` | `--ours`, `--theirs`, `--manual` | Resolve merge conflicts | ❌ Missing UI |
+
+### 1.5 Missing Commands — Not Yet Implemented
+
+| Command | Description | Priority |
+|---|---|---|
+| `muse lock` | Lock a branch (require PR + review) | High |
+| `muse sign` | GPG-sign a commit with artist identity | Medium |
+| `muse verify` | Verify signed commit | Medium |
+| `muse submodule` | Embed one Muse repo inside another (samples, loops) | High |
+| `muse lfs` | Large file storage for audio stems | High |
+| `muse bundle` | Package repo history for offline transfer | Low |
+| `muse archive` | Export a snapshot as a tar/zip | Low |
+| `muse clean` | Remove untracked working-tree files | Low |
+| `muse maintenance` | Run background optimization tasks | Low |
+
+---
+
+## 2. MUSEHUB URL TAXONOMY
+
+### 2.1 Current URL Surface
+
+```
+# Global
+GET /musehub/ui/feed                          ← activity feed (current user)
+GET /musehub/ui/search                        ← global cross-repo search
+GET /musehub/ui/explore                       ← public repo discovery grid
+GET /musehub/ui/trending                      ← repos sorted by stars
+
+# User Profile
+GET /musehub/ui/users/{username}              ← profile (repos, starred, watching tabs)
+
+# Repo — Core
+GET /musehub/ui/{owner}/{repo}                ← landing (README, stats, latest release)
+GET /musehub/ui/{owner}/{repo}/commits        ← commit list (branch filter, search)
+GET /musehub/ui/{owner}/{repo}/commits/{id}   ← commit detail + artifacts
+GET /musehub/ui/{owner}/{repo}/commits/{id}/diff ← musical diff (radar, piano roll, A/B)
+GET /musehub/ui/{owner}/{repo}/graph          ← DAG commit graph
+GET /musehub/ui/{owner}/{repo}/tree/{ref}     ← file tree root
+GET /musehub/ui/{owner}/{repo}/tree/{ref}/{path} ← file tree subdirectory
+GET /musehub/ui/{owner}/{repo}/compare/{base}...{head} ← two-ref musical diff
+
+# Repo — Collaboration
+GET /musehub/ui/{owner}/{repo}/pulls          ← PR list
+GET /musehub/ui/{owner}/{repo}/pulls/{pr_id}  ← PR detail (diff, comments, merge)
+GET /musehub/ui/{owner}/{repo}/issues         ← issue list
+GET /musehub/ui/{owner}/{repo}/issues/{number} ← issue detail + close/comment
+
+# Repo — Musical Analysis
+GET /musehub/ui/{owner}/{repo}/analysis/{ref}            ← dashboard (10 dimensions)
+GET /musehub/ui/{owner}/{repo}/analysis/{ref}/contour    ← melodic contour
+GET /musehub/ui/{owner}/{repo}/analysis/{ref}/tempo      ← tempo map
+GET /musehub/ui/{owner}/{repo}/analysis/{ref}/dynamics   ← dynamics envelope
+GET /musehub/ui/{owner}/{repo}/analysis/{ref}/key        ← key detection
+GET /musehub/ui/{owner}/{repo}/analysis/{ref}/meter      ← time signature
+GET /musehub/ui/{owner}/{repo}/analysis/{ref}/chord-map  ← chord progression
+GET /musehub/ui/{owner}/{repo}/analysis/{ref}/groove     ← rhythmic groove
+GET /musehub/ui/{owner}/{repo}/analysis/{ref}/emotion    ← emotion radar
+GET /musehub/ui/{owner}/{repo}/analysis/{ref}/form       ← formal structure
+GET /musehub/ui/{owner}/{repo}/analysis/{ref}/motifs     ← motif browser
+
+# Repo — Playback & Export
+GET /musehub/ui/{owner}/{repo}/listen/{ref}              ← full-mix playback
+GET /musehub/ui/{owner}/{repo}/listen/{ref}/{path}       ← single-stem playback
+GET /musehub/ui/{owner}/{repo}/arrange/{ref}             ← arrangement matrix
+GET /musehub/ui/{owner}/{repo}/piano-roll/{ref}          ← piano roll (all tracks)
+GET /musehub/ui/{owner}/{repo}/piano-roll/{ref}/{path}   ← piano roll (single track)
+GET /musehub/ui/{owner}/{repo}/embed/{ref}               ← iframe embeddable player
+
+# Repo — Metadata
+GET /musehub/ui/{owner}/{repo}/releases       ← release list
+GET /musehub/ui/{owner}/{repo}/releases/{tag} ← release detail + downloads
+GET /musehub/ui/{owner}/{repo}/sessions       ← recording session log
+GET /musehub/ui/{owner}/{repo}/sessions/{id}  ← session detail
+GET /musehub/ui/{owner}/{repo}/timeline       ← chronological SVG timeline
+GET /musehub/ui/{owner}/{repo}/divergence     ← branch divergence radar
+GET /musehub/ui/{owner}/{repo}/insights       ← repo analytics dashboard
+GET /musehub/ui/{owner}/{repo}/credits        ← liner notes / contributor credits
+GET /musehub/ui/{owner}/{repo}/context/{ref}  ← AI context viewer
+GET /musehub/ui/{owner}/{repo}/search         ← in-repo search (4 modes)
+```
+
+### 2.2 Missing URLs — High Priority
+
+```
+# Repo — Missing Muse Commands
+GET /musehub/ui/{owner}/{repo}/blame/{ref}/{path}   ← muse blame (note-level authorship)
+GET /musehub/ui/{owner}/{repo}/stash                ← stash list + apply/drop
+GET /musehub/ui/{owner}/{repo}/forks                ← fork network visualization
+GET /musehub/ui/{owner}/{repo}/milestones           ← milestone list + progress
+GET /musehub/ui/{owner}/{repo}/milestones/{number}  ← milestone detail + linked issues
+GET /musehub/ui/{owner}/{repo}/labels               ← label management
+GET /musehub/ui/{owner}/{repo}/similarity/{base}...{head} ← similarity score page
+GET /musehub/ui/{owner}/{repo}/emotion-diff/{base}...{head} ← emotional delta viz
+GET /musehub/ui/{owner}/{repo}/recall               ← semantic memory search over history
+GET /musehub/ui/{owner}/{repo}/harmony/{ref}        ← full harmonic analysis (Roman numeral map)
+GET /musehub/ui/{owner}/{repo}/webhooks             ← webhook management (admin)
+GET /musehub/ui/{owner}/{repo}/settings             ← repo settings (visibility, description, tags)
+
+# User — Missing
+GET /musehub/ui/users/{username}/followers  ← follower list
+GET /musehub/ui/users/{username}/following  ← following list
+
+# Global — Missing
+GET /musehub/ui/notifications               ← notification inbox
+GET /musehub/ui/new                         ← new repo wizard
+GET /musehub/ui/topics/{tag}                ← tag/topic browse page
+GET /musehub/ui/collections                 ← curated repo collections
+```
+
+### 2.3 JSON API Parity Gaps (needed for agent consumers)
+
+```
+# Missing endpoints
+GET  /api/v1/musehub/repos/{id}/blame/{ref}       ← muse blame output as JSON
+GET  /api/v1/musehub/repos/{id}/stash             ← stash list
+POST /api/v1/musehub/repos/{id}/stash             ← create stash
+POST /api/v1/musehub/repos/{id}/stash/{stash_id}/pop
+GET  /api/v1/musehub/repos/{id}/milestones        ← milestone list
+POST /api/v1/musehub/repos/{id}/milestones
+GET  /api/v1/musehub/repos/{id}/milestones/{n}
+PATCH /api/v1/musehub/repos/{id}/milestones/{n}
+DELETE /api/v1/musehub/repos/{id}/milestones/{n}
+GET  /api/v1/musehub/repos/{id}/labels            ← label management
+POST /api/v1/musehub/repos/{id}/labels
+PATCH /api/v1/musehub/repos/{id}/issues/{n}/labels ← assign labels to issue
+GET  /api/v1/musehub/repos/{id}/analysis/{ref}/similarity?compare={ref2}
+GET  /api/v1/musehub/repos/{id}/analysis/{ref}/emotion-diff?base={ref}
+GET  /api/v1/musehub/repos/{id}/analysis/{ref}/harmony
+GET  /api/v1/musehub/repos/{id}/analysis/{ref}/recall?q={query}
+GET  /api/v1/musehub/repos/{id}/settings
+PATCH /api/v1/musehub/repos/{id}/settings
+POST /api/v1/musehub/repos/{id}/transfer          ← transfer repo ownership
+DELETE /api/v1/musehub/repos/{id}                 ← delete repo
+GET  /api/v1/musehub/repos/{id}/collaborators     ← collaborator list
+POST /api/v1/musehub/repos/{id}/collaborators
+DELETE /api/v1/musehub/repos/{id}/collaborators/{username}
+GET  /api/v1/musehub/topics/{tag}/repos           ← repos by topic
+GET  /api/v1/musehub/users/{username}/activity    ← public activity feed
+```
+
+---
+
+## 3. PER-PAGE FEATURE MATRIX
+
+### 3.1 `/musehub/ui/explore` — Discovery Grid
+
+**Current:** Repo cards with name, owner, description, star count, tags.
+
+**Missing / Wanted:**
+- [ ] Filter by genre tag (Classical, EDM, Jazz, Rock, Ambient, etc.)
+- [ ] Filter by key signature (C major, A minor, etc.)
+- [ ] Filter by tempo range (BPM slider)
+- [ ] Filter by time signature
+- [ ] Filter by license (CC0, CC BY, CC BY-SA, All Rights Reserved)
+- [ ] Sort by: stars, forks, watchers, recently updated, recently created, most commits
+- [ ] "Trending this week" / "Trending this month" toggle
+- [ ] Inline audio preview on card hover (oEmbed player)
+- [ ] Fork count badge on card
+- [ ] "Made with Muse" verified badge
+- [ ] Language/instrument breakdown chip (shows dominant instrument)
+- [ ] Pagination + infinite scroll
+- [ ] Topic/tag browse sidebar
+- [ ] Featured collections carousel (curated by Stori team)
+
+### 3.2 `/musehub/ui/{owner}/{repo}` — Repo Landing
+
+**Current:** Branch selector, commit list preview, stats sidebar, README.
+
+**Missing / Wanted:**
+- [ ] README rendered as markdown (currently missing)
+- [ ] "Latest release" banner with audio player
+- [ ] Star / Watch / Fork action buttons with live counts
+- [ ] Contributors list (avatar grid with commit counts)
+- [ ] Activity graph (GitHub contribution-graph style, per-day commit heatmap)
+- [ ] Language/instrument bar (% of MIDI by instrument family)
+- [ ] Topics/tags as clickable chips → explore filter
+- [ ] License badge
+- [ ] Clone URL widget with copy button (`muse clone musehub://owner/repo`)
+- [ ] Open in DAW button (deep link to Stori DAW)
+- [ ] Branch picker with branch list + default branch indicator
+- [ ] Last commit message + author + relative timestamp on branch selector
+- [ ] File tree with MIDI file sizes
+- [ ] "Used by" counter (repos that fork this)
+- [ ] Pin to profile button (for own repos)
+- [ ] Report / DMCA button
+- [ ] Sponsor / support link (external URL from profile)
+- [ ] oEmbed metadata `<meta>` tags for social previews
+
+### 3.3 `/musehub/ui/{owner}/{repo}/commits` — Commit List
+
+**Current:** Commit list with message, author, timestamp, hash.
+
+**Missing / Wanted:**
+- [ ] Branch / tag / commit selector dropdown
+- [ ] Filter by author dropdown
+- [ ] Filter by date range picker
+- [ ] Search by commit message
+- [ ] Filter by tag annotation (emotion:*, stage:*, key:*, tempo:*)
+- [ ] Commit graph mini-lane on left (like GitHub's dot-and-line)
+- [ ] Grouped by day headers
+- [ ] Per-commit: changed instruments badge
+- [ ] Per-commit: tempo_bpm badge if annotated
+- [ ] Per-commit: key annotation badge if set
+- [ ] Per-commit: emotional character chip (from `emotion:*` tag)
+- [ ] Per-commit: musical summary from `muse describe` output
+- [ ] "Compare" checkbox mode → compare two selected commits
+- [ ] Copy commit hash button
+- [ ] Download commit as MIDI button
+- [ ] Verified/signed badge if commit is GPG-signed
+- [ ] Merge commit visual indicator (two parents)
+- [ ] Cherry-pick indicator badge
+
+### 3.4 `/musehub/ui/{owner}/{repo}/commits/{id}` — Commit Detail
+
+**Current:** Commit metadata, artifact list, diff link.
+
+**Missing / Wanted:**
+- [ ] Inline audio player (render_preview for this commit)
+- [ ] Instrument breakdown pie/bar
+- [ ] Full commit message with markdown rendering
+- [ ] Parent commit link(s) (shows two for merge commits)
+- [ ] All tags attached to this commit (emotion, stage, key, etc.)
+- [ ] Metadata badges: tempo_bpm, key, time_signature, duration
+- [ ] `muse describe` prose summary
+- [ ] Changed files (MIDI tracks) with +/- change indicators
+- [ ] Cherry-pick button (apply to another branch)
+- [ ] Revert button
+- [ ] Browse tree at this commit button
+- [ ] Download button (MIDI bundle)
+- [ ] Reactions (emoji reactions on the commit)
+- [ ] Comments thread (general comments on the commit)
+- [ ] Sessions that produced this commit (back-link to session)
+- [ ] "Mentioned in PRs/Issues" cross-reference
+
+### 3.5 `/musehub/ui/{owner}/{repo}/compare/{base}...{head}` — Multi-Diff
+
+**Current:** Radar chart, piano roll, audio A/B.
+
+**Missing / Wanted:**
+- [ ] Similarity score percentage badge
+- [ ] Emotion delta visualization (before/after radar)
+- [ ] Changed instrument list with diff stats per instrument
+- [ ] Merge/PR creation button from this view
+- [ ] Note-level diff table (added/removed/changed notes)
+- [ ] CC event diff (expression, modulation, sustain changes)
+- [ ] Tempo change indicator
+- [ ] Key change indicator
+- [ ] Time signature change indicator
+- [ ] `muse blame` panel showing per-note authorship in the diff
+- [ ] Export diff as JSON button (for agents)
+- [ ] "Open in DAW" button to load both refs for A/B comparison
+
+### 3.6 `/musehub/ui/{owner}/{repo}/pulls` — PR List
+
+**Current:** PR list with state filter.
+
+**Missing / Wanted:**
+- [ ] Filter by: Open / Merged / Closed / Draft
+- [ ] Filter by: author, assignee, label, milestone
+- [ ] Sort by: newest, oldest, most commented, recently updated
+- [ ] Search PRs by title / body
+- [ ] Assignee avatars on card
+- [ ] Label chips on card
+- [ ] Milestone indicator on card
+- [ ] Comment count badge
+- [ ] Reaction count badge
+- [ ] Approval status (approved / changes requested / pending)
+- [ ] CI/checks status badge
+- [ ] "Draft PR" indicator
+- [ ] Bulk actions (close multiple, assign milestone)
+
+### 3.7 `/musehub/ui/{owner}/{repo}/pulls/{pr_id}` — PR Detail
+
+**Current:** Diff, merge button, PR comments.
+
+**Missing / Wanted:**
+- [ ] PR description (markdown rendered)
+- [ ] Labels
+- [ ] Milestone link
+- [ ] Assignees
+- [ ] Reviewers + approval status per reviewer
+- [ ] Linked issues (closes #N cross-reference)
+- [ ] Check/CI status panel
+- [ ] Conversation timeline (comments, reviews, events interspersed)
+- [ ] Line-level (beat-level) review comments with threading
+- [ ] Review summary ("Changes requested by X", "Approved by Y")
+- [ ] Diff: note-level additions/deletions colour-coded
+- [ ] Diff: CC event changes highlighted
+- [ ] `muse emotion-diff` panel inline on PR
+- [ ] Audio A/B player (base vs head) inline
+- [ ] Merge options: merge commit / squash / rebase
+- [ ] Auto-merge checkbox (merge when all checks pass)
+- [ ] "Close and delete branch" button after merge
+- [ ] Reopen PR button
+- [ ] Edit PR title/body
+- [ ] @mention notifications
+- [ ] Reactions on PR body and on individual comments
+
+### 3.8 `/musehub/ui/{owner}/{repo}/issues` — Issue List
+
+**Current:** Issue list with open/closed filter.
+
+**Missing / Wanted:**
+- [ ] Filter by label
+- [ ] Filter by milestone
+- [ ] Filter by assignee
+- [ ] Filter by author
+- [ ] Search issues by title / body
+- [ ] Sort by: newest, oldest, most commented, most reactions, recently updated
+- [ ] Milestone progress bars in sidebar
+- [ ] Label legend sidebar
+- [ ] Bulk assign / bulk label / bulk close
+- [ ] "No milestone" filter
+- [ ] Issue templates (pre-filled forms for bug, feature, musical feedback)
+- [ ] Duplicate detection (show similar open issues)
+- [ ] Sub-issues / task lists (markdown checkboxes tracked as tasks)
+- [ ] Lock/unlock issue button
+
+### 3.9 `/musehub/ui/{owner}/{repo}/issues/{number}` — Issue Detail
+
+**Current:** Issue body, close button.
+
+**Missing / Wanted:**
+- [ ] Markdown rendered body
+- [ ] Labels display
+- [ ] Milestone link
+- [ ] Assignees
+- [ ] Comments thread with full markdown
+- [ ] Reactions on issue body and comments
+- [ ] Threaded replies on comments
+- [ ] Edit comment / delete comment
+- [ ] Cross-references (linked PRs, linked commits)
+- [ ] Timeline (comment/event interspersed: "closed by PR #5", "label added")
+- [ ] Lock issue
+- [ ] Pin issue to top of list
+- [ ] Convert to PR
+- [ ] @mention with notification
+- [ ] Subscribe / unsubscribe to notifications
+
+### 3.10 `/musehub/ui/{owner}/{repo}/milestones` — Milestones ❌ MISSING
+
+**Wanted:**
+- [ ] Milestone list with title, due date, open/closed issue count, progress bar
+- [ ] Filter: open / closed
+- [ ] Sort: due date, completeness, title
+- [ ] Create milestone form
+- [ ] Edit / delete milestone
+- [ ] Per-milestone: link to filtered issue list
+
+### 3.11 `/musehub/ui/{owner}/{repo}/releases` — Release List
+
+**Current:** Release list with tag, title, commit link.
+
+**Missing / Wanted:**
+- [ ] Release description (markdown rendered)
+- [ ] Embedded audio player per release
+- [ ] Download stats per release
+- [ ] Pre-release / latest badge
+- [ ] Compare with previous release link
+- [ ] Verify GPG signature badge
+- [ ] RSS feed link for releases
+- [ ] "Subscribe to releases" button (watch notifications)
+- [ ] Draft release creation form
+- [ ] Release assets panel (MIDI bundle, stems, MusicXML, MP3, metadata.json)
+
+### 3.12 `/musehub/ui/{owner}/{repo}/sessions` — Recording Sessions
+
+**Current:** Session log list.
+
+**Missing / Wanted:**
+- [ ] Session duration display
+- [ ] Participants avatars
+- [ ] Linked commits from session
+- [ ] Session intent / notes rendered as markdown
+- [ ] Timeline of events within session
+- [ ] Filter by: participant, date range, active/ended
+- [ ] Export session notes
+
+### 3.13 `/musehub/ui/{owner}/{repo}/analysis/{ref}` — Analysis Dashboard
+
+**Current:** 10-dimension panel with links to sub-pages.
+
+**Missing / Wanted:**
+- [ ] Historical trend charts (analysis over commit history)
+- [ ] Compare with another ref inline
+- [ ] "Analysis changed since last commit" delta indicators
+- [ ] Export analysis as JSON
+- [ ] Share analysis card (social preview)
+- [ ] Annotation layer (add notes to analysis — saved as commit metadata)
+- [ ] `muse similarity` score vs parent commit
+- [ ] Harmonic analysis sub-page (`/analysis/{ref}/harmony`)
+- [ ] Emotion-diff vs parent (`/analysis/{ref}/emotion-diff`)
+- [ ] Recall search panel (`/analysis/{ref}/recall`)
+
+### 3.14 `/musehub/ui/{owner}/{repo}/blame/{ref}/{path}` — Blame ❌ MISSING
+
+**Wanted:**
+- [ ] Per-note row: author avatar + username + commit hash + message
+- [ ] Colour-coded by author
+- [ ] Click on row → go to commit
+- [ ] Filter by instrument/track
+- [ ] Hover tooltip: full commit info
+- [ ] Beat-range selector (zoom in on a region)
+
+### 3.15 `/musehub/ui/{owner}/{repo}/forks` — Fork Network ❌ MISSING
+
+**Wanted:**
+- [ ] Fork tree visualization (original + fork children + their forks)
+- [ ] Each node: owner avatar, star count, last updated, divergence score
+- [ ] Filter: only show "active" forks (committed in last 90 days)
+- [ ] "Compare my fork" shortcut
+- [ ] "Contribute upstream" → create PR shortcut
+
+### 3.16 `/musehub/ui/users/{username}` — User Profile
+
+**Current:** Overview / Repositories / Starred / Watching tabs.
+
+**Missing / Wanted:**
+- [ ] Contribution graph (GitHub-style heatmap of commit activity)
+- [ ] Pinned repos section (up to 6, from `musehub_profiles.pinned_repo_ids`)
+- [ ] Bio + avatar + location + links
+- [ ] Followers / following counts with links to lists
+- [ ] Activity feed tab (recent commits, PRs, issues, stars)
+- [ ] Achievement badges (e.g. "100 commits", "First fork", "Genre Pioneer")
+- [ ] Organisations / collaborations section
+- [ ] Sponsor / support link
+- [ ] Follow / Unfollow button
+- [ ] Block user button
+- [ ] Recent releases section
+
+### 3.17 `/musehub/ui/notifications` — Notification Inbox ❌ MISSING
+
+**Wanted:**
+- [ ] Grouped by repo
+- [ ] Filter: unread / all / participating / mentioned
+- [ ] Type icons (PR, issue, commit, review, mention)
+- [ ] Mark as read individually
+- [ ] Mark all read button
+- [ ] Mute thread button
+- [ ] Notification settings link
+
+### 3.18 `/musehub/ui/{owner}/{repo}/insights` — Repo Analytics
+
+**Current:** View counts, download events, star history.
+
+**Missing / Wanted:**
+- [ ] Commit frequency chart (daily/weekly/monthly toggle)
+- [ ] Top contributors leaderboard
+- [ ] Issues opened/closed trend
+- [ ] PR merge rate
+- [ ] Fork growth chart
+- [ ] Watcher count history
+- [ ] Most-referenced commits
+- [ ] Most-downloaded releases
+- [ ] Geographic origin of listeners (if available)
+- [ ] Traffic sources (referrers)
+- [ ] Instrument popularity over time (which instruments used most across commits)
+- [ ] Tempo/key distribution histograms across commit history
+- [ ] Average session duration trend
+
+### 3.19 oEmbed / Embed Player
+
+**Current:** Basic iframe embed exists.
+
+**Missing / Wanted:**
+- [ ] oEmbed endpoint returning rich metadata (title, author, thumbnail, duration)
+- [ ] Open Graph `<meta>` tags on all repo/commit/release pages
+- [ ] Twitter/X card metadata
+- [ ] Spotify-style "Now Playing" card (shareable static image)
+- [ ] Waveform thumbnail generation from render_job assets
+
+---
+
+## 4. SEED DATA BLUEPRINT
+
+### 4.1 Real Creative Commons MIDI Artists
+
+The following are public domain or Creative Commons licensed and suitable for attribution in seed data:
+
+| Artist | Era / Genre | CC License | Source | Key Characteristics |
+|---|---|---|---|---|
+| **J.S. Bach** | Baroque, Classical | Public Domain | piano-midi.de, Mutopia | Complex counterpoint, fugues, all 24 keys, CC voicings |
+| **Ludwig van Beethoven** | Classical, Romantic | Public Domain | piano-midi.de | Wide dynamic range, dramatic velocity changes, complex pedal |
+| **Frédéric Chopin** | Romantic | Public Domain | piano-midi.de | Rubato, expressive CC1 (mod wheel), dense chord voicings |
+| **Claude Debussy** | Impressionist | Public Domain | various | Whole tone scales, lush pedal, free meter, color harmony |
+| **Scott Joplin** | Ragtime | Public Domain | multiple | Syncopated rhythm, ragtime groove, steady bass + ornate RH |
+| **Kevin MacLeod** | Modern / Multi-genre | CC BY 4.0 | incompetech.com | Wide variety: cinematic, jazz, ambient, uptempo; MIDI available |
+| **Kai Engel** | Ambient / Modern Classical | CC BY 4.0 | Free Music Archive | Long-form ambient, subtle dynamics, quiet velocity curves |
+| **Broke for Free** | Electronic / Lo-fi | CC BY | Free Music Archive | Electronic textures, drum machine patterns, synth basslines |
+| **Brad Sucks** | Indie Rock | CC BY | braadsucks.net | Guitar-driven, power chords, verse/chorus form, rock drumming |
+| **Chris Zabriskie** | Ambient / Cinematic | CC BY 4.0 | chriszabriskie.com | Cinematic pads, slow evolution, minimal note changes |
+
+### 4.2 Seed Users
+
+| Username | Real-world Archetype | Role in Seed |
+|---|---|---|
+| `bach` | J.S. Bach (historical CC) | Source of classical repos |
+| `chopin` | Frédéric Chopin (historical CC) | Source of romantic piano repos |
+| `scott_joplin` | Scott Joplin (historical CC) | Source of ragtime repos |
+| `kevin_macleod` | Kevin MacLeod (modern CC) | Multi-genre repos |
+| `gabriel` | Primary active user | Forks, PRs, issues, collaborations |
+| `sofia` | Active collaborator | Co-author on merge commits |
+| `marcus` | EDM producer archetype | Electronic repos, forks Bach |
+| `yuki` | Classical scholar | Studies Bach, opens analysis issues |
+| `aaliya` | Jazz fusion artist | Forks Chopin, adds jazz voicings |
+| `chen` | Film composer | Uses MacLeod as base, adds arrangements |
+| `fatou` | Afrobeats producer | Cross-genre forks, unique rhythmic commits |
+| `pierre` | French academic | Analysis-heavy commits, theory annotations |
+
+### 4.3 Seed Repositories
+
+| Repo | Owner | Genre | Description | Branches |
+|---|---|---|---|---|
+| `well-tempered-clavier` | `bach` | Baroque / Classical | All 48 preludes + fugues in all 24 keys | main, prelude-bk1, fugue-bk1, prelude-bk2, fugue-bk2 |
+| `goldberg-variations` | `bach` | Baroque | 30 variations + aria | main, aria-only, variation-13-experimental |
+| `nocturnes` | `chopin` | Romantic Piano | 21 nocturnes | main, op9, op15, op27, extended |
+| `maple-leaf-rag` | `scott_joplin` | Ragtime | Maple Leaf Rag + variations | main, slow-version, marcus-edm-remix |
+| `cinematic-strings` | `kevin_macleod` | Cinematic | Orchestral string pieces | main, orchestral, stripped-piano |
+| `ambient-textures` | `kai_engel` | Ambient | Long-form ambient works | main, v1, v2-extended |
+| `gabriel-neo-baroque` | `gabriel` | Cross-genre | Bach WTC fork with modern production | main, experiment/jazz-voicings, experiment/edm-bassline |
+| `aaliya-jazz-chopin` | `aaliya` | Jazz Fusion | Chopin nocturnes fork with jazz reharmonisation | main, reharmonized, trio-arrangement |
+| `marcus-ragtime-edm` | `marcus` | Electronic | Joplin fork with 808 drums + synth bass | main, trap-version, house-version |
+| `chen-film-score` | `chen` | Cinematic | MacLeod fork adapted for film scenes | main, act1, act2, act3 |
+| `fatou-polyrhythm` | `fatou` | Afrobeats | Original polyrhythmic compositions | main, 7-over-4, 5-over-3-experiment |
+| `community-collab` | `gabriel` | Multi-genre | Open collaboration repo, all users contribute | main, sofias-counterpoint, yukis-ornaments, pierres-analysis |
+
+### 4.4 Commit Data Requirements
+
+Per repo, generate commits exercising:
+- [ ] Simple single-instrument changes (velocity edits, note moves)
+- [ ] Multi-instrument commits (bass + keys + drums changed together)
+- [ ] Commits with `tempo_bpm` metadata annotation
+- [ ] Commits with `key` metadata annotation  
+- [ ] Commits with `emotion:*` tags (emotion:melancholic, emotion:joyful, emotion:tense, etc.)
+- [ ] Commits with `stage:*` tags (stage:rough-mix, stage:arrangement, stage:production, stage:mastering)
+- [ ] Commits with `ref:*` tags (ref:bach, ref:coltrane, ref:daft-punk)
+- [ ] Commits with CC event data (CC1 modulation, CC7 volume, CC11 expression, CC64 sustain, CC91 reverb)
+- [ ] Commits with full pitch_bends data
+- [ ] Commits with aftertouch data
+- [ ] Merge commits with two parents (cross-genre merges that should show conflicts)
+- [ ] Empty commits (muse commit --allow-empty for session markers)
+- [ ] Amend commits (shows --amend in history)
+- [ ] Commits that revert previous commits
+- [ ] Cherry-pick commits (applied from another branch)
+
+Minimum: **50 commits per repo**, **12 repos** = **600+ commits total**
+
+### 4.5 Branch Data Requirements
+
+Per repo:
+- [ ] `main` (default)
+- [ ] At least 2 feature branches (active/merged)
+- [ ] At least 1 abandoned branch (closed PR)
+- [ ] At least 1 long-running branch with many commits (shows realistic divergence)
+- [ ] At least 1 branch created from a tag (hotfix-like)
+
+### 4.6 Muse CLI Data (Currently Unseeded)
+
+#### muse_objects
+- [ ] 50+ unique content-addressed blobs (MIDI file bytes, sha256-keyed)
+- [ ] Objects with varying sizes (small loops 2KB → large orchestral pieces 200KB)
+- [ ] Deduplicated objects (same MIDI file on two branches → same object_id)
+
+#### muse_snapshots
+- [ ] One snapshot per commit (manifest: `{path: object_id}`)
+- [ ] Snapshots with 1 file (single instrument)
+- [ ] Snapshots with 8-16 files (full ensemble)
+- [ ] Snapshots with nested paths (e.g. `strings/violin.mid`, `brass/trumpet.mid`)
+
+#### muse_commits
+- [ ] Single-parent commits (linear history)
+- [ ] Merge commits with `parent2_commit_id` populated
+- [ ] Commits with `metadata.tempo_bpm` set
+- [ ] Commits with `metadata.key` set
+- [ ] Commits with `metadata.time_signature` set (future extension point)
+- [ ] Commits by multiple authors on the same repo
+
+#### muse_tags
+- [ ] `emotion:melancholic`, `emotion:joyful`, `emotion:tense`, `emotion:serene`, `emotion:triumphant`, `emotion:mysterious`, `emotion:playful`
+- [ ] `stage:sketch`, `stage:rough-mix`, `stage:arrangement`, `stage:production`, `stage:mixing`, `stage:mastering`, `stage:released`
+- [ ] `key:C`, `key:Am`, `key:G`, `key:Em`, `key:Bb`, `key:F#`, `key:Db`, `key:Abm`
+- [ ] `tempo:60bpm`, `tempo:80bpm`, `tempo:120bpm`, `tempo:140bpm`, `tempo:160bpm`
+- [ ] `ref:bach`, `ref:chopin`, `ref:debussy`, `ref:coltrane`, `ref:daft-punk`, `ref:beethoven`
+- [ ] `genre:baroque`, `genre:romantic`, `genre:ragtime`, `genre:edm`, `genre:ambient`, `genre:jazz`, `genre:afrobeats`
+- [ ] Free-form: `needs-work`, `favourite`, `breakout`, `experimental`, `send-to-band`
+
+#### muse_variations (DAW-level variation history)
+- [ ] 20+ variations per active repo (accepted + discarded + pending)
+- [ ] Variations with multiple phrases each
+- [ ] Phrases with note_changes (add, remove, modify)
+- [ ] Variations showing lineage (parent → child chain)
+- [ ] Merge-type variations (parent2_variation_id set)
+- [ ] Variations with CC event data in phrases
+- [ ] Variations with pitch_bend data in phrases
+- [ ] Variations with aftertouch data in phrases
+
+### 4.7 MuseHub Social Data (10x Current Scale)
+
+#### musehub_issues
+Minimum **15 issues per repo** with:
+- [ ] Mix of open / closed / locked
+- [ ] Issues with labels: `bug`, `enhancement`, `question`, `analysis`, `merge-conflict`, `needs-arrangement`, `help-wanted`, `good-first-issue`, `musical-theory`, `performance`
+- [ ] Issues assigned to multiple users
+- [ ] Issues linked to milestones
+- [ ] Issues with sub-tasks (markdown checkboxes in body)
+- [ ] Cross-repo references (`owner/repo#N`)
+- [ ] Issues closed by PR ("Closes #N" in PR body)
+
+#### musehub_issue_comments
+Minimum **5 comments per issue**:
+- [ ] Comments with markdown formatting
+- [ ] Comments with code blocks (MIDI snippet representations)
+- [ ] Comments with musical notation references
+- [ ] Threaded replies (`parent_id` set)
+- [ ] Comments with @mentions
+- [ ] Comments with reactions
+
+#### musehub_milestones
+Per repo:
+- [ ] 3-5 milestones (v0.1, v0.2, v1.0, "Bach Complete", "EDM Edition", etc.)
+- [ ] Mix of open / closed
+- [ ] With and without `due_on` dates
+- [ ] Linked to multiple issues
+
+#### musehub_pull_requests
+Minimum **8 PRs per repo**:
+- [ ] Open PRs (awaiting review)
+- [ ] Merged PRs (`merged_at` set, `merge_commit_id` set)
+- [ ] Closed PRs (rejected without merge)
+- [ ] Cross-genre "merge conflict" PRs (EDM bassline into classical piece)
+- [ ] PRs with detailed musical diff descriptions
+- [ ] PRs with linked issues (Closes #N)
+- [ ] PRs with multiple review comments
+
+#### musehub_pr_comments
+Per PR, 3-8 inline review comments:
+- [ ] General comments (`target_type: "general"`)
+- [ ] Track-specific comments (`target_type: "track"`, `target_track: "piano"`)
+- [ ] Region comments with beat range (`target_type: "region"`, `target_beat_start`, `target_beat_end`)
+- [ ] Note-specific comments (`target_type: "note"`, `target_note_pitch: 60`)
+- [ ] Threaded replies (`parent_comment_id` set)
+
+#### musehub_releases
+Per repo, 3-5 releases:
+- [ ] Semantic versions: v0.1.0, v0.2.0, v1.0.0
+- [ ] Release notes with markdown (what changed musically)
+- [ ] `download_urls` with all package types: `midi_bundle`, `stems`, `mp3`, `musicxml`, `metadata`
+- [ ] Pre-release and latest badges
+- [ ] Releases linked to commits
+
+#### musehub_sessions
+Per repo, 5-10 sessions:
+- [ ] Solo sessions (1 participant)
+- [ ] Duo sessions (2 participants)
+- [ ] Full-band sessions (4-6 participants)
+- [ ] Sessions with `intent` (what the session was trying to achieve)
+- [ ] Sessions with `notes` (what happened, discoveries, blockers)
+- [ ] Sessions linked to commits (commits made during that session)
+- [ ] Active sessions (1 per repo marked `is_active: true`)
+- [ ] Sessions at different locations (home studio, studio, remote collaboration)
+
+#### musehub_webhooks
+Per repo, 1-3 webhooks:
+- [ ] Webhook for `push` events (CI simulation)
+- [ ] Webhook for `pull_request` events
+- [ ] Webhook for `release` events (notify downstream consumers)
+- [ ] Fernet-encrypted secrets
+- [ ] Mix of active / inactive
+
+#### musehub_webhook_deliveries
+Per webhook, 5-20 deliveries:
+- [ ] Successful deliveries (response_status: 200)
+- [ ] Failed deliveries (response_status: 500, 404, 0 for timeout)
+- [ ] Multiple retry attempts (`attempt`: 1, 2, 3)
+
+#### musehub_render_jobs
+Per repo, 5-15 render jobs:
+- [ ] Completed jobs (status: "done", mp3_object_ids populated)
+- [ ] Failed jobs (status: "failed", error_message set)
+- [ ] Pending jobs (status: "pending")
+- [ ] Jobs with multiple MIDI files (midi_count > 1)
+
+#### musehub_events
+Per repo, 20+ activity events:
+- [ ] `push` events
+- [ ] `pull_request.opened`, `pull_request.merged`, `pull_request.closed`
+- [ ] `issue.opened`, `issue.closed`
+- [ ] `release.published`
+- [ ] `star` events (when users star)
+- [ ] `fork` events
+- [ ] `member.added` events (collaborator added)
+- [ ] `session.started`, `session.ended`
+
+#### Social Tables
+- [ ] **musehub_stars**: Every user stars 3-8 repos (not their own)
+- [ ] **musehub_watches**: Every user watches 4-10 repos
+- [ ] **musehub_follows**: Rich follow graph (each user follows 3-6 others)
+- [ ] **musehub_forks**: 2-4 forks per public repo, cross-genre where possible
+- [ ] **musehub_comments**: 3-8 comments per commit/release/PR
+- [ ] **musehub_reactions**: Full emoji set on commits, issues, comments (👍 ❤️ 🎵 🔥 🎹 👏 🤔 😢)
+- [ ] **musehub_notifications**: 10-20 unread notifications per user
+- [ ] **musehub_view_events**: 30-100 view events per repo (simulates real traffic)
+- [ ] **musehub_download_events**: 5-20 download events per release
+
+### 4.8 Dramatic Narrative Scenarios (for Rich Seed Data)
+
+The seed data should tell actual stories:
+
+1. **"The Bach Remix War"** — `marcus` forks `bach/well-tempered-clavier`, adds trap drums and 808 bass, opens PR back to `bach`. `yuki` leaves detailed analysis comments about harmonic integrity. `bach` (auto) closes the PR. Heated issue thread ensues. Eventually a compromise branch emerges.
+
+2. **"Chopin Meets Coltrane"** — `aaliya` forks `chopin/nocturnes`, reharmonises Nocturne Op.9 No.2 with Coltrane changes. 3-way merge conflict when `gabriel` also forks and adds jazz voicings. Beautiful merge commit resolves the conflict.
+
+3. **"The Ragtime EDM Collab"** — `marcus` and `fatou` open a collaborative session on `marcus/ragtime-edm`. 8-commit session, 3 participants, ends with a release "v1.0.0 - Maple Leaf Drops".
+
+4. **"Community Collab Chaos"** — `gabriel/community-collab` has all 10 users contributing. Multiple open PRs from different users, some conflicting, some cleanly merged. An open issue "Resolve the key signature — are we in G major or E minor?" with 20+ comments and a heated debate.
+
+5. **"The Goldberg Milestone"** — `bach/goldberg-variations` has milestone "All 30 Variations Complete". Issues track each variation as a task. 28/30 closed. 2 still open and hotly debated.
+
+---
+
+## 5. GITHUB ISSUE BACKLOG
+
+> Each item below should become one GitHub issue with appropriate labels.
+> Labels: `feature`, `missing-url`, `seed-data`, `analysis`, `ui`, `api`, `muse-command`
+
+### GROUP A — Missing MuseHub URLs (UI Implementation)
+
+- [ ] **A-01**: `GET /{owner}/{repo}/blame/{ref}/{path}` — Implement muse blame UI page with per-note authorship visualization
+- [ ] **A-02**: `GET /{owner}/{repo}/milestones` — Milestone list page with progress bars and issue linking
+- [ ] **A-03**: `GET /{owner}/{repo}/milestones/{number}` — Milestone detail page with filtered issue list
+- [ ] **A-04**: `GET /{owner}/{repo}/labels` — Label management page (create, edit, delete, colour picker)
+- [ ] **A-05**: `GET /{owner}/{repo}/stash` — Stash list page with apply/pop/drop actions
+- [ ] **A-06**: `GET /{owner}/{repo}/forks` — Fork network visualization page
+- [ ] **A-07**: `GET /{owner}/{repo}/settings` — Repo settings page (visibility, description, tags, danger zone)
+- [ ] **A-08**: `GET /{owner}/{repo}/webhooks` — Webhook management UI (list, create, test, delete)
+- [ ] **A-09**: `GET /{owner}/{repo}/similarity/{base}...{head}` — Musical similarity score page
+- [ ] **A-10**: `GET /{owner}/{repo}/emotion-diff/{base}...{head}` — Emotional delta visualization page
+- [ ] **A-11**: `GET /{owner}/{repo}/analysis/{ref}/harmony` — Full harmonic analysis sub-page (Roman numerals, cadences)
+- [ ] **A-12**: `GET /{owner}/{repo}/recall` — Semantic memory search over commit history
+- [ ] **A-13**: `GET /notifications` — Notification inbox page with group/filter/mark-read
+- [ ] **A-14**: `GET /users/{username}/followers` — Follower list page
+- [ ] **A-15**: `GET /users/{username}/following` — Following list page
+- [ ] **A-16**: `GET /topics/{tag}` — Topic browse page (repos grouped by tag)
+- [ ] **A-17**: `GET /new` — New repo wizard UI
+
+### GROUP B — Missing API Endpoints
+
+- [ ] **B-01**: `GET/POST/PATCH/DELETE /api/v1/musehub/repos/{id}/milestones/{n}` — Full milestone CRUD API
+- [ ] **B-02**: `GET/POST /api/v1/musehub/repos/{id}/labels` + `PATCH /issues/{n}/labels` — Label management API
+- [ ] **B-03**: `GET /api/v1/musehub/repos/{id}/analysis/{ref}/harmony` — Harmonic analysis endpoint
+- [ ] **B-04**: `GET /api/v1/musehub/repos/{id}/analysis/{ref}/similarity?compare={ref2}` — Similarity score endpoint
+- [ ] **B-05**: `GET /api/v1/musehub/repos/{id}/analysis/{ref}/emotion-diff?base={ref}` — Emotion delta endpoint
+- [ ] **B-06**: `GET /api/v1/musehub/repos/{id}/analysis/{ref}/recall?q={query}` — Semantic recall endpoint
+- [ ] **B-07**: `GET/PATCH /api/v1/musehub/repos/{id}/settings` — Repo settings read/write
+- [ ] **B-08**: `DELETE /api/v1/musehub/repos/{id}` — Repo deletion with cascade
+- [ ] **B-09**: `POST /api/v1/musehub/repos/{id}/transfer` — Transfer repo ownership
+- [ ] **B-10**: `GET/POST/DELETE /api/v1/musehub/repos/{id}/collaborators` — Collaborator management
+- [ ] **B-11**: `GET /api/v1/musehub/repos/{id}/blame/{ref}` — Blame output as JSON for agents
+- [ ] **B-12**: `GET/POST/DELETE /api/v1/musehub/repos/{id}/stash` + pop endpoint — Stash API
+- [ ] **B-13**: `GET /api/v1/musehub/users/{username}/activity` — Public activity feed for a user
+- [ ] **B-14**: `GET /api/v1/musehub/topics/{tag}/repos` — Repos by topic tag
+
+### GROUP C — Per-Page UI Enhancements
+
+- [ ] **C-01**: Explore page — Add filter sidebar (genre, key, tempo range, license, instrument)
+- [ ] **C-02**: Explore page — Inline audio preview on repo card hover
+- [ ] **C-03**: Repo landing — Contributor avatar grid with commit counts
+- [ ] **C-04**: Repo landing — Activity contribution heatmap graph
+- [ ] **C-05**: Repo landing — Instrument breakdown bar chart
+- [ ] **C-06**: Repo landing — Clone URL widget with copy button
+- [ ] **C-07**: Repo landing — README markdown rendering
+- [ ] **C-08**: Commits list — Filter by author, date range, tag annotation
+- [ ] **C-09**: Commits list — Per-commit instrument change badges + tempo/key metadata chips
+- [ ] **C-10**: Commits list — "Compare" multi-select mode for picking two commits to diff
+- [ ] **C-11**: Commit detail — Inline audio player (render_preview for the commit)
+- [ ] **C-12**: Commit detail — Reactions and comments thread on commit
+- [ ] **C-13**: PR list — Filter by assignee, label, milestone; sort options
+- [ ] **C-14**: PR detail — Approval status per reviewer; review request workflow
+- [ ] **C-15**: PR detail — Audio A/B inline player (base vs head)
+- [ ] **C-16**: PR detail — Merge options: merge commit / squash / rebase selector
+- [ ] **C-17**: Issue list — Filter by label, milestone, assignee; bulk actions
+- [ ] **C-18**: Issue detail — Reactions on body and comments; threaded replies
+- [ ] **C-19**: Issue detail — Timeline view (events + comments interspersed)
+- [ ] **C-20**: Release detail — Embedded audio player + download stats
+- [ ] **C-21**: Releases — RSS feed link + subscribe to releases button
+- [ ] **C-22**: Analysis dashboard — Historical trend charts over commit history
+- [ ] **C-23**: Analysis dashboard — "Analysis delta since parent commit" indicators
+- [ ] **C-24**: User profile — Contribution heatmap graph (GitHub-style)
+- [ ] **C-25**: User profile — Achievement badges system
+- [ ] **C-26**: Insights — Full analytics suite (commit frequency, PR merge rate, fork growth)
+
+### GROUP D — Muse Command UI Exposure (Missing)
+
+- [ ] **D-01**: `muse amend` — UI button on commit detail page: "Amend last commit"
+- [ ] **D-02**: `muse cherry-pick` — UI button on commit detail: "Apply to branch…"
+- [ ] **D-03**: `muse revert` — UI button on commit detail: "Revert this commit"
+- [ ] **D-04**: `muse rebase -i` — Interactive rebase UI (drag-to-reorder commits)
+- [ ] **D-05**: `muse stash` — Stash panel in sidebar: push, list, apply, drop
+- [ ] **D-06**: `muse bisect` — Bisect wizard UI: "Find the bad commit" binary search workflow
+- [ ] **D-07**: `muse transpose` — UI control on commit/branch: "Transpose to key…"
+- [ ] **D-08**: `muse tempo-scale` — UI control: "Time-stretch by factor…"
+- [ ] **D-09**: `muse humanize` — UI toggle on commit: "Apply humanization"
+- [ ] **D-10**: `muse validate` — UI badge on commit: "MIDI structure valid ✓"
+- [ ] **D-11**: `muse import` — Repo UI: "Import MIDI file" → creates commit
+- [ ] **D-12**: `muse describe` — Standalone page at `/{owner}/{repo}/describe/{ref}` with AI prose summary
+- [ ] **D-13**: `muse recall` — Search UI: "Search musical memory" (semantic search over history)
+- [ ] **D-14**: `muse resolve` — Merge conflict resolution UI with ours/theirs/manual options
+- [ ] **D-15**: `muse worktree` — Worktree list UI: see all active worktrees for a repo
+- [ ] **D-16**: `muse similarity` — Show similarity score on PR detail page (head vs base)
+- [ ] **D-17**: `muse emotion-diff` — Show emotional delta on PR detail page inline
+
+### GROUP E — Seed Data
+
+- [ ] **E-01**: Implement muse_objects / muse_snapshots / muse_commits / muse_tags seed data (all currently zero)
+- [ ] **E-02**: Implement muse_variations / muse_phrases / muse_note_changes seed data (all currently zero)
+- [ ] **E-03**: Create 12 artist/user profiles with bio, avatar, pinned repos (Bach, Chopin, Joplin, MacLeod, gabriel, sofia, marcus, yuki, aaliya, chen, fatou, pierre)
+- [ ] **E-04**: Seed 12 repos across genres (well-tempered-clavier, nocturnes, maple-leaf-rag, etc.) with 50+ commits each
+- [ ] **E-05**: Seed all muse_tags variants (emotion:*, stage:*, key:*, tempo:*, ref:*, genre:*)
+- [ ] **E-06**: Seed milestones + milestone-linked issues for each repo (3-5 milestones per repo)
+- [ ] **E-07**: Seed musehub_issue_comments (5+ per issue, with threading)
+- [ ] **E-08**: Seed musehub_pr_comments (review comments with track/region/note targeting)
+- [ ] **E-09**: Seed musehub_milestones + link to issues
+- [ ] **E-10**: Seed musehub_webhooks + musehub_webhook_deliveries (success and failure cases)
+- [ ] **E-11**: Seed musehub_render_jobs (pending, done, failed states)
+- [ ] **E-12**: Seed musehub_events (push, PR, issue, release, star, fork, session events)
+- [ ] **E-13**: Implement "Bach Remix War" narrative scenario (fork, PR, conflict, resolution)
+- [ ] **E-14**: Implement "Chopin Meets Coltrane" narrative scenario (cross-genre 3-way merge)
+- [ ] **E-15**: Implement "Ragtime EDM Collab" narrative scenario (multi-user session + release)
+- [ ] **E-16**: Implement "Community Collab Chaos" narrative scenario (10 users, open PRs, debates)
+- [ ] **E-17**: Implement "Goldberg Milestone" narrative scenario (milestone completion tracking)
+- [ ] **E-18**: Seed CC MIDI content — download and embed real MIDI data from piano-midi.de for Bach/Chopin/Joplin pieces
+- [ ] **E-19**: Seed full social graph — stars, watches, follows, forks, reactions (emojis including 🎵 🎹 🔥 👏)
+- [ ] **E-20**: Seed notifications for all users (10-20 unread each, all types)
+
+### GROUP F — Agent & Machine Readability
+
+- [ ] **F-01**: All HTML pages must have `Accept: application/json` equivalent JSON endpoint — audit and add any missing
+- [ ] **F-02**: Add `Link: rel=alternate type=application/json` headers on all UI pages
+- [ ] **F-03**: oEmbed endpoint — return rich metadata (title, author, thumbnail URL, audio URL, duration, BPM, key)
+- [ ] **F-04**: Open Graph + Twitter card meta tags on repo/commit/release/profile pages
+- [ ] **F-05**: `GET /musehub/ui/{owner}/{repo}/analysis/{ref}` → machine-readable `analysis.json` schema at same path with `Accept: application/json`
+- [ ] **F-06**: RSS/Atom feeds for: releases, commits, issues opened (per repo)
+- [ ] **F-07**: `robots.txt` + `sitemap.xml` generation for public repos
+- [ ] **F-08**: JSON-LD structured data (`schema.org/MusicComposition`) on repo landing pages
+- [ ] **F-09**: Pagination via `Link: rel=next/prev` headers on all list endpoints (RFC 8288)
+- [ ] **F-10**: Cursor-based pagination option alongside offset (better for agents with large datasets)
+
+---
+
+*Generated: 2026-03-01 | Version: 1.0 | Next review: after E-series issues are implemented*


### PR DESCRIPTION
## Summary

- Adds **`PARALLEL_CONDUCTOR.md`** — the 4th canonical prompt. One invocation reads GitHub label state, resolves the phase dependency graph, dispatches `ISSUE_TO_PR` and `PR_REVIEW` coordinators simultaneously for all ready batches, and creates a `conductor-reminder` GitHub issue when the pipeline is incomplete.
- Adds **`status/*` pipeline state labels** (`status/in-progress`, `status/pr-open`, `status/merged`, `conductor-reminder`) applied/removed by agents automatically so pipeline state is always queryable from GitHub.
- Adds **`ATTEMPT_N` anti-loop guard** to all three existing kickoff prompts — prevents agents from looping blindly when stuck.
- Adds **retry-without-strategy-mutation guard** — two identical failures force a strategy redesign, not a parameter tweak.
- Adds **regression feedback loop** (STEP 7 in PR_REVIEW) — post-merge test failures auto-create bug issues for the next batch with no human triage.
- **Fixes broken Alembic migration chain** — `0003_labels` `down_revision` was pointing to the deleted `0002_milestones`; corrected to `0001`.

## Failure taxonomy coverage (from Agent_Failure_Taxonomy_v1)

| Failure Mode | Guard Added |
|---|---|
| Retry Without Strategy Mutation | All 3 kickoff prompts: 2 identical failures → redesign |
| Anti-Loop Safeguards (attempt counters) | ATTEMPT_N field in all task files; > 2 → escalate |
| Orphaned Subagent | Conductor STEP 1: cleanup stale worktrees before every run |
| False Completion | Coordinator reports must include PR URLs / merge status |
| Context Drift | Conductor re-reads .agent-task at each STEP |
| Watchdog Chain Paradox | conductor-reminder issue is the external signal; human is top watchdog |
| Cascading Test Failure Blindness | Feedback loop in PR_REVIEW STEP 7 auto-files bug issues |
| Revert Nukes Work | Surgical undo guard in ISSUE_TO_PR: git restore -p only |

## Test plan

- [ ] Run Label Pre-flight from `PARALLEL_BUGS_TO_ISSUES.md` — verify `status/*` and `conductor-reminder` labels created on GitHub
- [ ] Create conductor worktree and run conductor kickoff — verify it queries GitHub and dispatches coordinators
- [ ] Verify conductor creates a `conductor-reminder` issue when batches are still open
- [ ] Verify `alembic upgrade head` runs cleanly (migration chain fix)