### PR TITLE
feat(musehub): add milestones UI pages with progress bars

### DIFF
--- a/maestro/api/routes/musehub/ui_milestones.py
+++ b/maestro/api/routes/musehub/ui_milestones.py
@@ -1,0 +1,242 @@
+"""Muse Hub milestones UI route handlers.
+
+Serves browser-readable HTML pages for the milestones section of a Muse Hub
+repo — analogous to GitHub's Milestones tab but for music projects.
+
+All pages are rendered via Jinja2 templates.  Route handlers resolve
+server-side data (repo_id, owner, slug, milestone data) and pass a minimal
+context dict to the template engine; all HTML, CSS, and JavaScript lives in
+the template files, not here.
+
+Endpoint summary:
+  GET /musehub/ui/{owner}/{repo_slug}/milestones        — milestones list with progress bars
+  GET /musehub/ui/{owner}/{repo_slug}/milestones/{number} — milestone detail with linked issues
+
+Content negotiation applies to both endpoints:
+  - Default (HTML): Jinja2 template with progress bars and issue counts.
+  - ``?format=json`` or ``Accept: application/json``: returns the raw Pydantic
+    response model with camelCase keys — the same contract used by the
+    ``/api/v1/musehub/...`` endpoints.
+
+These routes require NO JWT auth — they return HTML shells whose embedded
+JavaScript fetches data from the authed JSON API (``/api/v1/musehub/...``)
+using a token stored in ``localStorage``.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import status as http_status
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response as StarletteResponse
+
+from maestro.api.routes.musehub.negotiate import negotiate_response
+from maestro.db import get_db
+from maestro.models.musehub import (
+    IssueListResponse,
+    MilestoneListResponse,
+    MilestoneResponse,
+)
+from maestro.services import musehub_issues, musehub_repository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/musehub/ui", tags=["musehub-ui"])
+
+_TEMPLATE_DIR = Path(__file__).parent.parent.parent.parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _base_url(owner: str, repo_slug: str) -> str:
+    """Return the canonical UI base URL for a repo."""
+    return f"/musehub/ui/{owner}/{repo_slug}"
+
+
+def _breadcrumbs(*segments: tuple[str, str]) -> list[dict[str, str]]:
+    """Build breadcrumb_data list from (label, url) pairs."""
+    return [{"label": label, "url": url} for label, url in segments]
+
+
+async def _resolve_repo(
+    owner: str, repo_slug: str, db: AsyncSession
+) -> tuple[str, str]:
+    """Resolve owner+slug to repo_id; raise 404 if not found.
+
+    Returns (repo_id, base_url) so callers can unpack both in one line.
+    """
+    row = await musehub_repository.get_repo_orm_by_owner_slug(db, owner, repo_slug)
+    if row is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=f"Repo '{owner}/{repo_slug}' not found",
+        )
+    return str(row.repo_id), _base_url(owner, repo_slug)
+
+
+# ---------------------------------------------------------------------------
+# Milestones list page
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{owner}/{repo_slug}/milestones",
+    summary="Muse Hub milestones list page with progress bars",
+)
+async def milestones_list_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    state: str = Query(
+        "open",
+        pattern="^(open|closed|all)$",
+        description="Filter milestones by state: 'open', 'closed', or 'all'",
+    ),
+    sort: str = Query(
+        "due_on",
+        pattern="^(due_on|title|completeness)$",
+        description="Sort field: 'due_on', 'title', or 'completeness'",
+    ),
+    format: str | None = Query(None, description="Force response format: 'json' or omit for HTML"),
+    db: AsyncSession = Depends(get_db),
+) -> StarletteResponse:
+    """Render the milestones list page or return structured milestone data as JSON.
+
+    HTML (default): renders a filterable list of milestones with progress bars
+    showing percentage of closed issues, state badges, due-date indicators, and
+    links to each milestone's detail page.
+
+    JSON (``Accept: application/json`` or ``?format=json``): returns
+    ``MilestoneListResponse`` with all milestones for the given state.
+
+    Why this route exists: milestone overview is the primary entry point for
+    tracking compositional goals (album completion, mix revision milestones).
+    Progress bars make the completion status immediately scannable.
+
+    No JWT required — HTML shell; JS fetches authed data via localStorage token.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    milestone_data: MilestoneListResponse = await musehub_issues.list_milestones(
+        db, repo_id, state=state, sort=sort
+    )
+    return await negotiate_response(
+        request=request,
+        template_name="musehub/pages/milestones_list.html",
+        context={
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "base_url": base_url,
+            "current_page": "milestones",
+            "state": state,
+            "sort": sort,
+            "breadcrumb_data": _breadcrumbs(
+                (owner, f"/musehub/ui/{owner}"),
+                (repo_slug, base_url),
+                ("milestones", ""),
+            ),
+        },
+        templates=templates,
+        json_data=milestone_data,
+        format_param=format,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Milestone detail page
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{owner}/{repo_slug}/milestones/{number}",
+    summary="Muse Hub milestone detail page with linked issues",
+)
+async def milestone_detail_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    number: int,
+    issue_state: str = Query(
+        "open",
+        alias="state",
+        pattern="^(open|closed|all)$",
+        description="Filter linked issues by state: 'open', 'closed', or 'all'",
+    ),
+    format: str | None = Query(None, description="Force response format: 'json' or omit for HTML"),
+    db: AsyncSession = Depends(get_db),
+) -> StarletteResponse:
+    """Render the milestone detail page or return structured data as JSON.
+
+    HTML (default): renders milestone metadata (title, description, due date,
+    state badge, progress bar) followed by a filterable list of all issues
+    assigned to this milestone — showing open and closed issues with state
+    badges, labels, and links.
+
+    JSON (``Accept: application/json`` or ``?format=json``): returns a dict
+    containing both the ``MilestoneResponse`` and ``IssueListResponse`` for
+    issues linked to this milestone.
+
+    Why this route exists: the detail page is where composers track which
+    specific tasks (issues) belong to a compositional milestone — e.g.
+    "Mix Revision 2" might contain issues for each instrument's mix adjustments.
+    The linked issues list lets them triage remaining work without switching
+    to the issues tab.
+
+    No JWT required — HTML shell; JS fetches authed data via localStorage token.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+
+    milestone: MilestoneResponse | None = await musehub_issues.get_milestone(
+        db, repo_id, number
+    )
+    if milestone is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=f"Milestone #{number} not found in '{owner}/{repo_slug}'",
+        )
+
+    linked_issues = await musehub_issues.list_issues(
+        db, repo_id, state=issue_state, milestone_id=str(milestone.milestone_id)
+    )
+    issue_list = IssueListResponse(issues=linked_issues)
+
+    class _MilestoneDetailResponse(MilestoneResponse):
+        """Composite response: milestone + linked issues for JSON consumers."""
+
+        linked_issues: IssueListResponse
+
+    json_data = _MilestoneDetailResponse(
+        **milestone.model_dump(),
+        linked_issues=issue_list,
+    )
+
+    return await negotiate_response(
+        request=request,
+        template_name="musehub/pages/milestone_detail.html",
+        context={
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "milestone_id": str(milestone.milestone_id),
+            "milestone_number": number,
+            "base_url": base_url,
+            "current_page": "milestones",
+            "issue_state": issue_state,
+            "breadcrumb_data": _breadcrumbs(
+                (owner, f"/musehub/ui/{owner}"),
+                (repo_slug, base_url),
+                ("milestones", f"{base_url}/milestones"),
+                (f"#{number}", ""),
+            ),
+        },
+        templates=templates,
+        json_data=json_data,
+        format_param=format,
+    )

--- a/maestro/main.py
+++ b/maestro/main.py
@@ -25,6 +25,7 @@ from slowapi.errors import RateLimitExceeded
 from maestro.config import settings
 from maestro.api.routes import maestro, maestro_ui, health, users, conversations, assets, variation, muse, musehub
 from maestro.api.routes.musehub import ui as musehub_ui_routes
+from maestro.api.routes.musehub import ui_milestones as musehub_ui_milestones_routes
 from maestro.api.routes.musehub import discover as musehub_discover_routes
 from maestro.api.routes.musehub import users as musehub_user_routes
 from maestro.api.routes.musehub import oembed as musehub_oembed_routes
@@ -218,6 +219,9 @@ app.include_router(musehub_discover_routes.star_router, prefix="/api/v1", tags=[
 app.include_router(musehub.router, prefix="/api/v1")
 # UI routers: fixed-path routes (users, explore, trending) first, then wildcards.
 app.include_router(musehub_ui_routes.fixed_router, tags=["musehub-ui"])
+# Milestones UI routes registered before the main UI wildcard router so the
+# /{owner}/{repo_slug}/milestones paths are matched before /{owner}/{repo_slug}.
+app.include_router(musehub_ui_milestones_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_ui_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_oembed_routes.router, tags=["musehub-oembed"])
 app.include_router(musehub_raw_routes.router, prefix="/api/v1", tags=["musehub-raw"])

--- a/maestro/templates/musehub/pages/milestone_detail.html
+++ b/maestro/templates/musehub/pages/milestone_detail.html
@@ -1,0 +1,220 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Milestone #{{ milestone_number }}{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> /
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}/milestones">milestones</a> /
+  #{{ milestone_number }}
+{% endblock %}
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block extra_css %}
+<style>
+.progress-bar-track {
+  width: 100%;
+  height: 10px;
+  border-radius: 5px;
+  background: var(--bg-overlay, #161b22);
+  border: 1px solid var(--border, #30363d);
+  overflow: hidden;
+  margin-bottom: 4px;
+}
+.progress-bar-fill {
+  height: 100%;
+  border-radius: 5px;
+  background: var(--green, #3fb950);
+  transition: width 0.3s;
+}
+.progress-label { font-size: 13px; color: var(--text-muted, #8b949e); }
+.issue-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border, #30363d);
+}
+.issue-row:last-child { border-bottom: none; }
+.issue-meta { font-size: 12px; color: var(--text-muted, #8b949e); margin-top: 3px; }
+.issue-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+.issue-label-badge {
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--bg-overlay, #161b22);
+  border: 1px solid var(--border, #30363d);
+  color: var(--text-secondary, #c9d1d9);
+}
+.state-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--border, #30363d);
+  padding-bottom: 0;
+}
+.state-tab {
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  border: none;
+  background: none;
+  color: var(--text-muted, #8b949e);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  text-decoration: none;
+}
+.state-tab.active {
+  color: var(--text-primary, #e6edf3);
+  border-bottom-color: var(--accent, #58a6ff);
+}
+.state-tab:hover { color: var(--text-primary, #e6edf3); }
+</style>
+{% endblock %}
+
+{% block page_data %}
+const repoId          = {{ repo_id | tojson }};
+const milestoneId     = {{ milestone_id | tojson }};
+const milestoneNumber = {{ milestone_number }};
+const base            = {{ base_url | tojson }};
+const initIssueState  = {{ issue_state | tojson }};
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+let currentIssueState = initIssueState;
+
+function pct(ms) {
+  const total = (ms.openIssues || 0) + (ms.closedIssues || 0);
+  if (total === 0) return 0;
+  return Math.round((ms.closedIssues / total) * 100);
+}
+
+function dueDateLabel(dueOn) {
+  if (!dueOn) return '';
+  const d = new Date(dueOn);
+  const now = new Date();
+  const overdue = d < now;
+  const label = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  const color = overdue ? 'var(--red, #f85149)' : 'var(--text-muted, #8b949e)';
+  return `<span style="color:${color}">📅 Due ${escHtml(label)}${overdue ? ' (overdue)' : ''}</span>`;
+}
+
+function renderIssueRows(issues) {
+  if (!issues || issues.length === 0) {
+    return '<p class="loading">No ' + currentIssueState + ' issues in this milestone.</p>';
+  }
+  return issues.map(issue => {
+    const labels = (issue.labels || []).map(l =>
+      `<span class="issue-label-badge">${escHtml(l)}</span>`
+    ).join('');
+    return `
+      <div class="issue-row">
+        <span style="margin-top:2px;font-size:16px">${issue.state === 'open' ? '🟢' : '🟣'}</span>
+        <div style="flex:1;min-width:0">
+          <a href="${base}/issues/${issue.number}" style="font-weight:600">
+            ${escHtml(issue.title)}
+          </a>
+          <div class="issue-meta">
+            #${issue.number}
+            &bull; opened ${fmtDate(issue.createdAt)}
+            ${issue.assignee ? ' &bull; assigned to ' + escHtml(issue.assignee) : ''}
+            ${issue.commentCount > 0 ? ' &bull; 💬 ' + issue.commentCount : ''}
+          </div>
+          ${labels ? `<div class="issue-labels">${labels}</div>` : ''}
+        </div>
+        <span class="badge ${issue.state === 'open' ? 'badge-open' : 'badge-closed'}">${issue.state}</span>
+      </div>`;
+  }).join('');
+}
+
+function buildUrl(issueState) {
+  return base + '/milestones/' + milestoneNumber + '?state=' + encodeURIComponent(issueState);
+}
+
+async function load() {
+  initRepoNav(repoId);
+  document.getElementById('content').innerHTML = '<p class="loading">Loading milestone…</p>';
+  try {
+    const [msData, issuesData] = await Promise.all([
+      apiFetch('/repos/' + repoId + '/milestones/' + milestoneNumber),
+      apiFetch('/repos/' + repoId + '/issues?state=' + encodeURIComponent(currentIssueState)
+               + '&milestone_id=' + encodeURIComponent(milestoneId)),
+    ]);
+
+    const ms     = msData;
+    const issues = issuesData.issues || [];
+    const p      = pct(ms);
+    const total  = (ms.openIssues || 0) + (ms.closedIssues || 0);
+
+    document.getElementById('content').innerHTML = `
+      <div style="margin-bottom:12px">
+        <a href="${base}/milestones">&larr; All milestones</a>
+      </div>
+
+      <!-- Milestone header card -->
+      <div class="card" style="margin-bottom:16px">
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:8px;margin-bottom:12px">
+          <div>
+            <h1 style="margin:0 0 4px">🏁 ${escHtml(ms.title)}</h1>
+            <span class="badge ${ms.state === 'open' ? 'badge-open' : 'badge-closed'}">${ms.state}</span>
+            <span style="font-size:12px;color:var(--text-muted,#8b949e);margin-left:6px">
+              #${ms.number} &bull; ${total} issue${total !== 1 ? 's' : ''}
+            </span>
+          </div>
+          ${ms.dueOn ? `<div style="font-size:13px">${dueDateLabel(ms.dueOn)}</div>` : ''}
+        </div>
+
+        ${ms.description ? `<p style="color:var(--text-secondary,#c9d1d9);margin-bottom:12px">${escHtml(ms.description)}</p>` : ''}
+
+        <!-- Progress bar -->
+        <div style="max-width:400px">
+          <div class="progress-bar-track">
+            <div class="progress-bar-fill" style="width:${p}%"></div>
+          </div>
+          <div class="progress-label">
+            ${p}% complete &bull; ${ms.openIssues} open &bull; ${ms.closedIssues} closed
+          </div>
+        </div>
+      </div>
+
+      <!-- Issues section -->
+      <div class="card">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;flex-wrap:wrap;gap:8px">
+          <h2 style="margin:0">Issues</h2>
+          <span style="font-size:13px;color:var(--text-muted,#8b949e)">${issues.length} shown</span>
+        </div>
+
+        <!-- State filter tabs -->
+        <div class="state-tabs">
+          ${['open','closed','all'].map(s => `
+            <a class="state-tab ${currentIssueState === s ? 'active' : ''}"
+               href="${buildUrl(s)}"
+               onclick="event.preventDefault();setFilter('${s}')">${s.charAt(0).toUpperCase()+s.slice(1)}</a>
+          `).join('')}
+        </div>
+
+        <div id="issue-rows">
+          ${renderIssueRows(issues)}
+        </div>
+      </div>`;
+  } catch(e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML = '<p class="error">✕ ' + escHtml(e.message) + '</p>';
+  }
+}
+
+function setFilter(issueState) {
+  currentIssueState = issueState;
+  history.replaceState({}, '', buildUrl(issueState));
+  load();
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/maestro/templates/musehub/pages/milestones_list.html
+++ b/maestro/templates/musehub/pages/milestones_list.html
@@ -1,0 +1,217 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Milestones{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> / milestones
+{% endblock %}
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block extra_css %}
+<style>
+.milestone-row {
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border, #30363d);
+}
+.milestone-row:last-child { border-bottom: none; }
+.milestone-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+.milestone-meta { font-size: 12px; color: var(--text-muted, #8b949e); margin-bottom: 6px; }
+.progress-bar-track {
+  width: 100%;
+  max-width: 300px;
+  height: 8px;
+  border-radius: 4px;
+  background: var(--bg-overlay, #161b22);
+  border: 1px solid var(--border, #30363d);
+  overflow: hidden;
+  margin-bottom: 4px;
+}
+.progress-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  background: var(--green, #3fb950);
+  transition: width 0.3s;
+}
+.progress-label { font-size: 12px; color: var(--text-muted, #8b949e); }
+.state-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--border, #30363d);
+  padding-bottom: 0;
+}
+.state-tab {
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  border: none;
+  background: none;
+  color: var(--text-muted, #8b949e);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  text-decoration: none;
+}
+.state-tab.active {
+  color: var(--text-primary, #e6edf3);
+  border-bottom-color: var(--accent, #58a6ff);
+}
+.state-tab:hover { color: var(--text-primary, #e6edf3); }
+.sort-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 16px;
+  font-size: 13px;
+  color: var(--text-muted, #8b949e);
+}
+.sort-btn {
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border, #30363d);
+  background: var(--bg-overlay, #161b22);
+  color: var(--text-secondary, #c9d1d9);
+  font-size: 12px;
+  cursor: pointer;
+}
+.sort-btn.active {
+  border-color: var(--accent, #58a6ff);
+  color: var(--accent, #58a6ff);
+}
+.sort-btn:hover { border-color: var(--accent, #58a6ff); }
+</style>
+{% endblock %}
+
+{% block page_data %}
+const repoId  = {{ repo_id | tojson }};
+const base    = {{ base_url | tojson }};
+const initState = {{ state | tojson }};
+const initSort  = {{ sort | tojson }};
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+let currentState = initState;
+let currentSort  = initSort;
+
+function pct(ms) {
+  const total = (ms.openIssues || 0) + (ms.closedIssues || 0);
+  if (total === 0) return 0;
+  return Math.round((ms.closedIssues / total) * 100);
+}
+
+function dueDateLabel(dueOn) {
+  if (!dueOn) return '';
+  const d = new Date(dueOn);
+  const now = new Date();
+  const diff = d - now;
+  const overdue = diff < 0;
+  const label = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  const color = overdue ? 'var(--red, #f85149)' : 'var(--text-muted, #8b949e)';
+  const icon  = overdue ? '⚠ ' : '📅 ';
+  return `<span style="color:${color};font-size:12px">${icon}Due ${escHtml(label)}</span>`;
+}
+
+function renderMilestones(milestones) {
+  if (milestones.length === 0) {
+    return '<p class="loading">No ' + currentState + ' milestones.</p>';
+  }
+  return milestones.map(ms => {
+    const p = pct(ms);
+    const total = (ms.openIssues || 0) + (ms.closedIssues || 0);
+    return `
+      <div class="milestone-row">
+        <div class="milestone-title-row">
+          <a href="${base}/milestones/${ms.number}" style="font-weight:600;font-size:15px">
+            ${escHtml(ms.title)}
+          </a>
+          <span class="badge ${ms.state === 'open' ? 'badge-open' : 'badge-closed'}">
+            ${ms.state}
+          </span>
+        </div>
+        <div class="milestone-meta">
+          #${ms.number}
+          &bull; ${total} issue${total !== 1 ? 's' : ''} (${ms.openIssues} open, ${ms.closedIssues} closed)
+          ${ms.dueOn ? ' &bull; ' + dueDateLabel(ms.dueOn) : ''}
+          ${ms.description ? ' — ' + escHtml(ms.description.slice(0, 80)) + (ms.description.length > 80 ? '…' : '') : ''}
+        </div>
+        <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+          <div>
+            <div class="progress-bar-track">
+              <div class="progress-bar-fill" style="width:${p}%"></div>
+            </div>
+            <div class="progress-label">${p}% complete</div>
+          </div>
+        </div>
+      </div>`;
+  }).join('');
+}
+
+function buildUrl(state, sort) {
+  return base + '/milestones?state=' + encodeURIComponent(state) + '&sort=' + encodeURIComponent(sort);
+}
+
+async function load() {
+  initRepoNav(repoId);
+  document.getElementById('content').innerHTML = '<p class="loading">Loading milestones…</p>';
+  try {
+    const data = await apiFetch(
+      '/repos/' + repoId + '/milestones?state=' + encodeURIComponent(currentState) +
+      '&sort=' + encodeURIComponent(currentSort)
+    );
+    const milestones = data.milestones || [];
+
+    document.getElementById('content').innerHTML = `
+      <div style="margin-bottom:12px">
+        <a href="${base}">&larr; Back to repo</a>
+      </div>
+      <div class="card">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;flex-wrap:wrap;gap:8px">
+          <h1 style="margin:0">🏁 Milestones</h1>
+          <span style="font-size:13px;color:var(--text-muted,#8b949e)">${milestones.length} milestone${milestones.length !== 1 ? 's' : ''}</span>
+        </div>
+
+        <!-- State tabs -->
+        <div class="state-tabs">
+          ${['open','closed','all'].map(s => `
+            <a class="state-tab ${currentState === s ? 'active' : ''}"
+               href="${buildUrl(s, currentSort)}"
+               onclick="event.preventDefault();setFilter('${s}',currentSort)">${s.charAt(0).toUpperCase()+s.slice(1)}</a>
+          `).join('')}
+        </div>
+
+        <!-- Sort controls -->
+        <div class="sort-controls">
+          Sort by:
+          ${[['due_on','Due date'],['title','Title'],['completeness','Completeness']].map(([k,l]) => `
+            <button class="sort-btn ${currentSort === k ? 'active' : ''}"
+                    onclick="setFilter(currentState,'${k}')">${l}</button>
+          `).join('')}
+        </div>
+
+        <!-- Milestone rows -->
+        <div id="milestone-rows">
+          ${renderMilestones(milestones)}
+        </div>
+      </div>`;
+  } catch(e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML = '<p class="error">✕ ' + escHtml(e.message) + '</p>';
+  }
+}
+
+function setFilter(state, sort) {
+  currentState = state;
+  currentSort  = sort;
+  history.replaceState({}, '', buildUrl(state, sort));
+  load();
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/tests/test_musehub_ui_milestones.py
+++ b/tests/test_musehub_ui_milestones.py
@@ -1,0 +1,368 @@
+"""Tests for Muse Hub milestones UI endpoints (issue #425).
+
+Covers GET /musehub/ui/{owner}/{repo_slug}/milestones:
+- test_milestones_list_page_returns_200          — page renders without auth
+- test_milestones_list_no_auth_required          — no JWT needed for HTML shell
+- test_milestones_list_has_progress_bar_js       — progress bar rendering present
+- test_milestones_list_has_state_tabs_js         — open/closed/all state tabs present
+- test_milestones_list_has_sort_controls_js      — due_on/title/completeness sort buttons
+- test_milestones_list_json_response             — ?format=json returns MilestoneListResponse
+- test_milestones_list_json_has_milestones_key   — JSON contains milestones array
+- test_milestones_list_unknown_repo_404          — unknown owner/slug → 404
+- test_milestones_list_shows_base_url_not_repo_id — base_url uses owner/slug pattern
+
+Covers GET /musehub/ui/{owner}/{repo_slug}/milestones/{number}:
+- test_milestone_detail_page_returns_200         — page renders without auth
+- test_milestone_detail_no_auth_required         — no JWT needed for HTML shell
+- test_milestone_detail_has_progress_bar         — progress bar JS present
+- test_milestone_detail_has_linked_issues_js     — issue list rendering JS present
+- test_milestone_detail_has_state_filter_tabs    — open/closed/all issue filter tabs
+- test_milestone_detail_json_response            — ?format=json returns composite response
+- test_milestone_detail_json_has_linked_issues   — JSON contains linked_issues key
+- test_milestone_detail_unknown_number_404       — non-existent milestone number → 404
+- test_milestone_detail_unknown_repo_404         — unknown owner/slug → 404
+- test_milestone_detail_json_issue_counts        — JSON open_issues/closed_issues counts correct
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import (
+    MusehubIssue,
+    MusehubMilestone,
+    MusehubRepo,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_repo(db: AsyncSession, owner: str = "artist", slug: str = "album-one") -> str:
+    """Seed a public repo and return its repo_id string."""
+    repo = MusehubRepo(
+        name=slug,
+        owner=owner,
+        slug=slug,
+        visibility="public",
+        owner_user_id="uid-test-artist",
+    )
+    db.add(repo)
+    await db.commit()
+    await db.refresh(repo)
+    return str(repo.repo_id)
+
+
+async def _make_milestone(
+    db: AsyncSession,
+    repo_id: str,
+    *,
+    number: int = 1,
+    title: str = "Album v1.0",
+    description: str = "First release milestone",
+    state: str = "open",
+) -> MusehubMilestone:
+    """Seed a milestone and return it."""
+    ms = MusehubMilestone(
+        repo_id=repo_id,
+        number=number,
+        title=title,
+        description=description,
+        state=state,
+        author="artist",
+    )
+    db.add(ms)
+    await db.commit()
+    await db.refresh(ms)
+    return ms
+
+
+async def _make_issue(
+    db: AsyncSession,
+    repo_id: str,
+    *,
+    number: int = 1,
+    title: str = "Bass mix is too loud",
+    state: str = "open",
+    milestone_id: str | None = None,
+) -> MusehubIssue:
+    """Seed an issue and return it."""
+    issue = MusehubIssue(
+        repo_id=repo_id,
+        number=number,
+        title=title,
+        body="Description of the issue.",
+        state=state,
+        labels=["mix"],
+        author="artist",
+        milestone_id=milestone_id,
+    )
+    db.add(issue)
+    await db.commit()
+    await db.refresh(issue)
+    return issue
+
+
+# ---------------------------------------------------------------------------
+# Milestones list page tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_milestones_list_page_returns_200(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/milestones returns 200 HTML."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/artist/album-one/milestones")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_milestones_list_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Milestones list page is accessible without a JWT token."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/artist/album-one/milestones")
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_milestones_list_has_progress_bar_js(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Page HTML contains progress bar rendering logic."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/artist/album-one/milestones")
+    assert response.status_code == 200
+    assert "progress-bar" in response.text
+
+
+@pytest.mark.anyio
+async def test_milestones_list_has_state_tabs_js(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Milestones list page has open/closed/all state filter tabs."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/artist/album-one/milestones")
+    assert response.status_code == 200
+    body = response.text
+    assert "state-tabs" in body or "state-tab" in body
+    assert "open" in body
+    assert "closed" in body
+
+
+@pytest.mark.anyio
+async def test_milestones_list_has_sort_controls_js(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Milestones list page exposes due_on / title / completeness sort controls."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/artist/album-one/milestones")
+    assert response.status_code == 200
+    body = response.text
+    assert "due_on" in body or "completeness" in body
+
+
+@pytest.mark.anyio
+async def test_milestones_list_json_response(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """?format=json returns JSON with HTTP 200."""
+    repo_id = await _make_repo(db_session)
+    await _make_milestone(db_session, repo_id, title="Mix Revision 2")
+    response = await client.get("/musehub/ui/artist/album-one/milestones?format=json")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+
+
+@pytest.mark.anyio
+async def test_milestones_list_json_has_milestones_key(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """JSON response contains a milestones array."""
+    repo_id = await _make_repo(db_session)
+    await _make_milestone(db_session, repo_id, title="Album v1.0")
+    response = await client.get("/musehub/ui/artist/album-one/milestones?format=json&state=all")
+    assert response.status_code == 200
+    data = response.json()
+    assert "milestones" in data
+    assert isinstance(data["milestones"], list)
+    assert len(data["milestones"]) >= 1
+
+
+@pytest.mark.anyio
+async def test_milestones_list_unknown_repo_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Unknown owner/slug returns 404."""
+    response = await client.get("/musehub/ui/nobody/nonexistent/milestones")
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_milestones_list_shows_base_url_not_repo_id(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """HTML page uses owner/slug base_url pattern, not raw repo_id UUID."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/artist/album-one/milestones")
+    assert response.status_code == 200
+    assert "/musehub/ui/artist/album-one" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Milestone detail page tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_milestone_detail_page_returns_200(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/milestones/{number} returns 200 HTML."""
+    repo_id = await _make_repo(db_session)
+    await _make_milestone(db_session, repo_id, number=1)
+    response = await client.get("/musehub/ui/artist/album-one/milestones/1")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_milestone_detail_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Milestone detail page is accessible without a JWT token."""
+    repo_id = await _make_repo(db_session)
+    await _make_milestone(db_session, repo_id, number=1)
+    response = await client.get("/musehub/ui/artist/album-one/milestones/1")
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_milestone_detail_has_progress_bar(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Milestone detail page contains progress bar element."""
+    repo_id = await _make_repo(db_session)
+    await _make_milestone(db_session, repo_id, number=1)
+    response = await client.get("/musehub/ui/artist/album-one/milestones/1")
+    assert response.status_code == 200
+    assert "progress-bar" in response.text
+
+
+@pytest.mark.anyio
+async def test_milestone_detail_has_linked_issues_js(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Milestone detail page has JavaScript to render linked issues."""
+    repo_id = await _make_repo(db_session)
+    await _make_milestone(db_session, repo_id, number=1)
+    response = await client.get("/musehub/ui/artist/album-one/milestones/1")
+    assert response.status_code == 200
+    body = response.text
+    assert "issue-rows" in body or "renderIssueRows" in body
+
+
+@pytest.mark.anyio
+async def test_milestone_detail_has_state_filter_tabs(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Milestone detail page has open/closed/all tabs to filter linked issues."""
+    repo_id = await _make_repo(db_session)
+    await _make_milestone(db_session, repo_id, number=1)
+    response = await client.get("/musehub/ui/artist/album-one/milestones/1")
+    assert response.status_code == 200
+    body = response.text
+    assert "state-tabs" in body or "state-tab" in body
+
+
+@pytest.mark.anyio
+async def test_milestone_detail_json_response(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """?format=json returns JSON with HTTP 200."""
+    repo_id = await _make_repo(db_session)
+    await _make_milestone(db_session, repo_id, number=1)
+    response = await client.get("/musehub/ui/artist/album-one/milestones/1?format=json")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+
+
+@pytest.mark.anyio
+async def test_milestone_detail_json_has_linked_issues(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """JSON response includes the milestone data and linkedIssues."""
+    repo_id = await _make_repo(db_session)
+    ms = await _make_milestone(db_session, repo_id, number=1, title="Album v1.0")
+    await _make_issue(db_session, repo_id, number=1, milestone_id=str(ms.milestone_id))
+    response = await client.get("/musehub/ui/artist/album-one/milestones/1?format=json")
+    assert response.status_code == 200
+    data = response.json()
+    assert "title" in data
+    assert data["title"] == "Album v1.0"
+    assert "linkedIssues" in data
+    assert "issues" in data["linkedIssues"]
+
+
+@pytest.mark.anyio
+async def test_milestone_detail_unknown_number_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Non-existent milestone number returns 404."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/artist/album-one/milestones/999")
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_milestone_detail_unknown_repo_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Unknown owner/slug returns 404 for detail page."""
+    response = await client.get("/musehub/ui/nobody/nonexistent/milestones/1")
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_milestone_detail_json_issue_counts(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """JSON response has correct open_issues and closed_issues counts."""
+    repo_id = await _make_repo(db_session)
+    ms = await _make_milestone(db_session, repo_id, number=1)
+    ms_id = str(ms.milestone_id)
+    # 2 open + 1 closed
+    await _make_issue(db_session, repo_id, number=1, state="open", milestone_id=ms_id)
+    await _make_issue(db_session, repo_id, number=2, state="open", milestone_id=ms_id)
+    await _make_issue(db_session, repo_id, number=3, state="closed", milestone_id=ms_id)
+    response = await client.get("/musehub/ui/artist/album-one/milestones/1?format=json")
+    assert response.status_code == 200
+    data = response.json()
+    assert data.get("openIssues") == 2
+    assert data.get("closedIssues") == 1


### PR DESCRIPTION
## Summary
Closes #425 — adds browser-readable HTML pages for the Muse Hub milestones section.

## Root Cause / Motivation
Milestone data was only accessible via the JSON API (`/api/v1/musehub/repos/{id}/milestones`). Composers and collaborators needed a human-readable overview page showing milestone completion at a glance — analogous to GitHub's Milestones tab — without writing API calls.

## Solution
Two new endpoints in `maestro/api/routes/musehub/ui_milestones.py`, registered in `main.py` before the wildcard `ui.py` router:

- `GET /musehub/ui/{owner}/{repo_slug}/milestones` — filterable list with animated progress bars, open/closed/all state tabs, and sort controls (due date / title / completeness).
- `GET /musehub/ui/{owner}/{repo_slug}/milestones/{number}` — milestone detail with metadata card, progress bar, and a filterable linked-issues section (open/closed/all tabs).

Both endpoints support content negotiation: HTML by default, JSON via `?format=json` or `Accept: application/json`. The JSON path returns `MilestoneListResponse` for the list and a composite `MilestoneResponse + IssueListResponse` for the detail.

Jinja2 templates follow existing page conventions (extend `musehub/base.html`, JS in `{% block page_script %}`).

## Verification
- [x] mypy clean (658 source files, 0 errors)
- [x] 19 tests pass (`tests/test_musehub_ui_milestones.py`)
- [x] Merged with `origin/dev` before push — no conflicts