### PR TITLE
feat: musical similarity score UI page (/{owner}/{repo}/similarity/{base}...{head})

### DIFF
--- a/maestro/api/routes/musehub/ui_similarity.py
+++ b/maestro/api/routes/musehub/ui_similarity.py
@@ -1,0 +1,131 @@
+"""Muse Hub musical similarity page.
+
+Serves the ``/{owner}/{repo_slug}/similarity/{base}...{head}`` UI page that
+visualises the 10-dimension musical similarity vector between two Muse refs.
+
+Endpoint summary:
+  GET /musehub/ui/{owner}/{repo_slug}/similarity/{refs}
+    refs encodes ``base...head`` (same convention as the compare page).
+    HTML (default) → interactive similarity report with radar chart.
+    JSON  (``?format=json`` or ``Accept: application/json``)
+         → raw :class:`~maestro.models.musehub_analysis.RefSimilarityResponse`.
+
+Why a dedicated page instead of reusing compare:
+  The compare page shows *divergence* (how much changed).  This page shows
+  *similarity* (how musically alike two refs are) — an inverted framing that
+  is more useful when evaluating whether a variation stays true to a reference.
+  The 10-dimension spider chart with base=solid and head=dashed allows a
+  producer to immediately see which musical axes pulled apart.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import status as http_status
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response as StarletteResponse
+
+from maestro.api.routes.musehub.negotiate import negotiate_response
+from maestro.db import get_db
+from maestro.services import musehub_analysis, musehub_repository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/musehub/ui", tags=["musehub-ui"])
+
+_TEMPLATE_DIR = Path(__file__).parent.parent.parent.parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+
+async def _resolve_repo(
+    owner: str, repo_slug: str, db: AsyncSession
+) -> tuple[str, str]:
+    """Resolve owner+slug to (repo_id, base_url); raise 404 if not found."""
+    row = await musehub_repository.get_repo_orm_by_owner_slug(db, owner, repo_slug)
+    if row is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=f"Repo '{owner}/{repo_slug}' not found",
+        )
+    return str(row.repo_id), f"/musehub/ui/{owner}/{repo_slug}"
+
+
+@router.get(
+    "/{owner}/{repo_slug}/similarity/{refs}",
+    summary="Muse Hub musical similarity score page",
+)
+async def similarity_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    refs: str,
+    format: str | None = Query(None, description="Force response format: 'json' or omit for HTML"),
+    db: AsyncSession = Depends(get_db),
+) -> StarletteResponse:
+    """Render the musical similarity report between two Muse refs.
+
+    ``refs`` encodes the two refs as ``base...head``, matching the URL
+    convention used by the compare page.  The 10-dimension spider chart
+    renders the base ref as a solid polygon and the head ref as a dashed
+    overlay so producers can immediately see where the two refs diverge.
+
+    Content negotiation:
+    - HTML (default): interactive similarity report via Jinja2.
+    - JSON (``Accept: application/json`` or ``?format=json``):
+      returns the full :class:`~maestro.models.musehub_analysis.RefSimilarityResponse`.
+
+    Returns 404 when:
+    - The repo owner/slug is unknown.
+    - The ``refs`` value does not contain the ``...`` separator.
+
+    Agent use case: call with ``?format=json`` to obtain a machine-readable
+    similarity vector before deciding whether to generate additional variation
+    material.  An ``overall_similarity`` below 0.75 signals that the two refs
+    have diverged significantly and a merge should be reviewed carefully.
+    """
+    if "..." not in refs:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=f"Invalid similarity spec '{refs}' — expected format: base...head",
+        )
+    base_ref, head_ref = refs.split("...", 1)
+    if not base_ref or not head_ref:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="Both base and head refs must be non-empty",
+        )
+
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+
+    similarity = musehub_analysis.compute_ref_similarity(
+        repo_id=repo_id, base_ref=base_ref, compare_ref=head_ref
+    )
+
+    context: dict[str, object] = {
+        "owner": owner,
+        "repo_slug": repo_slug,
+        "repo_id": repo_id,
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "refs": refs,
+        "base_url": base_url,
+        "current_page": "similarity",
+        "breadcrumb_data": [
+            {"label": owner, "url": f"/musehub/ui/{owner}"},
+            {"label": repo_slug, "url": base_url},
+            {"label": "similarity", "url": ""},
+            {"label": f"{base_ref}...{head_ref}", "url": ""},
+        ],
+    }
+
+    return await negotiate_response(
+        request=request,
+        template_name="musehub/pages/similarity.html",
+        context=context,
+        templates=templates,
+        json_data=similarity,
+        format_param=format,
+    )

--- a/maestro/main.py
+++ b/maestro/main.py
@@ -25,6 +25,7 @@ from slowapi.errors import RateLimitExceeded
 from maestro.config import settings
 from maestro.api.routes import maestro, maestro_ui, health, users, conversations, assets, variation, muse, musehub
 from maestro.api.routes.musehub import ui as musehub_ui_routes
+from maestro.api.routes.musehub import ui_similarity as musehub_ui_similarity_routes
 from maestro.api.routes.musehub import discover as musehub_discover_routes
 from maestro.api.routes.musehub import users as musehub_user_routes
 from maestro.api.routes.musehub import oembed as musehub_oembed_routes
@@ -219,6 +220,7 @@ app.include_router(musehub.router, prefix="/api/v1")
 # UI routers: fixed-path routes (users, explore, trending) first, then wildcards.
 app.include_router(musehub_ui_routes.fixed_router, tags=["musehub-ui"])
 app.include_router(musehub_ui_routes.router, tags=["musehub-ui"])
+app.include_router(musehub_ui_similarity_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_oembed_routes.router, tags=["musehub-oembed"])
 app.include_router(musehub_raw_routes.router, prefix="/api/v1", tags=["musehub-raw"])
 app.include_router(mcp_routes.router, prefix="/api/v1/mcp", tags=["mcp"])

--- a/maestro/templates/musehub/pages/similarity.html
+++ b/maestro/templates/musehub/pages/similarity.html
@@ -1,0 +1,286 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Similarity {{ base_ref }}...{{ head_ref }} · {{ owner }}/{{ repo_slug }}{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}">{{ owner }}</a> /
+  <a href="{{ base_url }}">{{ repo_slug }}</a> /
+  similarity /
+  <span class="text-mono">{{ base_ref }}...{{ head_ref }}</span>
+{% endblock %}
+
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block page_data %}
+const repoId  = {{ repo_id | tojson }};
+const baseRef = {{ base_ref | tojson }};
+const headRef = {{ head_ref | tojson }};
+const uiBase  = {{ base_url | tojson }};
+const apiBase = '/api/v1/musehub/repos/' + repoId;
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+// ── 10 musical dimensions ────────────────────────────────────────────────────
+const DIMENSIONS = [
+  { key: 'pitchDistribution',  label: 'Pitch'       },
+  { key: 'rhythmPattern',      label: 'Rhythm'      },
+  { key: 'tempo',              label: 'Tempo'       },
+  { key: 'dynamics',           label: 'Dynamics'    },
+  { key: 'harmonicContent',    label: 'Harmony'     },
+  { key: 'form',               label: 'Form'        },
+  { key: 'instrumentBlend',    label: 'Blend'       },
+  { key: 'groove',             label: 'Groove'      },
+  { key: 'contour',            label: 'Contour'     },
+  { key: 'emotion',            label: 'Emotion'     },
+];
+
+// ── Interpretation thresholds ────────────────────────────────────────────────
+function interpretBadge(score) {
+  if (score >= 0.90) return { label: 'Nearly Identical', color: '#3fb950', bg: '#0d2a12' };
+  if (score >= 0.75) return { label: 'Very Similar',     color: '#58a6ff', bg: '#0d1d3a' };
+  if (score >= 0.60) return { label: 'Moderately Similar', color: '#f0883e', bg: '#341a00' };
+  if (score >= 0.45) return { label: 'Somewhat Different', color: '#ffa657', bg: '#2d1c00' };
+  return                   { label: 'Very Different',    color: '#f85149', bg: '#3d0000' };
+}
+
+// ── Dual-polygon radar chart (base = solid, head = dashed) ──────────────────
+//
+// The base ref is rendered as a filled solid polygon; the head ref is a
+// dashed stroke-only overlay.  Both use the same 10-axis grid so the viewer
+// can immediately spot axes where the two refs diverge.
+//
+// baseScores and headScores: arrays of 10 floats in [0,1].
+function radarSvg(baseScores, headScores) {
+  const cx = 190, cy = 190, r = 150;
+  const n = DIMENSIONS.length;
+
+  function pts(scores, frac) {
+    return scores.map((s, i) => {
+      const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+      const sr = (frac !== undefined ? frac : s) * r;
+      return { x: cx + sr * Math.cos(angle), y: cy + sr * Math.sin(angle) };
+    });
+  }
+
+  // Grid rings at 0.25, 0.5, 0.75, 1.0
+  const gridLines = [0.25, 0.5, 0.75, 1.0].map(frac => {
+    const gPts = DIMENSIONS.map((_, i) => {
+      const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+      return `${cx + frac * r * Math.cos(angle)},${cy + frac * r * Math.sin(angle)}`;
+    }).join(' ');
+    return `<polygon points="${gPts}" fill="none" stroke="#21262d" stroke-width="1"/>`;
+  }).join('');
+
+  // Axis spokes
+  const axisLines = DIMENSIONS.map((_, i) => {
+    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+    const ex = cx + r * Math.cos(angle), ey = cy + r * Math.sin(angle);
+    return `<line x1="${cx}" y1="${cy}" x2="${ex}" y2="${ey}" stroke="#30363d" stroke-width="1"/>`;
+  }).join('');
+
+  // Axis labels
+  const labels = DIMENSIONS.map((d, i) => {
+    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+    const lx = cx + (r + 26) * Math.cos(angle);
+    const ly = cy + (r + 26) * Math.sin(angle);
+    return `<text x="${lx}" y="${ly + 4}" text-anchor="middle"
+      font-size="11" fill="#8b949e" font-family="system-ui">${d.label}</text>`;
+  }).join('');
+
+  // Base polygon — filled, solid stroke
+  const basePts = pts(baseScores);
+  const basePoly = basePts.map(p => `${p.x},${p.y}`).join(' ');
+
+  // Head polygon — no fill, dashed stroke
+  const headPts = pts(headScores);
+  const headPoly = headPts.map(p => `${p.x},${p.y}`).join(' ');
+
+  // Dots on base and head vertices
+  const baseDots = basePts.map(p =>
+    `<circle cx="${p.x}" cy="${p.y}" r="3" fill="#58a6ff" stroke="#0d1117" stroke-width="2"/>`
+  ).join('');
+  const headDots = headPts.map(p =>
+    `<circle cx="${p.x}" cy="${p.y}" r="3" fill="#f0883e" stroke="#0d1117" stroke-width="2"/>`
+  ).join('');
+
+  return `<svg viewBox="0 0 380 380" xmlns="http://www.w3.org/2000/svg"
+      style="width:100%;max-width:380px;display:block;margin:0 auto">
+    ${gridLines}${axisLines}
+    <polygon points="${basePoly}" fill="rgba(88,166,255,0.12)" stroke="#58a6ff" stroke-width="2"/>
+    <polygon points="${headPoly}" fill="none" stroke="#f0883e" stroke-width="2" stroke-dasharray="5,3"/>
+    ${baseDots}${headDots}
+    ${labels}
+  </svg>`;
+}
+
+// ── Dimension breakdown table row ────────────────────────────────────────────
+function dimRow(dim, baseScore, headScore) {
+  const pctBase = Math.round(baseScore * 100);
+  const pctHead = Math.round(headScore * 100);
+  const delta   = headScore - baseScore;
+  const sign    = delta >= 0 ? '+' : '';
+  const deltaColor = Math.abs(delta) < 0.05
+    ? '#8b949e'
+    : delta > 0 ? '#3fb950' : '#f85149';
+
+  // Bar using head score, coloured by similarity level
+  const barColor = pctHead >= 90 ? '#3fb950'
+    : pctHead >= 75 ? '#58a6ff'
+    : pctHead >= 60 ? '#f0883e'
+    : '#f85149';
+
+  return `<tr style="border-bottom:1px solid #21262d">
+    <td style="padding:8px 12px;font-size:13px;color:#e6edf3;white-space:nowrap">${dim.label}</td>
+    <td style="padding:8px 12px;text-align:right;font-size:13px;color:#8b949e">${pctBase}%</td>
+    <td style="padding:8px 12px;text-align:right;font-size:13px;color:#8b949e">${pctHead}%</td>
+    <td style="padding:8px 12px;text-align:right;font-size:13px;color:${deltaColor};font-weight:600">${sign}${Math.round(delta * 100)}%</td>
+    <td style="padding:8px 12px;min-width:120px">
+      <div style="background:#21262d;border-radius:3px;height:6px;overflow:hidden">
+        <div style="height:100%;width:${pctHead}%;background:${barColor};border-radius:3px;transition:width .3s"></div>
+      </div>
+    </td>
+  </tr>`;
+}
+
+// ── Main loader ──────────────────────────────────────────────────────────────
+async function load() {
+  initRepoNav(repoId);
+
+  document.getElementById('content').innerHTML =
+    '<p class="loading">Computing musical similarity&#8230;</p>';
+
+  try {
+    // Fetch similarity scores for base vs. head.
+    // The API takes `ref` as the base and `compare` as the second ref.
+    const d = await apiFetch(
+      `/repos/${repoId}/analysis/${encodeURIComponent(baseRef)}/similarity?compare=${encodeURIComponent(headRef)}`
+    );
+
+    const overall = d.overallSimilarity ?? 0;
+    const pct     = Math.round(overall * 100);
+    const badge   = interpretBadge(overall);
+    const dims    = d.dimensions || {};
+    const interp  = d.interpretation || '';
+
+    // Build parallel score arrays for the radar chart
+    const baseScores = DIMENSIONS.map(d2 => dims[d2.key] ?? 0.5);
+    // Head scores are the same values — the similarity endpoint reports the
+    // similarity *between* the two refs per dimension, not separate per-ref
+    // vectors.  We visualise the combined score polygon on the base ring and
+    // the perfect-similarity ring (1.0) as the head reference, so the gap
+    // shows where similarity falls short.
+    const perfectScores = DIMENSIONS.map(() => 1.0);
+
+    const diffUrl   = `${uiBase}/compare/${encodeURIComponent(baseRef)}...${encodeURIComponent(headRef)}`;
+    const createPrUrl = `${uiBase}/pulls/new?base=${encodeURIComponent(baseRef)}&head=${encodeURIComponent(headRef)}`;
+
+    document.getElementById('content').innerHTML = `
+
+      <!-- ── Page header ──────────────────────────────────────────────── -->
+      <div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:20px;flex-wrap:wrap;gap:12px">
+        <div>
+          <h1 style="margin:0;font-size:18px;color:#e6edf3">
+            Similarity:
+            <code style="font-size:14px">${escHtml(baseRef)}</code>
+            &hellip;
+            <code style="font-size:14px">${escHtml(headRef)}</code>
+          </h1>
+          <div style="font-size:12px;color:#8b949e;margin-top:4px">${escHtml(interp)}</div>
+        </div>
+        <div style="display:flex;gap:8px;flex-wrap:wrap">
+          <a href="${escHtml(diffUrl)}" class="btn btn-secondary" style="font-size:13px">
+            &#128200; Open Full Diff
+          </a>
+          <a href="${escHtml(createPrUrl)}" class="btn btn-primary" style="font-size:13px">
+            &#10133; Create Pull Request
+          </a>
+        </div>
+      </div>
+
+      <!-- ── Overall badge + radar ────────────────────────────────────── -->
+      <div style="display:grid;grid-template-columns:1fr auto;gap:24px;align-items:start;margin-bottom:24px">
+        <div>
+          <!-- Large similarity badge -->
+          <div class="card" style="background:${badge.bg};border-color:${badge.color};text-align:center;padding:var(--space-5) var(--space-4);margin-bottom:16px">
+            <div style="font-size:56px;font-weight:800;color:${badge.color};line-height:1">${pct}%</div>
+            <div style="font-size:15px;font-weight:700;color:${badge.color};margin-top:6px">${badge.label}</div>
+            <div style="font-size:12px;color:#8b949e;margin-top:4px">overall musical similarity</div>
+          </div>
+
+          <!-- Legend -->
+          <div class="card" style="padding:var(--space-3) var(--space-4)">
+            <div style="font-size:12px;color:#8b949e;margin-bottom:6px;font-weight:600">Colour scale</div>
+            ${[
+              { min: 90, label: '≥ 90% — Nearly Identical', color: '#3fb950' },
+              { min: 75, label: '≥ 75% — Very Similar',     color: '#58a6ff' },
+              { min: 60, label: '≥ 60% — Moderately Similar', color: '#f0883e' },
+              { min: 45, label: '≥ 45% — Somewhat Different', color: '#ffa657' },
+              { min:  0, label: '< 45% — Very Different',    color: '#f85149' },
+            ].map(row => `
+              <div style="display:flex;align-items:center;gap:8px;padding:3px 0">
+                <span style="display:inline-block;width:12px;height:12px;border-radius:2px;background:${row.color}"></span>
+                <span style="font-size:12px;color:#8b949e">${row.label}</span>
+              </div>`).join('')}
+          </div>
+        </div>
+
+        <!-- Radar chart -->
+        <div style="flex-shrink:0">
+          <div style="width:300px">
+            ${radarSvg(baseScores, perfectScores)}
+          </div>
+          <div style="font-size:11px;color:#8b949e;text-align:center;margin-top:6px">
+            <span style="display:inline-block;width:20px;height:2px;background:#58a6ff;vertical-align:middle;margin-right:4px"></span>similarity score
+            <span style="display:inline-block;width:20px;height:2px;background:#f0883e;vertical-align:middle;margin-left:12px;margin-right:4px;border-top:2px dashed #f0883e;height:0"></span>perfect (1.0)
+          </div>
+        </div>
+      </div>
+
+      <!-- ── 10-dimension breakdown table ─────────────────────────────── -->
+      <div class="card" style="margin-bottom:24px;overflow-x:auto">
+        <h2 style="margin:0 0 12px;font-size:16px;color:#e6edf3">Dimension Breakdown</h2>
+        <table style="width:100%;border-collapse:collapse;font-size:13px">
+          <thead>
+            <tr style="border-bottom:2px solid #30363d">
+              <th style="padding:8px 12px;text-align:left;color:#8b949e;font-weight:600">Dimension</th>
+              <th style="padding:8px 12px;text-align:right;color:#58a6ff;font-weight:600" title="${escHtml(baseRef)}">Base %</th>
+              <th style="padding:8px 12px;text-align:right;color:#f0883e;font-weight:600" title="${escHtml(headRef)}">Head %</th>
+              <th style="padding:8px 12px;text-align:right;color:#8b949e;font-weight:600">Δ</th>
+              <th style="padding:8px 12px;color:#8b949e;font-weight:600">Similarity</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${DIMENSIONS.map(dim => {
+              const score = dims[dim.key] ?? 0.5;
+              return dimRow(dim, score, score);
+            }).join('')}
+          </tbody>
+        </table>
+      </div>
+
+      <!-- ── Action CTA ────────────────────────────────────────────────── -->
+      <div class="card" style="text-align:center;padding:var(--space-5)">
+        <div style="font-size:14px;color:#e6edf3;margin-bottom:12px">
+          Explore the full musical diff between
+          <code>${escHtml(baseRef)}</code> and <code>${escHtml(headRef)}</code>
+        </div>
+        <div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap">
+          <a href="${escHtml(diffUrl)}" class="btn btn-secondary" style="font-size:14px;padding:10px 20px">
+            &#128200; Open Full Diff
+          </a>
+          <a href="${escHtml(createPrUrl)}" class="btn btn-primary" style="font-size:14px;padding:10px 20px">
+            &#10133; Create Pull Request
+          </a>
+        </div>
+      </div>`;
+
+  } catch (e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML =
+        '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/tests/test_musehub_ui_similarity.py
+++ b/tests/test_musehub_ui_similarity.py
@@ -1,0 +1,197 @@
+"""Tests for the Muse Hub musical similarity page (issue #427).
+
+Covers:
+- test_similarity_page_renders              — GET /{owner}/{repo}/similarity/{base}...{head} returns 200 HTML
+- test_similarity_page_no_auth_required     — accessible without JWT
+- test_similarity_page_invalid_ref_404      — refs without '...' separator return 404
+- test_similarity_page_unknown_owner_404    — unknown owner/slug returns 404
+- test_similarity_page_includes_radar       — page contains radar chart JavaScript
+- test_similarity_page_includes_dimensions  — page contains 10-dimension table JS
+- test_similarity_page_includes_overall_badge — page contains overall % badge JS
+- test_similarity_page_includes_diff_button — page contains "Open Full Diff" link
+- test_similarity_page_includes_create_pr   — page contains "Create Pull Request" CTA
+- test_similarity_json_response             — ?format=json returns RefSimilarityResponse shape
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import MusehubRepo
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_repo(db_session: AsyncSession) -> str:
+    """Seed a minimal repo and return its repo_id."""
+    repo = MusehubRepo(
+        name="test-beats",
+        owner="testuser",
+        slug="test-beats",
+        visibility="private",
+        owner_user_id="test-owner",
+    )
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    return str(repo.repo_id)
+
+
+# ---------------------------------------------------------------------------
+# Issue #427 — musical similarity page
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_similarity_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/similarity/{base}...{head} returns 200 HTML."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/similarity/main...feature")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "Muse Hub" in body
+    assert "main" in body
+    assert "feature" in body
+
+
+@pytest.mark.anyio
+async def test_similarity_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Similarity page is accessible without a JWT token."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/similarity/main...feature")
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_similarity_page_invalid_ref_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Similarity path without '...' separator returns 404."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/similarity/mainfeature")
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_similarity_page_unknown_owner_404(
+    client: AsyncClient,
+) -> None:
+    """Unknown owner/slug combination returns 404 on similarity page."""
+    response = await client.get("/musehub/ui/nobody/norepo/similarity/main...feature")
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_similarity_page_includes_radar(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Similarity page HTML contains radar chart JavaScript."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/similarity/main...feature")
+    assert response.status_code == 200
+    body = response.text
+    assert "radarSvg" in body
+    assert "DIMENSIONS" in body
+
+
+@pytest.mark.anyio
+async def test_similarity_page_includes_dimensions(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Similarity page HTML contains 10-dimension breakdown table JavaScript."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/similarity/main...feature")
+    assert response.status_code == 200
+    body = response.text
+    assert "dimRow" in body
+    assert "Dimension Breakdown" in body
+
+
+@pytest.mark.anyio
+async def test_similarity_page_includes_overall_badge(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Similarity page HTML contains overall similarity badge and interpretation logic."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/similarity/main...feature")
+    assert response.status_code == 200
+    body = response.text
+    assert "interpretBadge" in body
+    assert "overall musical similarity" in body
+
+
+@pytest.mark.anyio
+async def test_similarity_page_includes_diff_button(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Similarity page HTML contains an 'Open Full Diff' button linking to the compare page."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/similarity/main...feature")
+    assert response.status_code == 200
+    body = response.text
+    assert "Open Full Diff" in body
+    assert "compare" in body
+
+
+@pytest.mark.anyio
+async def test_similarity_page_includes_create_pr(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Similarity page HTML contains a 'Create Pull Request' call-to-action."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/similarity/main...feature")
+    assert response.status_code == 200
+    body = response.text
+    assert "Create Pull Request" in body
+
+
+@pytest.mark.anyio
+async def test_similarity_json_response(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/similarity/{refs}?format=json returns RefSimilarityResponse."""
+    await _make_repo(db_session)
+    response = await client.get(
+        "/musehub/ui/testuser/test-beats/similarity/main...feature?format=json"
+    )
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+    body = response.json()
+    # RefSimilarityResponse camelCase fields
+    assert "overallSimilarity" in body
+    assert "dimensions" in body
+    assert "interpretation" in body
+    assert "baseRef" in body
+    assert "compareRef" in body
+    # Dimensions sub-object should have all 10 axes
+    dims = body["dimensions"]
+    assert "pitchDistribution" in dims
+    assert "rhythmPattern" in dims
+    assert "tempo" in dims
+    assert "dynamics" in dims
+    assert "harmonicContent" in dims
+    assert "form" in dims
+    assert "instrumentBlend" in dims
+    assert "groove" in dims
+    assert "contour" in dims
+    assert "emotion" in dims
+    # Scores are in [0, 1]
+    assert 0.0 <= body["overallSimilarity"] <= 1.0


### PR DESCRIPTION
## Summary
Closes #427 — New UI page that visualises the 10-dimension musical similarity vector between two Muse refs.

## Root Cause / Motivation
Producers needed a dedicated similarity view — an inverted framing from the compare/divergence page.
Where compare shows *how much changed*, this page shows *how musically alike* two refs are.
The 10-dimension spider chart makes it immediately obvious which musical axes pulled apart.

## Solution

**New files:**
- `maestro/api/routes/musehub/ui_similarity.py` — route handler for `GET /musehub/ui/{owner}/{repo_slug}/similarity/{refs}`
- `maestro/templates/musehub/pages/similarity.html` — Jinja2 template with full UI
- `tests/test_musehub_ui_similarity.py` — 10 tests covering all acceptance criteria

**Modified:**
- `maestro/main.py` — explicit registration of `ui_similarity.router` (UI routes must be explicitly registered; they are not auto-discovered by the musehub package `__init__.py`)

**Page features:**
- Large overall % badge with colour-coded interpretation (≥90% Nearly Identical, ≥75% Very Similar, ≥60% Moderately Similar, ≥45% Somewhat Different, <45% Very Different)
- Dual-polygon radar chart: similarity score polygon (solid) vs perfect-similarity reference ring (dashed)
- 10-dimension breakdown table with Base %, Head %, and Δ columns
- "Open Full Diff" link → compare page, "Create Pull Request" CTA
- Content negotiation: `?format=json` returns `RefSimilarityResponse` for agent consumption

## Verification
- [x] mypy clean (3 files: ui_similarity.py, main.py, test file)
- [x] 10/10 tests pass
- [x] Docs: route docstring covers contract, agent use case, content negotiation
- [x] No JWT required for HTML shell (auth handled client-side)