### PR TITLE
feat: add collaborator access-check endpoint to repos.py

### DIFF
--- a/maestro/api/routes/musehub/repos.py
+++ b/maestro/api/routes/musehub/repos.py
@@ -29,14 +29,14 @@ import logging
 
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from maestro.auth.dependencies import TokenClaims, optional_token, require_valid_token
 from maestro.db import get_db
-from maestro.db import musehub_models as db_models
 from maestro.db import musehub_collaborator_models as collab_models
-from sqlalchemy import select
+from maestro.db import musehub_models as db_models
 from maestro.models.musehub import (
     ActivityFeedResponse,
     ArrangementMatrixResponse,

--- a/maestro/api/routes/musehub/repos.py
+++ b/maestro/api/routes/musehub/repos.py
@@ -40,6 +40,7 @@ from maestro.models.musehub import (
     ArrangementMatrixResponse,
     BranchDetailListResponse,
     BranchListResponse,
+    CollaboratorAccessResponse,
     CommitDiffDimensionScore,
     CommitDiffSummaryResponse,
     CommitListResponse,
@@ -1414,6 +1415,69 @@ async def patch_repo_settings(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
     await db.commit()
     return updated
+
+
+# ── Collaborator access-check — before owner/slug catch-all ──────────────────
+
+
+@router.get(
+    "/repos/{repo_id}/collaborators/{username}/permission",
+    response_model=CollaboratorAccessResponse,
+    operation_id="checkCollaboratorAccess",
+    summary="Check a user's effective permission level on a repo",
+    tags=["Repos"],
+)
+async def check_collaborator_access(
+    repo_id: str,
+    username: str,
+    db: AsyncSession = Depends(get_db),
+    _: TokenClaims = Depends(require_valid_token),
+) -> CollaboratorAccessResponse:
+    """Return the effective permission level for *username* on *repo_id*.
+
+    The repo owner's effective permission is always ``"owner"`` with
+    ``accepted_at: null`` (ownership is immediate, not via invitation).
+
+    If *username* is found in the accepted collaborator list, the row's
+    ``permission`` and ``accepted_at`` values are returned.
+
+    Raises 404 when *username* is neither the owner nor an accepted collaborator,
+    so callers can distinguish a known absence from a positive grant.
+
+    Auth: requires a valid JWT Bearer token.
+    """
+    repo = await musehub_repository.get_repo(db, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Repo not found")
+
+    # Owner case: always returns "owner" permission immediately.
+    if username == repo.owner_user_id:
+        return CollaboratorAccessResponse(
+            username=username,
+            permission="owner",
+            accepted_at=None,
+        )
+
+    stmt = (
+        select(collab_models.MusehubCollaborator)
+        .where(
+            collab_models.MusehubCollaborator.repo_id == repo_id,
+            collab_models.MusehubCollaborator.user_id == username,
+        )
+    )
+    collab = (await db.execute(stmt)).scalar_one_or_none()
+
+    if collab is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"{username} is not a collaborator on this repo",
+        )
+
+    return CollaboratorAccessResponse(
+        username=username,
+        permission=str(collab.permission),
+        accepted_at=collab.accepted_at,
+    )
 
 
 # ── Owner/slug resolver — declared LAST to avoid shadowing /repos/... routes ──

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -2366,3 +2366,29 @@ class BlameResponse(CamelModel):
         default=0,
         description="Total number of blame entries in the response",
     )
+
+
+# ── Collaborator access-check model ─────────────────────────────────────────
+
+
+class CollaboratorAccessResponse(CamelModel):
+    """Response for the collaborator access-check endpoint.
+
+    Returns the effective permission level for a given username on a repo.
+    The owner's effective permission is always ``"owner"``.  Non-collaborators
+    are reported as 404 rather than returning a ``"none"`` permission value,
+    so callers can distinguish a known absence (404) from a positive result.
+
+    ``accepted_at`` is ``null`` for the repo owner (ownership is immediate)
+    and for collaborators whose invitation is still pending acceptance.
+    """
+
+    username: str = Field(..., description="User identifier supplied in the request path")
+    permission: str = Field(
+        ...,
+        description="Effective permission level: 'read' | 'write' | 'admin' | 'owner'",
+    )
+    accepted_at: datetime | None = Field(
+        None,
+        description="UTC timestamp when the collaborator accepted the invitation; null for owners",
+    )


### PR DESCRIPTION
## Summary

Closes #424 — adds `GET /repos/{repo_id}/collaborators/{username}/permission` to `repos.py` with 404-on-absence semantics and owner shortcut.

## Root Cause / Motivation

The DAW, MCP tools, and agent clients need a reliable way to check a user's effective permission level before attempting push or admin operations. The existing `collaborators.py` endpoint had the same URL pattern but returned `is_collaborator: false` (HTTP 200) for non-members, making it impossible to distinguish "not a collaborator" from a positive grant without inspecting the body. This endpoint uses HTTP 404 for non-members, which is the idiomatic REST signal for "this resource does not exist."

## Solution

- Added `CollaboratorAccessResponse` model to `maestro/models/musehub.py` — fields: `username`, `permission`, `accepted_at`.
- Added `GET /repos/{repo_id}/collaborators/{username}/permission` (op-id `checkCollaboratorAccess`) at the end of `repos.py`, before the `/{owner}/{repo_slug}` catch-all. Owner always returns `permission: "owner"` with `accepted_at: null`. Known collaborators return their stored permission and `accepted_at`. Non-collaborators receive 404.
- Removed the superseded `CollaboratorPermissionResponse` class and its `checkCollaboratorPermission` endpoint from `collaborators.py` — the two endpoints had identical URL patterns; keeping both would have caused the `collaborators.py` route (registered first) to shadow the new one. The new endpoint has strictly better semantics.
- Updated `test_musehub_collaborators.py` to reflect the consolidated endpoint contract (404 for non-members, `username`/`permission`/`acceptedAt` response shape).
- Added 6 new tests in `test_musehub_repos.py` covering owner, write collaborator, admin collaborator, non-collaborator 404, unknown repo 404, and auth 401.

## Verification

- [x] mypy clean (5 files: repos.py, collaborators.py, musehub.py, test_musehub_repos.py, test_musehub_collaborators.py)
- [x] 6 new tests pass (`test_musehub_repos.py -k collab_access`)
- [x] 12 existing collaborator tests pass (`test_musehub_collaborators.py`)
- [x] Docs updated (collaborators.py module docstring updated)