### PR TITLE
feat: add Muse Hub blame view UI page

### DIFF
--- a/maestro/api/routes/musehub/ui_blame.py
+++ b/maestro/api/routes/musehub/ui_blame.py
@@ -1,0 +1,168 @@
+"""Muse Hub blame view page — per-note commit attribution browser.
+
+Serves the blame UI page for a given MIDI file path at a commit ref.  Each note
+event is annotated with the commit that last introduced or modified it, giving
+musicians and AI agents a per-measure provenance view of the composition.
+
+Endpoint:
+  GET /musehub/ui/{owner}/{repo_slug}/blame/{ref}/{path:path}
+
+Content negotiation (one URL, two audiences):
+  HTML (default) — interactive blame view rendered via Jinja2.
+  JSON (``Accept: application/json`` or ``?format=json``) — returns
+  ``BlameResponse`` with the full list of ``BlameEntry`` items in camelCase,
+  mirroring the ``/api/v1/musehub/repos/{repo_id}/blame/{ref}`` API contract.
+
+Auth:
+  No JWT required to receive the HTML shell.  The client-side JavaScript reads
+  a token from ``localStorage`` and passes it as a Bearer header when calling the
+  JSON API, matching all other Muse Hub UI pages.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response
+
+from maestro.api.routes.musehub.blame import _build_blame_entries
+from maestro.api.routes.musehub.negotiate import negotiate_response
+from maestro.db import get_db
+from maestro.models.musehub import BlameResponse
+from maestro.services import musehub_repository
+from pathlib import Path
+from fastapi.templating import Jinja2Templates
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/musehub/ui", tags=["musehub-ui"])
+
+_TEMPLATE_DIR = Path(__file__).parent.parent.parent.parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+
+async def _resolve_repo(owner: str, repo_slug: str, db: AsyncSession) -> tuple[str, str]:
+    """Resolve owner + slug to (repo_id, base_url); raise 404 when missing.
+
+    Returns the repo_id string and the canonical UI base URL so callers can
+    unpack both in one line without repeating the lookup boilerplate.
+    """
+    from fastapi import HTTPException
+    from fastapi import status as http_status
+
+    row = await musehub_repository.get_repo_orm_by_owner_slug(db, owner, repo_slug)
+    if row is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=f"Repo '{owner}/{repo_slug}' not found",
+        )
+    return str(row.repo_id), f"/musehub/ui/{owner}/{repo_slug}"
+
+
+@router.get(
+    "/{owner}/{repo_slug}/blame/{ref}/{path:path}",
+    summary="Muse Hub blame view — per-note commit attribution",
+)
+async def blame_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    ref: str,
+    path: str,
+    track: str | None = Query(
+        None,
+        description="Filter blame to a single instrument track (e.g. 'piano', 'bass')",
+    ),
+    beat_start: float | None = Query(
+        None,
+        alias="beatStart",
+        description="Restrict to notes at or after this beat position",
+    ),
+    beat_end: float | None = Query(
+        None,
+        alias="beatEnd",
+        description="Restrict to notes before this beat position",
+    ),
+    format: str | None = Query(
+        None,
+        description="Force response format: 'json' or omit for HTML",
+    ),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Render the blame view for a MIDI file at a given commit ref.
+
+    Why this exists: musicians and AI agents need to know *which commit* last
+    changed each note or measure in a composition — the musical equivalent of
+    ``git blame``.  This page renders each note event coloured by its originating
+    commit, with inline author and timestamp labels, so a reviewer can trace
+    the evolution of any musical idea across the project's history.
+
+    HTML (default): interactive piano-roll-style blame view via Jinja2.  The
+    page shell fetches blame data from the JSON API client-side using the token
+    stored in ``localStorage``.  The optional ``track``, ``beatStart``, and
+    ``beatEnd`` query params are forwarded to the client for pre-filtering.
+
+    JSON (``Accept: application/json`` or ``?format=json``): returns
+    ``BlameResponse`` with camelCase keys.  Blame entries are built
+    deterministically from the repo's commit history so agents can reason about
+    provenance without navigating the HTML page.
+
+    Returns 404 when the repo owner/slug combination is unknown.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+
+    short_ref = ref[:8] if len(ref) >= 8 else ref
+    short_path = path.split("/")[-1] if path else path
+
+    # Eagerly compute blame data for JSON negotiation.
+    # For HTML, this data is not rendered server-side — the template fetches it
+    # client-side — but pre-computing here is cheap and enables the JSON path.
+    commits_raw, _total = await musehub_repository.list_commits(db, repo_id, limit=50)
+    commit_dicts: list[dict[str, object]] = [
+        {
+            "commit_id": c.commit_id,
+            "message": c.message,
+            "author": c.author,
+            "timestamp": c.timestamp,
+        }
+        for c in commits_raw
+    ]
+    entries = _build_blame_entries(
+        commits=commit_dicts,
+        path=path,
+        track_filter=track,
+        beat_start_filter=beat_start,
+        beat_end_filter=beat_end,
+    )
+    blame_data = BlameResponse(entries=entries, total_entries=len(entries))
+
+    logger.info(
+        "✅ Blame UI: repo=%s ref=%s path=%s entries=%d",
+        repo_id,
+        ref,
+        path,
+        len(entries),
+    )
+
+    return await negotiate_response(
+        request=request,
+        template_name="musehub/pages/blame.html",
+        context={
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "ref": ref,
+            "short_ref": short_ref,
+            "path": path,
+            "short_path": short_path,
+            "base_url": base_url,
+            "current_page": "blame",
+            "track": track or "",
+            "beat_start": beat_start,
+            "beat_end": beat_end,
+        },
+        templates=templates,
+        json_data=blame_data,
+        format_param=format,
+    )

--- a/maestro/main.py
+++ b/maestro/main.py
@@ -25,6 +25,7 @@ from slowapi.errors import RateLimitExceeded
 from maestro.config import settings
 from maestro.api.routes import maestro, maestro_ui, health, users, conversations, assets, variation, muse, musehub
 from maestro.api.routes.musehub import ui as musehub_ui_routes
+from maestro.api.routes.musehub import ui_blame as musehub_ui_blame_routes
 from maestro.api.routes.musehub import discover as musehub_discover_routes
 from maestro.api.routes.musehub import users as musehub_user_routes
 from maestro.api.routes.musehub import oembed as musehub_oembed_routes
@@ -219,6 +220,7 @@ app.include_router(musehub.router, prefix="/api/v1")
 # UI routers: fixed-path routes (users, explore, trending) first, then wildcards.
 app.include_router(musehub_ui_routes.fixed_router, tags=["musehub-ui"])
 app.include_router(musehub_ui_routes.router, tags=["musehub-ui"])
+app.include_router(musehub_ui_blame_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_oembed_routes.router, tags=["musehub-oembed"])
 app.include_router(musehub_raw_routes.router, prefix="/api/v1", tags=["musehub-raw"])
 app.include_router(mcp_routes.router, prefix="/api/v1/mcp", tags=["mcp"])

--- a/maestro/templates/musehub/pages/blame.html
+++ b/maestro/templates/musehub/pages/blame.html
@@ -1,0 +1,321 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}{{ owner }}/{{ repo_slug }} — blame/{{ short_ref }}/{{ short_path }}{% endblock %}
+
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}">{{ owner }}</a> /
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ repo_slug }}</a> /
+  blame /
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}/tree/{{ ref }}">{{ short_ref }}</a> /
+  {{ short_path }}
+{% endblock %}
+
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block extra_css %}
+<style>
+.blame-header {
+  display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap;
+  gap: 12px; margin-bottom: 16px;
+}
+.blame-filter-bar {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+  padding: 10px 16px; margin-bottom: 16px;
+}
+.blame-filter-bar label { font-size: 13px; color: #8b949e; display: flex; align-items: center; gap: 6px; }
+.blame-filter-bar select,
+.blame-filter-bar input[type="number"] {
+  background: #21262d; color: #c9d1d9; border: 1px solid #30363d;
+  border-radius: 6px; padding: 5px 10px; font-size: 13px; min-width: 90px;
+}
+.blame-filter-bar select:hover,
+.blame-filter-bar input[type="number"]:hover { border-color: #58a6ff; }
+.blame-table-wrap {
+  border: 1px solid #30363d; border-radius: 8px; overflow: hidden; margin-bottom: 16px;
+}
+.blame-table {
+  width: 100%; border-collapse: collapse; background: #0d1117;
+  font-size: 13px;
+}
+.blame-table th {
+  background: #161b22; color: #8b949e; padding: 9px 14px;
+  text-align: left; font-weight: 600; font-size: 12px;
+  border-bottom: 1px solid #30363d; white-space: nowrap;
+}
+.blame-table td {
+  padding: 9px 14px; border-bottom: 1px solid #21262d; color: #c9d1d9;
+  vertical-align: middle;
+}
+.blame-table tr:last-child td { border-bottom: none; }
+.blame-table tr:hover td { background: #161b22; }
+.commit-sha {
+  font-family: monospace; font-size: 12px;
+  color: #58a6ff; text-decoration: none; white-space: nowrap;
+}
+.commit-sha:hover { text-decoration: underline; }
+.blame-author { font-size: 12px; color: #8b949e; }
+.blame-date { font-size: 12px; color: #8b949e; white-space: nowrap; }
+.blame-msg {
+  max-width: 240px; overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; color: #e6edf3;
+}
+.pitch-badge {
+  display: inline-block; padding: 2px 8px;
+  border-radius: 12px; font-size: 11px; font-weight: 600;
+  background: #1f6feb33; color: #58a6ff; white-space: nowrap;
+}
+.track-badge {
+  display: inline-block; padding: 2px 8px;
+  border-radius: 12px; font-size: 11px; font-weight: 600;
+  background: #2ea04333; color: #3fb950; white-space: nowrap;
+}
+.beat-range { font-size: 12px; color: #8b949e; white-space: nowrap; }
+.velocity-bar {
+  display: inline-block; width: 60px; height: 6px;
+  background: #21262d; border-radius: 3px; vertical-align: middle;
+}
+.velocity-fill {
+  display: inline-block; height: 100%; border-radius: 3px;
+  background: #f0883e;
+}
+.blame-empty {
+  padding: 48px 16px; text-align: center; color: #8b949e;
+  font-size: 14px;
+}
+.blame-summary {
+  font-size: 13px; color: #8b949e; margin-bottom: 12px;
+}
+.blame-summary strong { color: #c9d1d9; }
+</style>
+{% endblock %}
+
+{% block page_data %}
+const repoId   = {{ repo_id | tojson }};
+const ref      = {{ ref | tojson }};
+const filePath = {{ path | tojson }};
+const owner    = {{ owner | tojson }};
+const repoSlug = {{ repo_slug | tojson }};
+const base     = {{ base_url | tojson }};
+const apiBase  = '/api/v1/musehub/repos/' + repoId;
+const initTrack     = {{ track | tojson }};
+const initBeatStart = {{ (beat_start | string) if beat_start is not none else 'null' }};
+const initBeatEnd   = {{ (beat_end | string) if beat_end is not none else 'null' }};
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+(function () {
+  // ── Pitch label helpers ───────────────────────────────────────────────────
+  const NOTE_NAMES = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
+  function pitchName(midi) {
+    return NOTE_NAMES[midi % 12] + Math.floor(midi / 12 - 1);
+  }
+
+  function escHtml(s) {
+    if (s === null || s === undefined) return '—';
+    return String(s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  // ── Filter state ──────────────────────────────────────────────────────────
+  let currentTrack     = initTrack || '';
+  let currentBeatStart = initBeatStart;
+  let currentBeatEnd   = initBeatEnd;
+
+  // ── Build query string from current filters ───────────────────────────────
+  function buildQs() {
+    const parts = [];
+    if (filePath)          parts.push('path=' + encodeURIComponent(filePath));
+    if (currentTrack)      parts.push('track=' + encodeURIComponent(currentTrack));
+    if (currentBeatStart !== null && currentBeatStart !== '') {
+      parts.push('beatStart=' + currentBeatStart);
+    }
+    if (currentBeatEnd !== null && currentBeatEnd !== '') {
+      parts.push('beatEnd=' + currentBeatEnd);
+    }
+    return parts.length ? '?' + parts.join('&') : '';
+  }
+
+  // ── Blame table renderer ──────────────────────────────────────────────────
+  function renderBlameTable(entries, total) {
+    const content = document.getElementById('content');
+    if (entries.length === 0) {
+      content.innerHTML = `
+        <div class="blame-empty">
+          <p>&#x1F3B5; No blame entries found for this path and filter combination.</p>
+          <p style="font-size:12px;margin-top:8px">
+            Try removing track or beat range filters, or check that the path is correct.
+          </p>
+        </div>`;
+      return;
+    }
+
+    const rows = entries.map(e => {
+      const shortSha = (e.commitId || '').substring(0, 8);
+      const commitUrl = base + '/commits/' + encodeURIComponent(e.commitId || '');
+      const velPct = Math.round(((e.noteVelocity || 0) / 127) * 100);
+      const dateStr = e.timestamp
+        ? new Date(e.timestamp).toLocaleDateString('en-US', {month:'short', day:'numeric', year:'numeric'})
+        : '—';
+      return `
+        <tr>
+          <td>
+            <a class="commit-sha" href="${commitUrl}">${escHtml(shortSha)}</a>
+          </td>
+          <td class="blame-msg" title="${escHtml(e.commitMessage)}">${escHtml(e.commitMessage)}</td>
+          <td class="blame-author">${escHtml(e.author)}</td>
+          <td class="blame-date">${dateStr}</td>
+          <td><span class="track-badge">${escHtml(e.track)}</span></td>
+          <td><span class="pitch-badge">${escHtml(pitchName(e.notePitch || 0))}</span></td>
+          <td class="beat-range">${(e.beatStart || 0).toFixed(2)} – ${(e.beatEnd || 0).toFixed(2)}</td>
+          <td>
+            <div class="velocity-bar" title="Velocity ${e.noteVelocity}">
+              <div class="velocity-fill" style="width:${velPct}%"></div>
+            </div>
+            <span style="font-size:11px;color:#8b949e;margin-left:4px">${e.noteVelocity}</span>
+          </td>
+          <td style="font-size:12px;color:#8b949e">${(e.noteDurationBeats || 0).toFixed(2)}b</td>
+        </tr>`;
+    }).join('');
+
+    content.innerHTML = `
+      <div class="blame-summary">
+        Showing <strong>${entries.length}</strong> of <strong>${total}</strong> blame entries
+        for <code style="background:#161b22;padding:2px 6px;border-radius:4px">${escHtml(filePath)}</code>
+        at <code style="background:#161b22;padding:2px 6px;border-radius:4px">${escHtml((ref||'').substring(0,12))}</code>
+      </div>
+      <div class="blame-table-wrap">
+        <table class="blame-table">
+          <thead>
+            <tr>
+              <th>Commit</th>
+              <th>Message</th>
+              <th>Author</th>
+              <th>Date</th>
+              <th>Track</th>
+              <th>Pitch</th>
+              <th>Beat range</th>
+              <th>Velocity</th>
+              <th>Duration</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>`;
+  }
+
+  // ── Main data loader ───────────────────────────────────────────────────────
+  async function load() {
+    document.getElementById('content').innerHTML =
+      '<p class="loading">Loading blame data&#8230;</p>';
+    try {
+      const qs = buildQs();
+      const url = '/repos/' + encodeURIComponent(repoId) + '/blame/' + encodeURIComponent(ref) + qs;
+      const resp = await apiFetch(url);
+      renderBlameTable(resp.entries || [], resp.totalEntries || 0);
+    } catch (e) {
+      if (e.message !== 'auth') {
+        document.getElementById('content').innerHTML =
+          '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+      }
+    }
+  }
+
+  // ── Filter controls ───────────────────────────────────────────────────────
+  function applyFilters() {
+    const trackSel = document.getElementById('blame-track-sel');
+    const bsInput  = document.getElementById('blame-beat-start');
+    const beInput  = document.getElementById('blame-beat-end');
+    currentTrack     = trackSel ? trackSel.value : '';
+    currentBeatStart = bsInput && bsInput.value !== '' ? parseFloat(bsInput.value) : null;
+    currentBeatEnd   = beInput && beInput.value !== '' ? parseFloat(beInput.value) : null;
+    load();
+  }
+
+  // Expose globally so onclick attributes work.
+  window.applyBlameFilters = applyFilters;
+
+  load();
+}());
+{% endraw %}
+{% endblock %}
+
+{% block body_extra %}
+<div class="blame-header"
+     style="padding: 0 0 8px; border-bottom: 1px solid #30363d; margin-bottom: 16px; margin-top: -8px;">
+  <div>
+    <h2 style="margin: 0; font-size: 18px; color: #e6edf3;">
+      &#x1F4CB; Blame &#8212;
+      <code style="font-size: 15px; background: #161b22; padding: 2px 8px; border-radius: 4px;">
+        {{ short_path }}
+      </code>
+    </h2>
+    <p style="margin: 4px 0 0; font-size: 13px; color: #8b949e;">
+      Per-note commit attribution at ref
+      <code style="background: #161b22; padding: 2px 6px; border-radius: 4px;">{{ short_ref }}</code>
+      &bull;
+      <a href="{{ base_url }}/tree/{{ ref }}/{{ path }}"
+         style="color: #58a6ff; text-decoration: none; font-size: 13px;">
+        View file &#8599;
+      </a>
+    </p>
+  </div>
+  <div style="display: flex; gap: 8px;">
+    <a href="{{ base_url }}/commits" class="btn btn-secondary" style="font-size: 12px;">
+      &#x1F4DC; Commits
+    </a>
+    <a href="{{ base_url }}/piano-roll/{{ ref }}/{{ path }}"
+       class="btn btn-secondary" style="font-size: 12px;">
+      &#127929; Piano Roll
+    </a>
+  </div>
+</div>
+
+<div class="blame-filter-bar" id="blame-filter-bar" style="display: none;">
+  <label>
+    Track:
+    <select id="blame-track-sel">
+      <option value="">All tracks</option>
+      <option value="piano">piano</option>
+      <option value="bass">bass</option>
+      <option value="drums">drums</option>
+      <option value="keys">keys</option>
+      <option value="strings">strings</option>
+      <option value="guitar">guitar</option>
+      <option value="lead">lead</option>
+      <option value="pads">pads</option>
+    </select>
+  </label>
+  <label>
+    Beat start ≥
+    <input type="number" id="blame-beat-start" min="0" step="0.25"
+           placeholder="0.0" style="width: 80px;" />
+  </label>
+  <label>
+    Beat end &lt;
+    <input type="number" id="blame-beat-end" min="0" step="0.25"
+           placeholder="32.0" style="width: 80px;" />
+  </label>
+  <button class="btn btn-primary" onclick="applyBlameFilters()" style="font-size: 13px;">
+    Apply
+  </button>
+</div>
+
+<script>
+  window.addEventListener('DOMContentLoaded', function () {
+    // Pre-populate filter controls from server-side values.
+    var trackSel = document.getElementById('blame-track-sel');
+    if (trackSel && initTrack) trackSel.value = initTrack;
+    var bsInput = document.getElementById('blame-beat-start');
+    if (bsInput && initBeatStart !== null) bsInput.value = initBeatStart;
+    var beInput = document.getElementById('blame-beat-end');
+    if (beInput && initBeatEnd !== null) beInput.value = initBeatEnd;
+
+    // Show the filter bar after JS variables are available.
+    var bar = document.getElementById('blame-filter-bar');
+    if (bar) bar.style.display = 'flex';
+  });
+</script>
+{% endblock %}

--- a/tests/test_musehub_ui_blame.py
+++ b/tests/test_musehub_ui_blame.py
@@ -1,0 +1,377 @@
+"""Tests for the Muse Hub blame UI page (issue #423).
+
+Covers:
+- test_blame_page_renders                  — GET /musehub/ui/{owner}/{slug}/blame/{ref}/{path} returns 200 HTML
+- test_blame_page_no_auth_required         — page accessible without a JWT
+- test_blame_page_unknown_repo_404         — bad owner/slug returns 404
+- test_blame_page_contains_table_headers   — HTML contains blame table column headers
+- test_blame_page_contains_filter_bar      — HTML includes track/beat filter controls
+- test_blame_page_contains_breadcrumb      — breadcrumb links owner, repo_slug, ref, and filename
+- test_blame_page_contains_piano_roll_link — quick-link to the piano-roll page present
+- test_blame_page_contains_commits_link    — quick-link to the commit list present
+- test_blame_json_response                 — Accept: application/json returns BlameResponse JSON
+- test_blame_json_has_entries_key          — JSON body contains 'entries' and 'totalEntries' keys
+- test_blame_json_format_param             — ?format=json returns JSON without Accept header
+- test_blame_page_path_injected_in_js      — file path passed as JS context variable
+- test_blame_page_ref_injected_in_js       — commit ref passed as JS context variable
+- test_blame_page_api_fetch_call           — page JS calls blame API endpoint
+- test_blame_page_filter_bar_track_options — track <select> lists standard instrument names
+- test_blame_page_pitch_name_helper        — pitchName helper renders note names in JS
+- test_blame_page_commit_sha_link          — commit SHA links to commit detail page in JS template
+- test_blame_page_velocity_bar_present     — velocity bar element present in JS template
+- test_blame_page_beat_range_column        — beat range column rendered in JS template
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import MusehubCommit, MusehubRepo
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_repo(
+    db_session: AsyncSession,
+    *,
+    owner: str = "testuser",
+    slug: str = "test-beats",
+    visibility: str = "public",
+) -> str:
+    """Seed a minimal repo and return its repo_id string."""
+    repo = MusehubRepo(
+        name=slug,
+        owner=owner,
+        slug=slug,
+        visibility=visibility,
+        owner_user_id="00000000-0000-0000-0000-000000000001",
+    )
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    return str(repo.repo_id)
+
+
+async def _add_commit(db_session: AsyncSession, repo_id: str) -> None:
+    """Seed a single commit so blame entries are non-empty."""
+    commit = MusehubCommit(
+        repo_id=repo_id,
+        commit_id="abc1234567890abcdef",
+        message="Add jazz piano chords",
+        author="testuser",
+        branch="main",
+    )
+    db_session.add(commit)
+    await db_session.commit()
+
+
+_OWNER = "testuser"
+_SLUG = "test-beats"
+_REF = "abc1234567890abcdef"
+_PATH = "tracks/piano.mid"
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/blame/{ref}/{path} must return 200 HTML."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_blame_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Blame page must be accessible without an Authorization header."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code != 401
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_blame_page_unknown_repo_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Unknown owner/slug must return 404."""
+    url = f"/musehub/ui/nobody/no-repo/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_blame_page_contains_table_headers(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Rendered HTML must contain the blame table column headers."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    assert "Commit" in body
+    assert "Author" in body
+    assert "Track" in body
+    assert "Pitch" in body
+    assert "Velocity" in body
+
+
+@pytest.mark.anyio
+async def test_blame_page_contains_filter_bar(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Rendered HTML must include the track and beat-range filter controls."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    assert "blame-track-sel" in body
+    assert "blame-beat-start" in body
+    assert "blame-beat-end" in body
+
+
+@pytest.mark.anyio
+async def test_blame_page_contains_breadcrumb(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Breadcrumb must reference owner, repo slug, ref, and filename."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    assert _OWNER in body
+    assert _SLUG in body
+    assert _REF[:8] in body
+    assert "piano.mid" in body
+
+
+@pytest.mark.anyio
+async def test_blame_page_contains_piano_roll_link(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Page must include a quick-link to the piano-roll view for the same file."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    assert "piano-roll" in body
+
+
+@pytest.mark.anyio
+async def test_blame_page_contains_commits_link(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Page must include a quick-link to the commits list."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    assert "/commits" in body
+
+
+# ---------------------------------------------------------------------------
+# JSON content negotiation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_json_response(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Accept: application/json must return a JSON response (not HTML)."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url, headers={"Accept": "application/json"})
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_blame_json_has_entries_key(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """JSON response must contain 'entries' and 'totalEntries' keys."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url, headers={"Accept": "application/json"})
+    assert response.status_code == 200
+    data = response.json()
+    assert "entries" in data
+    assert "totalEntries" in data
+    assert isinstance(data["entries"], list)
+    assert isinstance(data["totalEntries"], int)
+
+
+@pytest.mark.anyio
+async def test_blame_json_format_param(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """?format=json must return JSON without an Accept header."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}?format=json"
+    response = await client.get(url)
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+    data = response.json()
+    assert "entries" in data
+
+
+# ---------------------------------------------------------------------------
+# JS context variable injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_page_path_injected_in_js(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The MIDI file path must be passed as a JS variable (filePath)."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    assert "filePath" in body
+    assert _PATH in body
+
+
+@pytest.mark.anyio
+async def test_blame_page_ref_injected_in_js(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The commit ref must be passed as a JS variable (ref)."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    assert "const ref" in body
+    assert _REF in body
+
+
+@pytest.mark.anyio
+async def test_blame_page_api_fetch_call(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Page JS must call the blame API endpoint to load data."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    assert "/blame/" in body
+    assert "apiFetch" in body
+
+
+# ---------------------------------------------------------------------------
+# UI element assertions in JS template strings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_blame_page_filter_bar_track_options(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Track <select> must list standard instrument track names."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    for instrument in ("piano", "bass", "drums", "keys"):
+        assert instrument in body
+
+
+@pytest.mark.anyio
+async def test_blame_page_pitch_name_helper(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Page JS must define the pitchName helper for MIDI-to-note-name conversion."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    assert "pitchName" in body
+    assert "NOTE_NAMES" in body
+
+
+@pytest.mark.anyio
+async def test_blame_page_commit_sha_link(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Rendered JS template must generate commit SHA anchor links."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    assert "commit-sha" in body
+    assert "commitId" in body
+
+
+@pytest.mark.anyio
+async def test_blame_page_velocity_bar_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Velocity bar element must appear in the JS table template."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    assert "velocity-bar" in body
+    assert "velocity-fill" in body
+
+
+@pytest.mark.anyio
+async def test_blame_page_beat_range_column(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Beat range column must appear in the JS table template."""
+    await _make_repo(db_session)
+    url = f"/musehub/ui/{_OWNER}/{_SLUG}/blame/{_REF}/{_PATH}"
+    response = await client.get(url)
+    assert response.status_code == 200
+    body = response.text
+    assert "beat-range" in body
+    assert "beatStart" in body
+    assert "beatEnd" in body


### PR DESCRIPTION
## Summary

Closes #423 — adds the Muse Hub blame view browser page at
`GET /musehub/ui/{owner}/{repo_slug}/blame/{ref}/{path:path}`.

## Root Cause / Motivation

The Muse Hub UI had no way to display per-note commit attribution — the
musical equivalent of `git blame`. Musicians and AI agents needed a page
that shows which commit last introduced or modified each note event in a
MIDI file, so they can trace the evolution of any musical idea across the
project's history.

## Solution

- **`maestro/api/routes/musehub/ui_blame.py`** — new route handler with
  full HTML + JSON content negotiation via `negotiate_response()`. Reuses
  `_build_blame_entries` from the existing `blame.py` API module so the
  JSON alternate returns a `BlameResponse` that mirrors the
  `/api/v1/musehub/repos/{repo_id}/blame/{ref}` contract.  Optional
  `track`, `beatStart`, and `beatEnd` query params are forwarded to the
  blame engine and pre-populate the filter UI.

- **`maestro/templates/musehub/pages/blame.html`** — Jinja2 template
  extending `musehub/base.html`. Renders an interactive blame table with:
  commit SHA links, author, date, track badge, MIDI pitch name (via
  `pitchName()` helper), beat range, velocity bar, and duration.  Includes
  a track/beat-range filter bar that re-fetches blame data client-side
  without a page reload.  Quick-links to the piano roll and commit list.

- **`maestro/main.py`** — registers `musehub_ui_blame_routes.router`
  (prefix `/musehub/ui`) without an additional prefix, matching the
  pattern used for all other Muse Hub UI routers.

- **`tests/test_musehub_ui_blame.py`** — 19 tests covering: 200 HTML
  response, no-auth access, 404 for unknown repos, table column headers,
  filter bar elements, breadcrumb content, piano-roll and commits links,
  JSON content negotiation via `Accept` header and `?format=json` param,
  JS context variable injection, and in-template element assertions.

## Verification

- [x] mypy clean — 660 source files, no issues
- [x] Tests pass — 19/19 passed
- [x] Pre-push dev sync performed, no conflicts
- [x] No new dependencies introduced