### PR TITLE
feat(muse): implement muse rerere — reuse recorded musical merge resolutions

### DIFF
--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -5,10 +5,10 @@ subcommands (amend, arrange, ask, bisect, blame, cat-object, checkout, cherry-pi
 chord-map, clone, commit, commit-tree, context, contour, describe, diff, divergence,
 dynamics, emotion-diff, export, fetch, find, form, grep, groove-check, harmony,
 hash-object, humanize, import, init, inspect, key, log, merge, meter, motif, open,
-play, pull, push, read-tree, rebase, recall, release, remote, render-preview, reset,
-resolve, restore, rev-parse, revert, session, show, similarity, stash, status, swing,
-symbolic-ref, tag, tempo, tempo-scale, timeline, transpose, update-ref, validate,
-worktree, write-tree) as Typer sub-applications.
+play, pull, push, read-tree, rebase, recall, release, remote, render-preview, rerere,
+reset, resolve, restore, rev-parse, revert, session, show, similarity, stash, status,
+swing, symbolic-ref, tag, tempo, tempo-scale, timeline, transpose, update-ref,
+validate, worktree, write-tree) as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -61,6 +61,7 @@ from maestro.muse_cli.commands import (
     release,
     remote,
     render_preview,
+    rerere,
     reset,
     resolve,
     restore,
@@ -149,6 +150,7 @@ cli.add_typer(symbolic_ref.app, name="symbolic-ref", help="Read or write a symbo
 cli.add_typer(show.app, name="show", help="Inspect a commit: metadata, snapshot, diff, MIDI files, and audio preview.")
 cli.add_typer(render_preview.app, name="render-preview", help="Generate an audio preview of a commit's snapshot.")
 cli.add_typer(reset.app, name="reset", help="Reset the branch pointer to a prior commit.")
+cli.add_typer(rerere.app, name="rerere", help="Reuse recorded resolutions for musical merge conflicts.")
 cli.add_typer(resolve.app, name="resolve", help="Mark a conflicted file as resolved (--ours or --theirs).")
 cli.add_typer(restore.app, name="restore", help="Restore specific files from a commit or index into muse-work/.")
 cli.add_typer(groove_check.app, name="groove-check", help="Analyze rhythmic drift across commits to find groove regressions.")

--- a/maestro/muse_cli/commands/rerere.py
+++ b/maestro/muse_cli/commands/rerere.py
@@ -1,0 +1,148 @@
+"""muse rerere — reuse recorded resolutions for musical merge conflicts.
+
+Commands
+--------
+``muse rerere``
+    Attempt to auto-apply any cached resolution for conflicts currently
+    listed in ``.muse/MERGE_STATE.json``.  Prints the number resolved.
+
+``muse rerere list``
+    Show all conflict fingerprints currently in the rr-cache.  Entries
+    marked with ``[R]`` have a postimage (resolution recorded); entries
+    marked with ``[C]`` are conflict-only (awaiting resolution).
+
+``muse rerere forget <hash>``
+    Remove a single cached conflict/resolution from the rr-cache.
+
+``muse rerere clear``
+    Purge the entire rr-cache.  Use when cached resolutions are stale or
+    incorrect.
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+
+import typer
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.errors import ExitCode
+from maestro.services.muse_rerere import (
+    apply_rerere,
+    clear_rerere,
+    forget_rerere,
+    list_rerere,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(
+    name="rerere",
+    help="Reuse recorded resolutions for musical merge conflicts.",
+    no_args_is_help=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_current_conflicts(root: pathlib.Path) -> list[dict[str, object]]:
+    """Read conflict list from .muse/MERGE_STATE.json, if present."""
+    import json
+
+    merge_state_path = root / ".muse" / "MERGE_STATE.json"
+    if not merge_state_path.exists():
+        return []
+    try:
+        data = json.loads(merge_state_path.read_text(encoding="utf-8"))
+        raw = data.get("conflict_paths", [])
+        # conflict_paths is a list of file-path strings in the merge engine
+        # (file-level conflicts), not MergeConflict dicts.  Wrap each path
+        # in a minimal dict so rerere can fingerprint it.
+        return [{"region_id": p, "type": "file", "description": f"conflict in {p}"} for p in raw]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("⚠️ muse rerere: could not read MERGE_STATE.json: %s", exc)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Default command — apply cached resolution
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def rerere_apply(ctx: typer.Context) -> None:
+    """Auto-apply any cached resolution for current merge conflicts."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    root = require_repo()
+    conflicts = _load_current_conflicts(root)
+
+    if not conflicts:
+        typer.echo("✅ No active merge conflicts found (no MERGE_STATE.json or empty conflict list).")
+        return
+
+    applied, _resolution = apply_rerere(root, conflicts)
+    if applied:
+        typer.echo(f"✅ Resolved {applied} conflict(s) using rerere.")
+    else:
+        typer.echo("⚠️ No cached resolution found for current conflicts.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+
+# ---------------------------------------------------------------------------
+# list subcommand
+# ---------------------------------------------------------------------------
+
+
+@app.command("list")
+def rerere_list() -> None:
+    """Show all conflict fingerprints in the rr-cache."""
+    root = require_repo()
+    hashes = list_rerere(root)
+
+    if not hashes:
+        typer.echo("rr-cache is empty.")
+        return
+
+    typer.echo(f"rr-cache ({len(hashes)} entr{'y' if len(hashes) == 1 else 'ies'}):")
+    cache_root = root / ".muse" / "rr-cache"
+    for h in hashes:
+        postimage = cache_root / h / "postimage"
+        tag = "[R]" if postimage.exists() else "[C]"
+        typer.echo(f"  {tag} {h}")
+
+
+# ---------------------------------------------------------------------------
+# forget subcommand
+# ---------------------------------------------------------------------------
+
+
+@app.command("forget")
+def rerere_forget(
+    conflict_hash: str = typer.Argument(..., help="SHA-256 fingerprint hash to remove."),
+) -> None:
+    """Remove a single cached conflict/resolution from the rr-cache."""
+    root = require_repo()
+    removed = forget_rerere(root, conflict_hash)
+    if removed:
+        typer.echo(f"✅ Forgot rerere entry {conflict_hash[:12]}…")
+    else:
+        typer.echo(f"⚠️ Hash {conflict_hash[:12]}… not found in rr-cache.")
+        raise typer.Exit(code=ExitCode.USER_ERROR)
+
+
+# ---------------------------------------------------------------------------
+# clear subcommand
+# ---------------------------------------------------------------------------
+
+
+@app.command("clear")
+def rerere_clear() -> None:
+    """Purge the entire rr-cache."""
+    root = require_repo()
+    count = clear_rerere(root)
+    typer.echo(f"✅ Cleared {count} rr-cache entr{'y' if count == 1 else 'ies'}.")

--- a/maestro/muse_cli/commands/rerere.py
+++ b/maestro/muse_cli/commands/rerere.py
@@ -28,6 +28,7 @@ import typer
 from maestro.muse_cli._repo import require_repo
 from maestro.muse_cli.errors import ExitCode
 from maestro.services.muse_rerere import (
+    ConflictDict,
     apply_rerere,
     clear_rerere,
     forget_rerere,
@@ -48,7 +49,7 @@ app = typer.Typer(
 # ---------------------------------------------------------------------------
 
 
-def _load_current_conflicts(root: pathlib.Path) -> list[dict[str, object]]:
+def _load_current_conflicts(root: pathlib.Path) -> list[ConflictDict]:
     """Read conflict list from .muse/MERGE_STATE.json, if present."""
     import json
 
@@ -61,7 +62,7 @@ def _load_current_conflicts(root: pathlib.Path) -> list[dict[str, object]]:
         # conflict_paths is a list of file-path strings in the merge engine
         # (file-level conflicts), not MergeConflict dicts.  Wrap each path
         # in a minimal dict so rerere can fingerprint it.
-        return [{"region_id": p, "type": "file", "description": f"conflict in {p}"} for p in raw]
+        return [ConflictDict(region_id=p, type="file", description=f"conflict in {p}") for p in raw]
     except Exception as exc:  # noqa: BLE001
         logger.warning("⚠️ muse rerere: could not read MERGE_STATE.json: %s", exc)
         return []

--- a/maestro/services/muse_merge.py
+++ b/maestro/services/muse_merge.py
@@ -289,14 +289,18 @@ async def build_merge_checkout_plan(
         # never prevent the caller from receiving the conflict report.
         if repo_root is not None:
             try:
-                from maestro.services.muse_rerere import apply_rerere, record_conflict
+                from maestro.services.muse_rerere import (
+                    ConflictDict,
+                    apply_rerere,
+                    record_conflict,
+                )
 
                 conflict_dicts = [
-                    {
-                        "region_id": c.region_id,
-                        "type": c.type,
-                        "description": c.description,
-                    }
+                    ConflictDict(
+                        region_id=c.region_id,
+                        type=c.type,
+                        description=c.description,
+                    )
                     for c in result.conflicts
                 ]
                 record_conflict(repo_root, conflict_dicts)

--- a/maestro/services/muse_rerere.py
+++ b/maestro/services/muse_rerere.py
@@ -1,0 +1,263 @@
+"""Muse Rerere — Reuse Recorded Resolutions for musical merge conflicts.
+
+In parallel multi-branch Muse workflows identical merge conflicts appear
+repeatedly (e.g. the same MIDI region modified in the same way on two
+independent branches).  rerere records conflict shapes and their resolutions
+so they can be applied automatically on subsequent merges.
+
+Cache layout::
+
+    .muse/rr-cache/<hash>/
+        conflict    — serialised conflict fingerprint (JSON)
+        postimage   — serialised resolution (JSON, written only after resolve)
+
+The conflict fingerprint is a normalised, transposition-independent hash
+of the conflict shape.  Two conflicts with the same structural shape but
+different absolute pitches are treated as the same conflict so that a
+resolution recorded in one key can be applied in another.
+
+Boundary rules:
+  - Must NOT import StateStore, executor, MCP tools, routes, or handlers.
+  - May import muse_merge types.
+  - All file I/O uses pathlib.Path — never open() with bare strings.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_RR_CACHE_DIR = ".muse/rr-cache"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _rr_cache_root(repo_root: Path) -> Path:
+    """Return (and create if needed) the rr-cache directory."""
+    cache = repo_root / _RR_CACHE_DIR
+    cache.mkdir(parents=True, exist_ok=True)
+    return cache
+
+
+def _conflict_fingerprint(conflicts: list[dict[str, Any]]) -> str:
+    """Compute a normalised, transposition-independent fingerprint for *conflicts*.
+
+    Normalisation steps:
+    1.  Sort conflicts by (region_id, type, description) so that order does
+        not affect the fingerprint.
+    2.  Strip absolute pitch values from descriptions and replace them with
+        relative pitch offsets from the lowest pitch in the conflict set.
+        This makes the fingerprint invariant to transposition.
+    3.  SHA-256 the resulting JSON.
+    """
+    # Collect all numeric pitch values mentioned in descriptions for normalisation.
+    import re
+
+    pitch_re = re.compile(r"pitch=(\d+)")
+
+    all_pitches: list[int] = []
+    for c in conflicts:
+        for m in pitch_re.finditer(c.get("description", "")):
+            all_pitches.append(int(m.group(1)))
+
+    min_pitch = min(all_pitches) if all_pitches else 0
+
+    def _normalise(c: dict[str, Any]) -> dict[str, Any]:
+        desc = c.get("description", "")
+        normalised_desc = pitch_re.sub(
+            lambda m: f"pitch={int(m.group(1)) - min_pitch}",
+            desc,
+        )
+        return {
+            "region_id": c.get("region_id", ""),
+            "type": c.get("type", ""),
+            "description": normalised_desc,
+        }
+
+    normalised = sorted(
+        [_normalise(c) for c in conflicts],
+        key=lambda x: (x["region_id"], x["type"], x["description"]),
+    )
+    blob = json.dumps(normalised, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode()).hexdigest()
+
+
+def _hash_dir(repo_root: Path, conflict_hash: str) -> Path:
+    """Return the cache sub-directory for *conflict_hash*."""
+    return _rr_cache_root(repo_root) / conflict_hash
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def record_conflict(repo_root: Path, conflicts: list[dict[str, Any]]) -> str:
+    """Record a conflict shape in the rr-cache.
+
+    If the same conflict shape is already cached this is a no-op (idempotent).
+
+    Args:
+        repo_root:  Repository root (directory containing ``.muse/``).
+        conflicts:  List of conflict dicts (keys: region_id, type, description).
+                    These are typically derived from :class:`MergeConflict` instances.
+
+    Returns:
+        The SHA-256 fingerprint hash identifying this conflict shape.
+    """
+    h = _conflict_fingerprint(conflicts)
+    slot = _hash_dir(repo_root, h)
+    slot.mkdir(parents=True, exist_ok=True)
+
+    conflict_file = slot / "conflict"
+    if not conflict_file.exists():
+        conflict_file.write_text(
+            json.dumps(conflicts, indent=2),
+            encoding="utf-8",
+        )
+        logger.info("✅ muse rerere: recorded conflict %s", h[:12])
+    else:
+        logger.debug("muse rerere: conflict %s already cached", h[:12])
+
+    return h
+
+
+def record_resolution(
+    repo_root: Path,
+    conflict_hash: str,
+    resolution: dict[str, Any],
+) -> None:
+    """Persist a resolution for an existing conflict fingerprint.
+
+    Args:
+        repo_root:      Repository root.
+        conflict_hash:  Hash returned by :func:`record_conflict`.
+        resolution:     Arbitrary resolution data (e.g. merged snapshot or
+                        per-file resolution strategies).  Must be JSON-serialisable.
+
+    Raises:
+        FileNotFoundError: If *conflict_hash* is not in the cache (i.e.
+                           :func:`record_conflict` was never called for it).
+    """
+    slot = _hash_dir(repo_root, conflict_hash)
+    if not slot.is_dir():
+        raise FileNotFoundError(
+            f"rerere: conflict hash {conflict_hash!r} not found in rr-cache"
+        )
+    postimage = slot / "postimage"
+    postimage.write_text(
+        json.dumps(resolution, indent=2),
+        encoding="utf-8",
+    )
+    logger.info("✅ muse rerere: recorded resolution for %s", conflict_hash[:12])
+
+
+def apply_rerere(
+    repo_root: Path,
+    conflicts: list[dict[str, Any]],
+) -> tuple[int, dict[str, Any] | None]:
+    """Attempt to auto-apply a cached resolution for *conflicts*.
+
+    Args:
+        repo_root:  Repository root.
+        conflicts:  Current merge conflicts (same format as :func:`record_conflict`).
+
+    Returns:
+        A tuple ``(applied, resolution)`` where *applied* is the number of
+        conflicts resolved (0 or len(conflicts)) and *resolution* is the
+        cached resolution dict (or ``None`` when no cache hit exists).
+    """
+    if not conflicts:
+        return 0, None
+
+    h = _conflict_fingerprint(conflicts)
+    postimage = _hash_dir(repo_root, h) / "postimage"
+    if not postimage.exists():
+        logger.debug("muse rerere: no cached resolution for %s", h[:12])
+        return 0, None
+
+    resolution: dict[str, Any] = json.loads(postimage.read_text(encoding="utf-8"))
+    applied = len(conflicts)
+    logger.info(
+        "✅ muse rerere: resolved %d conflict(s) using rerere (hash %s)",
+        applied,
+        h[:12],
+    )
+    return applied, resolution
+
+
+def list_rerere(repo_root: Path) -> list[str]:
+    """Return all conflict fingerprint hashes currently in the rr-cache.
+
+    Only hashes that have an associated ``conflict`` file are returned.
+    Incomplete entries (e.g. conflict recorded but not yet resolved) are
+    included — they are distinct from resolved entries which also have a
+    ``postimage`` file.
+
+    Args:
+        repo_root:  Repository root.
+
+    Returns:
+        Sorted list of SHA-256 hex-digest strings.
+    """
+    cache = _rr_cache_root(repo_root)
+    hashes: list[str] = []
+    for entry in sorted(cache.iterdir()):
+        if entry.is_dir() and (entry / "conflict").exists():
+            hashes.append(entry.name)
+    return hashes
+
+
+def forget_rerere(repo_root: Path, conflict_hash: str) -> bool:
+    """Remove a single cached conflict/resolution from the rr-cache.
+
+    Args:
+        repo_root:      Repository root.
+        conflict_hash:  Hash to remove.
+
+    Returns:
+        ``True`` if the entry existed and was removed, ``False`` if it
+        was not found (idempotent — callers need not handle this as an error).
+    """
+    slot = _hash_dir(repo_root, conflict_hash)
+    if not slot.is_dir():
+        logger.warning("⚠️ muse rerere forget: hash %r not found", conflict_hash[:12])
+        return False
+
+    for child in slot.iterdir():
+        child.unlink()
+    slot.rmdir()
+    logger.info("✅ muse rerere: forgot %s", conflict_hash[:12])
+    return True
+
+
+def clear_rerere(repo_root: Path) -> int:
+    """Remove ALL entries from the rr-cache.
+
+    Args:
+        repo_root:  Repository root.
+
+    Returns:
+        Number of entries removed.
+    """
+    cache = _rr_cache_root(repo_root)
+    removed = 0
+    for entry in list(cache.iterdir()):
+        if entry.is_dir():
+            for child in entry.iterdir():
+                child.unlink()
+            entry.rmdir()
+            removed += 1
+    logger.info("✅ muse rerere: cleared %d cache entr%s", removed, "y" if removed == 1 else "ies")
+    return removed

--- a/tests/test_muse_rerere.py
+++ b/tests/test_muse_rerere.py
@@ -1,0 +1,228 @@
+"""Tests for Muse Rerere — reuse recorded resolutions (issue #484).
+
+Verifies:
+- record_conflict stores the conflict fingerprint hash correctly.
+- record_resolution stores the postimage.
+- apply_rerere returns the applied count and resolution on cache hit.
+- apply_rerere returns (0, None) on cache miss.
+- list_rerere returns all cached hashes.
+- forget_rerere removes a single hash.
+- clear_rerere empties the entire cache.
+- Fingerprint is transposition-invariant (same shape at different pitches → same hash).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from maestro.services.muse_rerere import (
+    apply_rerere,
+    clear_rerere,
+    forget_rerere,
+    list_rerere,
+    record_conflict,
+    record_resolution,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def repo_root(tmp_path: Path) -> Path:
+    """Return a temporary directory that looks like a Muse repo root."""
+    muse_dir = tmp_path / ".muse"
+    muse_dir.mkdir()
+    return tmp_path
+
+
+def _make_conflicts(region_id: str = "region-1", pitch: int = 60) -> list[dict[str, object]]:
+    """Helper: build a minimal conflict list."""
+    return [
+        {
+            "region_id": region_id,
+            "type": "note",
+            "description": f"Both sides modified note at pitch={pitch} beat=1.0",
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# record_conflict
+# ---------------------------------------------------------------------------
+
+
+def test_record_conflict_stores_hash_correctly(repo_root: Path) -> None:
+    """record_conflict returns a consistent hex SHA-256 hash."""
+    conflicts = _make_conflicts()
+    h = record_conflict(repo_root, conflicts)
+
+    assert isinstance(h, str)
+    assert len(h) == 64  # SHA-256 hex digest
+    assert (repo_root / ".muse" / "rr-cache" / h / "conflict").exists()
+
+
+def test_record_conflict_is_idempotent(repo_root: Path) -> None:
+    """Calling record_conflict twice with the same conflicts yields the same hash."""
+    conflicts = _make_conflicts()
+    h1 = record_conflict(repo_root, conflicts)
+    h2 = record_conflict(repo_root, conflicts)
+    assert h1 == h2
+
+
+def test_record_conflict_transposition_invariant(repo_root: Path) -> None:
+    """Conflicts at pitch=60 and pitch=72 (same interval pattern) → same hash."""
+    c_at_c4 = _make_conflicts(pitch=60)
+    c_at_c5 = _make_conflicts(pitch=72)
+    h1 = record_conflict(repo_root, c_at_c4)
+    h2 = record_conflict(repo_root, c_at_c5)
+    # Both have a single conflict with relative pitch offset 0 → same fingerprint.
+    assert h1 == h2
+
+
+def test_record_conflict_different_structure_gives_different_hash(repo_root: Path) -> None:
+    """Structurally different conflict sets produce different hashes."""
+    c1 = _make_conflicts(region_id="region-1")
+    c2 = _make_conflicts(region_id="region-2")
+    h1 = record_conflict(repo_root, c1)
+    h2 = record_conflict(repo_root, c2)
+    assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# record_resolution
+# ---------------------------------------------------------------------------
+
+
+def test_record_resolution_stores_postimage(repo_root: Path) -> None:
+    """record_resolution writes the postimage file for an existing conflict hash."""
+    conflicts = _make_conflicts()
+    h = record_conflict(repo_root, conflicts)
+    resolution = {"strategy": "ours", "region_id": "region-1"}
+
+    record_resolution(repo_root, h, resolution)
+
+    postimage = repo_root / ".muse" / "rr-cache" / h / "postimage"
+    assert postimage.exists()
+    stored = json.loads(postimage.read_text())
+    assert stored == resolution
+
+
+def test_record_resolution_raises_for_unknown_hash(repo_root: Path) -> None:
+    """record_resolution raises FileNotFoundError for an unrecognised hash."""
+    with pytest.raises(FileNotFoundError, match="not found in rr-cache"):
+        record_resolution(repo_root, "a" * 64, {"foo": "bar"})
+
+
+# ---------------------------------------------------------------------------
+# apply_rerere
+# ---------------------------------------------------------------------------
+
+
+def test_apply_rerere_returns_applied_count_on_cache_hit(repo_root: Path) -> None:
+    """apply_rerere returns (len(conflicts), resolution) when a postimage exists."""
+    conflicts = _make_conflicts()
+    h = record_conflict(repo_root, conflicts)
+    resolution = {"strategy": "ours"}
+    record_resolution(repo_root, h, resolution)
+
+    applied, returned_resolution = apply_rerere(repo_root, conflicts)
+
+    assert applied == len(conflicts)
+    assert returned_resolution == resolution
+
+
+def test_apply_rerere_returns_zero_on_cache_miss(repo_root: Path) -> None:
+    """apply_rerere returns (0, None) when no postimage is cached."""
+    conflicts = _make_conflicts()
+    # Record conflict but NOT the resolution → no postimage.
+    record_conflict(repo_root, conflicts)
+
+    applied, resolution = apply_rerere(repo_root, conflicts)
+
+    assert applied == 0
+    assert resolution is None
+
+
+def test_apply_rerere_returns_zero_for_unknown_conflicts(repo_root: Path) -> None:
+    """apply_rerere returns (0, None) for conflicts with no rr-cache entry at all."""
+    conflicts = _make_conflicts(region_id="never-seen-region")
+    applied, resolution = apply_rerere(repo_root, conflicts)
+    assert applied == 0
+    assert resolution is None
+
+
+def test_apply_rerere_empty_conflicts_returns_zero(repo_root: Path) -> None:
+    """apply_rerere short-circuits and returns (0, None) when conflict list is empty."""
+    applied, resolution = apply_rerere(repo_root, [])
+    assert applied == 0
+    assert resolution is None
+
+
+# ---------------------------------------------------------------------------
+# list_rerere
+# ---------------------------------------------------------------------------
+
+
+def test_list_rerere_returns_all_cached_hashes(repo_root: Path) -> None:
+    """list_rerere returns a sorted list of all conflict hashes in the cache."""
+    h1 = record_conflict(repo_root, _make_conflicts(region_id="r1"))
+    h2 = record_conflict(repo_root, _make_conflicts(region_id="r2"))
+
+    hashes = list_rerere(repo_root)
+
+    assert sorted([h1, h2]) == hashes
+
+
+def test_list_rerere_empty_cache(repo_root: Path) -> None:
+    """list_rerere returns an empty list when the cache is empty."""
+    assert list_rerere(repo_root) == []
+
+
+# ---------------------------------------------------------------------------
+# forget_rerere
+# ---------------------------------------------------------------------------
+
+
+def test_forget_rerere_removes_one_hash(repo_root: Path) -> None:
+    """forget_rerere removes exactly the specified entry."""
+    h1 = record_conflict(repo_root, _make_conflicts(region_id="r1"))
+    h2 = record_conflict(repo_root, _make_conflicts(region_id="r2"))
+
+    removed = forget_rerere(repo_root, h1)
+
+    assert removed is True
+    hashes = list_rerere(repo_root)
+    assert h1 not in hashes
+    assert h2 in hashes
+
+
+def test_forget_rerere_returns_false_for_unknown_hash(repo_root: Path) -> None:
+    """forget_rerere returns False (not an error) for an unknown hash."""
+    assert forget_rerere(repo_root, "b" * 64) is False
+
+
+# ---------------------------------------------------------------------------
+# clear_rerere
+# ---------------------------------------------------------------------------
+
+
+def test_clear_rerere_empties_cache(repo_root: Path) -> None:
+    """clear_rerere removes all entries from the rr-cache."""
+    record_conflict(repo_root, _make_conflicts(region_id="r1"))
+    record_conflict(repo_root, _make_conflicts(region_id="r2"))
+    record_conflict(repo_root, _make_conflicts(region_id="r3"))
+
+    removed = clear_rerere(repo_root)
+
+    assert removed == 3
+    assert list_rerere(repo_root) == []
+
+
+def test_clear_rerere_empty_cache_returns_zero(repo_root: Path) -> None:
+    """clear_rerere on an already empty cache returns 0."""
+    assert clear_rerere(repo_root) == 0

--- a/tests/test_muse_rerere.py
+++ b/tests/test_muse_rerere.py
@@ -17,7 +17,9 @@ from pathlib import Path
 
 import pytest
 
+from maestro.contracts.json_types import JSONObject
 from maestro.services.muse_rerere import (
+    ConflictDict,
     apply_rerere,
     clear_rerere,
     forget_rerere,
@@ -40,14 +42,14 @@ def repo_root(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def _make_conflicts(region_id: str = "region-1", pitch: int = 60) -> list[dict[str, object]]:
+def _make_conflicts(region_id: str = "region-1", pitch: int = 60) -> list[ConflictDict]:
     """Helper: build a minimal conflict list."""
     return [
-        {
-            "region_id": region_id,
-            "type": "note",
-            "description": f"Both sides modified note at pitch={pitch} beat=1.0",
-        }
+        ConflictDict(
+            region_id=region_id,
+            type="note",
+            description=f"Both sides modified note at pitch={pitch} beat=1.0",
+        )
     ]
 
 
@@ -102,7 +104,7 @@ def test_record_resolution_stores_postimage(repo_root: Path) -> None:
     """record_resolution writes the postimage file for an existing conflict hash."""
     conflicts = _make_conflicts()
     h = record_conflict(repo_root, conflicts)
-    resolution = {"strategy": "ours", "region_id": "region-1"}
+    resolution: JSONObject = {"strategy": "ours", "region_id": "region-1"}
 
     record_resolution(repo_root, h, resolution)
 
@@ -127,7 +129,7 @@ def test_apply_rerere_returns_applied_count_on_cache_hit(repo_root: Path) -> Non
     """apply_rerere returns (len(conflicts), resolution) when a postimage exists."""
     conflicts = _make_conflicts()
     h = record_conflict(repo_root, conflicts)
-    resolution = {"strategy": "ours"}
+    resolution: JSONObject = {"strategy": "ours"}
     record_resolution(repo_root, h, resolution)
 
     applied, returned_resolution = apply_rerere(repo_root, conflicts)


### PR DESCRIPTION
## Summary
Closes #484 — implement muse rerere (reuse recorded resolutions) for musical merge conflicts.

## Root Cause / Motivation
In parallel multi-branch Muse workflows, identical merge conflicts appear repeatedly. rerere records resolutions so they can be auto-applied on subsequent merges without user intervention.

## Solution
- `maestro/services/muse_rerere.py`: conflict fingerprinting (transposition-invariant SHA-256), `.muse/rr-cache` storage, full CRUD (`record_conflict`, `record_resolution`, `apply_rerere`, `list_rerere`, `forget_rerere`, `clear_rerere`)
- `maestro/muse_cli/commands/rerere.py`: CLI sub-app with four subcommands — `rerere` (apply), `rerere list`, `rerere forget <hash>`, `rerere clear`
- `maestro/muse_cli/app.py`: registered `rerere` sub-app
- `maestro/services/muse_merge.py`: best-effort rerere hook in `build_merge_checkout_plan()` — records conflict shape and auto-applies cached resolution when `repo_root` is provided; logs "Resolved N conflict(s) using rerere."
- `tests/test_muse_rerere.py`: 16 unit tests covering all public functions
- `docs/architecture/muse_vcs.md`: `## muse rerere` section with purpose, cache layout, commands, example output, and implementation table

## Verification
- [x] mypy clean (661 source files, 0 issues)
- [x] 16/16 tests pass
- [x] Docs updated
- [x] Merged cleanly with origin/dev (no conflicts)