### PR TITLE
feat: add Open Graph and Twitter card meta tag helpers to MuseHub UI

### DIFF
--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -157,6 +157,45 @@ async def _resolve_repo_full(
     return repo, _base_url(owner, repo_slug)
 
 
+def _og_tags(
+    *,
+    title: str,
+    description: str = "",
+    image: str = "",
+    og_type: str = "website",
+    twitter_card: str = "summary",
+) -> dict[str, str]:
+    """Build Open Graph and Twitter Card meta tag dict for a page template.
+
+    Returns a flat mapping of meta property name → content string.  Template
+    authors receive this as ``og_meta`` in the template context and iterate
+    over it to emit ``<meta property="..." content="...">`` tags in the
+    document ``<head>``.
+
+    Why a helper: OG tags are structurally repetitive (title, description, and
+    image appear once for OG and once for Twitter).  Centralising the mapping
+    ensures both protocol families stay in sync and reduces copy-paste errors
+    in handlers.
+
+    Call this for any page that should expose rich-preview metadata to social
+    crawlers and link-unfurling bots.  Omit ``image`` when no canonical preview
+    image exists — crawlers fall back to the site default.
+    """
+    tags: dict[str, str] = {
+        "og:title": title,
+        "og:type": og_type,
+        "twitter:card": twitter_card,
+        "twitter:title": title,
+    }
+    if description:
+        tags["og:description"] = description
+        tags["twitter:description"] = description
+    if image:
+        tags["og:image"] = image
+        tags["twitter:image"] = image
+    return tags
+
+
 # ---------------------------------------------------------------------------
 # Fixed-path routes (registered before wildcard routes in main.py)
 # ---------------------------------------------------------------------------
@@ -261,6 +300,11 @@ async def profile_page(request: Request, username: str) -> HTMLResponse:
         {
             "title": f"@{username}",
             "username": username,
+            "og_meta": _og_tags(
+                title=f"@{username} — Muse Hub",
+                description=f"{username}'s music repos on Muse Hub",
+                og_type="profile",
+            ),
         },
     )
 
@@ -299,6 +343,11 @@ async def repo_page(
             "repo_id": str(repo.repo_id),
             "base_url": base_url,
             "current_page": "home",
+            "og_meta": _og_tags(
+                title=f"{owner}/{repo_slug} — Muse Hub",
+                description=repo.description or f"Music composition repository by {owner}",
+                og_type="website",
+            ),
         },
         templates=templates,
         json_data=repo,
@@ -391,6 +440,7 @@ async def commit_page(
     """
     repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
     commit = await musehub_repository.get_commit(db, repo_id, commit_id)
+    commit_description = commit.message if commit is not None else ""
     return await negotiate_response(
         request=request,
         template_name="musehub/pages/commit.html",
@@ -406,6 +456,11 @@ async def commit_page(
                 (repo_slug, base_url),
                 ("commits", base_url),
                 (commit_id[:8], ""),
+            ),
+            "og_meta": _og_tags(
+                title=f"Commit {commit_id[:8]} · {owner}/{repo_slug} — Muse Hub",
+                description=commit_description,
+                og_type="music.song",
             ),
         },
         templates=templates,


### PR DESCRIPTION
## Summary
Closes #441 — adds `_og_tags()` helper and injects OG/Twitter Card meta tag context into three MuseHub page routes.

## Root Cause / Motivation
MuseHub pages lacked Open Graph and Twitter Card meta tags, which meant shared links to repo landing pages, commit detail pages, and user profiles showed no rich preview when shared on social platforms or messaging apps.

## Solution
- Added `_og_tags()` helper function in `maestro/api/routes/musehub/ui.py` (in the helpers section) that builds a flat `dict[str, str]` of `og:` and `twitter:` meta property → content pairs.
- Injected `og_meta` into the template context for:
  - `repo_page` — `og:title = "{owner}/{repo_slug} — Muse Hub"`, `og:description` from `repo.description`, `og:type = "website"`
  - `commit_page` — `og:title = "Commit {commit_id[:8]} · {owner}/{repo_slug} — Muse Hub"`, `og:description` from commit message, `og:type = "music.song"`
  - `profile_page` — `og:title = "@{username} — Muse Hub"`, `og:description` from username, `og:type = "profile"`
- Added 9 tests: 6 pure unit tests for `_og_tags()` and 3 integration tests verifying pages still render 200 after the context injection.

Templates receive `og_meta` as a typed `dict[str, str]` and will render `<meta property="..." content="...">` tags in a follow-up template-side update; this PR establishes the server-side data contract.

## Files Changed
- `maestro/api/routes/musehub/ui.py` — `_og_tags()` helper + context injection in 3 handlers
- `tests/test_musehub_ui.py` — 9 new tests for issue #441

## Verification
- [x] mypy clean (`PYTHONPATH=/worktrees/issue-441 mypy maestro/api/routes/musehub/ui.py` — no issues)
- [x] All 9 new tests pass
- [x] Pre-push sync with origin/dev completed (no conflicts)
- [x] No existing tests broken