### PR TITLE
feat: label management UI page (/{owner}/{repo}/labels)

### DIFF
--- a/maestro/api/routes/musehub/ui_labels.py
+++ b/maestro/api/routes/musehub/ui_labels.py
@@ -1,0 +1,517 @@
+"""Muse Hub label management UI route handlers.
+
+Serves the labels management page at ``/{owner}/{repo}/labels`` and
+provides POST handlers for label mutations (create, edit, delete, reset).
+
+Endpoint summary:
+  GET  /musehub/ui/{owner}/{repo_slug}/labels                          — label list page (public)
+  POST /musehub/ui/{owner}/{repo_slug}/labels                          — create label (auth required)
+  POST /musehub/ui/{owner}/{repo_slug}/labels/{label_id}/edit          — update label (auth required)
+  POST /musehub/ui/{owner}/{repo_slug}/labels/{label_id}/delete        — delete label (auth required)
+  POST /musehub/ui/{owner}/{repo_slug}/labels/reset                    — reset to 10 defaults (auth required)
+
+Auth policy:
+  GET: no authentication required — public repos are readable without a token.
+  POST mutations: require a valid Bearer JWT (``require_valid_token``).
+  The JS on the labels page reads a token from ``localStorage`` and sends it as
+  ``Authorization: Bearer <token>`` on every mutation call.
+
+Design rationale:
+  POST routes return JSON so the in-page JS can handle success/error inline
+  without a full page reload.  This keeps the UX snappy while keeping the
+  server-side contract simple and testable.
+
+  The ``reset`` route is UI-only (not in the JSON API): it wipes all repo
+  labels and re-seeds the canonical 10 defaults.  It is useful after
+  accidental bulk deletions or when onboarding a repo from an external source.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import status as http_status
+from fastapi.responses import JSONResponse
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response as StarletteResponse
+
+from maestro.api.routes.musehub.labels import DEFAULT_LABELS
+from maestro.api.routes.musehub.negotiate import negotiate_response
+from maestro.auth.dependencies import TokenClaims, optional_token, require_valid_token
+from maestro.db import get_db
+from maestro.services import musehub_repository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/musehub/ui", tags=["musehub-ui"])
+
+_TEMPLATE_DIR = Path(__file__).parent.parent.parent.parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Internal models
+# ---------------------------------------------------------------------------
+
+
+class _LabelRow(BaseModel):
+    """Internal representation of a label row with issue count."""
+
+    label_id: str
+    repo_id: str
+    name: str
+    color: str
+    description: str | None = None
+    issue_count: int = 0
+
+    model_config = {"from_attributes": True}
+
+
+class _LabelListPayload(BaseModel):
+    """JSON payload for the labels list — consumed by the template JS and agents."""
+
+    labels: list[_LabelRow]
+    total: int
+
+
+class _LabelCreateBody(BaseModel):
+    """Request body for creating a label."""
+
+    name: str = Field(..., min_length=1, max_length=50)
+    color: str = Field(..., pattern=r"^#[0-9a-fA-F]{6}$")
+    description: str | None = Field(None, max_length=200)
+
+
+class _LabelEditBody(BaseModel):
+    """Request body for editing a label (all fields optional)."""
+
+    name: str | None = Field(None, min_length=1, max_length=50)
+    color: str | None = Field(None, pattern=r"^#[0-9a-fA-F]{6}$")
+    description: str | None = Field(None, max_length=200)
+
+
+class _LabelActionResponse(BaseModel):
+    """Returned by create / edit / delete / reset — confirms the result."""
+
+    ok: bool
+    message: str
+    label_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _base_url(owner: str, repo_slug: str) -> str:
+    """Return the canonical UI base URL for a repo."""
+    return f"/musehub/ui/{owner}/{repo_slug}"
+
+
+async def _resolve_repo(
+    owner: str, repo_slug: str, db: AsyncSession
+) -> tuple[str, str]:
+    """Resolve owner+slug to (repo_id, base_url); raise 404 if not found."""
+    row = await musehub_repository.get_repo_orm_by_owner_slug(db, owner, repo_slug)
+    if row is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=f"Repo '{owner}/{repo_slug}' not found",
+        )
+    return str(row.repo_id), _base_url(owner, repo_slug)
+
+
+async def _fetch_labels(db: AsyncSession, repo_id: str) -> list[_LabelRow]:
+    """Return all labels for *repo_id* with their open-issue counts.
+
+    Uses a LEFT JOIN on ``musehub_issue_labels`` / ``musehub_issues`` so that
+    labels with zero issues still appear.  Sorted alphabetically by name.
+    """
+    result = await db.execute(
+        text(
+            """
+            SELECT
+              ml.id          AS label_id,
+              ml.repo_id     AS repo_id,
+              ml.name        AS name,
+              ml.color       AS color,
+              ml.description AS description,
+              COUNT(mil.label_id) AS issue_count
+            FROM musehub_labels ml
+            LEFT JOIN musehub_issue_labels mil ON mil.label_id = ml.id
+            WHERE ml.repo_id = :repo_id
+            GROUP BY ml.id, ml.repo_id, ml.name, ml.color, ml.description
+            ORDER BY ml.name ASC
+            """
+        ),
+        {"repo_id": repo_id},
+    )
+    rows = result.mappings().all()
+    return [_LabelRow(**dict(r)) for r in rows]
+
+
+async def _assert_label_exists(
+    db: AsyncSession, repo_id: str, label_id: str
+) -> None:
+    """Raise 404 if the label does not belong to this repo."""
+    result = await db.execute(
+        text(
+            "SELECT 1 FROM musehub_labels "
+            "WHERE id = :label_id AND repo_id = :repo_id"
+        ),
+        {"label_id": label_id, "repo_id": repo_id},
+    )
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="Label not found",
+        )
+
+
+# ---------------------------------------------------------------------------
+# GET — label list page
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{owner}/{repo_slug}/labels",
+    summary="Muse Hub label list page — view and manage repo labels",
+)
+async def labels_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    format: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    _claims: TokenClaims | None = Depends(optional_token),
+) -> StarletteResponse:
+    """Render the labels management page or return structured JSON.
+
+    HTML (default): renders ``musehub/pages/labels.html`` — an interactive
+    page with:
+      - Inline create form with a colour picker and description field
+      - Label list: colour swatch, name, description, issue count badge
+      - Edit and delete actions on each label (owner/write only, enforced JS-side)
+      - «Reset to defaults» button (owner/write only)
+
+    JSON (``Accept: application/json`` or ``?format=json``): returns
+    :class:`_LabelListPayload` with all labels and their issue counts.
+
+    Why this route exists: the labels page is the canonical place to define
+    the taxonomy used across issues and PRs in a music project repo.
+    Pre-seeded defaults (bug, enhancement, needs-arrangement, etc.) cover the
+    most common categories; this page lets project owners customise them.
+
+    No JWT required — the HTML shell loads public data. Mutations below
+    require a valid token injected via the in-page JS from localStorage.
+    """
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+    labels = await _fetch_labels(db, repo_id)
+    json_data = _LabelListPayload(labels=labels, total=len(labels))
+
+    return await negotiate_response(
+        request=request,
+        template_name="musehub/pages/labels.html",
+        context={
+            "owner": owner,
+            "repo_slug": repo_slug,
+            "repo_id": repo_id,
+            "base_url": base_url,
+            "current_page": "labels",
+            "breadcrumb_data": [
+                {"label": owner, "url": f"/musehub/ui/{owner}"},
+                {"label": repo_slug, "url": base_url},
+                {"label": "Labels", "url": ""},
+            ],
+        },
+        templates=templates,
+        json_data=json_data,
+        format_param=format,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST — create label
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{owner}/{repo_slug}/labels",
+    summary="Create a new label in a Muse Hub repo",
+    status_code=http_status.HTTP_201_CREATED,
+)
+async def create_label(
+    owner: str,
+    repo_slug: str,
+    body: _LabelCreateBody,
+    db: AsyncSession = Depends(get_db),
+    _token: TokenClaims = Depends(require_valid_token),
+) -> JSONResponse:
+    """Create a label with the given name, hex colour, and optional description.
+
+    Names must be unique within the repo.  Returns the new label's UUID and a
+    confirmation message so the in-page JS can optimistically add the row.
+
+    Called via ``fetch()`` from the in-page JavaScript with the Bearer token
+    read from ``localStorage``.
+    """
+    repo_id, _ = await _resolve_repo(owner, repo_slug, db)
+
+    existing = await db.execute(
+        text(
+            "SELECT 1 FROM musehub_labels "
+            "WHERE repo_id = :repo_id AND name = :name"
+        ),
+        {"repo_id": repo_id, "name": body.name},
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail=f"Label '{body.name}' already exists in this repo",
+        )
+
+    label_id = str(uuid.uuid4())
+    await db.execute(
+        text(
+            "INSERT INTO musehub_labels "
+            "(id, repo_id, name, color, description, created_at) "
+            "VALUES (:label_id, :repo_id, :name, :color, :description, CURRENT_TIMESTAMP)"
+        ),
+        {
+            "label_id": label_id,
+            "repo_id": repo_id,
+            "name": body.name,
+            "color": body.color,
+            "description": body.description,
+        },
+    )
+    await db.commit()
+    logger.info("✅ Created label '%s' (%s) in repo %s", body.name, label_id, repo_id)
+
+    response = _LabelActionResponse(
+        ok=True,
+        message=f"Label '{body.name}' created",
+        label_id=label_id,
+    )
+    return JSONResponse(content=response.model_dump(), status_code=http_status.HTTP_201_CREATED)
+
+
+# ---------------------------------------------------------------------------
+# POST — edit label
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{owner}/{repo_slug}/labels/{label_id}/edit",
+    summary="Update a label's name, colour, or description",
+)
+async def edit_label(
+    owner: str,
+    repo_slug: str,
+    label_id: str,
+    body: _LabelEditBody,
+    db: AsyncSession = Depends(get_db),
+    _token: TokenClaims = Depends(require_valid_token),
+) -> JSONResponse:
+    """Partially update an existing label.
+
+    Only fields present (non-null) in the request body are modified.
+    Returns an ``ok`` confirmation so the JS can update the DOM in place.
+
+    Path uses ``/edit`` suffix to distinguish from the delete action, matching
+    the HTML form-action convention used across the Muse Hub UI.
+    """
+    repo_id, _ = await _resolve_repo(owner, repo_slug, db)
+    await _assert_label_exists(db, repo_id, label_id)
+
+    # Fetch current values so we can apply partial updates.
+    current_result = await db.execute(
+        text(
+            "SELECT name, color, description "
+            "FROM musehub_labels WHERE id = :label_id"
+        ),
+        {"label_id": label_id},
+    )
+    current = dict(current_result.mappings().one())
+
+    new_name = body.name if body.name is not None else current["name"]
+    new_color = body.color if body.color is not None else current["color"]
+    new_description = body.description if body.description is not None else current["description"]
+
+    if body.name is not None and body.name != current["name"]:
+        collision = await db.execute(
+            text(
+                "SELECT 1 FROM musehub_labels "
+                "WHERE repo_id = :repo_id AND name = :name AND id != :label_id"
+            ),
+            {"repo_id": repo_id, "name": body.name, "label_id": label_id},
+        )
+        if collision.scalar_one_or_none() is not None:
+            raise HTTPException(
+                status_code=http_status.HTTP_409_CONFLICT,
+                detail=f"Label '{body.name}' already exists in this repo",
+            )
+
+    await db.execute(
+        text(
+            "UPDATE musehub_labels "
+            "SET name = :name, color = :color, description = :description "
+            "WHERE id = :label_id AND repo_id = :repo_id"
+        ),
+        {
+            "name": new_name,
+            "color": new_color,
+            "description": new_description,
+            "label_id": label_id,
+            "repo_id": repo_id,
+        },
+    )
+    await db.commit()
+    logger.info("✅ Updated label %s in repo %s", label_id, repo_id)
+
+    response = _LabelActionResponse(
+        ok=True,
+        message=f"Label '{new_name}' updated",
+        label_id=label_id,
+    )
+    return JSONResponse(content=response.model_dump())
+
+
+# ---------------------------------------------------------------------------
+# POST — delete label
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{owner}/{repo_slug}/labels/{label_id}/delete",
+    summary="Delete a label from a Muse Hub repo",
+)
+async def delete_label(
+    owner: str,
+    repo_slug: str,
+    label_id: str,
+    db: AsyncSession = Depends(get_db),
+    _token: TokenClaims = Depends(require_valid_token),
+) -> JSONResponse:
+    """Permanently delete a label and remove it from all issues and PRs.
+
+    Uses ``/delete`` suffix (not ``DELETE`` method) so the action can be
+    triggered from a standard HTML form via JavaScript fetch.
+
+    Associations are cleaned up before the label row is removed to satisfy
+    foreign-key constraints on ``musehub_issue_labels`` and ``musehub_pr_labels``.
+    """
+    repo_id, _ = await _resolve_repo(owner, repo_slug, db)
+    await _assert_label_exists(db, repo_id, label_id)
+
+    await db.execute(
+        text("DELETE FROM musehub_issue_labels WHERE label_id = :label_id"),
+        {"label_id": label_id},
+    )
+    await db.execute(
+        text("DELETE FROM musehub_pr_labels WHERE label_id = :label_id"),
+        {"label_id": label_id},
+    )
+    await db.execute(
+        text(
+            "DELETE FROM musehub_labels "
+            "WHERE id = :label_id AND repo_id = :repo_id"
+        ),
+        {"label_id": label_id, "repo_id": repo_id},
+    )
+    await db.commit()
+    logger.info("✅ Deleted label %s from repo %s", label_id, repo_id)
+
+    response = _LabelActionResponse(
+        ok=True,
+        message="Label deleted",
+        label_id=label_id,
+    )
+    return JSONResponse(content=response.model_dump())
+
+
+# ---------------------------------------------------------------------------
+# POST — reset to defaults
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{owner}/{repo_slug}/labels/reset",
+    summary="Reset repo labels to the 10 canonical defaults",
+)
+async def reset_labels(
+    owner: str,
+    repo_slug: str,
+    db: AsyncSession = Depends(get_db),
+    _token: TokenClaims = Depends(require_valid_token),
+) -> JSONResponse:
+    """Delete all existing labels and re-seed the 10 canonical defaults.
+
+    Why this route exists: useful after accidental bulk deletion or when
+    onboarding a repo from an external source that uses non-standard labels.
+    The reset is destructive — all custom labels and their issue/PR associations
+    are removed before the defaults are inserted.
+
+    This endpoint is UI-only (not exposed via the JSON API) because it is a
+    high-impact destructive action best surfaced through the labelled
+    «Reset to defaults» button with a confirmation dialog.
+    """
+    repo_id, _ = await _resolve_repo(owner, repo_slug, db)
+
+    # Remove all associations first, then all labels for this repo.
+    await db.execute(
+        text(
+            "DELETE FROM musehub_issue_labels "
+            "WHERE label_id IN ("
+            "  SELECT id FROM musehub_labels WHERE repo_id = :repo_id"
+            ")"
+        ),
+        {"repo_id": repo_id},
+    )
+    await db.execute(
+        text(
+            "DELETE FROM musehub_pr_labels "
+            "WHERE label_id IN ("
+            "  SELECT id FROM musehub_labels WHERE repo_id = :repo_id"
+            ")"
+        ),
+        {"repo_id": repo_id},
+    )
+    await db.execute(
+        text("DELETE FROM musehub_labels WHERE repo_id = :repo_id"),
+        {"repo_id": repo_id},
+    )
+
+    # Re-seed defaults.
+    for label_def in DEFAULT_LABELS:
+        await db.execute(
+            text(
+                "INSERT INTO musehub_labels "
+                "(id, repo_id, name, color, description, created_at) "
+                "VALUES (:label_id, :repo_id, :name, :color, :description, CURRENT_TIMESTAMP)"
+            ),
+            {
+                "label_id": str(uuid.uuid4()),
+                "repo_id": repo_id,
+                "name": label_def["name"],
+                "color": label_def["color"],
+                "description": label_def.get("description"),
+            },
+        )
+
+    await db.commit()
+    logger.info(
+        "✅ Reset labels to %d defaults for repo %s", len(DEFAULT_LABELS), repo_id
+    )
+
+    response = _LabelActionResponse(
+        ok=True,
+        message=f"Labels reset to {len(DEFAULT_LABELS)} defaults",
+        label_id=None,
+    )
+    return JSONResponse(content=response.model_dump())

--- a/maestro/main.py
+++ b/maestro/main.py
@@ -29,6 +29,7 @@ from maestro.api.routes.musehub import ui_milestones as musehub_ui_milestones_ro
 from maestro.api.routes.musehub import ui_blame as musehub_ui_blame_routes
 from maestro.api.routes.musehub import ui_notifications as musehub_ui_notifications_routes
 from maestro.api.routes.musehub import ui_collaborators as musehub_ui_collab_routes
+from maestro.api.routes.musehub import ui_labels as musehub_ui_labels_routes
 from maestro.api.routes.musehub import ui_settings as musehub_ui_settings_routes
 from maestro.api.routes.musehub import ui_similarity as musehub_ui_similarity_routes
 from maestro.api.routes.musehub import ui_user_profile as musehub_ui_profile_routes
@@ -234,6 +235,8 @@ app.include_router(musehub_ui_routes.fixed_router, tags=["musehub-ui"])
 # /{owner}/{repo_slug}/milestones paths are matched before /{owner}/{repo_slug}.
 app.include_router(musehub_ui_milestones_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_ui_collab_routes.router, tags=["musehub-ui"])
+# Label management UI page — registered before the wildcard router so /labels paths are matched first.
+app.include_router(musehub_ui_labels_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_ui_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_ui_blame_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_ui_settings_routes.router, tags=["musehub-ui-settings"])

--- a/maestro/templates/musehub/pages/labels.html
+++ b/maestro/templates/musehub/pages/labels.html
@@ -1,0 +1,413 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Labels{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> / labels
+{% endblock %}
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block extra_css %}
+<style>
+/* ── Label management page ─────────────────────────────────────────── */
+.labels-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.labels-toolbar h1 { margin: 0; }
+.toolbar-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* Create / edit form card */
+.label-form-card {
+  background: var(--bg-overlay, #161b22);
+  border: 1px solid var(--border, #30363d);
+  border-radius: 8px;
+  padding: 18px;
+  margin-bottom: 18px;
+  display: none;
+}
+.label-form-card.active { display: block; }
+.label-form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-end;
+  margin-bottom: 10px;
+}
+.label-form-group { display: flex; flex-direction: column; gap: 4px; flex: 1; min-width: 140px; }
+.label-form-group label { font-size: 12px; color: var(--text-muted, #8b949e); font-weight: 500; }
+.label-form-group input[type="text"],
+.label-form-group input[type="color"] {
+  border: 1px solid var(--border, #30363d);
+  border-radius: 6px;
+  background: var(--bg-base, #0d1117);
+  color: var(--text-primary, #e6edf3);
+  font-size: 14px;
+  padding: 6px 10px;
+}
+.label-form-group input[type="color"] {
+  padding: 3px 6px;
+  height: 36px;
+  cursor: pointer;
+  width: 60px;
+  flex: 0 0 60px;
+  min-width: 60px;
+}
+.form-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.color-preview {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-muted, #8b949e);
+}
+.color-preview-swatch {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  border: 1px solid var(--border, #30363d);
+}
+
+/* Label rows */
+.label-list { display: flex; flex-direction: column; gap: 0; }
+.label-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border, #30363d);
+  flex-wrap: wrap;
+}
+.label-row:last-child { border-bottom: none; }
+.label-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.label-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  padding: 3px 10px;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  white-space: nowrap;
+  /* color set inline */
+}
+.label-info { flex: 1; min-width: 120px; }
+.label-desc { font-size: 12px; color: var(--text-muted, #8b949e); margin-top: 2px; }
+.issue-count-badge {
+  font-size: 12px;
+  color: var(--text-muted, #8b949e);
+  white-space: nowrap;
+}
+.label-row-actions {
+  display: none;  /* shown only when authed */
+  gap: 6px;
+  flex-shrink: 0;
+}
+.label-row-actions.visible { display: flex; }
+
+/* Inline edit form row */
+.label-edit-form {
+  width: 100%;
+  background: var(--bg-overlay, #161b22);
+  border: 1px solid var(--border, #30363d);
+  border-radius: 8px;
+  padding: 14px;
+  margin-top: 8px;
+  display: none;
+}
+.label-edit-form.active { display: block; }
+
+/* Utility */
+.btn-danger { background: var(--red-dim, #3d1c1c); border-color: var(--red, #f85149); color: var(--red, #f85149); }
+.btn-danger:hover { background: var(--red, #f85149); color: #fff; }
+.empty-state { padding: 40px 0; text-align: center; color: var(--text-muted, #8b949e); }
+.form-error { color: var(--red, #f85149); font-size: 13px; margin-top: 6px; display: none; }
+.form-error.visible { display: block; }
+</style>
+{% endblock %}
+
+{% block page_data %}
+const repoId   = {{ repo_id | tojson }};
+const base     = {{ base_url | tojson }};
+const owner    = {{ owner | tojson }};
+const repoSlug = {{ repo_slug | tojson }};
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function contrastColor(hex) {
+  // Return #000 or #fff depending on luminance of background hex colour.
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? '#000000' : '#ffffff';
+}
+
+function pillStyle(color) {
+  return `background:${color};color:${contrastColor(color)}`;
+}
+
+// ── Render ─────────────────────────────────────────────────────────────────
+
+function renderLabelRow(label, authed) {
+  const actionsClass = authed ? 'label-row-actions visible' : 'label-row-actions';
+  const issueWord = label.issue_count === 1 ? 'issue' : 'issues';
+  return `
+    <div class="label-row" id="label-row-${label.label_id}" data-label-id="${label.label_id}">
+      <span class="label-pill" style="${pillStyle(label.color)}">
+        ${escHtml(label.name)}
+      </span>
+      <div class="label-info">
+        ${label.description ? `<div class="label-desc">${escHtml(label.description)}</div>` : ''}
+      </div>
+      <span class="issue-count-badge">
+        <a href="${base}/issues?label=${encodeURIComponent(label.name)}"
+           style="color:inherit;text-decoration:none">
+          ${label.issue_count} ${issueWord}
+        </a>
+      </span>
+      <div class="${actionsClass}">
+        <button class="btn btn-secondary" style="font-size:12px;padding:4px 10px"
+                onclick="openEditForm('${label.label_id}')">Edit</button>
+        <button class="btn btn-danger" style="font-size:12px;padding:4px 10px"
+                onclick="deleteLabel('${label.label_id}', '${escHtml(label.name)}')">Delete</button>
+      </div>
+      <!-- Inline edit form for this label -->
+      <div class="label-edit-form" id="edit-form-${label.label_id}">
+        <div class="label-form-row">
+          <div class="label-form-group">
+            <label>Name</label>
+            <input type="text" id="edit-name-${label.label_id}" value="${escHtml(label.name)}"
+                   maxlength="50" placeholder="Label name">
+          </div>
+          <div class="label-form-group" style="flex:0 0 auto">
+            <label>Colour</label>
+            <input type="color" id="edit-color-${label.label_id}" value="${label.color}"
+                   oninput="updateEditPreview('${label.label_id}')">
+          </div>
+          <div class="label-form-group">
+            <label>Description (optional)</label>
+            <input type="text" id="edit-desc-${label.label_id}"
+                   value="${label.description ? escHtml(label.description) : ''}"
+                   maxlength="200" placeholder="Short description">
+          </div>
+        </div>
+        <div class="form-actions">
+          <button class="btn btn-primary" style="font-size:13px"
+                  onclick="submitEdit('${label.label_id}')">Save changes</button>
+          <button class="btn btn-secondary" style="font-size:13px"
+                  onclick="closeEditForm('${label.label_id}')">Cancel</button>
+        </div>
+        <div class="form-error" id="edit-error-${label.label_id}"></div>
+      </div>
+    </div>`;
+}
+
+function renderLabels(labels, authed) {
+  if (labels.length === 0) {
+    return `<div class="empty-state">
+      <p>No labels yet. Click <strong>New label</strong> to get started.</p>
+    </div>`;
+  }
+  return `<div class="label-list">${labels.map(l => renderLabelRow(l, authed)).join('')}</div>`;
+}
+
+// ── Create form ────────────────────────────────────────────────────────────
+
+function updateColorPreview() {
+  const color = document.getElementById('create-color').value;
+  const swatch = document.getElementById('create-color-swatch');
+  const preview = document.getElementById('create-color-preview-pill');
+  if (swatch) swatch.style.background = color;
+  if (preview) {
+    preview.style.background = color;
+    preview.style.color = contrastColor(color);
+    const name = document.getElementById('create-name').value.trim();
+    preview.textContent = name || 'Preview';
+  }
+}
+
+function updateEditPreview(labelId) {
+  const color = document.getElementById(`edit-color-${labelId}`).value;
+  // Optionally update some preview — for now just let the save do it.
+}
+
+function toggleCreateForm() {
+  const form = document.getElementById('create-form');
+  if (!form) return;
+  const isActive = form.classList.contains('active');
+  form.classList.toggle('active', !isActive);
+  if (!isActive) document.getElementById('create-name').focus();
+}
+
+// ── Edit form ──────────────────────────────────────────────────────────────
+
+function openEditForm(labelId) {
+  // Close any other open edit forms first.
+  document.querySelectorAll('.label-edit-form.active').forEach(el => el.classList.remove('active'));
+  const form = document.getElementById(`edit-form-${labelId}`);
+  if (form) form.classList.add('active');
+}
+
+function closeEditForm(labelId) {
+  const form = document.getElementById(`edit-form-${labelId}`);
+  if (form) form.classList.remove('active');
+}
+
+// ── API calls ──────────────────────────────────────────────────────────────
+
+async function submitCreate() {
+  const name = document.getElementById('create-name').value.trim();
+  const color = document.getElementById('create-color').value;
+  const desc = document.getElementById('create-desc').value.trim() || null;
+  const errEl = document.getElementById('create-error');
+  if (!name) { showErr(errEl, 'Name is required'); return; }
+
+  try {
+    await apiFetch(`/ui/${owner}/${repoSlug}/labels`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, color, description: desc }),
+    });
+    hideErr(errEl);
+    document.getElementById('create-form').classList.remove('active');
+    document.getElementById('create-name').value = '';
+    document.getElementById('create-color').value = '#a2eeef';
+    document.getElementById('create-desc').value = '';
+    load();
+  } catch(e) {
+    if (e.message !== 'auth') showErr(errEl, e.message || 'Failed to create label');
+  }
+}
+
+async function submitEdit(labelId) {
+  const name  = document.getElementById(`edit-name-${labelId}`).value.trim() || null;
+  const color = document.getElementById(`edit-color-${labelId}`).value || null;
+  const desc  = document.getElementById(`edit-desc-${labelId}`).value.trim() || null;
+  const errEl = document.getElementById(`edit-error-${labelId}`);
+
+  try {
+    await apiFetch(`/ui/${owner}/${repoSlug}/labels/${labelId}/edit`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, color, description: desc }),
+    });
+    hideErr(errEl);
+    load();
+  } catch(e) {
+    if (e.message !== 'auth') showErr(errEl, e.message || 'Failed to save changes');
+  }
+}
+
+async function deleteLabel(labelId, labelName) {
+  if (!confirm(`Delete label "${labelName}"? This removes it from all issues and pull requests.`)) return;
+  try {
+    await apiFetch(`/ui/${owner}/${repoSlug}/labels/${labelId}/delete`, { method: 'POST' });
+    load();
+  } catch(e) {
+    if (e.message !== 'auth') alert('Failed to delete label: ' + (e.message || 'unknown error'));
+  }
+}
+
+async function resetLabels() {
+  if (!confirm('Reset to defaults? All current labels and their associations will be deleted and replaced with the 10 default labels.')) return;
+  try {
+    await apiFetch(`/ui/${owner}/${repoSlug}/labels/reset`, { method: 'POST' });
+    load();
+  } catch(e) {
+    if (e.message !== 'auth') alert('Reset failed: ' + (e.message || 'unknown error'));
+  }
+}
+
+// ── Utilities ──────────────────────────────────────────────────────────────
+
+function showErr(el, msg) { if (el) { el.textContent = msg; el.classList.add('visible'); } }
+function hideErr(el) { if (el) { el.textContent = ''; el.classList.remove('visible'); } }
+
+// ── Load ───────────────────────────────────────────────────────────────────
+
+async function load() {
+  initRepoNav(repoId);
+  document.getElementById('content').innerHTML = '<p class="loading">Loading labels…</p>';
+
+  try {
+    const data   = await apiFetch(`/repos/${repoId}/labels`);
+    const labels = data.items || [];
+    const authed = !!getToken();
+
+    const resetBtn = authed
+      ? `<button class="btn btn-secondary" onclick="resetLabels()"
+                style="font-size:13px">↺ Reset to defaults</button>`
+      : '';
+    const newBtn = authed
+      ? `<button class="btn btn-primary" onclick="toggleCreateForm()"
+                style="font-size:13px">+ New label</button>`
+      : '';
+
+    // Build create form (visible only when authed and toggled).
+    const createForm = authed ? `
+      <div class="label-form-card" id="create-form">
+        <h3 style="margin:0 0 14px">New label</h3>
+        <div class="label-form-row">
+          <div class="label-form-group">
+            <label>Name *</label>
+            <input type="text" id="create-name" maxlength="50" placeholder="e.g. bug"
+                   oninput="updateColorPreview()">
+          </div>
+          <div class="label-form-group" style="flex:0 0 auto">
+            <label>Colour</label>
+            <input type="color" id="create-color" value="#a2eeef"
+                   oninput="updateColorPreview()">
+          </div>
+          <div class="label-form-group">
+            <label>Description (optional)</label>
+            <input type="text" id="create-desc" maxlength="200" placeholder="Short description">
+          </div>
+        </div>
+        <div class="form-actions">
+          <button class="btn btn-primary" style="font-size:13px" onclick="submitCreate()">Create label</button>
+          <button class="btn btn-secondary" style="font-size:13px"
+                  onclick="document.getElementById('create-form').classList.remove('active')">Cancel</button>
+          <span class="color-preview">
+            Preview: <span id="create-color-preview-pill" class="label-pill" style="background:#a2eeef;color:#000">Preview</span>
+          </span>
+        </div>
+        <div class="form-error" id="create-error"></div>
+      </div>` : '';
+
+    document.getElementById('content').innerHTML = `
+      <div style="margin-bottom:12px">
+        <a href="${base}">&larr; Back to repo</a>
+      </div>
+      <div class="card">
+        <div class="labels-toolbar">
+          <h1>🏷 Labels <span style="font-size:16px;font-weight:400;color:var(--text-muted,#8b949e)">(${labels.length})</span></h1>
+          <div class="toolbar-actions">
+            ${resetBtn}
+            ${newBtn}
+          </div>
+        </div>
+        ${createForm}
+        ${renderLabels(labels, authed)}
+      </div>`;
+  } catch(e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML = '<p class="error">✕ ' + escHtml(e.message) + '</p>';
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/tests/test_musehub_ui_labels.py
+++ b/tests/test_musehub_ui_labels.py
@@ -1,0 +1,517 @@
+"""Tests for Muse Hub label management UI endpoints (issue #426).
+
+Covers GET /musehub/ui/{owner}/{repo_slug}/labels:
+- test_labels_page_returns_200               — page renders without auth
+- test_labels_page_no_auth_required          — GET needs no JWT
+- test_labels_page_unknown_repo_404          — unknown owner/slug → 404
+- test_labels_page_has_color_picker_js       — colour picker rendered in template
+- test_labels_page_has_label_list_js         — label list JS present
+- test_labels_page_json_format              — ?format=json returns structured data
+- test_labels_page_json_has_items_key       — JSON payload includes 'items' array
+- test_labels_page_shows_issue_count        — issue counts included in JSON response
+- test_labels_page_base_url_uses_slug       — base_url in context uses owner/slug not repo_id
+
+Covers POST /musehub/ui/{owner}/{repo_slug}/labels:
+- test_create_label_success                 — 201 + label_id returned
+- test_create_label_requires_auth          — 401 without Bearer token
+- test_create_label_duplicate_name_409     — duplicate name → 409
+- test_create_label_invalid_color_422      — bad hex color → 422
+- test_create_label_unknown_repo_404       — unknown repo → 404
+
+Covers POST /musehub/ui/{owner}/{repo_slug}/labels/{label_id}/edit:
+- test_edit_label_success                  — 200 + updated values
+- test_edit_label_requires_auth           — 401 without token
+- test_edit_label_unknown_label_404       — unknown label_id → 404
+- test_edit_label_name_conflict_409       — name collision → 409
+- test_edit_label_partial_update          — partial body updates only supplied fields
+
+Covers POST /musehub/ui/{owner}/{repo_slug}/labels/{label_id}/delete:
+- test_delete_label_success               — 200 ok=True
+- test_delete_label_requires_auth        — 401 without token
+- test_delete_label_unknown_label_404    — unknown label_id → 404
+
+Covers POST /musehub/ui/{owner}/{repo_slug}/labels/reset:
+- test_reset_labels_success              — 200 + 10 defaults seeded
+- test_reset_labels_requires_auth       — 401 without token
+- test_reset_labels_wipes_custom_labels — existing labels replaced
+- test_reset_labels_unknown_repo_404    — unknown repo → 404
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_label_models import MusehubLabel
+from maestro.db.musehub_models import MusehubIssue, MusehubRepo
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_repo(
+    db: AsyncSession,
+    owner: str = "beatmaker",
+    slug: str = "deep-cuts",
+) -> str:
+    """Seed a public repo and return its repo_id string."""
+    repo = MusehubRepo(
+        name=slug,
+        owner=owner,
+        slug=slug,
+        visibility="public",
+        owner_user_id="uid-beatmaker",
+    )
+    db.add(repo)
+    await db.commit()
+    await db.refresh(repo)
+    return str(repo.repo_id)
+
+
+async def _make_label(
+    db: AsyncSession,
+    repo_id: str,
+    *,
+    name: str = "bug",
+    color: str = "#d73a4a",
+    description: str | None = "Something isn't working",
+) -> MusehubLabel:
+    """Seed a label and return it."""
+    label = MusehubLabel(
+        repo_id=repo_id,
+        name=name,
+        color=color,
+        description=description,
+    )
+    db.add(label)
+    await db.commit()
+    await db.refresh(label)
+    return label
+
+
+# ---------------------------------------------------------------------------
+# GET /musehub/ui/{owner}/{repo_slug}/labels — label list page
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_labels_page_returns_200(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/labels returns 200 HTML."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/beatmaker/deep-cuts/labels")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_labels_page_no_auth_required(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Label list page is publicly accessible — no JWT required."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/beatmaker/deep-cuts/labels")
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_labels_page_unknown_repo_404(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Unknown owner/slug combination → 404."""
+    response = await client.get("/musehub/ui/nobody/nonexistent/labels")
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_labels_page_has_color_picker_js(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The labels page HTML includes a colour picker for creating labels."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/beatmaker/deep-cuts/labels")
+    assert response.status_code == 200
+    body = response.text
+    assert 'type="color"' in body or "color-picker" in body or "input" in body
+
+
+@pytest.mark.anyio
+async def test_labels_page_has_label_list_js(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The labels page contains JavaScript to render the label list."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/beatmaker/deep-cuts/labels")
+    assert response.status_code == 200
+    body = response.text
+    assert "renderLabel" in body or "label-list" in body or "label-row" in body
+
+
+@pytest.mark.anyio
+async def test_labels_page_json_format(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """?format=json returns a JSON response with a 200 status."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/beatmaker/deep-cuts/labels?format=json")
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_labels_page_json_has_items_key(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """JSON response contains 'labels' and 'total' keys."""
+    repo_id = await _make_repo(db_session)
+    await _make_label(db_session, repo_id, name="bug", color="#d73a4a")
+    response = await client.get("/musehub/ui/beatmaker/deep-cuts/labels?format=json")
+    assert response.status_code == 200
+    data = response.json()
+    assert "labels" in data
+    assert "total" in data
+    assert data["total"] == 1
+
+
+@pytest.mark.anyio
+async def test_labels_page_shows_issue_count(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """JSON response includes issue_count for each label."""
+    repo_id = await _make_repo(db_session)
+    await _make_label(db_session, repo_id, name="enhancement", color="#a2eeef")
+    response = await client.get("/musehub/ui/beatmaker/deep-cuts/labels?format=json")
+    assert response.status_code == 200
+    data = response.json()
+    labels = data["labels"]
+    assert len(labels) == 1
+    assert "issue_count" in labels[0]
+    assert labels[0]["issue_count"] == 0
+
+
+@pytest.mark.anyio
+async def test_labels_page_base_url_uses_slug(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The HTML page embeds the owner/slug base URL, not the repo UUID."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/beatmaker/deep-cuts/labels")
+    assert response.status_code == 200
+    body = response.text
+    assert "beatmaker" in body
+    assert "deep-cuts" in body
+
+
+# ---------------------------------------------------------------------------
+# POST /musehub/ui/{owner}/{repo_slug}/labels — create label
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_create_label_success(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /labels with valid body + auth returns 201 with label_id."""
+    await _make_repo(db_session)
+    response = await client.post(
+        "/musehub/ui/beatmaker/deep-cuts/labels",
+        json={"name": "needs-arrangement", "color": "#e4e669", "description": "Track needs arrangement"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["ok"] is True
+    assert "label_id" in data
+    assert data["label_id"] is not None
+
+
+@pytest.mark.anyio
+async def test_create_label_requires_auth(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """POST /labels without a JWT returns 401 or 403."""
+    await _make_repo(db_session)
+    response = await client.post(
+        "/musehub/ui/beatmaker/deep-cuts/labels",
+        json={"name": "bug", "color": "#d73a4a"},
+    )
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.anyio
+async def test_create_label_duplicate_name_409(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Creating a label with an existing name within the repo → 409."""
+    repo_id = await _make_repo(db_session)
+    await _make_label(db_session, repo_id, name="bug", color="#d73a4a")
+    response = await client.post(
+        "/musehub/ui/beatmaker/deep-cuts/labels",
+        json={"name": "bug", "color": "#ff0000"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_create_label_invalid_color_422(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """A malformed hex colour string → 422 validation error."""
+    await _make_repo(db_session)
+    response = await client.post(
+        "/musehub/ui/beatmaker/deep-cuts/labels",
+        json={"name": "test", "color": "not-a-color"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_create_label_unknown_repo_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Creating a label on a nonexistent repo → 404."""
+    response = await client.post(
+        "/musehub/ui/nobody/ghost-repo/labels",
+        json={"name": "bug", "color": "#d73a4a"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /musehub/ui/{owner}/{repo_slug}/labels/{label_id}/edit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_edit_label_success(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /labels/{label_id}/edit updates the label and returns ok=True."""
+    repo_id = await _make_repo(db_session)
+    label = await _make_label(db_session, repo_id, name="bug", color="#d73a4a")
+    response = await client.post(
+        f"/musehub/ui/beatmaker/deep-cuts/labels/{label.id}/edit",
+        json={"name": "critical-bug", "color": "#ff0000"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["label_id"] == str(label.id)
+
+
+@pytest.mark.anyio
+async def test_edit_label_requires_auth(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """POST /labels/{label_id}/edit without JWT → 401 or 403."""
+    repo_id = await _make_repo(db_session)
+    label = await _make_label(db_session, repo_id, name="bug", color="#d73a4a")
+    response = await client.post(
+        f"/musehub/ui/beatmaker/deep-cuts/labels/{label.id}/edit",
+        json={"name": "new-name"},
+    )
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.anyio
+async def test_edit_label_unknown_label_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Editing a non-existent label_id → 404."""
+    await _make_repo(db_session)
+    response = await client.post(
+        "/musehub/ui/beatmaker/deep-cuts/labels/00000000-0000-0000-0000-000000000000/edit",
+        json={"name": "x"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_edit_label_name_conflict_409(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Renaming a label to an already-existing name in the same repo → 409."""
+    repo_id = await _make_repo(db_session)
+    await _make_label(db_session, repo_id, name="bug", color="#d73a4a")
+    label_b = await _make_label(db_session, repo_id, name="enhancement", color="#a2eeef")
+    response = await client.post(
+        f"/musehub/ui/beatmaker/deep-cuts/labels/{label_b.id}/edit",
+        json={"name": "bug"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_edit_label_partial_update(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Sending only 'color' in the body preserves the existing name."""
+    repo_id = await _make_repo(db_session)
+    label = await _make_label(db_session, repo_id, name="bug", color="#d73a4a")
+    response = await client.post(
+        f"/musehub/ui/beatmaker/deep-cuts/labels/{label.id}/edit",
+        json={"color": "#ff6600"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    # Name should remain "bug" — verified by the message containing the name
+    assert "bug" in data["message"]
+
+
+# ---------------------------------------------------------------------------
+# POST /musehub/ui/{owner}/{repo_slug}/labels/{label_id}/delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_delete_label_success(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /labels/{label_id}/delete removes the label and returns ok=True."""
+    repo_id = await _make_repo(db_session)
+    label = await _make_label(db_session, repo_id, name="bug", color="#d73a4a")
+    response = await client.post(
+        f"/musehub/ui/beatmaker/deep-cuts/labels/{label.id}/delete",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+
+
+@pytest.mark.anyio
+async def test_delete_label_requires_auth(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """POST /labels/{label_id}/delete without JWT → 401 or 403."""
+    repo_id = await _make_repo(db_session)
+    label = await _make_label(db_session, repo_id, name="bug", color="#d73a4a")
+    response = await client.post(
+        f"/musehub/ui/beatmaker/deep-cuts/labels/{label.id}/delete",
+    )
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.anyio
+async def test_delete_label_unknown_label_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Deleting a non-existent label_id → 404."""
+    await _make_repo(db_session)
+    response = await client.post(
+        "/musehub/ui/beatmaker/deep-cuts/labels/00000000-0000-0000-0000-000000000000/delete",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /musehub/ui/{owner}/{repo_slug}/labels/reset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_reset_labels_success(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /labels/reset returns 200 with ok=True and seeds 10 defaults."""
+    from maestro.api.routes.musehub.labels import DEFAULT_LABELS
+
+    await _make_repo(db_session)
+    response = await client.post(
+        "/musehub/ui/beatmaker/deep-cuts/labels/reset",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert str(len(DEFAULT_LABELS)) in data["message"]
+
+
+@pytest.mark.anyio
+async def test_reset_labels_requires_auth(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """POST /labels/reset without JWT → 401 or 403."""
+    await _make_repo(db_session)
+    response = await client.post("/musehub/ui/beatmaker/deep-cuts/labels/reset")
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.anyio
+async def test_reset_labels_wipes_custom_labels(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """Reset removes all existing custom labels and replaces with defaults."""
+    from maestro.api.routes.musehub.labels import DEFAULT_LABELS
+
+    repo_id = await _make_repo(db_session)
+    # Seed a custom label that is NOT in the defaults list.
+    await _make_label(db_session, repo_id, name="my-custom-label", color="#123456")
+
+    response = await client.post(
+        "/musehub/ui/beatmaker/deep-cuts/labels/reset",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+
+    # After reset, the JSON endpoint should return exactly the defaults.
+    list_response = await client.get(
+        "/musehub/ui/beatmaker/deep-cuts/labels?format=json"
+    )
+    assert list_response.status_code == 200
+    data = list_response.json()
+    label_names = {lbl["name"] for lbl in data["labels"]}
+    default_names = {d["name"] for d in DEFAULT_LABELS}
+    # Custom label must be gone; all defaults must be present.
+    assert "my-custom-label" not in label_names
+    assert default_names == label_names
+
+
+@pytest.mark.anyio
+async def test_reset_labels_unknown_repo_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /labels/reset on nonexistent repo → 404."""
+    response = await client.post(
+        "/musehub/ui/nobody/ghost-repo/labels/reset",
+        headers=auth_headers,
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
Closes #426 — adds the label management UI page at `/{owner}/{repo}/labels`.

## Root Cause / Motivation
The Phase 2 labels JSON API (already merged) provides full CRUD for labels but has no browser-accessible UI. Users need a way to view, create, edit, delete, and reset labels without issuing raw API calls.

## Solution

**New files:**
- `maestro/api/routes/musehub/ui_labels.py` — 5 route handlers (GET + 4 POST mutations)
- `maestro/templates/musehub/pages/labels.html` — interactive Jinja2 template
- `tests/test_musehub_ui_labels.py` — 26 tests covering all routes and error paths

**Routes added:**
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/musehub/ui/{owner}/{repo_slug}/labels` | public | Label list page or JSON |
| POST | `/musehub/ui/{owner}/{repo_slug}/labels` | required | Create label |
| POST | `/musehub/ui/{owner}/{repo_slug}/labels/{id}/edit` | required | Update label |
| POST | `/musehub/ui/{owner}/{repo_slug}/labels/{id}/delete` | required | Delete label |
| POST | `/musehub/ui/{owner}/{repo_slug}/labels/reset` | required | Reset to 10 defaults |

**UI features:**
- Inline create form with HTML colour picker and live preview pill
- Label list: colour pill (with auto-contrast text), name, description, issue count badge
- Per-label edit (inline form) and delete (confirmation dialog)
- «Reset to defaults» button — destructive, wipes all labels and re-seeds canonical 10
- Auth-gated actions (JWT from localStorage via fetch); GET is public

**Modified files:**
- `maestro/main.py` — added import and `app.include_router` for `musehub_ui_labels_routes`

## Verification
- [x] mypy clean (692 source files, 0 errors)
- [x] 26 tests pass (all routes, auth enforcement, 404/409/422 error paths, partial update, reset)
- [x] Content negotiation: HTML default, JSON via `?format=json` or `Accept: application/json`
- [x] Docs updated (route handlers have full docstrings explaining why each route exists)

---
<!-- maestro-fingerprint
role: python-developer
batch: none
session: eng-20260301T082040Z-0054
issue: 426
timestamp: 2026-03-01T08:31:04Z
-->
> 🤖 *Opened by Maestro pipeline — batch `none`, session `eng-20260301T082040Z-0054`*