### PR TITLE
feat: notification inbox UI page (/musehub/ui/notifications)

### DIFF
--- a/maestro/api/routes/musehub/ui_notifications.py
+++ b/maestro/api/routes/musehub/ui_notifications.py
@@ -1,0 +1,275 @@
+"""Muse Hub notification inbox UI page.
+
+Serves the authenticated notification inbox at ``/musehub/ui/notifications``.
+
+Endpoint:
+  GET /musehub/ui/notifications
+    - HTML (default): paginated, filterable notification inbox with
+      mark-as-read and mark-all-read controls.
+    - JSON (``?format=json`` or ``Accept: application/json``): structured
+      ``NotificationsPageResponse`` for agent consumption.
+
+Query parameters (HTML and JSON):
+  type        Filter by notification event type (e.g. ``mention``, ``watch``,
+              ``fork``).  Omit to show all types.
+  unread_only Show only unread notifications (default: ``false``).
+  page        Page number (1-indexed, default: 1).
+  per_page    Items per page (1–100, default: 25).
+  format      Force ``json`` response regardless of Accept header.
+
+Auth: JWT required for JSON responses (personal data); the HTML shell is
+served without auth so the browser can display a JWT entry prompt for users
+who are not yet authenticated.  Client-side JavaScript enforces auth via the
+``localStorage`` token before fetching notification data from the API.
+
+Auto-discovered by ``maestro.api.routes.musehub.__init__`` because this
+module exposes a ``router`` attribute.  No changes to ``__init__.py`` needed.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import status as http_status
+from fastapi.requests import Request
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response
+
+from maestro.api.routes.musehub.negotiate import negotiate_response
+from maestro.auth.dependencies import TokenClaims, optional_token
+from maestro.db import get_db
+from maestro.db.musehub_models import MusehubNotification
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/musehub/ui", tags=["musehub-ui-notifications"])
+
+_TEMPLATE_DIR = Path(__file__).parent.parent.parent.parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class NotificationItem(BaseModel):
+    """A single notification entry in the inbox response.
+
+    ``created_at`` is ISO 8601 so JSON consumers can parse it without knowing
+    the server's timezone.  Keys are camelCase for consistency with all other
+    MuseHub JSON endpoints.
+    """
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+
+    notif_id: str
+    event_type: str
+    repo_id: str | None
+    actor: str
+    payload: dict[str, object]
+    is_read: bool
+    created_at: str
+
+
+class NotificationsPageResponse(BaseModel):
+    """Paginated notification inbox — returned for JSON consumers.
+
+    Includes the notification list, pagination metadata, and the active filter
+    state so agents can construct follow-up requests without re-parsing URLs.
+
+    ``unread_count`` reflects the global unread count for the user (not scoped
+    to the current type/unread_only filter) so badge displays stay accurate.
+
+    Keys are camelCase (alias_generator) so the JSON contract matches all other
+    MuseHub ``negotiate_response`` endpoints.
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+
+    notifications: list[NotificationItem]
+    total: int
+    page: int
+    per_page: int
+    total_pages: int
+    unread_count: int
+    type_filter: str | None
+    unread_only: bool
+
+
+# ---------------------------------------------------------------------------
+# Route handler
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/notifications",
+    summary="Muse Hub notification inbox",
+)
+async def notifications_page(
+    request: Request,
+    type: str | None = Query(
+        None,
+        description="Filter by notification event type (e.g. mention, watch, fork)",
+    ),
+    unread_only: bool = Query(False, description="Show only unread notifications"),
+    page: int = Query(1, ge=1, description="Page number (1-indexed)"),
+    per_page: int = Query(25, ge=1, le=100, description="Items per page"),
+    format: str | None = Query(
+        None, description="Force response format: 'json' or omit for HTML"
+    ),
+    db: AsyncSession = Depends(get_db),
+    claims: TokenClaims | None = Depends(optional_token),
+) -> Response:
+    """Render the notification inbox or return paginated JSON for agent consumption.
+
+    Why auth is split between HTML and JSON paths: the HTML shell is always
+    returned so the browser can display a JWT entry form for unauthenticated
+    users; the JSON path enforces auth directly because there is no shell to
+    fall back to and notification data is personal.
+
+    Filters are applied additively: ``type`` narrows by event type and
+    ``unread_only`` further restricts to unread rows when both are supplied.
+    """
+    wants_json = _prefers_json(request, format)
+
+    # JSON callers need real data — enforce auth here.
+    if wants_json and claims is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required to read notifications.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    context: dict[str, object] = {
+        "title": "Notifications",
+        "type_filter": type or "",
+        "unread_only": unread_only,
+        "page": page,
+        "per_page": per_page,
+        "current_page": "notifications",
+    }
+
+    json_data: NotificationsPageResponse | None = None
+    if wants_json and claims is not None:
+        user_id: str = claims.get("sub", "")
+        json_data = await _build_notifications_page(
+            db=db,
+            user_id=user_id,
+            type_filter=type,
+            unread_only=unread_only,
+            page=page,
+            per_page=per_page,
+        )
+
+    return await negotiate_response(
+        request=request,
+        template_name="musehub/pages/notifications.html",
+        context=context,
+        templates=templates,
+        json_data=json_data,
+        format_param=format,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _prefers_json(request: Request, format_param: str | None) -> bool:
+    """Return True when the caller prefers a JSON response.
+
+    Mirrors the logic in ``negotiate.py`` without importing the private
+    ``_wants_json`` helper.  Decision order: ``?format=json`` param, then
+    ``Accept: application/json`` header.
+    """
+    if format_param == "json":
+        return True
+    return "application/json" in request.headers.get("accept", "")
+
+
+async def _build_notifications_page(
+    *,
+    db: AsyncSession,
+    user_id: str,
+    type_filter: str | None,
+    unread_only: bool,
+    page: int,
+    per_page: int,
+) -> NotificationsPageResponse:
+    """Query the DB and assemble a paginated NotificationsPageResponse.
+
+    ``unread_count`` is always the global count for the user — independent of
+    ``type_filter`` and ``unread_only`` — so the inbox badge stays accurate
+    even when a narrow filter is active.
+    """
+    base_q = select(MusehubNotification).where(
+        MusehubNotification.recipient_id == user_id
+    )
+    if type_filter:
+        base_q = base_q.where(MusehubNotification.event_type == type_filter)
+    if unread_only:
+        base_q = base_q.where(MusehubNotification.is_read.is_(False))
+
+    total: int = (
+        await db.execute(select(func.count()).select_from(base_q.subquery()))
+    ).scalar_one()
+
+    unread_count: int = (
+        await db.execute(
+            select(func.count()).where(
+                MusehubNotification.recipient_id == user_id,
+                MusehubNotification.is_read.is_(False),
+            )
+        )
+    ).scalar_one()
+
+    offset = (page - 1) * per_page
+    rows = (
+        await db.execute(
+            base_q.order_by(MusehubNotification.created_at.desc())
+            .offset(offset)
+            .limit(per_page)
+        )
+    ).scalars().all()
+
+    notifications = [
+        NotificationItem(
+            notif_id=str(r.notif_id),
+            event_type=str(r.event_type),
+            repo_id=str(r.repo_id) if r.repo_id is not None else None,
+            actor=str(r.actor),
+            payload=dict(r.payload) if r.payload else {},
+            is_read=bool(r.is_read),
+            created_at=r.created_at.isoformat()
+            if isinstance(r.created_at, datetime)
+            else str(r.created_at),
+        )
+        for r in rows
+    ]
+
+    total_pages = max(1, (total + per_page - 1) // per_page)
+    return NotificationsPageResponse(
+        notifications=notifications,
+        total=total,
+        page=page,
+        per_page=per_page,
+        total_pages=total_pages,
+        unread_count=unread_count,
+        type_filter=type_filter,
+        unread_only=unread_only,
+    )

--- a/maestro/main.py
+++ b/maestro/main.py
@@ -25,6 +25,7 @@ from slowapi.errors import RateLimitExceeded
 from maestro.config import settings
 from maestro.api.routes import maestro, maestro_ui, health, users, conversations, assets, variation, muse, musehub
 from maestro.api.routes.musehub import ui as musehub_ui_routes
+from maestro.api.routes.musehub import ui_notifications as musehub_ui_notifications_routes
 from maestro.api.routes.musehub import discover as musehub_discover_routes
 from maestro.api.routes.musehub import users as musehub_user_routes
 from maestro.api.routes.musehub import oembed as musehub_oembed_routes
@@ -216,7 +217,9 @@ app.include_router(musehub_discover_routes.router, prefix="/api/v1", tags=["Disc
 app.include_router(musehub_discover_routes.star_router, prefix="/api/v1", tags=["Social"])
 # Main musehub router — includes the /{owner}/{repo_slug} wildcard last.
 app.include_router(musehub.router, prefix="/api/v1")
-# UI routers: fixed-path routes (users, explore, trending) first, then wildcards.
+# UI routers: notifications first (concrete path) so it is not shadowed by the
+# /{username} catch-all declared in fixed_router, then fixed-path routes, then wildcards.
+app.include_router(musehub_ui_notifications_routes.router, tags=["musehub-ui-notifications"])
 app.include_router(musehub_ui_routes.fixed_router, tags=["musehub-ui"])
 app.include_router(musehub_ui_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_oembed_routes.router, tags=["musehub-oembed"])

--- a/maestro/templates/musehub/pages/notifications.html
+++ b/maestro/templates/musehub/pages/notifications.html
@@ -1,0 +1,342 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Notifications{% endblock %}
+{% block breadcrumb %}Notifications{% endblock %}
+
+{% block page_script %}
+{% raw %}
+// ── Config ─────────────────────────────────────────────────────────────────
+
+/** How many notifications to show per page. Synced from template context. */
+const PER_PAGE = typeof notifPerPage !== 'undefined' ? notifPerPage : 25;
+
+/** Active filter state — preserved across mark-as-read calls. */
+let currentType    = (new URLSearchParams(location.search)).get('type')    || '';
+let currentUnread  = (new URLSearchParams(location.search)).get('unread_only') === 'true';
+let currentPage    = parseInt((new URLSearchParams(location.search)).get('page') || '1', 10);
+
+// ── Event metadata ─────────────────────────────────────────────────────────
+
+const EVENT_META = {
+  comment:      { icon: '🗨️',  label: 'commented',       sentence: (a, r) => `${actorLink(a)} commented on ${repoLink(r)}` },
+  mention:      { icon: '💬',  label: 'mentioned you',   sentence: (a, r) => `${actorLink(a)} mentioned you in ${repoLink(r)}` },
+  pr_opened:    { icon: '🔀',  label: 'opened a PR',     sentence: (a, r) => `${actorLink(a)} opened a PR in ${repoLink(r)}` },
+  pr_merged:    { icon: '✅',  label: 'merged a PR',     sentence: (a, r) => `${actorLink(a)} merged a PR in ${repoLink(r)}` },
+  issue_opened: { icon: '🐛',  label: 'opened an issue', sentence: (a, r) => `${actorLink(a)} opened an issue in ${repoLink(r)}` },
+  issue_closed: { icon: '✔️', label: 'closed an issue', sentence: (a, r) => `${actorLink(a)} closed an issue in ${repoLink(r)}` },
+  new_commit:   { icon: '🎵',  label: 'committed',       sentence: (a, r) => `${actorLink(a)} committed to ${repoLink(r)}` },
+  new_follower: { icon: '👤',  label: 'followed you',    sentence: (a) => `${actorLink(a)} followed you` },
+  watch:        { icon: '👁️', label: 'watched',         sentence: (a, r) => `${actorLink(a)} started watching ${repoLink(r)}` },
+  fork:         { icon: '🍴',  label: 'forked',          sentence: (a, r) => `${actorLink(a)} forked ${repoLink(r)}` },
+};
+
+// ── DOM helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Deterministic HSL hue from an actor string — stable, visually distinct
+ * colour per user without any stored data.
+ */
+function actorHsl(actor) {
+  let hash = 0;
+  for (let i = 0; i < actor.length; i++) {
+    hash = actor.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return 'hsl(' + (Math.abs(hash) % 360) + ',50%,38%)';
+}
+
+function actorAvatar(actor) {
+  const bg      = actorHsl(actor);
+  const initial = escHtml((actor || '?').charAt(0).toUpperCase());
+  return `<div class="comment-avatar" style="background:${bg};color:#e6edf3;font-weight:700;font-size:14px;border:none">${initial}</div>`;
+}
+
+function actorLink(actor) {
+  return `<a href="/musehub/ui/users/${encodeURIComponent(actor)}" style="color:var(--text-primary);font-weight:600">${escHtml(actor)}</a>`;
+}
+
+function repoLink(repoId) {
+  if (!repoId) return '';
+  const parts = repoId.split('/');
+  const label = parts.length >= 2 ? escHtml(parts[1]) : escHtml(repoId);
+  return `<a href="/musehub/ui/${encodeURIComponent(repoId)}" style="color:var(--color-accent)">${label}</a>`;
+}
+
+// ── Notification card ──────────────────────────────────────────────────────
+
+/**
+ * Render a single notification as an inbox card.
+ *
+ * Unread cards have a left-border accent and a ✓ "Mark read" button that
+ * calls POST /notifications/{notif_id}/read and applies the read style in-
+ * place without a full page reload.
+ */
+function notifCard(item) {
+  const meta      = EVENT_META[item.eventType] || { icon: '•', sentence: (a) => actorLink(a) };
+  const icon      = meta.icon;
+  const sentence  = meta.sentence(item.actor, item.repoId || '');
+  const timestamp = fmtRelative(item.createdAt);
+  const isUnread  = !item.isRead;
+
+  const cardStyle = isUnread
+    ? 'border-left:3px solid var(--color-accent);padding-left:calc(var(--space-3) - 3px);'
+    : 'border-left:3px solid transparent;padding-left:calc(var(--space-3) - 3px);opacity:0.75;';
+
+  const markReadBtn = isUnread
+    ? `<button
+         class="mark-read-btn"
+         data-notif-id="${escHtml(item.notifId)}"
+         onclick="markOneRead(this)"
+         title="Mark as read"
+         style="background:none;border:1px solid var(--border-color);border-radius:50%;width:22px;height:22px;cursor:pointer;color:var(--text-muted);font-size:12px;line-height:1;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;margin-left:var(--space-2)"
+       >&#10003;</button>`
+    : '';
+
+  const unreadDot = isUnread
+    ? '<span class="unread-dot" style="display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--color-accent);margin-left:var(--space-2);flex-shrink:0"></span>'
+    : '';
+
+  return `
+    <div class="comment-item" data-notif-id="${escHtml(item.notifId)}" style="${cardStyle}">
+      ${actorAvatar(item.actor)}
+      <div class="comment-body" style="flex:1;min-width:0">
+        <div class="comment-meta" style="display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap">
+          <span style="font-size:16px;line-height:1;flex-shrink:0">${icon}</span>
+          <span style="flex:1;min-width:0">${sentence}${unreadDot}</span>
+          <span style="white-space:nowrap;display:flex;align-items:center;gap:var(--space-2);flex-shrink:0">
+            <span style="color:var(--text-muted);font-size:12px">${escHtml(timestamp)}</span>
+            ${markReadBtn}
+          </span>
+        </div>
+      </div>
+    </div>`;
+}
+
+// ── Mark-as-read actions ───────────────────────────────────────────────────
+
+/**
+ * Mark a single notification as read via POST /notifications/{id}/read.
+ * Updates the card styling and nav badge count in-place on success.
+ */
+async function markOneRead(btn) {
+  const notifId = btn.dataset.notifId;
+  if (!notifId) return;
+  try {
+    await apiFetch('/notifications/' + encodeURIComponent(notifId) + '/read', { method: 'POST' });
+    const card = document.querySelector('.comment-item[data-notif-id="' + CSS.escape(notifId) + '"]');
+    if (card) {
+      card.style.borderLeft = '3px solid transparent';
+      card.style.opacity    = '0.75';
+      const dot = card.querySelector('.unread-dot');
+      if (dot) dot.remove();
+    }
+    btn.remove();
+    decrementNavBadge();
+  } catch (e) {
+    if (e.message !== 'auth') btn.style.color = 'var(--color-danger)';
+  }
+}
+
+/**
+ * Mark all notifications as read via POST /notifications/read-all.
+ * Applies read styling to every card and resets the nav badge to 0.
+ */
+async function markAllRead() {
+  const markAllBtn = document.getElementById('mark-all-read-btn');
+  if (markAllBtn) markAllBtn.disabled = true;
+  try {
+    await apiFetch('/notifications/read-all', { method: 'POST' });
+    document.querySelectorAll('.comment-item').forEach(card => {
+      card.style.borderLeft = '3px solid transparent';
+      card.style.opacity    = '0.75';
+      const dot = card.querySelector('.unread-dot');
+      if (dot) dot.remove();
+      const btn = card.querySelector('.mark-read-btn');
+      if (btn) btn.remove();
+    });
+    const badge = document.getElementById('nav-notif-badge');
+    if (badge) badge.style.display = 'none';
+    if (markAllBtn) markAllBtn.remove();
+  } catch (e) {
+    if (markAllBtn) markAllBtn.disabled = false;
+    if (e.message !== 'auth') {
+      const err = document.getElementById('notif-error');
+      if (err) err.textContent = 'Could not mark all as read: ' + e.message;
+    }
+  }
+}
+
+/**
+ * Decrement the nav badge count by 1; hide it when it reaches 0.
+ */
+function decrementNavBadge() {
+  const badge = document.getElementById('nav-notif-badge');
+  if (!badge) return;
+  const current = parseInt(badge.textContent, 10);
+  if (isNaN(current) || current <= 1) {
+    badge.style.display = 'none';
+  } else {
+    badge.textContent = String(current - 1);
+  }
+}
+
+// ── Filters ────────────────────────────────────────────────────────────────
+
+/**
+ * Apply filter changes and reload: update currentType / currentUnread /
+ * currentPage, push a new history state (for back-button support), and
+ * fetch notifications with the updated parameters.
+ */
+function applyFilters() {
+  const typeSel    = document.getElementById('type-filter');
+  const unreadChk  = document.getElementById('unread-filter');
+  currentType      = typeSel   ? typeSel.value           : currentType;
+  currentUnread    = unreadChk ? unreadChk.checked        : currentUnread;
+  currentPage      = 1;
+  pushState();
+  loadNotifications();
+}
+
+function goToPage(p) {
+  currentPage = p;
+  pushState();
+  loadNotifications();
+}
+
+/** Update the browser URL without a full reload. */
+function pushState() {
+  const qs = buildQs();
+  history.pushState({}, '', '/musehub/ui/notifications' + (qs ? '?' + qs : ''));
+}
+
+function buildQs() {
+  const params = new URLSearchParams();
+  if (currentType)   params.set('type', currentType);
+  if (currentUnread) params.set('unread_only', 'true');
+  if (currentPage > 1) params.set('page', String(currentPage));
+  return params.toString();
+}
+
+// ── Pagination ─────────────────────────────────────────────────────────────
+
+function renderPagination(page, totalPages) {
+  if (totalPages <= 1) return '';
+  const prev = page > 1
+    ? `<button class="btn btn-secondary" style="font-size:12px;padding:4px 10px" onclick="goToPage(${page - 1})">&#8592; Prev</button>`
+    : `<button class="btn btn-secondary" style="font-size:12px;padding:4px 10px;opacity:0.4" disabled>&#8592; Prev</button>`;
+  const next = page < totalPages
+    ? `<button class="btn btn-secondary" style="font-size:12px;padding:4px 10px" onclick="goToPage(${page + 1})">Next &#8594;</button>`
+    : `<button class="btn btn-secondary" style="font-size:12px;padding:4px 10px;opacity:0.4" disabled>Next &#8594;</button>`;
+  return `
+    <div style="display:flex;align-items:center;gap:var(--space-2);justify-content:center;padding:var(--space-3)">
+      ${prev}
+      <span style="font-size:13px;color:var(--text-muted)">Page ${page} of ${totalPages}</span>
+      ${next}
+    </div>`;
+}
+
+// ── Main loader ────────────────────────────────────────────────────────────
+
+async function loadNotifications() {
+  document.getElementById('content').innerHTML = '<p class="loading">Loading notifications&#8230;</p>';
+  try {
+    const qsBase = buildQs();
+    const qs = qsBase ? qsBase + '&format=json' : 'format=json';
+    // Fetch the UI endpoint directly (not via apiFetch which prepends /api/v1/musehub).
+    // The UI endpoint serves JSON when ?format=json is present and a valid JWT is sent.
+    const res = await fetch('/musehub/ui/notifications?' + qs, { headers: authHeaders() });
+    if (res.status === 401 || res.status === 403) {
+      showTokenForm('Session expired or invalid token — please re-enter your JWT.');
+      throw new Error('auth');
+    }
+    if (!res.ok) { throw new Error(res.status + ': ' + (await res.text())); }
+    const data = await res.json();
+
+    const items      = data.notifications || [];
+    const total      = data.total        || 0;
+    const totalPages = data.totalPages   || 1;
+    const unread     = data.unreadCount  || 0;
+
+    // Refresh nav badge to global unread count.
+    const badge = document.getElementById('nav-notif-badge');
+    if (badge) {
+      if (unread > 0) {
+        badge.textContent = String(Math.min(unread, 99));
+        badge.style.display = 'inline-flex';
+      } else {
+        badge.style.display = 'none';
+      }
+    }
+
+    const hasUnread  = items.some(n => !n.isRead);
+    const markAllBtn = hasUnread && getToken()
+      ? `<button id="mark-all-read-btn" class="btn btn-secondary"
+           style="font-size:12px;padding:4px 10px" onclick="markAllRead()">&#10003; Mark all as read</button>`
+      : '';
+
+    // Build type filter options.
+    const typeOptions = [
+      { value: '',        label: 'All types' },
+      { value: 'mention', label: '💬 Mentions' },
+      { value: 'watch',   label: '👁️ Watches' },
+      { value: 'fork',    label: '🍴 Forks' },
+      { value: 'comment', label: '🗨️ Comments' },
+      { value: 'pr_opened',    label: '🔀 PRs opened' },
+      { value: 'pr_merged',    label: '✅ PRs merged' },
+      { value: 'issue_opened', label: '🐛 Issues opened' },
+      { value: 'issue_closed', label: '✔️ Issues closed' },
+      { value: 'new_commit',   label: '🎵 Commits' },
+      { value: 'new_follower', label: '👤 Followers' },
+    ].map(o =>
+      `<option value="${escHtml(o.value)}" ${o.value === currentType ? 'selected' : ''}>${escHtml(o.label)}</option>`
+    ).join('');
+
+    const listHtml = items.length > 0
+      ? `<div class="card" style="padding:0">${items.map(notifCard).join('')}</div>`
+      : `<div class="empty-state">
+           <div class="empty-icon">&#128276;</div>
+           <p class="empty-title">${currentUnread ? 'No unread notifications' : 'No notifications yet'}</p>
+           <p class="empty-desc">
+             ${currentUnread
+               ? 'You are all caught up. <a href="/musehub/ui/notifications">View all notifications</a>.'
+               : 'Follow musicians, watch repos, and contribute to see notifications here.'}
+           </p>
+         </div>`;
+
+    document.getElementById('content').innerHTML = `
+      <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2);margin-bottom:var(--space-4)">
+        <h1 style="margin:0">
+          Notifications
+          ${total > 0 ? `<span style="font-size:14px;font-weight:400;color:var(--text-muted);margin-left:var(--space-2)">${total} total</span>` : ''}
+        </h1>
+        ${markAllBtn}
+      </div>
+
+      <p id="notif-error" style="color:var(--color-danger);font-size:13px"></p>
+
+      <div style="display:flex;align-items:center;gap:var(--space-3);flex-wrap:wrap;margin-bottom:var(--space-4)">
+        <label style="display:flex;align-items:center;gap:var(--space-2);font-size:13px;color:var(--text-muted)">
+          Type:
+          <select id="type-filter" onchange="applyFilters()"
+                  style="font-size:13px;padding:4px 8px;background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:6px;color:var(--text-primary)">
+            ${typeOptions}
+          </select>
+        </label>
+        <label style="display:flex;align-items:center;gap:var(--space-2);font-size:13px;color:var(--text-muted);cursor:pointer">
+          <input type="checkbox" id="unread-filter" ${currentUnread ? 'checked' : ''} onchange="applyFilters()">
+          Unread only
+        </label>
+      </div>
+
+      ${listHtml}
+      ${renderPagination(currentPage, totalPages)}`;
+
+  } catch (e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML =
+        '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+  }
+}
+
+loadNotifications();
+{% endraw %}
+{% endblock %}

--- a/tests/test_musehub_ui_notifications.py
+++ b/tests/test_musehub_ui_notifications.py
@@ -1,0 +1,398 @@
+"""Tests for the Muse Hub notification inbox UI page (ui_notifications.py).
+
+Covers issue #428 — GET /musehub/ui/notifications:
+
+HTML page (unauthenticated shell):
+- test_notifications_page_returns_200_html         — page renders without auth
+- test_notifications_page_contains_load_function   — loadNotifications() JS present
+- test_notifications_page_contains_filter_controls — type filter and unread-only controls
+- test_notifications_page_contains_mark_all_read   — markAllRead() JS function present
+- test_notifications_page_contains_mark_one_read   — markOneRead() JS function present
+- test_notifications_page_contains_pagination      — renderPagination() JS function present
+
+JSON alternate (authenticated):
+- test_notifications_json_requires_auth            — JSON path returns 401 without token
+- test_notifications_json_returns_empty_inbox      — authenticated user with no notifs
+- test_notifications_json_pagination               — per_page / page respected
+- test_notifications_json_type_filter_mention      — type=mention filters by event_type
+- test_notifications_json_type_filter_watch        — type=watch filters by event_type
+- test_notifications_json_type_filter_fork         — type=fork filters by event_type
+- test_notifications_json_unread_only              — unread_only=true excludes read items
+- test_notifications_json_mark_one_read_reflected  — read status respected in JSON response
+- test_notifications_json_unread_count_global      — unread_count not scoped by type filter
+- test_notifications_json_accept_header            — Accept: application/json triggers JSON path
+- test_notifications_json_pagination_metadata      — total / total_pages / page in response
+- test_notifications_json_empty_state_structure    — empty inbox returns valid schema
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import MusehubNotification
+
+_TEST_USER_ID = "550e8400-e29b-41d4-a716-446655440000"
+_UI_PATH = "/musehub/ui/notifications"
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_notif(
+    recipient_id: str,
+    event_type: str = "mention",
+    is_read: bool = False,
+    repo_id: str | None = None,
+) -> MusehubNotification:
+    return MusehubNotification(
+        notif_id=str(uuid.uuid4()),
+        recipient_id=recipient_id,
+        event_type=event_type,
+        repo_id=repo_id or str(uuid.uuid4()),
+        actor="some-actor",
+        payload={"ref": "main"},
+        is_read=is_read,
+        created_at=datetime.now(tz=timezone.utc),
+    )
+
+
+async def _seed(db: AsyncSession, *notifs: MusehubNotification) -> None:
+    for n in notifs:
+        db.add(n)
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# HTML page (unauthenticated shell)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_notifications_page_returns_200_html(client: AsyncClient) -> None:
+    """GET /musehub/ui/notifications returns 200 HTML without auth."""
+    resp = await client.get(_UI_PATH)
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_notifications_page_contains_load_function(client: AsyncClient) -> None:
+    """The HTML shell embeds the loadNotifications() JavaScript function."""
+    resp = await client.get(_UI_PATH)
+    assert resp.status_code == 200
+    assert "loadNotifications" in resp.text
+
+
+@pytest.mark.anyio
+async def test_notifications_page_contains_filter_controls(client: AsyncClient) -> None:
+    """The page includes type filter select and unread-only checkbox JS."""
+    resp = await client.get(_UI_PATH)
+    assert resp.status_code == 200
+    assert "type-filter" in resp.text
+    assert "unread-filter" in resp.text
+
+
+@pytest.mark.anyio
+async def test_notifications_page_contains_mark_all_read(client: AsyncClient) -> None:
+    """The page includes the markAllRead() JS function."""
+    resp = await client.get(_UI_PATH)
+    assert resp.status_code == 200
+    assert "markAllRead" in resp.text
+
+
+@pytest.mark.anyio
+async def test_notifications_page_contains_mark_one_read(client: AsyncClient) -> None:
+    """The page includes the markOneRead() JS function."""
+    resp = await client.get(_UI_PATH)
+    assert resp.status_code == 200
+    assert "markOneRead" in resp.text
+
+
+@pytest.mark.anyio
+async def test_notifications_page_contains_pagination(client: AsyncClient) -> None:
+    """The page includes renderPagination() for multi-page navigation."""
+    resp = await client.get(_UI_PATH)
+    assert resp.status_code == 200
+    assert "renderPagination" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# JSON alternate — unauthenticated guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_notifications_json_requires_auth(client: AsyncClient) -> None:
+    """JSON path returns 401 when no bearer token is provided."""
+    resp = await client.get(_UI_PATH, params={"format": "json"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_notifications_json_requires_auth_accept_header(
+    client: AsyncClient,
+) -> None:
+    """JSON path via Accept header also returns 401 without auth."""
+    resp = await client.get(
+        _UI_PATH, headers={"Accept": "application/json"}
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# JSON alternate — authenticated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_notifications_json_returns_empty_inbox(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Authenticated user with no notifications gets empty inbox."""
+    resp = await client.get(
+        _UI_PATH, params={"format": "json"}, headers=auth_headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["notifications"] == []
+    assert data["total"] == 0
+    assert data["unreadCount"] == 0
+
+
+@pytest.mark.anyio
+async def test_notifications_json_empty_state_structure(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Empty inbox JSON response has all required schema fields."""
+    resp = await client.get(
+        _UI_PATH, params={"format": "json"}, headers=auth_headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    required_fields = {
+        "notifications", "total", "page", "perPage",
+        "totalPages", "unreadCount", "typeFilter", "unreadOnly",
+    }
+    assert required_fields <= set(data.keys()), f"Missing fields: {required_fields - set(data.keys())}"
+
+
+@pytest.mark.anyio
+async def test_notifications_json_pagination(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """per_page and page query params are respected; page 2 returns correct slice."""
+    await _seed(db_session, *[_make_notif(_TEST_USER_ID) for _ in range(5)])
+
+    resp = await client.get(
+        _UI_PATH,
+        params={"format": "json", "per_page": 2, "page": 2},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["page"] == 2
+    assert data["perPage"] == 2
+    assert len(data["notifications"]) == 2
+    assert data["total"] == 5
+    assert data["totalPages"] == 3
+
+
+@pytest.mark.anyio
+async def test_notifications_json_pagination_metadata(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """total / total_pages / page metadata is correct on a single-page inbox."""
+    await _seed(db_session, _make_notif(_TEST_USER_ID))
+
+    resp = await client.get(
+        _UI_PATH, params={"format": "json"}, headers=auth_headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["totalPages"] == 1
+    assert data["page"] == 1
+
+
+@pytest.mark.anyio
+async def test_notifications_json_type_filter_mention(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """type=mention returns only mention events."""
+    await _seed(
+        db_session,
+        _make_notif(_TEST_USER_ID, event_type="mention"),
+        _make_notif(_TEST_USER_ID, event_type="fork"),
+    )
+    resp = await client.get(
+        _UI_PATH,
+        params={"format": "json", "type": "mention"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert all(n["eventType"] == "mention" for n in data["notifications"])
+    assert data["typeFilter"] == "mention"
+
+
+@pytest.mark.anyio
+async def test_notifications_json_type_filter_watch(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """type=watch returns only watch events."""
+    await _seed(
+        db_session,
+        _make_notif(_TEST_USER_ID, event_type="watch"),
+        _make_notif(_TEST_USER_ID, event_type="comment"),
+    )
+    resp = await client.get(
+        _UI_PATH,
+        params={"format": "json", "type": "watch"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert all(n["eventType"] == "watch" for n in data["notifications"])
+
+
+@pytest.mark.anyio
+async def test_notifications_json_type_filter_fork(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """type=fork returns only fork events."""
+    await _seed(
+        db_session,
+        _make_notif(_TEST_USER_ID, event_type="fork"),
+        _make_notif(_TEST_USER_ID, event_type="mention"),
+    )
+    resp = await client.get(
+        _UI_PATH,
+        params={"format": "json", "type": "fork"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert all(n["eventType"] == "fork" for n in data["notifications"])
+
+
+@pytest.mark.anyio
+async def test_notifications_json_unread_only(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """unread_only=true excludes already-read notifications."""
+    await _seed(
+        db_session,
+        _make_notif(_TEST_USER_ID, is_read=False),
+        _make_notif(_TEST_USER_ID, is_read=True),
+        _make_notif(_TEST_USER_ID, is_read=False),
+    )
+    resp = await client.get(
+        _UI_PATH,
+        params={"format": "json", "unread_only": "true"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    assert all(not n["isRead"] for n in data["notifications"])
+    assert data["unreadOnly"] is True
+
+
+@pytest.mark.anyio
+async def test_notifications_json_mark_one_read_reflected(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """Notification seeded as is_read=True appears with isRead=true in JSON."""
+    await _seed(db_session, _make_notif(_TEST_USER_ID, is_read=True))
+
+    resp = await client.get(
+        _UI_PATH, params={"format": "json"}, headers=auth_headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["notifications"]) == 1
+    assert data["notifications"][0]["isRead"] is True
+
+
+@pytest.mark.anyio
+async def test_notifications_json_unread_count_global(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """unread_count is the global count, not scoped by the active type filter."""
+    await _seed(
+        db_session,
+        _make_notif(_TEST_USER_ID, event_type="mention", is_read=False),
+        _make_notif(_TEST_USER_ID, event_type="fork", is_read=False),
+    )
+    # Filter to mention only — but unread_count must reflect BOTH unread items.
+    resp = await client.get(
+        _UI_PATH,
+        params={"format": "json", "type": "mention"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["unreadCount"] == 2
+
+
+@pytest.mark.anyio
+async def test_notifications_json_accept_header(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Accept: application/json triggers the JSON response path."""
+    headers = {**auth_headers, "Accept": "application/json"}
+    resp = await client.get(_UI_PATH, headers=headers)
+    assert resp.status_code == 200
+    assert "application/json" in resp.headers["content-type"]
+    data = resp.json()
+    assert "notifications" in data
+
+
+@pytest.mark.anyio
+async def test_notifications_json_only_own_notifications(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """Notifications for other users are not returned in the inbox."""
+    other_user_id = str(uuid.uuid4())
+    await _seed(
+        db_session,
+        _make_notif(_TEST_USER_ID),
+        _make_notif(other_user_id),   # belongs to a different user
+    )
+    resp = await client.get(
+        _UI_PATH, params={"format": "json"}, headers=auth_headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1


### PR DESCRIPTION
## Summary
Closes #428 — adds the authenticated notification inbox page at `GET /musehub/ui/notifications`.

## Root Cause / Motivation
MuseHub users had no web UI to browse their notifications (mentions, watches, forks, etc.).
The JSON API existed in `social.py` but there was no HTML inbox page with filtering, pagination, or mark-as-read controls.

## Solution

### New files
- **`maestro/api/routes/musehub/ui_notifications.py`** — FastAPI router auto-discovered by `musehub/__init__.py`.
  - `GET /musehub/ui/notifications` — HTML or JSON (content negotiation via `?format=json` / `Accept: application/json`)
  - HTML shell: public (no JWT at route level); the browser can prompt for a JWT before loading data
  - JSON path: enforces `optional_token` + explicit 401 guard — personal data is never leaked unauthenticated
  - Query params: `type` (mention/watch/fork/…), `unread_only`, `page`, `per_page`
  - `NotificationItem` and `NotificationsPageResponse` Pydantic models with `alias_generator=to_camel` for consistent camelCase JSON keys
  - `unread_count` is always the global count (unscoped by type filter) so nav badge displays stay accurate

- **`maestro/templates/musehub/pages/notifications.html`** — Jinja2 template extending `musehub/base.html`.
  - `loadNotifications()` — fetches from `/musehub/ui/notifications?format=json` with `fetch()` + `authHeaders()` (bypasses `apiFetch` which would prepend `/api/v1/musehub`)
  - `markOneRead()` — POST `/notifications/{id}/read`, updates card styling in-place
  - `markAllRead()` — POST `/notifications/read-all`, resets nav badge to 0
  - `renderPagination()` — Prev/Next buttons with page count indicator
  - `applyFilters()` / `pushState()` — filter changes update URL without full reload
  - Type filter: All, Mentions, Watches, Forks, Comments, PRs, Issues, Commits, Followers

### Modified files
- **`maestro/main.py`** — registers `ui_notifications.router` **before** `musehub_ui_routes.fixed_router` so the concrete `/notifications` path is matched before the `/{username}` catch-all in `fixed_router`

### Tests (`tests/test_musehub_ui_notifications.py`) — 20 tests
- HTML shell returns 200 without auth; contains `loadNotifications`, `markAllRead`, `markOneRead`, `renderPagination`, `type-filter`, `unread-filter`
- JSON path returns 401 without token (both `?format=json` and `Accept: application/json`)
- Pagination: `per_page` / `page` respected; `total_pages` accurate
- Type filters: `mention`, `watch`, `fork` each isolate the correct events
- `unread_only=true` excludes read notifications
- `unread_count` is global (not scoped by type filter)
- Only the calling user's notifications are returned

## Verification
- [x] mypy clean (658 → 660 files, 0 errors)
- [x] All 20 tests pass
- [x] Clean merge with `origin/dev` (no conflicts)
- [x] Router registered before `/{username}` catch-all to prevent shadowing