### PR TITLE
feat: emotion-diff UI visualization page (issue #432)

### DIFF
--- a/maestro/api/routes/musehub/ui_emotion_diff.py
+++ b/maestro/api/routes/musehub/ui_emotion_diff.py
@@ -1,0 +1,140 @@
+"""Muse Hub emotion-diff UI page.
+
+Serves the ``/{owner}/{repo_slug}/emotion-diff/{base}...{head}`` page that
+visualises the 8-axis emotional shift between two Muse refs.
+
+Endpoint summary:
+  GET /musehub/ui/{owner}/{repo_slug}/emotion-diff/{refs}
+    refs encodes ``base...head`` (same convention as the compare page).
+    HTML (default) → interactive emotion-diff report with side-by-side
+                     radar charts, delta bar chart, and trajectory timeline.
+    JSON  (``?format=json`` or ``Accept: application/json``)
+         → raw :class:`~maestro.models.musehub_analysis.EmotionDiffResponse`.
+
+Why a dedicated page instead of reusing the PR detail emotion widget:
+  The PR detail page embeds the emotion radar as one panel among many.  This
+  page gives the full-screen emotion-diff view with per-ref 8D radar charts,
+  a delta bar chart, a prose interpretation, a "Listen to comparison" button,
+  and an emotional trajectory timeline — features that do not fit in the PR
+  detail sidebar.
+
+Auto-discovered by the package ``__init__.py`` — do NOT edit that file.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import status as http_status
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response as StarletteResponse
+
+from maestro.api.routes.musehub.negotiate import negotiate_response
+from maestro.db import get_db
+from maestro.services import musehub_analysis, musehub_repository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/musehub/ui", tags=["musehub-ui"])
+
+_TEMPLATE_DIR = Path(__file__).parent.parent.parent.parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+
+async def _resolve_repo(
+    owner: str, repo_slug: str, db: AsyncSession
+) -> tuple[str, str]:
+    """Resolve owner+slug to (repo_id, base_url); raise 404 if not found."""
+    row = await musehub_repository.get_repo_orm_by_owner_slug(db, owner, repo_slug)
+    if row is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=f"Repo '{owner}/{repo_slug}' not found",
+        )
+    return str(row.repo_id), f"/musehub/ui/{owner}/{repo_slug}"
+
+
+@router.get(
+    "/{owner}/{repo_slug}/emotion-diff/{refs}",
+    summary="Muse Hub emotion-diff page — 8-axis emotional shift between two refs",
+)
+async def emotion_diff_page(
+    request: Request,
+    owner: str,
+    repo_slug: str,
+    refs: str,
+    format: str | None = Query(None, description="Force response format: 'json' or omit for HTML"),
+    db: AsyncSession = Depends(get_db),
+) -> StarletteResponse:
+    """Render the 8-axis emotional diff page between two Muse refs.
+
+    ``refs`` encodes the two refs as ``base...head``, matching the URL
+    convention used by the compare and similarity pages.  The page renders:
+
+    - Side-by-side 8-dimension radar charts (one per ref, same axis scale)
+    - A delta bar chart per axis: green = increase, red = decrease
+    - A prose interpretation of the dominant emotional shifts
+    - A "Listen to comparison" button for both refs
+    - An emotional trajectory timeline across commits between base and head
+
+    Content negotiation:
+    - HTML (default): interactive report via Jinja2.
+    - JSON (``Accept: application/json`` or ``?format=json``):
+      returns the raw :class:`~maestro.models.musehub_analysis.EmotionDiffResponse`.
+
+    Returns 404 when:
+    - The repo owner/slug is unknown.
+    - The ``refs`` value does not contain the ``...`` separator.
+
+    Agent use case: call with ``?format=json`` to obtain a machine-readable
+    emotion-diff payload for programmatic analysis of emotional shifts between
+    two commits — e.g. to decide whether a generative commit increased tension
+    relative to the main branch without opening the browser.
+    """
+    if "..." not in refs:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=f"Invalid emotion-diff spec '{refs}' — expected format: base...head",
+        )
+    base_ref, head_ref = refs.split("...", 1)
+    if not base_ref or not head_ref:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="Both base and head refs must be non-empty",
+        )
+
+    repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+
+    diff = musehub_analysis.compute_emotion_diff(
+        repo_id=repo_id,
+        head_ref=head_ref,
+        base_ref=base_ref,
+    )
+
+    context: dict[str, object] = {
+        "owner": owner,
+        "repo_slug": repo_slug,
+        "repo_id": repo_id,
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "refs": refs,
+        "base_url": base_url,
+        "current_page": "emotion-diff",
+        "breadcrumb_data": [
+            {"label": owner, "url": f"/musehub/ui/{owner}"},
+            {"label": repo_slug, "url": base_url},
+            {"label": "emotion-diff", "url": ""},
+            {"label": f"{base_ref}...{head_ref}", "url": ""},
+        ],
+    }
+
+    return await negotiate_response(
+        request=request,
+        template_name="musehub/pages/emotion_diff.html",
+        context=context,
+        templates=templates,
+        json_data=diff,
+        format_param=format,
+    )

--- a/maestro/main.py
+++ b/maestro/main.py
@@ -31,6 +31,7 @@ from maestro.api.routes.musehub import ui_notifications as musehub_ui_notificati
 from maestro.api.routes.musehub import ui_collaborators as musehub_ui_collab_routes
 from maestro.api.routes.musehub import ui_settings as musehub_ui_settings_routes
 from maestro.api.routes.musehub import ui_similarity as musehub_ui_similarity_routes
+from maestro.api.routes.musehub import ui_emotion_diff as musehub_ui_emotion_diff_routes
 from maestro.api.routes.musehub import ui_user_profile as musehub_ui_profile_routes
 from maestro.api.routes.musehub import discover as musehub_discover_routes
 from maestro.api.routes.musehub import users as musehub_user_routes
@@ -238,6 +239,7 @@ app.include_router(musehub_ui_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_ui_blame_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_ui_settings_routes.router, tags=["musehub-ui-settings"])
 app.include_router(musehub_ui_similarity_routes.router, tags=["musehub-ui"])
+app.include_router(musehub_ui_emotion_diff_routes.router, tags=["musehub-ui"])
 app.include_router(musehub_oembed_routes.router, tags=["musehub-oembed"])
 app.include_router(musehub_raw_routes.router, prefix="/api/v1", tags=["musehub-raw"])
 # Sitemap and robots.txt — top-level (no /api/v1 prefix), outside musehub auto-discovery.

--- a/maestro/templates/musehub/pages/emotion_diff.html
+++ b/maestro/templates/musehub/pages/emotion_diff.html
@@ -1,0 +1,390 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Emotion Diff {{ base_ref[:8] }}...{{ head_ref[:8] }} · {{ owner }}/{{ repo_slug }}{% endblock %}
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}">{{ owner }}</a> /
+  <a href="{{ base_url }}">{{ repo_slug }}</a> /
+  emotion-diff /
+  <span class="text-mono">{{ base_ref[:8] }}...{{ head_ref[:8] }}</span>
+{% endblock %}
+
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block page_data %}
+const repoId  = {{ repo_id | tojson }};
+const baseRef = {{ base_ref | tojson }};
+const headRef = {{ head_ref | tojson }};
+const uiBase  = {{ base_url | tojson }};
+const apiBase = '/api/v1/musehub/repos/' + repoId;
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+// ── 8 emotional dimensions (matches EmotionVector8D model) ───────────────────
+const DIMENSIONS = [
+  { key: 'valence',     label: 'Valence',     desc: 'dark/negative → bright/positive'  },
+  { key: 'energy',      label: 'Energy',      desc: 'passive/still → active/driving'   },
+  { key: 'tension',     label: 'Tension',     desc: 'relaxed → tense/dissonant'        },
+  { key: 'complexity',  label: 'Complexity',  desc: 'sparse/simple → dense/complex'    },
+  { key: 'warmth',      label: 'Warmth',      desc: 'cold/sterile → warm/intimate'     },
+  { key: 'brightness',  label: 'Brightness',  desc: 'dark/dull → bright/shimmering'    },
+  { key: 'darkness',    label: 'Darkness',    desc: 'luminous → brooding/ominous'      },
+  { key: 'playfulness', label: 'Playfulness', desc: 'serious/solemn → playful/whimsical' },
+];
+
+const BASE_COLOR = '#58a6ff';
+const HEAD_COLOR = '#f0883e';
+const INC_COLOR  = '#3fb950';
+const DEC_COLOR  = '#f85149';
+const NEU_COLOR  = '#8b949e';
+
+// ── Single-ref 8D radar chart SVG ────────────────────────────────────────────
+//
+// Renders a single filled polygon for a given 8-axis score array.
+// Used side-by-side: one for base, one for head.
+function radarSvg(scores, color, label) {
+  const cx = 160, cy = 160, r = 120;
+  const n = DIMENSIONS.length;
+
+  function pt(score, i) {
+    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+    const sr = score * r;
+    return { x: cx + sr * Math.cos(angle), y: cy + sr * Math.sin(angle) };
+  }
+
+  // Grid rings at 0.25, 0.5, 0.75, 1.0
+  const gridLines = [0.25, 0.5, 0.75, 1.0].map(frac => {
+    const gPts = DIMENSIONS.map((_, i) => {
+      const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+      return `${cx + frac * r * Math.cos(angle)},${cy + frac * r * Math.sin(angle)}`;
+    }).join(' ');
+    return `<polygon points="${gPts}" fill="none" stroke="#21262d" stroke-width="1"/>`;
+  }).join('');
+
+  // Axis spokes
+  const axisLines = DIMENSIONS.map((_, i) => {
+    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+    const ex = cx + r * Math.cos(angle), ey = cy + r * Math.sin(angle);
+    return `<line x1="${cx}" y1="${cy}" x2="${ex}" y2="${ey}" stroke="#30363d" stroke-width="1"/>`;
+  }).join('');
+
+  // Axis labels
+  const axisLabels = DIMENSIONS.map((d, i) => {
+    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+    const lx = cx + (r + 24) * Math.cos(angle);
+    const ly = cy + (r + 24) * Math.sin(angle);
+    return `<text x="${lx}" y="${ly + 4}" text-anchor="middle"
+      font-size="10" fill="#8b949e" font-family="system-ui">${d.label}</text>`;
+  }).join('');
+
+  // Data polygon
+  const pts = scores.map((s, i) => pt(s, i));
+  const poly = pts.map(p => `${p.x},${p.y}`).join(' ');
+
+  // Vertex dots
+  const dots = pts.map(p =>
+    `<circle cx="${p.x}" cy="${p.y}" r="3" fill="${color}" stroke="#0d1117" stroke-width="1.5"/>`
+  ).join('');
+
+  // Ref label in centre
+  const shortLabel = label.length > 10 ? label.slice(0, 8) + '…' : label;
+
+  return `<svg viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg"
+      style="width:100%;max-width:320px;display:block;margin:0 auto" role="img"
+      aria-label="8-axis emotion radar for ${label}">
+    ${gridLines}${axisLines}
+    <polygon points="${poly}"
+      fill="${color}20" stroke="${color}" stroke-width="2"/>
+    ${dots}
+    ${axisLabels}
+    <text x="${cx}" y="${cy + 4}" text-anchor="middle"
+      font-size="10" fill="${color}" font-family="monospace">${escHtml(shortLabel)}</text>
+  </svg>`;
+}
+
+// ── Delta bar chart row ───────────────────────────────────────────────────────
+//
+// Each row shows the per-axis delta value as a centred bar: bars to the right
+// of centre are green (increase), bars to the left are red (decrease).
+function deltaRow(dim, delta) {
+  const pct = Math.round(delta * 100);
+  const sign = delta >= 0 ? '+' : '';
+  const color = Math.abs(delta) < 0.04 ? NEU_COLOR : delta > 0 ? INC_COLOR : DEC_COLOR;
+  const label = Math.abs(delta) < 0.04 ? 'unchanged' : delta > 0 ? '▲ increase' : '▼ decrease';
+
+  // Bar: centred at 50%. Positive deltas extend right; negative extend left.
+  const barWidthPct = Math.min(50, Math.abs(pct / 2));
+  const barLeft = delta >= 0 ? 50 : (50 - barWidthPct);
+
+  return `<tr style="border-bottom:1px solid #21262d">
+    <td style="padding:8px 12px;font-size:13px;color:#e6edf3;white-space:nowrap;min-width:110px">
+      ${dim.label}
+    </td>
+    <td style="padding:8px 12px;min-width:200px">
+      <div style="position:relative;height:12px;background:#21262d;border-radius:4px;overflow:hidden">
+        <!-- Centre divider -->
+        <div style="position:absolute;left:50%;top:0;width:1px;height:100%;background:#30363d"></div>
+        <!-- Delta bar -->
+        <div style="position:absolute;top:1px;height:10px;border-radius:2px;
+                    left:${barLeft}%;width:${barWidthPct}%;background:${color}"></div>
+      </div>
+    </td>
+    <td style="padding:8px 12px;text-align:right;font-size:13px;font-weight:600;color:${color};white-space:nowrap">
+      ${sign}${pct}%
+    </td>
+    <td style="padding:8px 12px;font-size:11px;color:${color};white-space:nowrap">
+      ${label}
+    </td>
+  </tr>`;
+}
+
+// ── Trajectory timeline ───────────────────────────────────────────────────────
+//
+// Renders a mini sparkline per dimension showing how each 8D axis evolved
+// across the commits returned by the emotion-map endpoint.
+// Points are normalised to [0, 1]; each line is drawn as an SVG polyline.
+function trajectorySection(trajectory) {
+  if (!trajectory || trajectory.length < 2) {
+    return `<p style="color:#8b949e;font-size:13px">
+      Not enough commits in the range to render a trajectory timeline.
+    </p>`;
+  }
+
+  const W = 300, H = 48, PAD = 4;
+  const n = trajectory.length;
+
+  // One sparkline per dimension
+  const sparklines = DIMENSIONS.map(dim => {
+    const values = trajectory.map(c => c[dim.key] ?? 0.5);
+    const pts = values.map((v, i) => {
+      const x = PAD + (i / (n - 1)) * (W - PAD * 2);
+      const y = H - PAD - v * (H - PAD * 2);
+      return `${x},${y}`;
+    }).join(' ');
+
+    // Colour the sparkline by average value
+    const avg = values.reduce((a, b) => a + b, 0) / values.length;
+    const lineColor = avg > 0.65 ? INC_COLOR : avg < 0.35 ? DEC_COLOR : BASE_COLOR;
+
+    return `<div style="margin-bottom:12px">
+      <div style="font-size:11px;color:#8b949e;margin-bottom:4px">${dim.label}</div>
+      <svg viewBox="0 0 ${W} ${H}" style="width:100%;height:${H}px;display:block"
+           role="img" aria-label="${dim.label} trajectory">
+        <polyline points="${pts}"
+          fill="none" stroke="${lineColor}" stroke-width="1.5"
+          stroke-linejoin="round" stroke-linecap="round"/>
+        <!-- Start and end markers -->
+        ${values.length > 0 ? (() => {
+          const sx = PAD, sy = H - PAD - values[0] * (H - PAD * 2);
+          const ex = PAD + (W - PAD * 2), ey = H - PAD - values[n - 1] * (H - PAD * 2);
+          return `<circle cx="${sx}" cy="${sy}" r="3" fill="${BASE_COLOR}"/>
+                  <circle cx="${ex}" cy="${ey}" r="3" fill="${HEAD_COLOR}"/>`;
+        })() : ''}
+      </svg>
+    </div>`;
+  }).join('');
+
+  return `<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:16px">
+    ${sparklines}
+  </div>
+  <div style="font-size:11px;color:#8b949e;margin-top:8px">
+    <span style="display:inline-block;width:10px;height:2px;background:${BASE_COLOR};vertical-align:middle;margin-right:4px"></span>base ref
+    <span style="display:inline-block;width:10px;height:2px;background:${HEAD_COLOR};vertical-align:middle;margin-left:12px;margin-right:4px"></span>head ref
+    <span style="margin-left:16px">${n} commits in range</span>
+  </div>`;
+}
+
+// ── Main loader ───────────────────────────────────────────────────────────────
+async function load() {
+  initRepoNav(repoId);
+
+  document.getElementById('content').innerHTML =
+    '<p class="loading">Computing emotional diff&#8230;</p>';
+
+  try {
+    // ── Fetch 8-axis emotion diff ────────────────────────────────────────────
+    const diff = await apiFetch(
+      `/repos/${repoId}/analysis/${encodeURIComponent(headRef)}/emotion-diff` +
+      `?base=${encodeURIComponent(baseRef)}`
+    );
+
+    const base  = diff.baseEmotion  || {};
+    const head  = diff.headEmotion  || {};
+    const delta = diff.delta        || {};
+    const interp = diff.interpretation || '';
+
+    const baseScores = DIMENSIONS.map(d => base[d.key] ?? 0);
+    const headScores = DIMENSIONS.map(d => head[d.key] ?? 0);
+    const deltas     = DIMENSIONS.map(d => delta[d.key] ?? 0);
+
+    // ── Fetch emotional trajectory via emotion-map ────────────────────────────
+    let trajectory = [];
+    try {
+      const mapData = await apiFetch(
+        `/repos/${repoId}/analysis/${encodeURIComponent(headRef)}/emotion-map`
+      );
+      // The trajectory is the per-beat emotion list; for the timeline we use
+      // per-commit snapshots if available, else fall back to the beat trajectory.
+      trajectory = mapData.commitTrajectory || mapData.beats || [];
+      // Normalise beat objects to the same key shape as DIMENSIONS
+      if (trajectory.length > 0 && trajectory[0].primaryEmotion !== undefined) {
+        // Beat objects — map to pseudo-vector using available fields
+        trajectory = trajectory.map(b => ({
+          valence:     b.valence     ?? 0.5,
+          energy:      b.arousal     ?? 0.5,   // arousal ≈ energy
+          tension:     b.tension     ?? 0.5,
+          complexity:  b.complexity  ?? 0.5,
+          warmth:      b.warmth      ?? 0.5,
+          brightness:  b.brightness  ?? 0.5,
+          darkness:    b.darkness    ?? 0.5,
+          playfulness: b.playfulness ?? 0.5,
+        }));
+      }
+    } catch (_) {
+      // Trajectory is optional — page still works without it
+    }
+
+    const listenBaseUrl = `${uiBase}/listen/${encodeURIComponent(baseRef)}`;
+    const listenHeadUrl = `${uiBase}/listen/${encodeURIComponent(headRef)}`;
+    const compareUrl    = `${uiBase}/compare/${encodeURIComponent(baseRef)}...${encodeURIComponent(headRef)}`;
+
+    document.getElementById('content').innerHTML = `
+
+      <!-- ── Page header ────────────────────────────────────────────────── -->
+      <div style="display:flex;align-items:flex-start;justify-content:space-between;
+                  margin-bottom:20px;flex-wrap:wrap;gap:12px">
+        <div>
+          <h1 style="margin:0;font-size:18px;color:#e6edf3">
+            Emotion Diff:
+            <code style="font-size:14px">${escHtml(baseRef.slice(0, 10))}</code>
+            &hellip;
+            <code style="font-size:14px">${escHtml(headRef.slice(0, 10))}</code>
+          </h1>
+          <div style="font-size:12px;color:#8b949e;margin-top:6px;max-width:620px;line-height:1.5">
+            ${escHtml(interp)}
+          </div>
+        </div>
+        <!-- ── "Listen to comparison" button ─────────────────────────────── -->
+        <div style="display:flex;gap:8px;flex-wrap:wrap;flex-shrink:0">
+          <a href="${escHtml(listenBaseUrl)}" class="btn btn-secondary" style="font-size:13px"
+             title="Listen to base ref: ${escHtml(baseRef)}">
+            &#9654; Listen Base
+          </a>
+          <a href="${escHtml(listenHeadUrl)}" class="btn btn-secondary" style="font-size:13px"
+             title="Listen to head ref: ${escHtml(headRef)}">
+            &#9654; Listen Head
+          </a>
+          <a href="${escHtml(compareUrl)}" class="btn btn-primary" style="font-size:13px">
+            &#128200; Full Diff
+          </a>
+        </div>
+      </div>
+
+      <!-- ── Side-by-side radar charts ─────────────────────────────────── -->
+      <div class="card" style="margin-bottom:24px">
+        <h2 style="margin:0 0 16px;font-size:15px;color:#e6edf3">
+          8-Dimension Emotional Signature
+        </h2>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:24px;align-items:start">
+          <!-- Base radar -->
+          <div>
+            <div style="text-align:center;margin-bottom:8px">
+              <span style="font-size:12px;color:${BASE_COLOR};font-weight:600">
+                Base — <code style="font-size:11px">${escHtml(baseRef.slice(0, 10))}</code>
+              </span>
+            </div>
+            ${radarSvg(baseScores, BASE_COLOR, baseRef)}
+          </div>
+          <!-- Head radar -->
+          <div>
+            <div style="text-align:center;margin-bottom:8px">
+              <span style="font-size:12px;color:${HEAD_COLOR};font-weight:600">
+                Head — <code style="font-size:11px">${escHtml(headRef.slice(0, 10))}</code>
+              </span>
+            </div>
+            ${radarSvg(headScores, HEAD_COLOR, headRef)}
+          </div>
+        </div>
+        <!-- Axis key -->
+        <div style="margin-top:16px;display:flex;flex-wrap:wrap;gap:8px 16px">
+          ${DIMENSIONS.map(d => `
+            <div style="font-size:11px;color:#8b949e">
+              <strong style="color:#e6edf3">${d.label}:</strong> ${d.desc}
+            </div>`).join('')}
+        </div>
+      </div>
+
+      <!-- ── Delta bar chart ────────────────────────────────────────────── -->
+      <div class="card" style="margin-bottom:24px;overflow-x:auto">
+        <h2 style="margin:0 0 12px;font-size:15px;color:#e6edf3">
+          Per-Axis Delta
+          <span style="font-size:12px;font-weight:400;color:#8b949e;margin-left:8px">
+            (head &minus; base)
+          </span>
+        </h2>
+        <!-- Legend -->
+        <div style="font-size:11px;color:#8b949e;margin-bottom:12px;display:flex;gap:16px">
+          <span>
+            <span style="display:inline-block;width:10px;height:10px;background:${INC_COLOR};border-radius:2px;vertical-align:middle;margin-right:4px"></span>
+            increase
+          </span>
+          <span>
+            <span style="display:inline-block;width:10px;height:10px;background:${DEC_COLOR};border-radius:2px;vertical-align:middle;margin-right:4px"></span>
+            decrease
+          </span>
+          <span>
+            <span style="display:inline-block;width:10px;height:10px;background:${NEU_COLOR};border-radius:2px;vertical-align:middle;margin-right:4px"></span>
+            unchanged (&lt;4%)
+          </span>
+        </div>
+        <table style="width:100%;border-collapse:collapse">
+          <thead>
+            <tr style="border-bottom:2px solid #30363d">
+              <th style="padding:8px 12px;text-align:left;color:#8b949e;font-weight:600;font-size:12px">Dimension</th>
+              <th style="padding:8px 12px;text-align:left;color:#8b949e;font-weight:600;font-size:12px">Shift</th>
+              <th style="padding:8px 12px;text-align:right;color:#8b949e;font-weight:600;font-size:12px">Δ</th>
+              <th style="padding:8px 12px;text-align:left;color:#8b949e;font-weight:600;font-size:12px">Direction</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${DIMENSIONS.map((dim, i) => deltaRow(dim, deltas[i])).join('')}
+          </tbody>
+        </table>
+      </div>
+
+      <!-- ── Emotional trajectory timeline ────────────────────────────── -->
+      <div class="card" style="margin-bottom:24px">
+        <h2 style="margin:0 0 12px;font-size:15px;color:#e6edf3">
+          Emotional Trajectory
+          <span style="font-size:12px;font-weight:400;color:#8b949e;margin-left:8px">
+            how the 8 dimensions evolved between base and head
+          </span>
+        </h2>
+        ${trajectorySection(trajectory)}
+      </div>
+
+      <!-- ── Listen to comparison CTA ──────────────────────────────────── -->
+      <div class="card" style="text-align:center;padding:var(--space-5)">
+        <div style="font-size:14px;color:#e6edf3;margin-bottom:12px">
+          Listen to both refs and compare the emotional character directly
+        </div>
+        <div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap">
+          <a href="${escHtml(listenBaseUrl)}" class="btn btn-secondary" style="font-size:14px;padding:10px 20px">
+            &#9654; Base: <code style="font-size:12px">${escHtml(baseRef.slice(0, 10))}</code>
+          </a>
+          <a href="${escHtml(listenHeadUrl)}" class="btn btn-primary" style="font-size:14px;padding:10px 20px">
+            &#9654; Head: <code style="font-size:12px">${escHtml(headRef.slice(0, 10))}</code>
+          </a>
+        </div>
+      </div>`;
+
+  } catch (e) {
+    if (e.message !== 'auth')
+      document.getElementById('content').innerHTML =
+        '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
+  }
+}
+
+load();
+{% endraw %}
+{% endblock %}

--- a/tests/test_musehub_ui_emotion_diff.py
+++ b/tests/test_musehub_ui_emotion_diff.py
@@ -1,0 +1,242 @@
+"""Tests for the Muse Hub emotion-diff UI page (issue #432).
+
+Covers:
+- test_emotion_diff_page_renders              — GET /{owner}/{repo}/emotion-diff/{base}...{head} returns 200 HTML
+- test_emotion_diff_page_no_auth_required     — accessible without JWT
+- test_emotion_diff_page_invalid_ref_404      — refs without '...' separator return 404
+- test_emotion_diff_page_unknown_owner_404    — unknown owner/slug returns 404
+- test_emotion_diff_page_includes_radar       — page contains radar chart JavaScript
+- test_emotion_diff_page_includes_8_dimensions — page contains all 8 emotion-diff dimension keys
+- test_emotion_diff_page_includes_delta_chart — page contains delta bar chart JavaScript
+- test_emotion_diff_page_includes_trajectory  — page contains trajectory timeline JavaScript
+- test_emotion_diff_page_includes_listen_button — page contains "Listen" comparison buttons
+- test_emotion_diff_page_includes_interpretation — page contains interpretation text
+- test_emotion_diff_json_response             — ?format=json returns EmotionDiffResponse shape
+- test_emotion_diff_page_empty_base_ref_404   — base ref empty returns 404
+- test_emotion_diff_page_empty_head_ref_404   — head ref empty returns 404
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import MusehubRepo
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_repo(db_session: AsyncSession) -> str:
+    """Seed a minimal repo and return its repo_id."""
+    repo = MusehubRepo(
+        name="test-beats",
+        owner="testuser",
+        slug="test-beats",
+        visibility="private",
+        owner_user_id="test-owner",
+    )
+    db_session.add(repo)
+    await db_session.commit()
+    await db_session.refresh(repo)
+    return str(repo.repo_id)
+
+
+_BASE_URL = "/musehub/ui/testuser/test-beats/emotion-diff/main...feature"
+
+
+# ---------------------------------------------------------------------------
+# Issue #432 — emotion-diff UI page
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_page_renders(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/emotion-diff/{base}...{head} returns 200 HTML."""
+    await _make_repo(db_session)
+    response = await client.get(_BASE_URL)
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "Muse Hub" in body
+    assert "main" in body
+    assert "feature" in body
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_page_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Emotion-diff page is accessible without a JWT token."""
+    await _make_repo(db_session)
+    response = await client.get(_BASE_URL)
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_page_invalid_ref_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Emotion-diff path without '...' separator returns 404."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/emotion-diff/mainfeature")
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_page_unknown_owner_404(
+    client: AsyncClient,
+) -> None:
+    """Unknown owner/slug combination returns 404 on emotion-diff page."""
+    response = await client.get("/musehub/ui/nobody/norepo/emotion-diff/main...feature")
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_page_empty_base_ref_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Emotion-diff path with empty base ref (starts with '...') returns 404."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/emotion-diff/...feature")
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_page_empty_head_ref_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Emotion-diff path with empty head ref (ends with '...') returns 404."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/testuser/test-beats/emotion-diff/main...")
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_page_includes_radar(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Emotion-diff page HTML contains radar chart JavaScript."""
+    await _make_repo(db_session)
+    response = await client.get(_BASE_URL)
+    assert response.status_code == 200
+    body = response.text
+    assert "radarSvg" in body
+    assert "DIMENSIONS" in body
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_page_includes_8_dimensions(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Emotion-diff page HTML references all 8 emotional dimension keys."""
+    await _make_repo(db_session)
+    response = await client.get(_BASE_URL)
+    assert response.status_code == 200
+    body = response.text
+    # All 8 axes from EmotionVector8D must appear in the JS DIMENSIONS array
+    for dim in ("valence", "energy", "tension", "complexity", "warmth", "brightness", "darkness", "playfulness"):
+        assert dim in body, f"Dimension '{dim}' missing from page"
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_page_includes_delta_chart(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Emotion-diff page HTML contains the delta bar chart JavaScript."""
+    await _make_repo(db_session)
+    response = await client.get(_BASE_URL)
+    assert response.status_code == 200
+    body = response.text
+    assert "deltaRow" in body
+    assert "Per-Axis Delta" in body
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_page_includes_trajectory(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Emotion-diff page HTML contains the emotional trajectory timeline JavaScript."""
+    await _make_repo(db_session)
+    response = await client.get(_BASE_URL)
+    assert response.status_code == 200
+    body = response.text
+    assert "trajectorySection" in body
+    assert "Emotional Trajectory" in body
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_page_includes_listen_button(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Emotion-diff page HTML contains listen comparison buttons for both refs."""
+    await _make_repo(db_session)
+    response = await client.get(_BASE_URL)
+    assert response.status_code == 200
+    body = response.text
+    assert "Listen Base" in body
+    assert "Listen Head" in body
+    assert "listen" in body
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_page_includes_interpretation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Emotion-diff page HTML contains interpretation output from the emotion-diff service."""
+    await _make_repo(db_session)
+    response = await client.get(_BASE_URL)
+    assert response.status_code == 200
+    body = response.text
+    # The JS variable interp is extracted from diff.interpretation
+    assert "interpretation" in body
+
+
+@pytest.mark.anyio
+async def test_emotion_diff_json_response(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/emotion-diff/{refs}?format=json returns EmotionDiffResponse."""
+    await _make_repo(db_session)
+    response = await client.get(f"{_BASE_URL}?format=json")
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+    body = response.json()
+    # EmotionDiffResponse camelCase fields
+    assert "baseRef" in body
+    assert "headRef" in body
+    assert "baseEmotion" in body
+    assert "headEmotion" in body
+    assert "delta" in body
+    assert "interpretation" in body
+    assert "repoId" in body
+    # All 8 axes on base and head emotion vectors
+    for vec_key in ("baseEmotion", "headEmotion"):
+        vec = body[vec_key]
+        for axis in ("valence", "energy", "tension", "complexity", "warmth", "brightness", "darkness", "playfulness"):
+            assert axis in vec, f"Axis '{axis}' missing from {vec_key}"
+            assert 0.0 <= vec[axis] <= 1.0, f"{vec_key}.{axis} out of [0, 1]"
+    # Delta axes allow signed values in [-1, 1]
+    delta = body["delta"]
+    for axis in ("valence", "energy", "tension", "complexity", "warmth", "brightness", "darkness", "playfulness"):
+        assert axis in delta, f"Axis '{axis}' missing from delta"
+        assert -1.0 <= delta[axis] <= 1.0, f"delta.{axis} out of [-1, 1]"
+    # interpretation is a non-empty string
+    assert isinstance(body["interpretation"], str)
+    assert len(body["interpretation"]) > 10


### PR DESCRIPTION
## Summary

Closes #432 — adds the full-screen emotion-diff visualization page at \`/{owner}/{repo}/emotion-diff/{base}...{head}\`.

## Root Cause / Motivation

The PR detail page embeds a compact emotion radar widget, but there was no dedicated full-screen page for exploring the 8-axis emotional shift between two Muse refs. Producers needed a way to visually compare the emotional character of two commits side-by-side with supporting tools (trajectory timeline, delta bar chart, listen buttons).

## Solution

### New files
- **`maestro/api/routes/musehub/ui_emotion_diff.py`** — FastAPI route handler for `GET /musehub/ui/{owner}/{repo_slug}/emotion-diff/{refs}`. Calls `musehub_analysis.compute_emotion_diff()` (already on dev) and delegates rendering via `negotiate_response()`. Supports `?format=json` for machine-readable output.
- **`maestro/templates/musehub/pages/emotion_diff.html`** — Interactive HTML page with:
  - Side-by-side 8D radar charts (base = blue, head = orange, same axis scale)
  - Per-axis delta bar chart (green = increase, red = decrease, grey = < 4% change)
  - Interpretation paragraph from the emotion-diff service
  - "Listen Base" / "Listen Head" buttons linking to the audio playback page
  - Emotional trajectory timeline (sparklines per dimension from the emotion-map API)
- **`tests/test_musehub_ui_emotion_diff.py`** — 13 tests covering: 200 HTML rendering, no-auth access, 404 for invalid refs/unknown owner, all UI features present in rendered HTML, JSON content negotiation, per-axis data correctness.

### Modified files
- **`maestro/main.py`** — Added `ui_emotion_diff` import and `app.include_router()` call (same pattern as `ui_similarity`).

## Verification
- [x] mypy clean (692 source files, no issues)
- [x] All 13 tests pass
- [x] No auth required for page load (data fetched client-side via `apiFetch`)
- [x] JSON content negotiation (`?format=json`) returns `EmotionDiffResponse` with all 8 axes

---
<!-- maestro-fingerprint
role: python-developer
batch: none
session: eng-20260301T082042Z-4ba4
issue: 432
timestamp: 2026-03-01T08:30:00Z
-->
> 🤖 *Opened by Maestro pipeline — batch `none`, session `eng-20260301T082042Z-4ba4`*