### PR TITLE
feat: add sitemap.xml and robots.txt generation for MuseHub

### DIFF
--- a/maestro/api/routes/musehub/sitemap.py
+++ b/maestro/api/routes/musehub/sitemap.py
@@ -1,0 +1,356 @@
+"""Muse Hub sitemap.xml and robots.txt generation.
+
+Endpoint summary:
+  GET /sitemap.xml  — XML sitemap of all public MuseHub content (repos, users, topics, releases)
+  GET /robots.txt   — crawl policy for search engines and AI agents
+
+These endpoints live at the top level (no /api/v1 prefix) so standard crawlers
+and search engines find them at the expected paths.
+
+Registration: registered in ``maestro.main`` directly:
+  app.include_router(sitemap_routes.router, tags=["musehub-sitemap"])
+NOT via the musehub __init__.py auto-discovery (these are not /musehub/ sub-paths).
+
+Sitemap format follows the sitemaps.org protocol (XML namespace
+http://www.sitemaps.org/schemas/sitemap/0.9).  Priority and changefreq are
+assigned by content type:
+  repos    → priority 0.8, daily (active) or monthly (inactive > 90 days)
+  profiles → priority 0.7, weekly
+  topics   → priority 0.6, weekly
+  releases → priority 0.5, monthly
+  static   → priority 0.9, monthly
+
+The sitemap is capped at 50,000 URLs per the sitemaps.org spec.  When
+content grows beyond that limit add a sitemap index endpoint (sitemapindex XML)
+and paginate via ?page=N — the infrastructure is already designed for it.
+
+Performance: all queries use lightweight column projections (no ORM lazy-loading).
+The endpoint is unauthenticated and suitable for public crawlers.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import PlainTextResponse, Response
+from sqlalchemy import func, outerjoin, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db import get_db
+from maestro.db import musehub_models as db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Maximum URLs per sitemap index (sitemaps.org spec).
+_SITEMAP_URL_LIMIT = 50_000
+
+# Static pages always present in the sitemap regardless of DB content.
+_STATIC_PAGES: list[tuple[str, str, str]] = [
+    # (path, changefreq, priority)
+    ("/musehub/ui/explore", "daily", "0.9"),
+    ("/musehub/ui/trending", "daily", "0.9"),
+    ("/musehub/ui/topics", "weekly", "0.6"),
+]
+
+# Agents known to index content for discovery — granted explicit Allow in robots.txt.
+_KNOWN_AGENT_BOTS = [
+    "Googlebot",
+    "GPTBot",
+    "ClaudeBot",
+    "CursorBot",
+    "anthropic-ai",
+    "CCBot",
+    "Omgilibot",
+    "PerplexityBot",
+]
+
+
+def _utcnow_iso() -> str:
+    """Return the current UTC time as an ISO-8601 date string (YYYY-MM-DD)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _to_date(dt: datetime | None) -> str:
+    """Format a datetime as YYYY-MM-DD for the sitemap lastmod field.
+
+    Falls back to today's date when the timestamp is unavailable.
+    """
+    if dt is None:
+        return _utcnow_iso()
+    return dt.strftime("%Y-%m-%d")
+
+
+def _is_inactive(dt: datetime | None) -> bool:
+    """Return True when the last-activity timestamp is older than 90 days.
+
+    Used to assign 'monthly' changefreq to dormant repos instead of 'daily',
+    reducing unnecessary crawl budget consumption.
+    """
+    if dt is None:
+        return True
+    age = datetime.now(timezone.utc) - dt.replace(tzinfo=timezone.utc)
+    return age.days > 90
+
+
+def _build_sitemap_xml(entries: list[dict[str, str]]) -> bytes:
+    """Serialise a list of URL entries into a UTF-8 encoded sitemap XML document.
+
+    Each entry dict may contain: loc (required), lastmod, changefreq, priority.
+    Returns raw bytes suitable for a ``Response(content=..., media_type="application/xml")``.
+    """
+    urlset = Element(
+        "urlset",
+        xmlns="http://www.sitemaps.org/schemas/sitemap/0.9",
+    )
+    for entry in entries:
+        url_el = SubElement(urlset, "url")
+        SubElement(url_el, "loc").text = entry["loc"]
+        if "lastmod" in entry:
+            SubElement(url_el, "lastmod").text = entry["lastmod"]
+        if "changefreq" in entry:
+            SubElement(url_el, "changefreq").text = entry["changefreq"]
+        if "priority" in entry:
+            SubElement(url_el, "priority").text = entry["priority"]
+
+    xml_bytes = b'<?xml version="1.0" encoding="UTF-8"?>\n' + tostring(
+        urlset, encoding="unicode"
+    ).encode("utf-8")
+    return xml_bytes
+
+
+async def _fetch_sitemap_entries(
+    session: AsyncSession,
+    base_url: str,
+) -> list[dict[str, str]]:
+    """Query all public content and return URL entries for the sitemap.
+
+    Queries (in order):
+      1. Public repos — joined with commits to get latest activity timestamp.
+      2. Public user profiles — username used in the profile URL.
+      3. Distinct topic tags — aggregated from public repo tags.
+      4. Releases — per public repo.
+
+    Args:
+        session:  Async SQLAlchemy session.
+        base_url: Scheme + host of the server (e.g. ``https://musehub.stori.app``),
+                  used as the URL prefix for all sitemap loc entries.
+
+    Returns:
+        List of URL entry dicts, ordered static → repos → profiles → topics → releases.
+    """
+    entries: list[dict[str, str]] = []
+
+    # ── 1. Static pages ───────────────────────────────────────────────────────
+    today = _utcnow_iso()
+    for path, changefreq, priority in _STATIC_PAGES:
+        entries.append(
+            {
+                "loc": f"{base_url}{path}",
+                "lastmod": today,
+                "changefreq": changefreq,
+                "priority": priority,
+            }
+        )
+
+    # ── 2. Public repos (with latest commit timestamp) ────────────────────────
+    latest_commit_col = func.max(db.MusehubCommit.timestamp).label("latest_commit")
+    repo_q = (
+        select(
+            db.MusehubRepo.owner,
+            db.MusehubRepo.slug,
+            db.MusehubRepo.created_at,
+            latest_commit_col,
+        )
+        .select_from(
+            outerjoin(
+                db.MusehubRepo,
+                db.MusehubCommit,
+                db.MusehubRepo.repo_id == db.MusehubCommit.repo_id,
+            )
+        )
+        .where(db.MusehubRepo.visibility == "public")
+        .group_by(
+            db.MusehubRepo.repo_id,
+            db.MusehubRepo.owner,
+            db.MusehubRepo.slug,
+            db.MusehubRepo.created_at,
+        )
+        .limit(_SITEMAP_URL_LIMIT)
+    )
+    repo_rows = await session.execute(repo_q)
+    repo_entries: list[tuple[str, str, datetime | None]] = []
+    for owner, slug, created_at, latest_commit in repo_rows:
+        activity_ts: datetime | None = latest_commit or created_at
+        repo_entries.append((owner, slug, activity_ts))
+        changefreq = "monthly" if _is_inactive(activity_ts) else "daily"
+        lastmod = _to_date(activity_ts)
+        entries.append(
+            {
+                "loc": f"{base_url}/musehub/ui/{owner}/{slug}",
+                "lastmod": lastmod,
+                "changefreq": changefreq,
+                "priority": "0.8",
+            }
+        )
+        entries.append(
+            {
+                "loc": f"{base_url}/musehub/ui/{owner}/{slug}/commits",
+                "lastmod": lastmod,
+                "changefreq": changefreq,
+                "priority": "0.7",
+            }
+        )
+        entries.append(
+            {
+                "loc": f"{base_url}/musehub/ui/{owner}/{slug}/issues",
+                "lastmod": lastmod,
+                "changefreq": "weekly",
+                "priority": "0.5",
+            }
+        )
+
+    # ── 3. Public user profiles ───────────────────────────────────────────────
+    profile_q = select(db.MusehubProfile.username, db.MusehubProfile.updated_at).limit(
+        _SITEMAP_URL_LIMIT
+    )
+    profile_rows = await session.execute(profile_q)
+    profile_count = 0
+    for username, updated_at in profile_rows:
+        profile_count += 1
+        entries.append(
+            {
+                "loc": f"{base_url}/musehub/ui/users/{username}",
+                "lastmod": _to_date(updated_at),
+                "changefreq": "weekly",
+                "priority": "0.7",
+            }
+        )
+
+    # ── 4. Topic pages from public repo tags ──────────────────────────────────
+    tag_q = select(db.MusehubRepo.tags).where(db.MusehubRepo.visibility == "public")
+    tag_rows = await session.execute(tag_q)
+    seen_topics: set[str] = set()
+    for (tags,) in tag_rows:
+        for tag in tags or []:
+            t = str(tag).lower().strip()
+            if t and t not in seen_topics:
+                seen_topics.add(t)
+                entries.append(
+                    {
+                        "loc": f"{base_url}/musehub/ui/topics/{t}",
+                        "changefreq": "weekly",
+                        "priority": "0.6",
+                    }
+                )
+
+    # ── 5. Release pages ──────────────────────────────────────────────────────
+    release_q = (
+        select(
+            db.MusehubRepo.owner,
+            db.MusehubRepo.slug,
+            db.MusehubRelease.tag,
+            db.MusehubRelease.created_at,
+        )
+        .join(db.MusehubRelease, db.MusehubRepo.repo_id == db.MusehubRelease.repo_id)
+        .where(db.MusehubRepo.visibility == "public")
+        .limit(_SITEMAP_URL_LIMIT)
+    )
+    release_rows = await session.execute(release_q)
+    for owner, slug, tag, created_at in release_rows:
+        entries.append(
+            {
+                "loc": f"{base_url}/musehub/ui/{owner}/{slug}/releases/{tag}",
+                "lastmod": _to_date(created_at),
+                "changefreq": "monthly",
+                "priority": "0.5",
+            }
+        )
+
+    logger.info(
+        "✅ Sitemap built — %d URLs (%d repos, %d profiles, %d topics)",
+        len(entries),
+        len(repo_entries),
+        profile_count,
+        len(seen_topics),
+    )
+    return entries[: _SITEMAP_URL_LIMIT]
+
+
+@router.get(
+    "/sitemap.xml",
+    response_class=Response,
+    operation_id="getSitemap",
+    summary="XML sitemap of all public MuseHub content",
+    tags=["musehub-sitemap"],
+)
+async def get_sitemap(
+    request: Request,
+    db_session: AsyncSession = Depends(get_db),
+) -> Response:
+    """Return an XML sitemap of all public MuseHub content.
+
+    Why this exists: search engines and AI discovery agents use sitemap.xml to
+    find and index all indexable URLs without crawling every page.  Including
+    repos, profiles, topics, and releases here ensures new content is indexed
+    quickly after it is published.
+
+    The ``base_url`` is derived from the incoming request so the sitemap works
+    correctly in dev, staging, and production without hardcoded hostnames.
+
+    Changefreq heuristic:
+    - Active repos (commit in the last 90 days) → daily.
+    - Inactive repos → monthly.
+    - Profiles, topics → weekly.
+    - Releases → monthly (published artefacts rarely change).
+
+    Capped at 50,000 URLs per the sitemaps.org spec.
+    """
+    base = str(request.base_url).rstrip("/")
+    entries = await _fetch_sitemap_entries(db_session, base)
+    xml_bytes = _build_sitemap_xml(entries)
+    return Response(content=xml_bytes, media_type="application/xml")
+
+
+@router.get(
+    "/robots.txt",
+    response_class=PlainTextResponse,
+    operation_id="getRobotsTxt",
+    summary="Crawl policy for search engines and AI agents",
+    tags=["musehub-sitemap"],
+)
+async def get_robots_txt(request: Request) -> PlainTextResponse:
+    """Return robots.txt crawl directives for the MuseHub site.
+
+    Why this exists: without robots.txt, well-behaved crawlers assume nothing
+    is allowed.  We explicitly open public MuseHub content to all crawlers
+    (including AI agents) while protecting user-private pages (settings,
+    notifications) from indexing.
+
+    Special-case ``Allow`` directives for named AI agents acknowledge that
+    MuseHub is designed for agent-native discovery alongside human browsers.
+
+    The Sitemap declaration at the bottom lets crawlers find all indexable
+    content without brute-force path guessing.
+    """
+    base = str(request.base_url).rstrip("/")
+    sitemap_url = f"{base}/sitemap.xml"
+
+    agent_allows = "\n".join(
+        f"User-agent: {bot}\nAllow: /musehub/\n" for bot in _KNOWN_AGENT_BOTS
+    )
+
+    body = f"""\
+User-agent: *
+Allow: /musehub/ui/
+Disallow: /musehub/ui/*/settings
+Disallow: /musehub/ui/notifications
+Disallow: /api/
+
+{agent_allows}
+Sitemap: {sitemap_url}
+"""
+    return PlainTextResponse(content=body)

--- a/maestro/main.py
+++ b/maestro/main.py
@@ -29,6 +29,7 @@ from maestro.api.routes.musehub import discover as musehub_discover_routes
 from maestro.api.routes.musehub import users as musehub_user_routes
 from maestro.api.routes.musehub import oembed as musehub_oembed_routes
 from maestro.api.routes.musehub import raw as musehub_raw_routes
+from maestro.api.routes.musehub import sitemap as musehub_sitemap_routes
 from maestro.api.routes import mcp as mcp_routes
 from maestro.db import init_db, close_db
 from maestro.services.storpheus import get_storpheus_client, close_storpheus_client
@@ -221,6 +222,8 @@ app.include_router(musehub_ui_routes.fixed_router, tags=["musehub-ui"])
 app.include_router(musehub_ui_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_oembed_routes.router, tags=["musehub-oembed"])
 app.include_router(musehub_raw_routes.router, prefix="/api/v1", tags=["musehub-raw"])
+# Sitemap and robots.txt — top-level (no /api/v1 prefix), outside musehub auto-discovery.
+app.include_router(musehub_sitemap_routes.router, tags=["musehub-sitemap"])
 app.include_router(mcp_routes.router, prefix="/api/v1/mcp", tags=["mcp"])
 
 from maestro.protocol.endpoints import router as protocol_router

--- a/tests/test_musehub_sitemap.py
+++ b/tests/test_musehub_sitemap.py
@@ -1,0 +1,332 @@
+"""Tests for the MuseHub sitemap.xml and robots.txt endpoints.
+
+Covers acceptance criteria from issue #439:
+- test_sitemap_returns_xml                   — GET /sitemap.xml returns 200 with XML content-type
+- test_sitemap_contains_static_pages        — static explore/trending/topics URLs are always present
+- test_sitemap_contains_public_repo         — a seeded public repo appears in the sitemap
+- test_sitemap_excludes_private_repo        — private repos do NOT appear in the sitemap
+- test_sitemap_contains_user_profile        — seeded user profile URL appears in sitemap
+- test_sitemap_contains_topic_urls          — repo tags generate /topics/{tag} entries
+- test_sitemap_contains_release_url         — a release URL appears for repos with releases
+- test_sitemap_xml_well_formed              — sitemap can be parsed as valid XML
+- test_sitemap_loc_uses_request_host        — loc entries use the base URL from the request
+- test_robots_txt_returns_plain_text        — GET /robots.txt returns 200 text/plain
+- test_robots_txt_allows_musehub_ui         — Allow: /musehub/ui/ is present
+- test_robots_txt_disallows_settings        — settings path is disallowed
+- test_robots_txt_disallows_notifications   — notifications path is disallowed
+- test_robots_txt_disallows_api             — /api/ directory is disallowed
+- test_robots_txt_contains_sitemap_url      — Sitemap: directive points to /sitemap.xml
+- test_robots_txt_names_known_agents        — known AI bots appear with explicit Allow
+- test_robots_txt_no_auth_required          — endpoint is accessible without JWT
+- test_sitemap_no_auth_required             — sitemap is accessible without JWT
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from xml.etree import ElementTree as ET
+
+from maestro.db.musehub_models import (
+    MusehubProfile,
+    MusehubRelease,
+    MusehubRepo,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_public_repo(
+    db_session: AsyncSession,
+    *,
+    owner: str = "sitemap-user",
+    slug: str = "sitemap-repo",
+    tags: list[str] | None = None,
+    visibility: str = "public",
+) -> MusehubRepo:
+    """Seed a repo and return the ORM object."""
+    repo = MusehubRepo(
+        name=slug,
+        owner=owner,
+        slug=slug,
+        visibility=visibility,
+        owner_user_id="sitemap-user-id",
+        description="test repo for sitemap",
+        tags=tags or [],
+    )
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    return repo
+
+
+async def _make_profile(
+    db_session: AsyncSession,
+    *,
+    username: str = "sitemap-user",
+    user_id: str = "sitemap-user-id",
+) -> MusehubProfile:
+    """Seed a user profile and return the ORM object."""
+    profile = MusehubProfile(
+        user_id=user_id,
+        username=username,
+    )
+    db_session.add(profile)
+    await db_session.commit()
+    await db_session.refresh(profile)
+    return profile
+
+
+async def _make_release(
+    db_session: AsyncSession,
+    repo_id: str,
+    *,
+    tag: str = "v1.0",
+) -> MusehubRelease:
+    """Seed a release and return the ORM object."""
+    release = MusehubRelease(
+        repo_id=repo_id,
+        tag=tag,
+        title=f"Release {tag}",
+        body="",
+        author="sitemap-user",
+    )
+    db_session.add(release)
+    await db_session.commit()
+    await db_session.refresh(release)
+    return release
+
+
+# ---------------------------------------------------------------------------
+# Sitemap tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_sitemap_returns_xml(client: AsyncClient, db_session: AsyncSession) -> None:
+    """GET /sitemap.xml returns 200 with an XML content-type."""
+    response = await client.get("/sitemap.xml")
+    assert response.status_code == 200
+    assert "xml" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_sitemap_contains_static_pages(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Static explore, trending, and topics pages are always included in the sitemap."""
+    response = await client.get("/sitemap.xml")
+    assert response.status_code == 200
+    body = response.text
+    assert "/musehub/ui/explore" in body
+    assert "/musehub/ui/trending" in body
+    assert "/musehub/ui/topics" in body
+
+
+@pytest.mark.anyio
+async def test_sitemap_contains_public_repo(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A seeded public repo's UI URL appears in the sitemap."""
+    await _make_public_repo(db_session, owner="artist", slug="cool-track")
+    response = await client.get("/sitemap.xml")
+    assert response.status_code == 200
+    body = response.text
+    assert "/musehub/ui/artist/cool-track" in body
+
+
+@pytest.mark.anyio
+async def test_sitemap_excludes_private_repo(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Private repos must not appear anywhere in the sitemap."""
+    await _make_public_repo(db_session, owner="secretuser", slug="hidden-project", visibility="private")
+    response = await client.get("/sitemap.xml")
+    assert response.status_code == 200
+    body = response.text
+    assert "hidden-project" not in body
+    assert "secretuser" not in body
+
+
+@pytest.mark.anyio
+async def test_sitemap_contains_user_profile(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A seeded user profile generates a /musehub/ui/users/{username} entry."""
+    await _make_profile(db_session, username="jazzmaster", user_id="jazzmaster-uid")
+    response = await client.get("/sitemap.xml")
+    assert response.status_code == 200
+    assert "/musehub/ui/users/jazzmaster" in response.text
+
+
+@pytest.mark.anyio
+async def test_sitemap_contains_topic_urls(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Tags on public repos generate /musehub/ui/topics/{tag} entries."""
+    await _make_public_repo(db_session, owner="producer", slug="beats", tags=["lo-fi", "jazz"])
+    response = await client.get("/sitemap.xml")
+    assert response.status_code == 200
+    body = response.text
+    assert "/musehub/ui/topics/lo-fi" in body
+    assert "/musehub/ui/topics/jazz" in body
+
+
+@pytest.mark.anyio
+async def test_sitemap_contains_release_url(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A release on a public repo generates a /releases/{tag} sitemap entry."""
+    repo = await _make_public_repo(db_session, owner="bandname", slug="debut-album")
+    await _make_release(db_session, repo.repo_id, tag="v1.0")
+    response = await client.get("/sitemap.xml")
+    assert response.status_code == 200
+    assert "/musehub/ui/bandname/debut-album/releases/v1.0" in response.text
+
+
+@pytest.mark.anyio
+async def test_sitemap_xml_well_formed(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The sitemap response must be parseable as valid XML."""
+    response = await client.get("/sitemap.xml")
+    assert response.status_code == 200
+    # This raises if the document is not well-formed XML.
+    root = ET.fromstring(response.content)
+    assert root.tag.endswith("urlset")
+
+
+@pytest.mark.anyio
+async def test_sitemap_loc_uses_request_host(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """loc entries in the sitemap use the base URL from the incoming request."""
+    await _make_public_repo(db_session, owner="testowner", slug="testrepo")
+    response = await client.get("/sitemap.xml")
+    assert response.status_code == 200
+    # The test client uses base_url="http://test" — every loc must start with http://test.
+    body = response.text
+    assert "<loc>http://test" in body
+
+
+@pytest.mark.anyio
+async def test_sitemap_no_auth_required(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Sitemap endpoint must be accessible without a JWT (crawlers don't authenticate)."""
+    response = await client.get("/sitemap.xml")
+    assert response.status_code != 401
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_sitemap_repo_commits_page_included(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Each public repo's /commits page also appears in the sitemap."""
+    await _make_public_repo(db_session, owner="composer", slug="symphony-no1")
+    response = await client.get("/sitemap.xml")
+    assert response.status_code == 200
+    assert "/musehub/ui/composer/symphony-no1/commits" in response.text
+
+
+@pytest.mark.anyio
+async def test_sitemap_repo_issues_page_included(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Each public repo's /issues page also appears in the sitemap."""
+    await _make_public_repo(db_session, owner="composer", slug="symphony-no2")
+    response = await client.get("/sitemap.xml")
+    assert response.status_code == 200
+    assert "/musehub/ui/composer/symphony-no2/issues" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Robots.txt tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_robots_txt_returns_plain_text(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """GET /robots.txt returns 200 with text/plain content-type."""
+    response = await client.get("/robots.txt")
+    assert response.status_code == 200
+    assert "text/plain" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_robots_txt_allows_musehub_ui(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Allow: /musehub/ui/ is present for all crawlers."""
+    response = await client.get("/robots.txt")
+    assert response.status_code == 200
+    assert "Allow: /musehub/ui/" in response.text
+
+
+@pytest.mark.anyio
+async def test_robots_txt_disallows_settings(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Settings paths are disallowed to prevent indexing of private user config pages."""
+    response = await client.get("/robots.txt")
+    assert response.status_code == 200
+    assert "Disallow: /musehub/ui/*/settings" in response.text
+
+
+@pytest.mark.anyio
+async def test_robots_txt_disallows_notifications(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Notification pages are disallowed (user-private inbox content)."""
+    response = await client.get("/robots.txt")
+    assert response.status_code == 200
+    assert "Disallow: /musehub/ui/notifications" in response.text
+
+
+@pytest.mark.anyio
+async def test_robots_txt_disallows_api(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """API paths are disallowed — crawlers should use the sitemap, not the REST API."""
+    response = await client.get("/robots.txt")
+    assert response.status_code == 200
+    assert "Disallow: /api/" in response.text
+
+
+@pytest.mark.anyio
+async def test_robots_txt_contains_sitemap_url(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Sitemap: directive is present and points to /sitemap.xml."""
+    response = await client.get("/robots.txt")
+    assert response.status_code == 200
+    assert "Sitemap:" in response.text
+    assert "sitemap.xml" in response.text
+
+
+@pytest.mark.anyio
+async def test_robots_txt_names_known_agents(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Known AI discovery bots (GPTBot, ClaudeBot, etc.) appear with explicit Allow."""
+    response = await client.get("/robots.txt")
+    assert response.status_code == 200
+    body = response.text
+    for bot in ("GPTBot", "ClaudeBot", "Googlebot", "CursorBot"):
+        assert bot in body
+
+
+@pytest.mark.anyio
+async def test_robots_txt_no_auth_required(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """robots.txt must be accessible without authentication."""
+    response = await client.get("/robots.txt")
+    assert response.status_code != 401
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
Closes #439 — add `GET /sitemap.xml` and `GET /robots.txt` endpoints for machine-readable MuseHub discovery.

## Root Cause / Motivation
Without a sitemap, search engines and AI agents must crawl every page blindly. A dynamically-generated sitemap derived from live DB content ensures new repos, profiles, topics, and releases are indexed immediately after publication.

## Solution
- **`maestro/api/routes/musehub/sitemap.py`** — new module with two endpoints:
  - `GET /sitemap.xml`: queries all public repos (with latest commit timestamp for `lastmod`), user profiles, topic tags, and releases. Assembles a standard sitemaps.org XML document using `xml.etree.ElementTree` (no new dependencies). Changefreq heuristic: repos active in last 90 days → `daily`, otherwise `monthly`.
  - `GET /robots.txt`: allows all crawlers to index `/musehub/ui/`, disallows `/musehub/ui/*/settings`, `/musehub/ui/notifications`, and `/api/`. Grants explicit `Allow` to named AI agents (GPTBot, ClaudeBot, CursorBot, Googlebot, anthropic-ai, PerplexityBot, etc.). Includes `Sitemap:` directive pointing to `/sitemap.xml`.
- **`maestro/main.py`** — registered `musehub_sitemap_routes.router` at top level (no `/api/v1` prefix) so the paths live at `/sitemap.xml` and `/robots.txt` as crawlers expect.
- Both endpoints are unauthenticated and excluded from musehub `__init__.py` auto-discovery (they're not under `/musehub/`).
- Static pages (explore, trending, topics index) are always included regardless of DB state.

## Files Changed
- `maestro/api/routes/musehub/sitemap.py` — NEW
- `maestro/main.py` — import + register sitemap router
- `tests/test_musehub_sitemap.py` — NEW, 20 tests

## Verification
- [x] mypy clean (658 source files, 0 errors)
- [x] 20 tests pass (XML validity, URL inclusion/exclusion, robots directives, unauthenticated access)
- [x] Pre-push dev sync completed — no conflicts