### PR TITLE
feat: repo settings page with danger zone (/{owner}/{repo}/settings)

### DIFF
--- a/maestro/api/routes/musehub/ui_settings.py
+++ b/maestro/api/routes/musehub/ui_settings.py
@@ -23,8 +23,11 @@ Auth contract:
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import status as http_status
+from fastapi.templating import Jinja2Templates
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import Response
 
@@ -36,9 +39,6 @@ from maestro.services import musehub_repository
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/musehub/ui", tags=["musehub-ui-settings"])
-
-from pathlib import Path
-from fastapi.templating import Jinja2Templates
 
 _TEMPLATE_DIR = Path(__file__).parent.parent.parent.parent / "templates"
 _templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
@@ -95,8 +95,6 @@ async def settings_page(
     """
     row = await musehub_repository.get_repo_orm_by_owner_slug(db, owner, repo_slug)
     if row is None:
-        from fastapi import HTTPException
-        from fastapi import status as http_status
         raise HTTPException(
             status_code=http_status.HTTP_404_NOT_FOUND,
             detail=f"Repo '{owner}/{repo_slug}' not found",

--- a/maestro/api/routes/musehub/ui_settings.py
+++ b/maestro/api/routes/musehub/ui_settings.py
@@ -1,0 +1,126 @@
+"""Muse Hub repo settings page routes.
+
+Serves the repository settings UI at ``/{owner}/{repo_slug}/settings``.
+The page is split into four sidebar sections:
+
+- **General** — name, description, homepage URL, topics, license, visibility.
+- **Collaboration** — collaborator management panel.
+- **Merge Settings** — merge/squash/rebase strategy toggles and auto-delete option.
+- **Danger Zone** — archive, transfer ownership, and delete repo (with name confirmation).
+
+Content negotiation:
+- HTML (default): full interactive settings page via Jinja2 template.
+- JSON (``Accept: application/json`` or ``?format=json``): returns
+  ``RepoSettingsResponse`` — same model as the API endpoint
+  ``GET /api/v1/musehub/repos/{repo_id}/settings``.
+
+Auth contract:
+- The HTML shell requires no JWT to render.  Client-side JavaScript reads the
+  JWT from ``localStorage`` and fetches/patches settings via the API.
+- Write operations (rename, visibility change, delete) call the authed API
+  endpoints and are rejected with 401/403 by the API when unauthenticated.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response
+
+from maestro.api.routes.musehub.negotiate import negotiate_response
+from maestro.db import get_db
+from maestro.models.musehub import RepoSettingsResponse
+from maestro.services import musehub_repository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/musehub/ui", tags=["musehub-ui-settings"])
+
+from pathlib import Path
+from fastapi.templating import Jinja2Templates
+
+_TEMPLATE_DIR = Path(__file__).parent.parent.parent.parent / "templates"
+_templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+
+def _base_url(owner: str, repo_slug: str) -> str:
+    """Return the canonical UI base URL for a repo."""
+    return f"/musehub/ui/{owner}/{repo_slug}"
+
+
+@router.get(
+    "/{owner}/{repo_slug}/settings",
+    summary="Muse Hub repo settings page",
+)
+async def settings_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    section: str = Query(
+        "general",
+        pattern="^(general|collaboration|merge|danger)$",
+        description="Settings sidebar section to show on load",
+    ),
+    format: str | None = Query(None, description="Force response format: 'json' or omit for HTML"),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Render the repo settings page or return current settings as JSON.
+
+    Why this exists: all mutable repo properties — visibility, name, merge
+    strategy, collaborators, and destructive operations — live in one place,
+    mirroring GitHub's ``/{owner}/{repo}/settings`` pattern so musicians
+    and agents have a predictable entry point for administrative changes.
+
+    HTML sections (sidebar navigation):
+    - ``general``       — Basic identity: name, description, URL, topics, license, visibility.
+    - ``collaboration`` — Invite/remove collaborators; set per-collaborator permissions.
+    - ``merge``         — Enable/disable merge commit, squash, and rebase merge strategies;
+                          toggle auto-delete of head branch after merge.
+    - ``danger``        — Archive repo (read-only), transfer to another owner,
+                          delete repo (requires typing the full repo name to confirm).
+
+    Content negotiation:
+    - HTML (default): interactive settings shell; JS fetches
+      ``GET /api/v1/musehub/repos/{repo_id}/settings`` and patches via
+      ``PATCH /api/v1/musehub/repos/{repo_id}/settings``.
+    - JSON (``Accept: application/json`` or ``?format=json``): returns the
+      current ``RepoSettingsResponse`` for programmatic inspection.
+
+    The ``?section=`` param pre-scrolls the sidebar to the requested section
+    on load, so deep-links like ``?section=danger`` work without JS.
+
+    No JWT required to render the HTML shell.  All write operations require
+    a valid owner/admin JWT, enforced by the API layer.
+    """
+    row = await musehub_repository.get_repo_orm_by_owner_slug(db, owner, repo_slug)
+    if row is None:
+        from fastapi import HTTPException
+        from fastapi import status as http_status
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=f"Repo '{owner}/{repo_slug}' not found",
+        )
+
+    repo_id = str(row.repo_id)
+    base_url = _base_url(owner, repo_slug)
+
+    settings: RepoSettingsResponse | None = await musehub_repository.get_repo_settings(
+        db, repo_id
+    )
+
+    return await negotiate_response(
+        request=request,
+        template_name="musehub/pages/settings.html",
+        context={
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "base_url": base_url,
+            "active_section": section,
+            "current_page": "settings",
+        },
+        templates=_templates,
+        json_data=settings,
+        format_param=format,
+    )

--- a/maestro/main.py
+++ b/maestro/main.py
@@ -25,6 +25,7 @@ from slowapi.errors import RateLimitExceeded
 from maestro.config import settings
 from maestro.api.routes import maestro, maestro_ui, health, users, conversations, assets, variation, muse, musehub
 from maestro.api.routes.musehub import ui as musehub_ui_routes
+from maestro.api.routes.musehub import ui_settings as musehub_ui_settings_routes
 from maestro.api.routes.musehub import discover as musehub_discover_routes
 from maestro.api.routes.musehub import users as musehub_user_routes
 from maestro.api.routes.musehub import oembed as musehub_oembed_routes
@@ -219,6 +220,7 @@ app.include_router(musehub.router, prefix="/api/v1")
 # UI routers: fixed-path routes (users, explore, trending) first, then wildcards.
 app.include_router(musehub_ui_routes.fixed_router, tags=["musehub-ui"])
 app.include_router(musehub_ui_routes.router, tags=["musehub-ui"])
+app.include_router(musehub_ui_settings_routes.router, tags=["musehub-ui-settings"])
 app.include_router(musehub_oembed_routes.router, tags=["musehub-oembed"])
 app.include_router(musehub_raw_routes.router, prefix="/api/v1", tags=["musehub-raw"])
 app.include_router(mcp_routes.router, prefix="/api/v1/mcp", tags=["mcp"])

--- a/maestro/templates/musehub/pages/settings.html
+++ b/maestro/templates/musehub/pages/settings.html
@@ -1,0 +1,690 @@
+{% extends "musehub/base.html" %}
+{% block title %}Settings · {{ owner }}/{{ repo_slug }}{% endblock %}
+{% block extra_css %}
+<style>
+.settings-layout {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: var(--space-5);
+  align-items: start;
+}
+@media (max-width: 700px) {
+  .settings-layout { grid-template-columns: 1fr; }
+  .settings-sidebar { display: flex; flex-wrap: wrap; gap: var(--space-2); border-right: none; padding-right: 0; border-bottom: 1px solid var(--border-subtle); padding-bottom: var(--space-3); margin-bottom: var(--space-3); }
+}
+.settings-sidebar {
+  border-right: 1px solid var(--border-subtle);
+  padding-right: var(--space-4);
+  position: sticky;
+  top: 72px;
+}
+.settings-nav-link {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md, 6px);
+  font-size: var(--font-size-sm, 13px);
+  color: var(--text-primary);
+  text-decoration: none;
+  margin-bottom: 2px;
+  cursor: pointer;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+}
+.settings-nav-link:hover { background: var(--bg-overlay); }
+.settings-nav-link.active { background: var(--bg-overlay); font-weight: 600; color: var(--color-accent); }
+.settings-nav-group { margin-bottom: var(--space-3); }
+.settings-nav-group-label {
+  font-size: var(--font-size-xs, 11px);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0 var(--space-3);
+  margin-bottom: var(--space-1);
+}
+.settings-section { display: none; }
+.settings-section.active { display: block; }
+.form-group { margin-bottom: var(--space-4); }
+.form-label { display: block; font-size: var(--font-size-sm, 13px); font-weight: 600; margin-bottom: var(--space-1); color: var(--text-primary); }
+.form-description { font-size: var(--font-size-xs, 11px); color: var(--text-muted); margin-bottom: var(--space-2); }
+.form-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 10px;
+  background: var(--bg-surface, #0d1117);
+  border: 1px solid var(--border-default, #30363d);
+  border-radius: var(--radius-md, 6px);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm, 13px);
+}
+.form-input:focus { outline: none; border-color: var(--color-accent); box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 25%, transparent); }
+.form-checkbox-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  background: var(--bg-surface, #0d1117);
+  border: 1px solid var(--border-subtle, #21262d);
+  border-radius: var(--radius-md, 6px);
+  margin-bottom: var(--space-2);
+}
+.form-checkbox-row input[type=checkbox] { margin-top: 2px; flex-shrink: 0; }
+.form-checkbox-label { font-size: var(--font-size-sm, 13px); font-weight: 600; color: var(--text-primary); }
+.form-checkbox-desc { font-size: var(--font-size-xs, 11px); color: var(--text-muted); margin-top: 2px; }
+.danger-zone {
+  border: 1px solid #f85149;
+  border-radius: var(--radius-md, 6px);
+  overflow: hidden;
+}
+.danger-zone-header {
+  background: rgba(248,81,73,0.08);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid #f8514920;
+  font-size: 14px;
+  font-weight: 600;
+  color: #f85149;
+}
+.danger-action-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+  gap: var(--space-4);
+}
+.danger-action-row:last-child { border-bottom: none; }
+.danger-action-info { flex: 1; }
+.danger-action-title { font-size: var(--font-size-sm, 13px); font-weight: 600; color: var(--text-primary); }
+.danger-action-desc { font-size: var(--font-size-xs, 11px); color: var(--text-muted); margin-top: 2px; }
+.confirm-modal-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  z-index: 1000;
+  align-items: center;
+  justify-content: center;
+}
+.confirm-modal-overlay.open { display: flex; }
+.confirm-modal {
+  background: var(--bg-canvas, #0d1117);
+  border: 1px solid var(--border-default, #30363d);
+  border-radius: var(--radius-lg, 12px);
+  padding: var(--space-5);
+  max-width: 440px;
+  width: 90%;
+}
+.confirm-modal h3 { margin: 0 0 var(--space-3); font-size: 16px; color: #f85149; }
+.confirm-modal p { font-size: var(--font-size-sm, 13px); color: var(--text-muted); margin-bottom: var(--space-3); }
+.confirm-modal-actions { display: flex; gap: var(--space-3); justify-content: flex-end; margin-top: var(--space-4); }
+.tag-input-container { display: flex; flex-wrap: wrap; gap: 6px; padding: 6px 8px; background: var(--bg-surface, #0d1117); border: 1px solid var(--border-default, #30363d); border-radius: var(--radius-md, 6px); cursor: text; }
+.tag-pill { display: inline-flex; align-items: center; gap: 4px; background: var(--bg-overlay); border-radius: 20px; padding: 2px 8px; font-size: 12px; color: var(--text-primary); }
+.tag-pill-remove { cursor: pointer; color: var(--text-muted); font-size: 14px; line-height: 1; background: none; border: none; padding: 0; }
+.tag-pill-remove:hover { color: #f85149; }
+.tag-text-input { border: none; outline: none; background: transparent; color: var(--text-primary); font-size: var(--font-size-sm, 13px); min-width: 80px; flex: 1; }
+</style>
+{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}">{{ owner }}</a> /
+  <a href="{{ base_url }}">{{ repo_slug }}</a> /
+  Settings
+{% endblock %}
+
+{% block repo_nav %}
+{% include "musehub/partials/repo_nav.html" %}
+{% endblock %}
+
+{% block page_data %}
+const repoId      = {{ repo_id | tojson }};
+const owner       = {{ owner | tojson }};
+const repoSlug    = {{ repo_slug | tojson }};
+const base        = {{ base_url | tojson }};
+const apiBase     = '/api/v1/musehub/repos/' + repoId;
+const activeSection = {{ active_section | tojson }};
+{% endblock %}
+
+{% block token_form %}
+<div class="token-form" id="token-form" style="display:none">
+  <p id="token-msg">Enter your Maestro JWT to manage this repo's settings.</p>
+  <input type="password" id="token-input" placeholder="eyJ..." />
+  <button class="btn btn-primary" onclick="saveToken()">Save &amp; Load</button>
+  &nbsp;
+  <button class="btn btn-secondary" onclick="clearToken();location.reload()">Clear</button>
+</div>
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+// ── State ─────────────────────────────────────────────────────────────────────
+let _settings  = null;
+let _topics    = [];
+let _activeSection = activeSection || 'general';
+
+// ── Sidebar navigation ────────────────────────────────────────────────────────
+function activateSection(name) {
+  _activeSection = name;
+  document.querySelectorAll('.settings-nav-link').forEach(el => {
+    el.classList.toggle('active', el.dataset.section === name);
+  });
+  document.querySelectorAll('.settings-section').forEach(el => {
+    el.classList.toggle('active', el.id === 'section-' + name);
+  });
+  history.replaceState(null, '', '?section=' + encodeURIComponent(name));
+}
+
+// ── Topic tag input ───────────────────────────────────────────────────────────
+function renderTopics() {
+  const container = document.getElementById('topics-container');
+  if (!container) return;
+  const pills = _topics.map((t, i) =>
+    `<span class="tag-pill">
+      ${escHtml(t)}
+      <button class="tag-pill-remove" onclick="removeTopic(${i})" title="Remove">&times;</button>
+    </span>`
+  ).join('');
+  const input = '<input class="tag-text-input" id="topic-input" placeholder="Add topic…" onkeydown="onTopicKey(event)" maxlength="50">';
+  container.innerHTML = pills + input;
+  // Re-focus after render if user typed
+}
+
+function onTopicKey(e) {
+  if (e.key === 'Enter' || e.key === ',') {
+    e.preventDefault();
+    const val = e.target.value.trim().toLowerCase().replace(/[^a-z0-9-]/g, '-');
+    if (val && !_topics.includes(val) && _topics.length < 20) {
+      _topics.push(val);
+      renderTopics();
+      const inp = document.getElementById('topic-input');
+      if (inp) inp.focus();
+    }
+  } else if (e.key === 'Backspace' && e.target.value === '' && _topics.length > 0) {
+    _topics.pop();
+    renderTopics();
+    const inp = document.getElementById('topic-input');
+    if (inp) inp.focus();
+  }
+}
+
+function removeTopic(i) {
+  _topics.splice(i, 1);
+  renderTopics();
+}
+
+// ── Save helpers ──────────────────────────────────────────────────────────────
+function showMsg(id, text, isError) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.textContent = text;
+  el.style.color = isError ? '#f85149' : '#3fb950';
+  el.style.display = 'block';
+  setTimeout(() => { el.style.display = 'none'; }, 5000);
+}
+
+async function patchSettings(patch, msgId) {
+  try {
+    const token = getToken();
+    if (!token) {
+      showMsg(msgId, '⚠️ A JWT is required to save settings.', true);
+      return false;
+    }
+    const resp = await fetch(apiBase + '/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+      body: JSON.stringify(patch),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ detail: resp.statusText }));
+      showMsg(msgId, '❌ ' + (err.detail || 'Failed to save.'), true);
+      return false;
+    }
+    showMsg(msgId, '✅ Saved.', false);
+    return true;
+  } catch (e) {
+    showMsg(msgId, '❌ ' + e.message, true);
+    return false;
+  }
+}
+
+// ── General section ───────────────────────────────────────────────────────────
+async function saveGeneral(e) {
+  e.preventDefault();
+  const name        = document.getElementById('s-name').value.trim();
+  const description = document.getElementById('s-description').value.trim();
+  const homepageUrl = document.getElementById('s-homepage').value.trim() || null;
+  const visibility  = document.getElementById('s-visibility').value;
+  const license     = document.getElementById('s-license').value.trim() || null;
+  if (!name) { showMsg('general-msg', '⚠️ Repo name is required.', true); return; }
+  const ok = await patchSettings({ name, description, homepageUrl, visibility, license, topics: _topics }, 'general-msg');
+  if (ok) {
+    _settings.name        = name;
+    _settings.description = description;
+    _settings.homepageUrl = homepageUrl;
+    _settings.visibility  = visibility;
+    _settings.license     = license;
+    _settings.topics      = [..._topics];
+    document.title = 'Settings · ' + escHtml(owner) + '/' + escHtml(name) + ' — Muse Hub';
+  }
+}
+
+// ── Merge settings section ────────────────────────────────────────────────────
+async function saveMerge(e) {
+  e.preventDefault();
+  const patch = {
+    allowMergeCommit:    document.getElementById('s-merge-commit').checked,
+    allowSquashMerge:    document.getElementById('s-squash-merge').checked,
+    allowRebaseMerge:    document.getElementById('s-rebase-merge').checked,
+    deleteBranchOnMerge: document.getElementById('s-delete-branch').checked,
+  };
+  await patchSettings(patch, 'merge-msg');
+}
+
+// ── Danger zone actions ───────────────────────────────────────────────────────
+function openModal(id) {
+  const overlay = document.getElementById(id);
+  if (overlay) overlay.classList.add('open');
+}
+
+function closeModal(id) {
+  const overlay = document.getElementById(id);
+  if (overlay) {
+    overlay.classList.remove('open');
+    // Clear any confirmation inputs
+    const inp = overlay.querySelector('.confirm-name-input');
+    if (inp) inp.value = '';
+  }
+}
+
+async function archiveRepo() {
+  const ok = await patchSettings({ archived: true }, 'danger-msg');
+  if (ok) {
+    closeModal('modal-archive');
+    window.location.href = base;
+  }
+}
+
+async function deleteRepo() {
+  const input = document.getElementById('confirm-delete-name');
+  const expected = owner + '/' + repoSlug;
+  if (!input || input.value.trim() !== expected) {
+    document.getElementById('delete-name-error').style.display = 'block';
+    return;
+  }
+  try {
+    const token = getToken();
+    if (!token) { showMsg('danger-msg', '⚠️ A JWT is required.', true); return; }
+    const resp = await fetch(apiBase, {
+      method: 'DELETE',
+      headers: { 'Authorization': 'Bearer ' + token },
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ detail: resp.statusText }));
+      showMsg('danger-msg', '❌ ' + (err.detail || 'Delete failed.'), true);
+      closeModal('modal-delete');
+      return;
+    }
+    closeModal('modal-delete');
+    window.location.href = '/musehub/ui/' + encodeURIComponent(owner);
+  } catch (e) {
+    showMsg('danger-msg', '❌ ' + e.message, true);
+    closeModal('modal-delete');
+  }
+}
+
+async function transferOwnership() {
+  const newOwner = document.getElementById('confirm-transfer-owner').value.trim();
+  if (!newOwner) {
+    document.getElementById('transfer-owner-error').textContent = 'New owner username is required.';
+    document.getElementById('transfer-owner-error').style.display = 'block';
+    return;
+  }
+  try {
+    const token = getToken();
+    if (!token) { showMsg('danger-msg', '⚠️ A JWT is required.', true); return; }
+    const resp = await fetch(apiBase + '/transfer', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+      body: JSON.stringify({ newOwner }),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ detail: resp.statusText }));
+      document.getElementById('transfer-owner-error').textContent = err.detail || 'Transfer failed.';
+      document.getElementById('transfer-owner-error').style.display = 'block';
+      return;
+    }
+    closeModal('modal-transfer');
+    window.location.href = '/musehub/ui/' + encodeURIComponent(newOwner) + '/' + encodeURIComponent(repoSlug);
+  } catch (e) {
+    document.getElementById('transfer-owner-error').textContent = e.message;
+    document.getElementById('transfer-owner-error').style.display = 'block';
+  }
+}
+
+// ── Main loader ───────────────────────────────────────────────────────────────
+async function load() {
+  initRepoNav(repoId);
+
+  try {
+    _settings = await apiFetch('/repos/' + repoId + '/settings');
+  } catch (e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML = '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+    return;
+  }
+
+  _topics = Array.isArray(_settings.topics) ? [..._settings.topics] : [];
+
+  const visOpts = ['public', 'private'].map(v =>
+    `<option value="${v}"${_settings.visibility === v ? ' selected' : ''}>${v.charAt(0).toUpperCase() + v.slice(1)}</option>`
+  ).join('');
+
+  document.getElementById('content').innerHTML = `
+    <div class="settings-layout">
+      <!-- Sidebar -->
+      <nav class="settings-sidebar" aria-label="Settings navigation">
+        <div class="settings-nav-group">
+          <div class="settings-nav-group-label">Repository</div>
+          <button class="settings-nav-link" data-section="general" onclick="activateSection('general')">General</button>
+          <button class="settings-nav-link" data-section="collaboration" onclick="activateSection('collaboration')">Collaboration</button>
+          <button class="settings-nav-link" data-section="merge" onclick="activateSection('merge')">Merge settings</button>
+        </div>
+        <div class="settings-nav-group">
+          <div class="settings-nav-group-label">Risk</div>
+          <button class="settings-nav-link" data-section="danger" onclick="activateSection('danger')"
+                  style="color:#f85149">Danger Zone</button>
+        </div>
+      </nav>
+
+      <!-- Content panels -->
+      <div class="settings-content">
+
+        <!-- ── General ──────────────────────────────────────────────────────── -->
+        <section id="section-general" class="settings-section">
+          <div class="card">
+            <h2 style="margin-bottom:var(--space-4)">General Settings</h2>
+            <form id="form-general" onsubmit="saveGeneral(event)">
+              <div class="form-group">
+                <label class="form-label" for="s-name">Repository name</label>
+                <div class="form-description">The name used in URLs. Changing it will redirect old links.</div>
+                <input class="form-input" id="s-name" type="text" value="${escHtml(_settings.name)}" required maxlength="100" pattern="[a-zA-Z0-9._-]+" title="Alphanumeric, hyphens, underscores, dots only">
+              </div>
+
+              <div class="form-group">
+                <label class="form-label" for="s-description">Description</label>
+                <div class="form-description">A short description shown on your repo's home page and explore grid.</div>
+                <input class="form-input" id="s-description" type="text" value="${escHtml(_settings.description || '')}" maxlength="350">
+              </div>
+
+              <div class="form-group">
+                <label class="form-label" for="s-homepage">Website URL</label>
+                <div class="form-description">A link to your project's home page, portfolio, or streaming platform.</div>
+                <input class="form-input" id="s-homepage" type="url" value="${escHtml(_settings.homepageUrl || '')}" placeholder="https://example.com">
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Topics</label>
+                <div class="form-description">Free-form keyword tags that help listeners discover your repo. Press <kbd>Enter</kbd> or <kbd>,</kbd> to add.</div>
+                <div class="tag-input-container" id="topics-container" onclick="document.getElementById('topic-input') && document.getElementById('topic-input').focus()"></div>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label" for="s-license">License</label>
+                <div class="form-description">SPDX identifier or display name (e.g. <code>CC BY 4.0</code>, <code>MIT</code>).</div>
+                <input class="form-input" id="s-license" type="text" value="${escHtml(_settings.license || '')}" placeholder="CC BY 4.0" maxlength="100">
+              </div>
+
+              <div class="form-group">
+                <label class="form-label" for="s-visibility">Visibility</label>
+                <div class="form-description">Public repos are visible to everyone. Private repos are only visible to you and your collaborators.</div>
+                <select class="form-input" id="s-visibility">${visOpts}</select>
+              </div>
+
+              <div style="display:flex;align-items:center;gap:var(--space-3)">
+                <button class="btn btn-primary" type="submit">Save changes</button>
+                <span id="general-msg" style="font-size:13px;display:none"></span>
+              </div>
+            </form>
+          </div>
+        </section>
+
+        <!-- ── Collaboration ─────────────────────────────────────────────────── -->
+        <section id="section-collaboration" class="settings-section">
+          <div class="card">
+            <h2 style="margin-bottom:var(--space-2)">Collaborators</h2>
+            <p class="form-description" style="margin-bottom:var(--space-4)">
+              Manage who has access to this repository. Collaborators can push commits,
+              review pull requests, and manage issues depending on their permission level.
+            </p>
+            <div id="collaborators-list"><p class="loading">Loading collaborators&#8230;</p></div>
+
+            <div style="margin-top:var(--space-5);padding-top:var(--space-4);border-top:1px solid var(--border-subtle)">
+              <h3 style="margin-bottom:var(--space-3)">Invite a collaborator</h3>
+              <div style="display:flex;gap:var(--space-3)">
+                <input class="form-input" id="invite-username" type="text" placeholder="GitHub username" style="max-width:260px">
+                <select class="form-input" id="invite-role" style="max-width:140px">
+                  <option value="read">Read</option>
+                  <option value="write" selected>Write</option>
+                  <option value="admin">Admin</option>
+                </select>
+                <button class="btn btn-primary" onclick="inviteCollaborator()">Invite</button>
+              </div>
+              <span id="invite-msg" style="font-size:13px;display:none;margin-top:8px;display:none"></span>
+            </div>
+          </div>
+        </section>
+
+        <!-- ── Merge settings ────────────────────────────────────────────────── -->
+        <section id="section-merge" class="settings-section">
+          <div class="card">
+            <h2 style="margin-bottom:var(--space-2)">Merge settings</h2>
+            <p class="form-description" style="margin-bottom:var(--space-4)">
+              Choose which merge strategies are allowed when merging pull requests.
+              At least one strategy must remain enabled.
+            </p>
+            <form id="form-merge" onsubmit="saveMerge(event)">
+              <div class="form-checkbox-row">
+                <input type="checkbox" id="s-merge-commit" ${_settings.allowMergeCommit ? 'checked' : ''}>
+                <div>
+                  <div class="form-checkbox-label">Allow merge commits</div>
+                  <div class="form-checkbox-desc">Add all commits from the head branch to the base branch with a merge commit.</div>
+                </div>
+              </div>
+              <div class="form-checkbox-row">
+                <input type="checkbox" id="s-squash-merge" ${_settings.allowSquashMerge ? 'checked' : ''}>
+                <div>
+                  <div class="form-checkbox-label">Allow squash merging</div>
+                  <div class="form-checkbox-desc">Combine all commits from the head branch into a single commit before merging.</div>
+                </div>
+              </div>
+              <div class="form-checkbox-row">
+                <input type="checkbox" id="s-rebase-merge" ${_settings.allowRebaseMerge ? 'checked' : ''}>
+                <div>
+                  <div class="form-checkbox-label">Allow rebase merging</div>
+                  <div class="form-checkbox-desc">Add all commits from the head branch individually to the base branch.</div>
+                </div>
+              </div>
+              <div class="form-checkbox-row" style="margin-top:var(--space-4)">
+                <input type="checkbox" id="s-delete-branch" ${_settings.deleteBranchOnMerge ? 'checked' : ''}>
+                <div>
+                  <div class="form-checkbox-label">Automatically delete head branches</div>
+                  <div class="form-checkbox-desc">After pull requests are merged, delete head branches automatically.</div>
+                </div>
+              </div>
+              <div style="display:flex;align-items:center;gap:var(--space-3);margin-top:var(--space-4)">
+                <button class="btn btn-primary" type="submit">Save merge settings</button>
+                <span id="merge-msg" style="font-size:13px;display:none"></span>
+              </div>
+            </form>
+          </div>
+        </section>
+
+        <!-- ── Danger Zone ───────────────────────────────────────────────────── -->
+        <section id="section-danger" class="settings-section">
+          <span id="danger-msg" style="font-size:13px;display:none;margin-bottom:var(--space-3)"></span>
+          <div class="danger-zone">
+            <div class="danger-zone-header">&#9888; Danger Zone</div>
+
+            <div class="danger-action-row">
+              <div class="danger-action-info">
+                <div class="danger-action-title">Archive this repository</div>
+                <div class="danger-action-desc">Mark this repo as read-only. Commits, pull requests, and issues will be disabled. This can be reversed.</div>
+              </div>
+              <button class="btn" style="border:1px solid #f85149;color:#f85149;white-space:nowrap" onclick="openModal('modal-archive')">Archive repository</button>
+            </div>
+
+            <div class="danger-action-row">
+              <div class="danger-action-info">
+                <div class="danger-action-title">Transfer ownership</div>
+                <div class="danger-action-desc">Transfer this repository to another user or organisation. You will lose owner access.</div>
+              </div>
+              <button class="btn" style="border:1px solid #f85149;color:#f85149;white-space:nowrap" onclick="openModal('modal-transfer')">Transfer ownership</button>
+            </div>
+
+            <div class="danger-action-row">
+              <div class="danger-action-info">
+                <div class="danger-action-title">Delete this repository</div>
+                <div class="danger-action-desc">Once deleted, this repository and all its data cannot be recovered. Think twice.</div>
+              </div>
+              <button class="btn" style="background:#f85149;color:#fff;border:none;white-space:nowrap" onclick="openModal('modal-delete')">Delete repository</button>
+            </div>
+          </div>
+        </section>
+
+      </div><!-- /.settings-content -->
+    </div><!-- /.settings-layout -->
+
+    <!-- ── Archive confirmation modal ──────────────────────────────────────── -->
+    <div class="confirm-modal-overlay" id="modal-archive">
+      <div class="confirm-modal">
+        <h3>&#9888; Archive repository?</h3>
+        <p>Archiving makes the repository read-only. Commits, issues, and pull requests will be disabled. You can unarchive later from this settings page.</p>
+        <div class="confirm-modal-actions">
+          <button class="btn btn-secondary" onclick="closeModal('modal-archive')">Cancel</button>
+          <button class="btn" style="background:#f85149;color:#fff;border:none" onclick="archiveRepo()">Archive</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Transfer confirmation modal ─────────────────────────────────────── -->
+    <div class="confirm-modal-overlay" id="modal-transfer">
+      <div class="confirm-modal">
+        <h3>Transfer ownership</h3>
+        <p>Enter the username of the new owner. You will lose owner access to this repository and all its data will be transferred.</p>
+        <div class="form-group">
+          <label class="form-label" for="confirm-transfer-owner">New owner username</label>
+          <input class="form-input confirm-name-input" id="confirm-transfer-owner" type="text" placeholder="username" autocomplete="off">
+          <span id="transfer-owner-error" style="font-size:12px;color:#f85149;display:none;margin-top:4px;display:none"></span>
+        </div>
+        <div class="confirm-modal-actions">
+          <button class="btn btn-secondary" onclick="closeModal('modal-transfer')">Cancel</button>
+          <button class="btn" style="background:#f85149;color:#fff;border:none" onclick="transferOwnership()">Transfer</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Delete confirmation modal ────────────────────────────────────────── -->
+    <div class="confirm-modal-overlay" id="modal-delete">
+      <div class="confirm-modal">
+        <h3>&#128465; Delete repository?</h3>
+        <p>This action <strong>cannot be undone</strong>. All commits, pull requests, issues, and objects will be permanently deleted.</p>
+        <div class="form-group">
+          <label class="form-label" for="confirm-delete-name">
+            Type <code>${escHtml(owner + '/' + repoSlug)}</code> to confirm
+          </label>
+          <input class="form-input confirm-name-input" id="confirm-delete-name" type="text" placeholder="${escHtml(owner + '/' + repoSlug)}" autocomplete="off">
+          <span id="delete-name-error" style="font-size:12px;color:#f85149;display:none;margin-top:4px">
+            The name you entered does not match.
+          </span>
+        </div>
+        <div class="confirm-modal-actions">
+          <button class="btn btn-secondary" onclick="closeModal('modal-delete')">Cancel</button>
+          <button class="btn" style="background:#f85149;color:#fff;border:none" onclick="deleteRepo()">Delete forever</button>
+        </div>
+      </div>
+    </div>
+  `;
+
+  // Render topics tag-input
+  renderTopics();
+
+  // Load collaborators
+  loadCollaborators();
+
+  // Activate the section requested in the URL
+  activateSection(_activeSection);
+}
+
+// ── Collaborators loader ──────────────────────────────────────────────────────
+async function loadCollaborators() {
+  const el = document.getElementById('collaborators-list');
+  if (!el) return;
+  try {
+    const data = await apiFetch('/repos/' + repoId + '/collaborators');
+    const collabs = data.collaborators || [];
+    if (collabs.length === 0) {
+      el.innerHTML = '<p class="text-muted text-sm">No collaborators yet. Invite someone below.</p>';
+      return;
+    }
+    el.innerHTML = collabs.map(c => `
+      <div style="display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) 0;border-bottom:1px solid var(--border-subtle)">
+        <div style="flex:1">
+          <a href="/musehub/ui/users/${escHtml(c.username)}" class="text-sm" style="font-weight:500">${escHtml(c.username)}</a>
+          <span class="badge badge-${c.role === 'admin' ? 'open' : 'inactive'}" style="font-size:10px;margin-left:6px">${escHtml(c.role)}</span>
+        </div>
+        <button class="btn btn-secondary btn-sm" onclick="removeCollaborator('${escHtml(c.username)}')">Remove</button>
+      </div>`
+    ).join('');
+  } catch (e) {
+    if (e.message !== 'auth')
+      el.innerHTML = '<p class="error text-sm">Could not load collaborators.</p>';
+  }
+}
+
+async function inviteCollaborator() {
+  const username = document.getElementById('invite-username').value.trim();
+  const role     = document.getElementById('invite-role').value;
+  const msgEl    = document.getElementById('invite-msg');
+  if (!username) return;
+  try {
+    const token = getToken();
+    if (!token) { showMsg('invite-msg', '⚠️ JWT required.', true); return; }
+    const resp = await fetch(apiBase + '/collaborators', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+      body: JSON.stringify({ username, role }),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ detail: resp.statusText }));
+      showMsg('invite-msg', '❌ ' + (err.detail || 'Invite failed.'), true);
+      return;
+    }
+    document.getElementById('invite-username').value = '';
+    showMsg('invite-msg', '✅ Invited ' + escHtml(username), false);
+    loadCollaborators();
+  } catch (e) {
+    showMsg('invite-msg', '❌ ' + e.message, true);
+  }
+}
+
+async function removeCollaborator(username) {
+  try {
+    const token = getToken();
+    if (!token) { showMsg('danger-msg', '⚠️ JWT required.', true); return; }
+    const resp = await fetch(apiBase + '/collaborators/' + encodeURIComponent(username), {
+      method: 'DELETE',
+      headers: { 'Authorization': 'Bearer ' + token },
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ detail: resp.statusText }));
+      alert('Remove failed: ' + (err.detail || resp.statusText));
+      return;
+    }
+    loadCollaborators();
+  } catch (e) {
+    alert('Remove failed: ' + e.message);
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/tests/test_musehub_ui_settings.py
+++ b/tests/test_musehub_ui_settings.py
@@ -1,0 +1,296 @@
+"""Tests for Muse Hub repo settings page (issue #429).
+
+Covers the new ``GET /musehub/ui/{owner}/{repo_slug}/settings`` endpoint
+implemented in ``maestro/api/routes/musehub/ui_settings.py``.
+
+Test matrix:
+- test_settings_page_returns_200                 — happy-path HTML response
+- test_settings_page_no_auth_required            — HTML shell needs no JWT
+- test_settings_page_unknown_repo_404            — unknown owner/slug → 404
+- test_settings_page_contains_general_section    — General settings form present
+- test_settings_page_contains_danger_zone        — Danger Zone section present
+- test_settings_page_contains_merge_section      — Merge settings section present
+- test_settings_page_contains_collaboration      — Collaboration section present
+- test_settings_page_sidebar_navigation          — Sidebar nav links present
+- test_settings_page_section_param               — ?section= pre-selects sidebar section
+- test_settings_json_response                    — ?format=json returns RepoSettingsResponse fields
+- test_settings_json_has_visibility              — JSON includes visibility field
+- test_settings_json_has_merge_flags             — JSON includes merge strategy flags
+- test_settings_page_topic_tag_input             — tag input container present in template
+- test_settings_page_danger_zone_delete_confirm  — delete confirmation pattern present
+- test_settings_page_danger_zone_transfer        — transfer ownership action present
+- test_settings_page_danger_zone_archive         — archive action present
+- test_settings_page_uses_owner_slug_base_url    — base URL uses owner/slug not UUID
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import MusehubRepo
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+async def _make_repo(
+    db_session: AsyncSession,
+    owner: str = "settingsowner",
+    slug: str = "settings-repo",
+    visibility: str = "private",
+) -> MusehubRepo:
+    """Seed a minimal repo for settings tests and return the ORM row."""
+    repo = MusehubRepo(
+        name=slug,
+        owner=owner,
+        slug=slug,
+        visibility=visibility,
+        owner_user_id="settings-owner-uid",
+    )
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Happy-path — HTML responses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_settings_page_returns_200(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/settings returns HTTP 200."""
+    repo = await _make_repo(db_session)
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings")
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_settings_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The settings HTML shell is publicly accessible without a JWT.
+
+    Auth is enforced client-side when writing (PATCH/DELETE), not on the HTML
+    shell itself — consistent with all other MuseHub UI pages.
+    """
+    repo = await _make_repo(db_session, owner="pubowner", slug="pub-repo", visibility="public")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers.get("content-type", "")
+
+
+@pytest.mark.anyio
+async def test_settings_page_unknown_repo_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/settings returns 404 for unknown repos."""
+    resp = await client.get("/musehub/ui/ghost-owner/nonexistent-repo/settings")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Content checks — sections and navigation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_settings_page_contains_general_section(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Settings page HTML contains the General settings form."""
+    repo = await _make_repo(db_session, owner="genowner", slug="gen-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings")
+    assert resp.status_code == 200
+    assert "section-general" in resp.text
+
+
+@pytest.mark.anyio
+async def test_settings_page_contains_danger_zone(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Settings page HTML contains the Danger Zone section."""
+    repo = await _make_repo(db_session, owner="dangowner", slug="dang-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings")
+    assert resp.status_code == 200
+    assert "danger" in resp.text.lower()
+    assert "Delete" in resp.text or "delete" in resp.text
+
+
+@pytest.mark.anyio
+async def test_settings_page_contains_merge_section(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Settings page HTML contains the Merge settings section."""
+    repo = await _make_repo(db_session, owner="mergeowner", slug="merge-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings")
+    assert resp.status_code == 200
+    assert "section-merge" in resp.text
+
+
+@pytest.mark.anyio
+async def test_settings_page_contains_collaboration(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Settings page HTML contains the Collaboration section."""
+    repo = await _make_repo(db_session, owner="collabowner", slug="collab-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings")
+    assert resp.status_code == 200
+    assert "section-collaboration" in resp.text
+
+
+@pytest.mark.anyio
+async def test_settings_page_sidebar_navigation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Settings page HTML contains sidebar navigation buttons."""
+    repo = await _make_repo(db_session, owner="navowner", slug="nav-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings")
+    assert resp.status_code == 200
+    html = resp.text
+    assert "activateSection" in html
+    assert "data-section=" in html
+
+
+@pytest.mark.anyio
+async def test_settings_page_section_param(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """?section=danger pre-selects the danger sidebar section in the template context."""
+    repo = await _make_repo(db_session, owner="secpowner", slug="secp-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings?section=danger")
+    assert resp.status_code == 200
+    # The activeSection JS variable should be populated from the context
+    assert "activeSection" in resp.text or "active_section" in resp.text or "danger" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Content negotiation — JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_settings_json_response(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/settings?format=json returns RepoSettingsResponse."""
+    repo = await _make_repo(db_session, owner="jsonowner", slug="json-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings?format=json")
+    assert resp.status_code == 200
+    assert "application/json" in resp.headers.get("content-type", "")
+    data = resp.json()
+    assert "name" in data or "visibility" in data
+
+
+@pytest.mark.anyio
+async def test_settings_json_has_visibility(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """JSON response includes the ``visibility`` field."""
+    repo = await _make_repo(db_session, owner="visowner", slug="vis-repo", visibility="public")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings?format=json")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("visibility") == "public"
+
+
+@pytest.mark.anyio
+async def test_settings_json_has_merge_flags(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """JSON response includes merge strategy boolean flags."""
+    repo = await _make_repo(db_session, owner="flagowner", slug="flag-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings?format=json")
+    assert resp.status_code == 200
+    data = resp.json()
+    # RepoSettingsResponse uses camelCase via by_alias=True in negotiate_response
+    assert "allowMergeCommit" in data or "allow_merge_commit" in data
+
+
+# ---------------------------------------------------------------------------
+# Template content — specific UI elements
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_settings_page_topic_tag_input(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Settings page includes the topic tag input container."""
+    repo = await _make_repo(db_session, owner="tagowner", slug="tag-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings")
+    assert resp.status_code == 200
+    assert "topics-container" in resp.text or "tag-input" in resp.text
+
+
+@pytest.mark.anyio
+async def test_settings_page_danger_zone_delete_confirm(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Settings page requires typing the full repo name to confirm deletion."""
+    repo = await _make_repo(db_session, owner="delowner", slug="del-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings")
+    assert resp.status_code == 200
+    # Confirmation input pattern for repo name
+    assert "confirm-delete-name" in resp.text or "deleteRepo" in resp.text
+
+
+@pytest.mark.anyio
+async def test_settings_page_danger_zone_transfer(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Settings page includes a transfer ownership action."""
+    repo = await _make_repo(db_session, owner="tfrowner", slug="tfr-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings")
+    assert resp.status_code == 200
+    assert "transfer" in resp.text.lower()
+    assert "transferOwnership" in resp.text or "modal-transfer" in resp.text
+
+
+@pytest.mark.anyio
+async def test_settings_page_danger_zone_archive(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Settings page includes an archive repository action."""
+    repo = await _make_repo(db_session, owner="archowner", slug="arch-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings")
+    assert resp.status_code == 200
+    assert "archive" in resp.text.lower()
+    assert "archiveRepo" in resp.text or "modal-archive" in resp.text
+
+
+@pytest.mark.anyio
+async def test_settings_page_uses_owner_slug_base_url(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The page injects the owner/slug-based base URL into the JS context, not a UUID.
+
+    Regression guard: all MuseHub UI pages must use ``/musehub/ui/{owner}/{slug}``
+    style URLs so breadcrumb links and API calls are human-readable.
+    """
+    repo = await _make_repo(db_session, owner="slugowner", slug="slug-repo")
+    resp = await client.get(f"/musehub/ui/{repo.owner}/{repo.slug}/settings")
+    assert resp.status_code == 200
+    assert f"/musehub/ui/{repo.owner}/{repo.slug}" in resp.text


### PR DESCRIPTION
## Summary

Closes #429 — adds the repository settings page at `/musehub/ui/{owner}/{repo_slug}/settings`.

## Root Cause / Motivation

The MuseHub UI was missing a settings page. Musicians and AI agents had no web UI entry point for changing repo metadata (name, description, visibility, topics, license), managing collaborators, configuring merge strategy, or performing destructive operations (archive, transfer, delete).

## Solution

- **New route:** `GET /musehub/ui/{owner}/{repo_slug}/settings` in `maestro/api/routes/musehub/ui_settings.py`
- **Four sidebar sections** matching GitHub's repo settings pattern:
  - **General** — name, description, homepage URL, topic tag-input, license, visibility toggle
  - **Collaboration** — collaborator list with invite/remove; role selector (read/write/admin)
  - **Merge Settings** — merge commit / squash / rebase toggles; auto-delete head branch flag
  - **Danger Zone** — archive (reversible), transfer ownership, delete repo (requires typing `owner/repo` to confirm)
- **Content negotiation:** `?format=json` or `Accept: application/json` returns `RepoSettingsResponse` — same model as `GET /api/v1/musehub/repos/{repo_id}/settings`
- **`?section=` param** — pre-scrolls the sidebar to `general`, `collaboration`, `merge`, or `danger` on load, enabling deep-links
- **Explicit registration in `main.py`** following the same pattern as `ui.py` (UI routes bypass the `/api/v1/musehub` prefix)
- **Template:** `maestro/templates/musehub/pages/settings.html` extends `musehub/base.html` with sticky sidebar navigation, form state management, and modal confirmation dialogs for destructive actions
- **17 targeted tests** in `tests/test_musehub_ui_settings.py`

## Verification

- [x] mypy clean (`ui_settings.py`, `main.py`, `test_musehub_ui_settings.py`)
- [x] 17/17 tests pass
- [x] Clean merge from `origin/dev` (no conflicts)