### PR TITLE
feat(muse): implement .museattributes — per-repo merge strategy config for musical dimensions

### DIFF
--- a/docs/reference/museattributes.md
+++ b/docs/reference/museattributes.md
@@ -1,0 +1,147 @@
+# .museattributes Reference
+
+`.museattributes` is a per-repository configuration file that declares merge strategies for specific track patterns and musical dimensions. It lives in the repository root, next to `.muse/`.
+
+---
+
+## Purpose
+
+Without `.museattributes`, every musical dimension conflict requires manual resolution, even when the resolution is obvious — for example, the drum tracks are always authoritative and should never be overwritten by a collaborator's edits.
+
+`.museattributes` lets you encode that domain knowledge once, so `muse merge` can skip conflict detection and take the correct side automatically.
+
+---
+
+## File Format
+
+One rule per line:
+
+```
+<track-pattern>  <dimension>  <strategy>
+```
+
+- **`track-pattern`** — An [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) glob matched against the track name (e.g. `drums/*`, `bass/electric`, `*`).
+- **`dimension`** — A musical dimension name or `*` (all dimensions). Valid dimension names: `harmonic`, `rhythmic`, `melodic`, `structural`, `dynamic`.
+- **`strategy`** — How to resolve conflicts for matching track + dimension pairs (see table below).
+
+Lines starting with `#` and blank lines are ignored. Tokens are separated by any whitespace. The **first matching rule wins** — order matters.
+
+---
+
+## Strategies
+
+| Strategy | Meaning |
+|----------|---------|
+| `ours`   | Take the current branch's version. Skip conflict detection. |
+| `theirs` | Take the incoming branch's version. Skip conflict detection. |
+| `union`  | Attempt to include both sides (falls through to three-way merge). |
+| `auto`   | Let the merge engine decide (default when no rule matches). |
+| `manual` | Flag this dimension for mandatory manual resolution. Falls through to three-way merge. |
+
+> **Note:** `ours` and `theirs` are the only strategies that bypass conflict detection. All others participate in the normal three-way merge.
+
+---
+
+## Examples
+
+### Drums are always authoritative
+
+```
+# Drums are owned by the arranger — always keep ours.
+drums/*  *  ours
+```
+
+### Accept collaborator's harmonic changes wholesale
+
+```
+# Incoming harmonic edits from the collaborator win.
+keys/*   harmonic  theirs
+bass/*   harmonic  theirs
+```
+
+### Explicit per-dimension rules with fallback
+
+```
+# Drums: our rhythmic pattern is never overwritten.
+drums/*  rhythmic  ours
+
+# Melodic content from the collaborator is accepted.
+*        melodic   theirs
+
+# Everything else: normal automatic merge.
+*        *         auto
+```
+
+### Full example
+
+```
+# Percussion is always ours.
+drums/*     *         ours
+percussion  *         ours
+
+# Harmonic collaborations from the feature branch are accepted.
+keys/*      harmonic  theirs
+strings/*   harmonic  theirs
+
+# Structural sections require manual sign-off.
+*           structural  manual
+
+# Fall through to automatic merge for everything else.
+*           *           auto
+```
+
+---
+
+## CLI
+
+```
+muse attributes [--json]
+```
+
+Reads and displays the `.museattributes` rules from the current repository.
+
+**Example output:**
+
+```
+.museattributes — 3 rule(s)
+
+Track Pattern  Dimension  Strategy
+-------------  ---------  --------
+drums/*        *          ours
+keys/*         harmonic   theirs
+*              *          auto
+```
+
+Use `--json` for machine-readable output:
+
+```json
+[
+  {"track_pattern": "drums/*", "dimension": "*", "strategy": "ours"},
+  {"track_pattern": "keys/*", "dimension": "harmonic", "strategy": "theirs"},
+  {"track_pattern": "*", "dimension": "*", "strategy": "auto"}
+]
+```
+
+---
+
+## Behaviour During `muse merge`
+
+1. `muse merge` calls `load_attributes(repo_path)` to read the file.
+2. For each region in the merge, the region's track name and dimension are passed to `resolve_strategy(attributes, track, dimension)`.
+3. If the resolved strategy is `ours`, the left (current) snapshot is taken without conflict detection.
+4. If the resolved strategy is `theirs`, the right (incoming) snapshot is taken without conflict detection.
+5. For all other strategies (`union`, `auto`, `manual`), the normal three-way merge runs and may produce conflicts.
+
+---
+
+## Resolution Precedence
+
+Rules are evaluated top-to-bottom. The first rule whose `track-pattern` **and** `dimension` both match (using fnmatch) wins. If no rule matches, `auto` is used.
+
+---
+
+## Notes
+
+- The file is optional. If `.museattributes` does not exist, `muse merge` behaves as if all dimensions use `auto`.
+- Track names typically follow the format `<family>/<instrument>` (e.g. `drums/kick`, `bass/electric`). The exact names depend on your project's MIDI track naming.
+- `ours` and `theirs` in `.museattributes` are **positional**, not branch-named. `ours` = the branch you are merging **into** (left / current HEAD). `theirs` = the branch you are merging **from** (right / incoming).

--- a/maestro/muse_cli/app.py
+++ b/maestro/muse_cli/app.py
@@ -1,14 +1,14 @@
 """Muse CLI — Typer application root.
 
 Entry point for the ``muse`` console script. Registers all MVP
-subcommands (amend, arrange, ask, bisect, blame, cat-object, checkout, cherry-pick,
-chord-map, clone, commit, commit-tree, context, contour, describe, diff, divergence,
-dynamics, emotion-diff, export, fetch, find, form, grep, groove-check, harmony,
-hash-object, humanize, import, init, inspect, key, log, merge, meter, motif, open,
-play, pull, push, read-tree, rebase, recall, release, remote, render-preview, reset,
-resolve, restore, rev-parse, revert, session, show, similarity, stash, status, swing,
-symbolic-ref, tag, tempo, tempo-scale, timeline, transpose, update-ref, validate,
-worktree, write-tree) as Typer sub-applications.
+subcommands (amend, arrange, ask, attributes, bisect, blame, cat-object, checkout,
+cherry-pick, chord-map, clone, commit, commit-tree, context, contour, describe, diff,
+divergence, dynamics, emotion-diff, export, fetch, find, form, grep, groove-check,
+harmony, hash-object, humanize, import, init, inspect, key, log, merge, meter, motif,
+open, play, pull, push, read-tree, rebase, recall, release, remote, render-preview,
+reset, resolve, restore, rev-parse, revert, session, show, similarity, stash, status,
+swing, symbolic-ref, tag, tempo, tempo-scale, timeline, transpose, update-ref,
+validate, worktree, write-tree) as Typer sub-applications.
 """
 from __future__ import annotations
 
@@ -16,6 +16,7 @@ import typer
 
 from maestro.muse_cli.commands import (
     amend,
+    attributes,
     arrange,
     ask,
     bisect,
@@ -91,6 +92,7 @@ cli = typer.Typer(
 )
 
 cli.add_typer(amend.app, name="amend", help="Fold working-tree changes into the most recent commit.")
+cli.add_typer(attributes.app, name="attributes", help="Read and validate the .museattributes merge-strategy configuration.")
 cli.add_typer(bisect.app, name="bisect", help="Binary search for the commit that introduced a regression.")
 cli.add_typer(blame.app, name="blame", help="Annotate files with the commit that last changed each one.")
 cli.add_typer(cat_object.app, name="cat-object", help="Read and display a stored object by its SHA-256 hash.")

--- a/maestro/muse_cli/commands/attributes.py
+++ b/maestro/muse_cli/commands/attributes.py
@@ -11,7 +11,7 @@ Usage::
 Exit codes:
 - ``0``: parsed successfully (or file not found — that is not an error).
 - ``1``: file is present but contains no valid rules.
-- ``2``: internal error.
+- ``3``: internal error.
 """
 from __future__ import annotations
 

--- a/maestro/muse_cli/commands/attributes.py
+++ b/maestro/muse_cli/commands/attributes.py
@@ -1,0 +1,115 @@
+"""muse attributes — read and validate the .museattributes configuration file.
+
+A plumbing command that parses the ``.museattributes`` file in the current
+repository root and displays the resulting rules in a human-readable table
+(or machine-readable JSON).
+
+Usage::
+
+    muse attributes [--json]
+
+Exit codes:
+- ``0``: parsed successfully (or file not found — that is not an error).
+- ``1``: file is present but contains no valid rules.
+- ``2``: internal error.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+import typer
+from typing_extensions import Annotated
+
+from maestro.muse_cli._repo import require_repo
+from maestro.muse_cli.errors import ExitCode
+from maestro.services.muse_attributes import (
+    MuseAttribute,
+    load_attributes,
+)
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(no_args_is_help=False)
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+
+def _format_attributes(attributes: list[MuseAttribute], *, as_json: bool) -> str:
+    """Render parsed attributes as a table or JSON."""
+    if as_json:
+        payload = [
+            {
+                "track_pattern": a.track_pattern,
+                "dimension": a.dimension,
+                "strategy": a.strategy.value,
+            }
+            for a in attributes
+        ]
+        return json.dumps(payload, indent=2)
+
+    if not attributes:
+        return "No rules defined. Create a .museattributes file in the repository root."
+
+    col_widths = (
+        max(len(a.track_pattern) for a in attributes),
+        max(len(a.dimension) for a in attributes),
+        max(len(a.strategy.value) for a in attributes),
+    )
+    col_widths = (
+        max(col_widths[0], len("Track Pattern")),
+        max(col_widths[1], len("Dimension")),
+        max(col_widths[2], len("Strategy")),
+    )
+
+    sep = "  "
+    header = sep.join(
+        label.ljust(w)
+        for label, w in zip(
+            ("Track Pattern", "Dimension", "Strategy"), col_widths, strict=True
+        )
+    )
+    divider = sep.join("-" * w for w in col_widths)
+    rows = [
+        sep.join(
+            cell.ljust(w)
+            for cell, w in zip(
+                (a.track_pattern, a.dimension, a.strategy.value), col_widths, strict=True
+            )
+        )
+        for a in attributes
+    ]
+    lines = [f".museattributes — {len(attributes)} rule(s)", "", header, divider, *rows]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Command
+# ---------------------------------------------------------------------------
+
+
+@app.callback(invoke_without_command=True)
+def attributes_show(
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable JSON output."),
+    ] = False,
+) -> None:
+    """Read and display the .museattributes merge-strategy configuration."""
+    root = require_repo()
+
+    try:
+        rules = load_attributes(root)
+        output = _format_attributes(rules, as_json=as_json)
+        typer.echo(output)
+        if not rules:
+            raise typer.Exit(code=ExitCode.USER_ERROR)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"❌ muse attributes failed: {exc}")
+        logger.error("❌ muse attributes error: %s", exc, exc_info=True)
+        raise typer.Exit(code=ExitCode.INTERNAL_ERROR)

--- a/maestro/services/muse_attributes.py
+++ b/maestro/services/muse_attributes.py
@@ -1,0 +1,207 @@
+"""Muse Attributes — .museattributes parser and merge-strategy resolver.
+
+``.museattributes`` is a per-repository configuration file (placed in the
+repository root, next to ``.muse/``) that declares merge strategies for
+specific track patterns and musical dimensions.
+
+File format (one rule per line)::
+
+    # comment
+    <track-pattern>  <dimension>  <strategy>
+
+Where:
+- ``<track-pattern>`` is an fnmatch glob (e.g. ``drums/*``, ``bass/*``, ``*``).
+- ``<dimension>`` is a musical dimension name or ``*`` (all dimensions).
+- ``<strategy>`` is one of: ``ours``, ``theirs``, ``union``, ``auto``, ``manual``.
+
+Resolution precedence: the *first* matching rule wins.
+
+Example::
+
+    # Drums are always authoritative — keep ours on conflict.
+    drums/*  *        ours
+    # Accept collaborator keys wholesale.
+    keys/*   harmonic theirs
+    # Everything else: automatic merge.
+    *        *        auto
+"""
+from __future__ import annotations
+
+import fnmatch
+import logging
+from enum import Enum
+from pathlib import Path
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+MUSEATTRIBUTES_FILENAME = ".museattributes"
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+class MergeStrategy(str, Enum):
+    """Merge strategy choices for a musical dimension."""
+
+    OURS = "ours"
+    THEIRS = "theirs"
+    UNION = "union"
+    AUTO = "auto"
+    MANUAL = "manual"
+
+
+class MuseAttribute(BaseModel):
+    """A single rule parsed from a ``.museattributes`` file."""
+
+    track_pattern: str
+    dimension: str
+    strategy: MergeStrategy
+
+    model_config = {"frozen": True}
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def parse_museattributes_file(content: str) -> list[MuseAttribute]:
+    """Parse the text content of a ``.museattributes`` file into a list of rules.
+
+    Lines that are empty or start with ``#`` are ignored.  Each rule line must
+    contain exactly three whitespace-separated tokens; malformed lines are
+    logged as warnings and skipped.
+
+    Args:
+        content: Raw text content of the ``.museattributes`` file.
+
+    Returns:
+        Ordered list of ``MuseAttribute`` instances (first-match-wins).
+    """
+    attributes: list[MuseAttribute] = []
+
+    for lineno, raw_line in enumerate(content.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        tokens = line.split()
+        if len(tokens) != 3:
+            logger.warning(
+                "⚠️ .museattributes line %d: expected 3 tokens, got %d — skipping: %r",
+                lineno,
+                len(tokens),
+                line,
+            )
+            continue
+
+        track_pattern, dimension, strategy_raw = tokens
+
+        try:
+            strategy = MergeStrategy(strategy_raw.lower())
+        except ValueError:
+            valid = ", ".join(s.value for s in MergeStrategy)
+            logger.warning(
+                "⚠️ .museattributes line %d: unknown strategy %r (valid: %s) — skipping",
+                lineno,
+                strategy_raw,
+                valid,
+            )
+            continue
+
+        attributes.append(
+            MuseAttribute(
+                track_pattern=track_pattern,
+                dimension=dimension,
+                strategy=strategy,
+            )
+        )
+
+    logger.debug("✅ Parsed %d rule(s) from .museattributes", len(attributes))
+    return attributes
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def load_attributes(repo_path: Path) -> list[MuseAttribute]:
+    """Load ``.museattributes`` from the repository root.
+
+    Args:
+        repo_path: Path to the Muse repository root (the directory that contains
+            the ``.muse/`` folder).
+
+    Returns:
+        Parsed list of ``MuseAttribute`` rules.  Returns an empty list if the
+        file does not exist; never raises.
+    """
+    attr_file = repo_path / MUSEATTRIBUTES_FILENAME
+    if not attr_file.exists():
+        logger.debug("ℹ️ No .museattributes found at %s", attr_file)
+        return []
+
+    try:
+        content = attr_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("⚠️ Could not read .museattributes: %s", exc)
+        return []
+
+    return parse_museattributes_file(content)
+
+
+# ---------------------------------------------------------------------------
+# Strategy resolver
+# ---------------------------------------------------------------------------
+
+
+def resolve_strategy(
+    attributes: list[MuseAttribute],
+    track: str,
+    dimension: str,
+) -> MergeStrategy:
+    """Return the configured ``MergeStrategy`` for a track + dimension pair.
+
+    Iterates through ``attributes`` in order (first-match-wins).  The
+    ``track_pattern`` is matched using ``fnmatch`` so patterns like
+    ``drums/*``, ``*``, or ``bass/kick`` all work as expected.  The
+    ``dimension`` is matched with fnmatch as well, allowing ``*`` to cover
+    all dimensions.
+
+    If no rule matches, returns ``MergeStrategy.AUTO`` (the safe default).
+
+    Args:
+        attributes: Ordered list of ``MuseAttribute`` rules (from
+            ``load_attributes`` or ``parse_museattributes_file``).
+        track: Concrete track name to resolve (e.g. ``"drums/kick"``).
+        dimension: Musical dimension name (e.g. ``"harmonic"``, ``"rhythmic"``).
+
+    Returns:
+        The first matching ``MergeStrategy``, or ``MergeStrategy.AUTO`` when
+        no rule matches.
+    """
+    for attr in attributes:
+        track_matches = fnmatch.fnmatch(track, attr.track_pattern)
+        dim_matches = fnmatch.fnmatch(dimension, attr.dimension)
+        if track_matches and dim_matches:
+            logger.debug(
+                "✅ .museattributes: track=%r dim=%r matched pattern=%r/%r → %s",
+                track,
+                dimension,
+                attr.track_pattern,
+                attr.dimension,
+                attr.strategy.value,
+            )
+            return attr.strategy
+
+    logger.debug(
+        "ℹ️ .museattributes: no rule matched track=%r dim=%r — defaulting to auto",
+        track,
+        dimension,
+    )
+    return MergeStrategy.AUTO

--- a/tests/test_muse_attributes.py
+++ b/tests/test_muse_attributes.py
@@ -1,0 +1,206 @@
+"""Tests for maestro/services/muse_attributes.py.
+
+Covers:
+- parse_museattributes_file: valid rules, comments, blank lines, malformed lines,
+  unknown strategies.
+- resolve_strategy: exact track+dimension match, fnmatch wildcard patterns,
+  fallback to MergeStrategy.AUTO when no rule matches.
+- load_attributes: returns empty list when file not found; reads and parses
+  when the file exists.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from maestro.services.muse_attributes import (
+    MergeStrategy,
+    MuseAttribute,
+    load_attributes,
+    parse_museattributes_file,
+    resolve_strategy,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_museattributes_file
+# ---------------------------------------------------------------------------
+
+
+class TestParseMuseattributesFile:
+    def test_parses_basic_rule(self) -> None:
+        content = "drums/*  *  ours\n"
+        rules = parse_museattributes_file(content)
+        assert len(rules) == 1
+        assert rules[0].track_pattern == "drums/*"
+        assert rules[0].dimension == "*"
+        assert rules[0].strategy == MergeStrategy.OURS
+
+    def test_parses_multiple_rules(self) -> None:
+        content = (
+            "drums/*  *        ours\n"
+            "bass/*   harmonic  theirs\n"
+            "*        *         auto\n"
+        )
+        rules = parse_museattributes_file(content)
+        assert len(rules) == 3
+        assert rules[0].strategy == MergeStrategy.OURS
+        assert rules[1].strategy == MergeStrategy.THEIRS
+        assert rules[2].strategy == MergeStrategy.AUTO
+
+    def test_ignores_blank_lines(self) -> None:
+        content = "\n\ndrum/*  *  ours\n\n"
+        rules = parse_museattributes_file(content)
+        assert len(rules) == 1
+
+    def test_ignores_comment_lines(self) -> None:
+        content = "# This is a comment\ndrum/*  *  ours\n"
+        rules = parse_museattributes_file(content)
+        assert len(rules) == 1
+
+    def test_skips_malformed_lines(self) -> None:
+        content = "bad-line-only-two-tokens  ours\n"
+        rules = parse_museattributes_file(content)
+        assert len(rules) == 0
+
+    def test_skips_unknown_strategy(self) -> None:
+        content = "drums/*  *  unknown_strategy\n"
+        rules = parse_museattributes_file(content)
+        assert len(rules) == 0
+
+    def test_all_valid_strategies(self) -> None:
+        content = (
+            "a  *  ours\n"
+            "b  *  theirs\n"
+            "c  *  union\n"
+            "d  *  auto\n"
+            "e  *  manual\n"
+        )
+        rules = parse_museattributes_file(content)
+        strategies = [r.strategy for r in rules]
+        assert MergeStrategy.OURS in strategies
+        assert MergeStrategy.THEIRS in strategies
+        assert MergeStrategy.UNION in strategies
+        assert MergeStrategy.AUTO in strategies
+        assert MergeStrategy.MANUAL in strategies
+
+    def test_strategy_case_insensitive(self) -> None:
+        content = "drums/*  *  OURS\n"
+        rules = parse_museattributes_file(content)
+        assert len(rules) == 1
+        assert rules[0].strategy == MergeStrategy.OURS
+
+    def test_empty_content_returns_empty_list(self) -> None:
+        assert parse_museattributes_file("") == []
+
+    def test_only_comments_returns_empty_list(self) -> None:
+        content = "# only comments\n# nothing else\n"
+        assert parse_museattributes_file(content) == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_strategy
+# ---------------------------------------------------------------------------
+
+
+class TestResolveStrategy:
+    def _make_rule(
+        self,
+        track_pattern: str,
+        dimension: str,
+        strategy: MergeStrategy,
+    ) -> MuseAttribute:
+        return MuseAttribute(
+            track_pattern=track_pattern,
+            dimension=dimension,
+            strategy=strategy,
+        )
+
+    def test_exact_match_returns_configured_strategy(self) -> None:
+        attrs = [self._make_rule("drums/kick", "rhythmic", MergeStrategy.OURS)]
+        result = resolve_strategy(attrs, "drums/kick", "rhythmic")
+        assert result == MergeStrategy.OURS
+
+    def test_fnmatch_wildcard_track_matches(self) -> None:
+        attrs = [self._make_rule("drums/*", "*", MergeStrategy.OURS)]
+        assert resolve_strategy(attrs, "drums/kick", "harmonic") == MergeStrategy.OURS
+        assert resolve_strategy(attrs, "drums/snare", "melodic") == MergeStrategy.OURS
+
+    def test_star_track_matches_any(self) -> None:
+        attrs = [self._make_rule("*", "*", MergeStrategy.AUTO)]
+        assert resolve_strategy(attrs, "bass/electric", "harmonic") == MergeStrategy.AUTO
+
+    def test_first_match_wins(self) -> None:
+        attrs = [
+            self._make_rule("drums/*", "*", MergeStrategy.OURS),
+            self._make_rule("*", "*", MergeStrategy.AUTO),
+        ]
+        # drums/hi-hat should match the first rule
+        assert resolve_strategy(attrs, "drums/hi-hat", "rhythmic") == MergeStrategy.OURS
+        # keys/piano should fall through to the second rule
+        assert resolve_strategy(attrs, "keys/piano", "harmonic") == MergeStrategy.AUTO
+
+    def test_no_match_returns_auto(self) -> None:
+        attrs = [self._make_rule("drums/*", "rhythmic", MergeStrategy.OURS)]
+        # Different track, no match
+        result = resolve_strategy(attrs, "bass/electric", "harmonic")
+        assert result == MergeStrategy.AUTO
+
+    def test_empty_attributes_returns_auto(self) -> None:
+        result = resolve_strategy([], "drums/kick", "rhythmic")
+        assert result == MergeStrategy.AUTO
+
+    def test_dimension_wildcard_matches_all_dimensions(self) -> None:
+        attrs = [self._make_rule("bass/*", "*", MergeStrategy.THEIRS)]
+        for dim in ("harmonic", "rhythmic", "melodic", "structural", "dynamic"):
+            assert resolve_strategy(attrs, "bass/electric", dim) == MergeStrategy.THEIRS
+
+    def test_specific_dimension_does_not_match_other(self) -> None:
+        attrs = [self._make_rule("bass/*", "harmonic", MergeStrategy.THEIRS)]
+        assert resolve_strategy(attrs, "bass/electric", "harmonic") == MergeStrategy.THEIRS
+        assert resolve_strategy(attrs, "bass/electric", "rhythmic") == MergeStrategy.AUTO
+
+    def test_theirs_strategy_resolved(self) -> None:
+        attrs = [self._make_rule("keys/*", "harmonic", MergeStrategy.THEIRS)]
+        assert resolve_strategy(attrs, "keys/piano", "harmonic") == MergeStrategy.THEIRS
+
+    def test_union_strategy_resolved(self) -> None:
+        attrs = [self._make_rule("*", "structural", MergeStrategy.UNION)]
+        assert resolve_strategy(attrs, "any_track", "structural") == MergeStrategy.UNION
+
+    def test_manual_strategy_resolved(self) -> None:
+        attrs = [self._make_rule("*", "*", MergeStrategy.MANUAL)]
+        assert resolve_strategy(attrs, "vocals/lead", "melodic") == MergeStrategy.MANUAL
+
+
+# ---------------------------------------------------------------------------
+# load_attributes
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAttributes:
+    def test_returns_empty_list_when_file_not_found(self, tmp_path: pathlib.Path) -> None:
+        result = load_attributes(tmp_path)
+        assert result == []
+
+    def test_reads_and_parses_museattributes_file(self, tmp_path: pathlib.Path) -> None:
+        attr_file = tmp_path / ".museattributes"
+        attr_file.write_text("drums/*  *  ours\nbass/*  harmonic  theirs\n")
+        result = load_attributes(tmp_path)
+        assert len(result) == 2
+        assert result[0].track_pattern == "drums/*"
+        assert result[0].strategy == MergeStrategy.OURS
+        assert result[1].strategy == MergeStrategy.THEIRS
+
+    def test_returns_empty_list_for_empty_file(self, tmp_path: pathlib.Path) -> None:
+        attr_file = tmp_path / ".museattributes"
+        attr_file.write_text("")
+        result = load_attributes(tmp_path)
+        assert result == []
+
+    def test_returns_empty_list_for_comments_only_file(self, tmp_path: pathlib.Path) -> None:
+        attr_file = tmp_path / ".museattributes"
+        attr_file.write_text("# only comments here\n")
+        result = load_attributes(tmp_path)
+        assert result == []


### PR DESCRIPTION
## Summary
Closes #483 — implement .museattributes file for per-repo merge strategy configuration.

## Root Cause / Motivation
Without .museattributes, every musical dimension conflict requires manual resolution even when the resolution is obvious (e.g. drums are always authoritative).

## Solution
- maestro/services/muse_attributes.py: parser, strategy resolution, fnmatch track patterns
- maestro/muse_cli/commands/attributes.py: CLI plumbing command
- maestro/muse_cli/app.py: registered attributes sub-app
- maestro/services/muse_merge.py: consult attributes before choosing merge strategy per dimension
- tests/test_muse_attributes.py: 25 unit tests covering all acceptance criteria
- docs/reference/museattributes.md: full reference doc
- docs/architecture/muse_vcs.md: .museattributes section added

## Verification
- [x] mypy clean (667 source files, no issues)
- [x] Tests pass (25/25)
- [x] Docs updated