### PR TITLE
feat: add RFC 8288 Link header pagination to all list endpoints

### DIFF
--- a/maestro/api/routes/musehub/issues.py
+++ b/maestro/api/routes/musehub/issues.py
@@ -25,10 +25,11 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from maestro.auth.dependencies import TokenClaims, optional_token, require_valid_token
+from maestro.api.routes.musehub.pagination import PaginationParams, build_link_header, paginate_list
 from maestro.db import get_db
 from maestro.models.musehub import (
     IssueAssignRequest,
@@ -106,13 +107,21 @@ async def create_issue(
 )
 async def list_issues(
     repo_id: str,
+    request: Request,
+    response: Response,
     state: str = Query("open", pattern="^(open|closed|all)$", description="Filter by state"),
     label: str | None = Query(None, description="Filter by label string"),
     milestone_id: str | None = Query(None, description="Filter by milestone UUID"),
+    pagination: PaginationParams = Depends(PaginationParams),
     db: AsyncSession = Depends(get_db),
     claims: TokenClaims | None = Depends(optional_token),
 ) -> IssueListResponse:
     """Return issues for a repo. Defaults to open issues only.
+
+    Supports RFC 8288 page-based pagination via ``?page=N&per_page=N``.
+    The ``Link`` response header contains ``rel="first"``, ``rel="last"``,
+    ``rel="prev"`` (when not on the first page), and ``rel="next"`` (when
+    more pages remain).
 
     Use ``?state=all`` to include closed issues, ``?state=closed`` for closed only.
     Use ``?label=<string>`` to filter by a specific label.
@@ -127,10 +136,12 @@ async def list_issues(
             detail="Authentication required to access private repos.",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    issues = await musehub_issues.list_issues(
+    all_issues = await musehub_issues.list_issues(
         db, repo_id, state=state, label=label, milestone_id=milestone_id
     )
-    return IssueListResponse(issues=issues)
+    page_issues, total = paginate_list(all_issues, pagination.page, pagination.per_page)
+    response.headers["Link"] = build_link_header(request, total, pagination.page, pagination.per_page)
+    return IssueListResponse(issues=page_issues, total=total)
 
 
 @router.get(

--- a/maestro/api/routes/musehub/pagination.py
+++ b/maestro/api/routes/musehub/pagination.py
@@ -1,0 +1,138 @@
+"""RFC 8288 Link header pagination helpers for Muse Hub list endpoints.
+
+Why this exists: large repos with hundreds of commits, issues, or PRs are
+unusable when list endpoints return everything in a single unbounded response.
+This module provides a reusable FastAPI dependency (PaginationParams) and two
+Link header builders — one for page-based pagination and one for cursor-based —
+so every list endpoint can participate in RFC 8288 navigation without duplicating
+the header-construction logic.
+
+Usage (page-based):
+    @router.get("/repos/{repo_id}/issues")
+    async def list_issues(
+        pagination: PaginationParams = Depends(),
+        response: Response = None,
+        ...
+    ) -> IssueListResponse:
+        all_issues = await svc.list_issues(db, repo_id)
+        page_items, total = paginate_list(all_issues, pagination.page, pagination.per_page)
+        response.headers["Link"] = build_link_header(request, total, pagination.page, pagination.per_page)
+        return IssueListResponse(issues=page_items, total=total)
+
+Usage (cursor-based, e.g. repos list):
+    if result.next_cursor:
+        response.headers["Link"] = build_cursor_link_header(request, result.next_cursor, limit)
+"""
+from __future__ import annotations
+
+import math
+from typing import TypeVar
+from urllib.parse import urlencode, urljoin
+
+from fastapi import Query, Request
+
+T = TypeVar("T")
+
+
+class PaginationParams:
+    """FastAPI dependency that captures both page-based and cursor-based pagination query params.
+
+    Supports two pagination modes:
+    - Page-based: ``?page=N&per_page=N`` — use with ``build_link_header`` and ``paginate_list``.
+    - Cursor-based: ``?cursor=X&limit=N`` — use with ``build_cursor_link_header``.
+
+    Both sets of params are always parsed; route handlers pick the mode that matches
+    their backing service.  Unused params are silently ignored by the endpoint.
+    """
+
+    def __init__(
+        self,
+        page: int = Query(1, ge=1, description="Page number (1-indexed, used with per_page)"),
+        per_page: int = Query(20, ge=1, le=100, description="Items per page (used with page)"),
+        cursor: str | None = Query(None, description="Opaque cursor string from a previous response"),
+        limit: int = Query(20, ge=1, le=200, description="Max items per page (used with cursor)"),
+    ) -> None:
+        self.page = page
+        self.per_page = per_page
+        self.cursor = cursor
+        self.limit = limit
+
+
+def build_link_header(request: Request, total: int, page: int, per_page: int) -> str:
+    """Build an RFC 8288 Link header string for page-based pagination.
+
+    Always emits rel="first" and rel="last".  Emits rel="prev" when page > 1
+    and rel="next" when page < last_page.  Query parameters already present on
+    the request URL are preserved; ``page`` and ``per_page`` are overridden.
+
+    Args:
+        request: The current FastAPI Request — used to derive the base URL and
+                 carry-forward any existing query string parameters.
+        total:   Total number of items across all pages (used to compute last page).
+        page:    Current 1-indexed page number.
+        per_page: Number of items per page.
+
+    Returns:
+        A comma-joined RFC 8288 Link header value string, e.g.:
+        ``<https://…?page=1&per_page=20>; rel="first", <https://…?page=3&per_page=20>; rel="last"``
+    """
+    last_page = max(1, math.ceil(total / per_page)) if per_page > 0 else 1
+    base_url = str(request.url).split("?")[0]
+    existing_params = dict(request.query_params)
+
+    def _page_url(p: int) -> str:
+        q = {**existing_params, "page": str(p), "per_page": str(per_page)}
+        return f"{base_url}?{urlencode(q)}"
+
+    links: list[str] = []
+    links.append(f'<{_page_url(1)}>; rel="first"')
+    links.append(f'<{_page_url(last_page)}>; rel="last"')
+    if page > 1:
+        links.append(f'<{_page_url(page - 1)}>; rel="prev"')
+    if page < last_page:
+        links.append(f'<{_page_url(page + 1)}>; rel="next"')
+
+    return ", ".join(links)
+
+
+def build_cursor_link_header(request: Request, next_cursor: str, limit: int) -> str:
+    """Build an RFC 8288 Link header with rel="next" for cursor-based pagination.
+
+    Only emits rel="next" — cursor pagination cannot derive "prev", "first", or
+    "last" without a separate total count query, which would be expensive for
+    repos that may have thousands of items.
+
+    Args:
+        request:     The current FastAPI Request — used to derive the base URL.
+        next_cursor: Opaque cursor value returned by the backing service.
+        limit:       The page size that was used for the current request.
+
+    Returns:
+        A single RFC 8288 link: ``<https://…?cursor=X&limit=N>; rel="next"``
+    """
+    base_url = str(request.url).split("?")[0]
+    existing_params = dict(request.query_params)
+    q = {**existing_params, "cursor": next_cursor, "limit": str(limit)}
+    next_url = f"{base_url}?{urlencode(q)}"
+    return f'<{next_url}>; rel="next"'
+
+
+def paginate_list(items: list[T], page: int, per_page: int) -> tuple[list[T], int]:
+    """Slice a list to the requested page window.
+
+    Used for endpoints where the backing service fetches all matching rows (e.g.
+    after an in-memory label filter) and the route layer applies pagination.
+
+    Args:
+        items:    Full result list from the service layer.
+        page:     1-indexed page number requested by the client.
+        per_page: Number of items per page.
+
+    Returns:
+        A tuple of (page_slice, total) where ``total`` is ``len(items)`` before
+        slicing and ``page_slice`` is the subset for this page.
+    """
+    total = len(items)
+    start = (page - 1) * per_page
+    end = start + per_page
+    return items[start:end], total

--- a/maestro/models/musehub.py
+++ b/maestro/models/musehub.py
@@ -387,9 +387,14 @@ class IssueResponse(CamelModel):
 
 
 class IssueListResponse(CamelModel):
-    """List of issues for a repo."""
+    """Paginated list of issues for a repo.
+
+    ``total`` reflects the total number of matching issues before pagination.
+    Clients should use the RFC 8288 ``Link`` response header to navigate pages.
+    """
 
     issues: list[IssueResponse]
+    total: int = Field(0, ge=0, description="Total matching issues across all pages")
 
 
 # ── Musical context reference models ──────────────────────────────────────────
@@ -564,9 +569,14 @@ class PRResponse(CamelModel):
 
 
 class PRListResponse(CamelModel):
-    """List of pull requests for a repo."""
+    """Paginated list of pull requests for a repo.
+
+    ``total`` reflects the total number of matching PRs before pagination.
+    Clients should use the RFC 8288 ``Link`` response header to navigate pages.
+    """
 
     pull_requests: list[PRResponse]
+    total: int = Field(0, ge=0, description="Total matching pull requests across all pages")
 
 
 class PRMergeRequest(CamelModel):

--- a/tests/test_musehub_pagination.py
+++ b/tests/test_musehub_pagination.py
@@ -34,7 +34,6 @@ from maestro.api.routes.musehub.pagination import (
 
 def _make_request(url: str) -> StarletteRequest:
     """Build a minimal Starlette Request for testing URL construction."""
-    from starlette.datastructures import Headers
     scope = {
         "type": "http",
         "method": "GET",

--- a/tests/test_musehub_pagination.py
+++ b/tests/test_musehub_pagination.py
@@ -1,0 +1,386 @@
+"""Tests for RFC 8288 Link header pagination on Muse Hub list endpoints.
+
+Covers acceptance criteria from issue #456:
+- PaginationParams dependency parses page/per_page and cursor/limit query params
+- build_link_header emits correct RFC 8288 rel links for first/last/prev/next
+- build_cursor_link_header emits a rel="next" link with cursor and limit
+- paginate_list slices correctly and returns accurate total
+- GET /musehub/repos/{repo_id}/issues returns Link header and total field
+- GET /musehub/repos/{repo_id}/pull-requests returns Link header and total field
+- GET /musehub/repos/{repo_id}/commits returns Link header when per_page > 0
+- GET /musehub/repos returns rel="next" Link header when next_cursor is present
+
+All tests use fixtures from conftest.py. No live external APIs are called.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.requests import Request as StarletteRequest
+
+from maestro.api.routes.musehub.pagination import (
+    PaginationParams,
+    build_cursor_link_header,
+    build_link_header,
+    paginate_list,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — pagination helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(url: str) -> StarletteRequest:
+    """Build a minimal Starlette Request for testing URL construction."""
+    from starlette.datastructures import Headers
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": url.split("?")[0],
+        "query_string": url.split("?")[1].encode() if "?" in url else b"",
+        "headers": [],
+    }
+    return StarletteRequest(scope)
+
+
+def test_paginate_list_first_page() -> None:
+    """paginate_list returns the first page slice and correct total."""
+    items = list(range(55))
+    page, total = paginate_list(items, page=1, per_page=20)
+    assert total == 55
+    assert page == list(range(20))
+
+
+def test_paginate_list_middle_page() -> None:
+    """paginate_list returns the correct middle page slice."""
+    items = list(range(55))
+    page, total = paginate_list(items, page=2, per_page=20)
+    assert total == 55
+    assert page == list(range(20, 40))
+
+
+def test_paginate_list_last_partial_page() -> None:
+    """paginate_list returns a partial slice on the final page."""
+    items = list(range(55))
+    page, total = paginate_list(items, page=3, per_page=20)
+    assert total == 55
+    assert page == list(range(40, 55))
+
+
+def test_paginate_list_beyond_last_page_returns_empty() -> None:
+    """paginate_list returns an empty slice when page exceeds total."""
+    items = list(range(10))
+    page, total = paginate_list(items, page=5, per_page=10)
+    assert total == 10
+    assert page == []
+
+
+def test_paginate_list_empty_input() -> None:
+    """paginate_list handles empty input gracefully."""
+    page_items: list[int]
+    page_items, total = paginate_list([], page=1, per_page=20)
+    assert total == 0
+    assert page_items == []
+
+
+def test_build_link_header_single_page() -> None:
+    """build_link_header emits only first and last when there is exactly one page."""
+    req = _make_request("http://test/api/v1/musehub/repos/r1/issues?page=1&per_page=20")
+    header = build_link_header(req, total=5, page=1, per_page=20)
+    assert 'rel="first"' in header
+    assert 'rel="last"' in header
+    assert 'rel="next"' not in header
+    assert 'rel="prev"' not in header
+
+
+def test_build_link_header_first_of_many() -> None:
+    """build_link_header emits first, last, and next (but not prev) on page 1 of N."""
+    req = _make_request("http://test/api/v1/musehub/repos/r1/issues?page=1&per_page=10")
+    header = build_link_header(req, total=55, page=1, per_page=10)
+    assert 'rel="first"' in header
+    assert 'rel="last"' in header
+    assert 'rel="next"' in header
+    assert 'rel="prev"' not in header
+    assert "page=2" in header
+    assert "page=6" in header  # last page for 55 items at 10/page
+
+
+def test_build_link_header_middle_page() -> None:
+    """build_link_header emits all four rels on an interior page."""
+    req = _make_request("http://test/api/v1/musehub/repos/r1/issues?page=3&per_page=10")
+    header = build_link_header(req, total=55, page=3, per_page=10)
+    assert 'rel="first"' in header
+    assert 'rel="last"' in header
+    assert 'rel="next"' in header
+    assert 'rel="prev"' in header
+    assert "page=4" in header
+    assert "page=2" in header
+
+
+def test_build_link_header_last_page() -> None:
+    """build_link_header emits prev (but not next) on the last page."""
+    req = _make_request("http://test/api/v1/musehub/repos/r1/issues?page=6&per_page=10")
+    header = build_link_header(req, total=55, page=6, per_page=10)
+    assert 'rel="first"' in header
+    assert 'rel="last"' in header
+    assert 'rel="prev"' in header
+    assert 'rel="next"' not in header
+
+
+def test_build_link_header_preserves_existing_query_params() -> None:
+    """build_link_header keeps non-pagination query params on generated URLs."""
+    req = _make_request("http://test/api/v1/musehub/repos/r1/issues?state=open&page=1&per_page=10")
+    header = build_link_header(req, total=30, page=1, per_page=10)
+    assert "state=open" in header
+
+
+def test_build_cursor_link_header_emits_next_only() -> None:
+    """build_cursor_link_header emits exactly one rel="next" with cursor and limit encoded."""
+    req = _make_request("http://test/api/v1/musehub/repos?limit=20")
+    header = build_cursor_link_header(req, next_cursor="abc123", limit=20)
+    assert 'rel="next"' in header
+    assert "cursor=abc123" in header
+    assert "limit=20" in header
+    assert 'rel="prev"' not in header
+    assert 'rel="first"' not in header
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — issues list endpoint
+# ---------------------------------------------------------------------------
+
+
+async def _create_repo(client: AsyncClient, auth_headers: dict[str, str], name: str) -> str:
+    r = await client.post(
+        "/api/v1/musehub/repos",
+        json={"name": name, "owner": "testuser"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 201
+    repo_id: str = r.json()["repoId"]
+    return repo_id
+
+
+async def _create_issue(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    repo_id: str,
+    title: str,
+) -> None:
+    r = await client.post(
+        f"/api/v1/musehub/repos/{repo_id}/issues",
+        json={"title": title, "body": ""},
+        headers=auth_headers,
+    )
+    assert r.status_code == 201
+
+
+@pytest.mark.anyio
+async def test_list_issues_link_header_present(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /issues includes a Link header when pagination is active."""
+    repo_id = await _create_repo(client, auth_headers, "pagination-issues-link")
+    for i in range(5):
+        await _create_issue(client, auth_headers, repo_id, f"Issue {i}")
+
+    r = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/issues?page=1&per_page=2",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert "Link" in r.headers
+    link = r.headers["Link"]
+    assert 'rel="first"' in link
+    assert 'rel="last"' in link
+    assert 'rel="next"' in link
+
+
+@pytest.mark.anyio
+async def test_list_issues_total_field_returned(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /issues response body includes ``total`` with the count across all pages."""
+    repo_id = await _create_repo(client, auth_headers, "pagination-issues-total")
+    for i in range(7):
+        await _create_issue(client, auth_headers, repo_id, f"Track issue {i}")
+
+    r = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/issues?page=1&per_page=3",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 7
+    assert len(body["issues"]) == 3
+
+
+@pytest.mark.anyio
+async def test_list_issues_last_page_no_next(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /issues Link header on the last page has no rel=\"next\"."""
+    repo_id = await _create_repo(client, auth_headers, "pagination-issues-last")
+    for i in range(4):
+        await _create_issue(client, auth_headers, repo_id, f"Issue {i}")
+
+    r = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/issues?page=2&per_page=3",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    link = r.headers["Link"]
+    assert 'rel="next"' not in link
+    assert 'rel="prev"' in link
+
+
+@pytest.mark.anyio
+async def test_list_issues_default_page_returns_all_when_small(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /issues with no pagination params returns results on page 1 (default)."""
+    repo_id = await _create_repo(client, auth_headers, "pagination-issues-default")
+    for i in range(3):
+        await _create_issue(client, auth_headers, repo_id, f"Default page {i}")
+
+    r = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/issues",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["issues"]) == 3
+    assert body["total"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — PRs list endpoint
+# ---------------------------------------------------------------------------
+
+
+
+@pytest.mark.anyio
+async def test_list_prs_link_header_present(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """GET /pull-requests includes a Link header when pagination is active."""
+    from maestro.db.musehub_models import MusehubPullRequest
+
+    repo_id = await _create_repo(client, auth_headers, "pagination-prs-link")
+
+    # Insert PRs directly to avoid branch validation complexity in tests
+    for i in range(3):
+        db_session.add(MusehubPullRequest(
+            repo_id=repo_id,
+            title=f"PR {i}",
+            from_branch=f"feat/{i}",
+            to_branch="main",
+            author="testuser",
+        ))
+    await db_session.commit()
+
+    r = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/pull-requests?page=1&per_page=2",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert "Link" in r.headers
+    link = r.headers["Link"]
+    assert 'rel="first"' in link
+    assert 'rel="next"' in link
+
+
+@pytest.mark.anyio
+async def test_list_prs_total_field_returned(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """GET /pull-requests response body includes ``total`` field."""
+    from maestro.db.musehub_models import MusehubPullRequest
+
+    repo_id = await _create_repo(client, auth_headers, "pagination-prs-total")
+
+    for i in range(4):
+        db_session.add(MusehubPullRequest(
+            repo_id=repo_id,
+            title=f"PR {i}",
+            from_branch=f"feat/{i}",
+            to_branch="main",
+            author="testuser",
+        ))
+    await db_session.commit()
+
+    r = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/pull-requests",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert "total" in body
+    assert body["total"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — commits list endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_list_commits_link_header_with_per_page(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> None:
+    """GET /commits with per_page > 0 includes an RFC 8288 Link header."""
+    from datetime import datetime, timezone, timedelta
+    from maestro.db.musehub_models import MusehubCommit
+
+    repo_id = await _create_repo(client, auth_headers, "pagination-commits-link")
+    now = datetime.now(tz=timezone.utc)
+
+    for i in range(5):
+        db_session.add(MusehubCommit(
+            commit_id=f"sha-{i:04d}",
+            repo_id=repo_id,
+            branch="main",
+            parent_ids=[],
+            message=f"Commit {i}",
+            author="testuser",
+            timestamp=now + timedelta(seconds=i),
+        ))
+    await db_session.commit()
+
+    r = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/commits?page=1&per_page=2",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert "Link" in r.headers
+    link = r.headers["Link"]
+    assert 'rel="first"' in link
+    assert 'rel="next"' in link
+
+
+@pytest.mark.anyio
+async def test_list_commits_no_link_header_without_per_page(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /commits without per_page does NOT add a Link header (legacy mode)."""
+    repo_id = await _create_repo(client, auth_headers, "pagination-commits-no-link")
+
+    r = await client.get(
+        f"/api/v1/musehub/repos/{repo_id}/commits",
+        headers=auth_headers,
+    )
+    assert r.status_code == 200
+    assert "Link" not in r.headers


### PR DESCRIPTION
## Summary

Closes #456 — adds RFC 8288 Link header pagination and cursor-based pagination to all list endpoints.

## Root Cause / Motivation

List endpoints returned all results with no pagination, making large repos unusable for machine clients. An issues endpoint with 500 issues returned all 500 in a single unbounded response. Cursor-aware HTTP clients (agents, CLI tools) had no standard way to navigate pages.

## Solution

New reusable module `maestro/api/routes/musehub/pagination.py`:
- `PaginationParams` FastAPI dependency — captures `page`/`per_page` (page-based) and `cursor`/`limit` (cursor-based) from query string.
- `build_link_header(request, total, page, per_page)` — emits RFC 8288 `rel="first"`, `rel="last"`, `rel="prev"`, `rel="next"` links.
- `build_cursor_link_header(request, next_cursor, limit)` — emits a single `rel="next"` link for cursor-based endpoints.
- `paginate_list(items, page, per_page)` — in-memory slicer returning `(page_slice, total)`.

Applied to four list endpoints:
| Endpoint | Mode | Change |
|----------|------|--------|
| `GET /repos` | Cursor-based | `rel="next"` Link header when `next_cursor` present |
| `GET /repos/{id}/commits` | Page-based | Link header when `per_page > 0`; legacy `limit`-only mode unchanged |
| `GET /repos/{id}/issues` | Page-based | `PaginationParams` dep + Link header + `total` field in body |
| `GET /repos/{id}/pull-requests` | Page-based | `PaginationParams` dep + Link header + `total` field in body |

`IssueListResponse` and `PRListResponse` gain a `total: int` field (default 0 — backwards-compatible). `ui_milestones.py` updated to supply `total` when constructing `IssueListResponse`.

## Layers Affected
- [x] Muse Hub API routes (`maestro/api/routes/musehub/`)
- [x] Muse Hub models (`maestro/models/musehub.py`)

## Verification
- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (687 source files)
- [x] `docker compose exec storpheus mypy .` — N/A (storpheus unchanged)
- [x] 19 tests pass: `tests/test_musehub_pagination.py`
- [x] No protocol/SSE change — no handoff required

## Tests Added
- `test_paginate_list_first_page` — regression: correct first-page slice
- `test_paginate_list_middle_page` — middle-page slicing
- `test_paginate_list_last_partial_page` — partial last page
- `test_paginate_list_beyond_last_page_returns_empty` — graceful overflow
- `test_paginate_list_empty_input` — empty list edge case
- `test_build_link_header_single_page` — no prev/next when one page
- `test_build_link_header_first_of_many` — next present, prev absent
- `test_build_link_header_middle_page` — all four rels present
- `test_build_link_header_last_page` — prev present, next absent
- `test_build_link_header_preserves_existing_query_params` — carry-forward filters
- `test_build_cursor_link_header_emits_next_only` — cursor link correctness
- `test_list_issues_link_header_present` — integration: issues Link header
- `test_list_issues_total_field_returned` — integration: issues total field
- `test_list_issues_last_page_no_next` — integration: last-page correctness
- `test_list_issues_default_page_returns_all_when_small` — default params
- `test_list_prs_link_header_present` — integration: PRs Link header
- `test_list_prs_total_field_returned` — integration: PRs total field
- `test_list_commits_link_header_with_per_page` — integration: commits Link header
- `test_list_commits_no_link_header_without_per_page` — legacy mode unchanged

## Handoff
N/A — no SSE/MCP protocol change.