### PR TITLE
feat: enhance issue list — filter sidebar, bulk actions, milestone/label sidebars, template selector

### DIFF
--- a/maestro/templates/musehub/pages/issue_list.html
+++ b/maestro/templates/musehub/pages/issue_list.html
@@ -11,16 +11,308 @@ const repoId = {{ repo_id | tojson }};
 const base   = {{ base_url | tojson }};
 {% endblock %}
 
+{% block extra_style %}
+<style>
+/* ── Issue list layout ─────────────────────────────────────────────────────── */
+.issues-layout {
+  display: grid;
+  grid-template-columns: 220px 1fr 220px;
+  gap: var(--space-4);
+  align-items: start;
+}
+@media (max-width: 1100px) {
+  .issues-layout { grid-template-columns: 200px 1fr; }
+  .sidebar-right  { display: none; }
+}
+@media (max-width: 768px) {
+  .issues-layout { grid-template-columns: 1fr; }
+  .sidebar-left, .sidebar-right { display: none; }
+}
+
+/* ── Filter sidebar ────────────────────────────────────────────────────────── */
+.filter-sidebar {
+  position: sticky;
+  top: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.filter-section {
+  background: var(--color-surface-2, #161b22);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: var(--space-3);
+}
+.filter-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  margin: 0 0 var(--space-2) 0;
+}
+.label-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 2px solid transparent;
+  margin: 2px;
+  transition: border-color .15s, opacity .15s;
+  user-select: none;
+}
+.label-chip.active {
+  border-color: var(--color-fg, #e6edf3);
+  opacity: 1;
+}
+.label-chip:not(.active) { opacity: .75; }
+.label-chip:hover { opacity: 1; }
+
+.filter-select, .filter-input {
+  width: 100%;
+  background: var(--color-surface-3, #0d1117);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: var(--color-fg, #e6edf3);
+  font-size: 12px;
+  padding: 4px 6px;
+  box-sizing: border-box;
+}
+.filter-select:focus, .filter-input:focus {
+  outline: none;
+  border-color: var(--color-accent, #1f6feb);
+}
+.sort-radio-group { display: flex; flex-direction: column; gap: 4px; }
+.sort-radio-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--color-fg, #e6edf3);
+  cursor: pointer;
+}
+.filter-clear-btn {
+  width: 100%;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: #8b949e;
+  font-size: 11px;
+  padding: 4px;
+  cursor: pointer;
+  margin-top: var(--space-2);
+}
+.filter-clear-btn:hover { color: var(--color-fg, #e6edf3); border-color: var(--color-fg, #e6edf3); }
+
+/* ── Right sidebar ─────────────────────────────────────────────────────────── */
+.sidebar-right {
+  position: sticky;
+  top: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.sidebar-section {
+  background: var(--color-surface-2, #161b22);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: var(--space-3);
+}
+.sidebar-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  margin: 0 0 var(--space-2) 0;
+}
+.milestone-progress-item { margin-bottom: var(--space-3); }
+.milestone-progress-item:last-child { margin-bottom: 0; }
+.milestone-progress-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-fg, #e6edf3);
+  margin-bottom: 2px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.milestone-progress-bar-track {
+  height: 6px;
+  background: var(--color-surface-3, #0d1117);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: 2px;
+}
+.milestone-progress-bar-fill {
+  height: 100%;
+  background: var(--color-success, #3fb950);
+  border-radius: 3px;
+  transition: width .4s ease;
+}
+.milestone-progress-counts {
+  font-size: 10px;
+  color: #8b949e;
+}
+.sidebar-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+.sidebar-label-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.sidebar-label-name {
+  font-size: 12px;
+  color: var(--color-fg, #e6edf3);
+  flex: 1;
+  margin: 0 6px;
+  cursor: pointer;
+}
+.sidebar-label-name:hover { text-decoration: underline; }
+.sidebar-label-count {
+  font-size: 11px;
+  color: #8b949e;
+  background: var(--color-surface-3, #0d1117);
+  border-radius: 10px;
+  padding: 0 6px;
+}
+
+/* ── Bulk actions toolbar ──────────────────────────────────────────────────── */
+#bulk-toolbar {
+  display: none;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-accent-subtle, #1c2d3f);
+  border: 1px solid var(--color-accent, #1f6feb);
+  border-radius: 6px;
+  margin-bottom: var(--space-3);
+  flex-wrap: wrap;
+}
+#bulk-toolbar.visible { display: flex; }
+#bulk-count { font-size: 13px; color: var(--color-fg, #e6edf3); font-weight: 600; }
+.bulk-action-btn {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-2, #161b22);
+  color: var(--color-fg, #e6edf3);
+}
+.bulk-action-btn:hover { border-color: var(--color-accent, #1f6feb); }
+#bulk-label-select, #bulk-milestone-select {
+  font-size: 12px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-2, #161b22);
+  color: var(--color-fg, #e6edf3);
+}
+.bulk-sep {
+  width: 1px;
+  height: 20px;
+  background: var(--color-border);
+  flex-shrink: 0;
+}
+
+/* ── Issue row selection ───────────────────────────────────────────────────── */
+.issue-row { display: flex; align-items: flex-start; gap: var(--space-2); }
+.issue-row-check {
+  width: 14px;
+  height: 14px;
+  margin-top: 3px;
+  flex-shrink: 0;
+  cursor: pointer;
+  accent-color: var(--color-accent, #1f6feb);
+}
+
+/* ── Issue template selector ───────────────────────────────────────────────── */
+.template-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+.template-card {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: var(--space-3);
+  cursor: pointer;
+  background: var(--color-surface-2, #161b22);
+  transition: border-color .15s;
+}
+.template-card:hover { border-color: var(--color-accent, #1f6feb); }
+.template-card-title { font-size: 13px; font-weight: 600; margin-bottom: 4px; }
+.template-card-desc { font-size: 11px; color: #8b949e; }
+.template-card-icon { font-size: 22px; margin-bottom: 6px; }
+</style>
+{% endblock %}
+
 {% block page_script %}
 {% raw %}
 // ── State ──────────────────────────────────────────────────────────────────
-let allIssues   = [];     // full list from API (state-filtered only)
-let activeLabel = null;   // label string currently filtering, or null
-let activeSort  = 'newest'; // 'newest' | 'oldest' | 'most-commented'
-let commentCounts  = {};  // { issue_id: count } — populated eagerly on load
-let issueReactions = {};  // { issue_id: [{emoji, count}] } — populated eagerly on load
-let cachedOpen   = null;  // cached open issues array after first fetch
-let cachedClosed = null;  // cached closed issues array after first fetch
+let allIssues        = [];
+let activeLabels     = new Set();   // multi-select label filter
+let activeMilestone  = null;        // milestone_id string or null
+let activeAssignee   = null;        // string or null
+let activeAuthor     = '';          // string (empty = all)
+let activeSort       = 'newest';    // 'newest' | 'oldest' | 'most-commented'
+let commentCounts    = {};
+let issueReactions   = {};
+let cachedOpen       = null;
+let cachedClosed     = null;
+let allLabels        = [];          // [{label_id, name, color, description}]
+let allMilestones    = [];          // [{milestone_id, number, title, open_issues, closed_issues}]
+let selectedIssues   = new Set();   // issue_id strings
+
+// Issue templates (static definitions — teams can extend via PR)
+const ISSUE_TEMPLATES = [
+  {
+    id: 'blank',
+    icon: '📝',
+    title: 'Blank Issue',
+    description: 'Start with a clean slate.',
+    body: '',
+  },
+  {
+    id: 'bug',
+    icon: '🐛',
+    title: 'Bug Report',
+    description: 'Something isn\'t working as expected.',
+    body: '## What happened?\n\n\n## Steps to reproduce\n\n1. \n2. \n3. \n\n## Expected behaviour\n\n\n## Actual behaviour\n\n',
+  },
+  {
+    id: 'feature',
+    icon: '✨',
+    title: 'Feature Request',
+    description: 'Suggest a new musical idea or capability.',
+    body: '## Summary\n\n\n## Motivation\n\n\n## Proposed approach\n\n',
+  },
+  {
+    id: 'arrangement',
+    icon: '🎵',
+    title: 'Arrangement Issue',
+    description: 'Track needs musical arrangement work.',
+    body: '## Track / Section\n\n\n## Current arrangement\n\n\n## Desired arrangement\n\n\n## Musical context\n\n',
+  },
+  {
+    id: 'theory',
+    icon: '🎼',
+    title: 'Music Theory',
+    description: 'Related to harmony, rhythm, or theory decisions.',
+    body: '## Theory concern\n\n\n## Affected section / instrument\n\n\n## Suggested resolution\n\n',
+  },
+];
 
 // ── Body preview ───────────────────────────────────────────────────────────
 function bodyPreview(body) {
@@ -37,32 +329,54 @@ function sortedIssues(issues) {
   } else if (activeSort === 'most-commented') {
     copy.sort((a, b) => (commentCounts[b.issueId] || 0) - (commentCounts[a.issueId] || 0));
   } else {
-    // newest (default)
     copy.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
   }
   return copy;
 }
 
-// ── Label filter ───────────────────────────────────────────────────────────
-function setLabelFilter(label) {
-  activeLabel = (activeLabel === label) ? null : label;
-  renderRows();
+// ── Filter application ─────────────────────────────────────────────────────
+function applyFilters(issues) {
+  let out = issues;
+
+  // Multi-select label filter (issue must have ALL active labels)
+  if (activeLabels.size > 0) {
+    out = out.filter(i => {
+      const iLabels = i.labels || [];
+      for (const l of activeLabels) {
+        if (!iLabels.includes(l)) return false;
+      }
+      return true;
+    });
+  }
+
+  // Milestone filter
+  if (activeMilestone) {
+    out = out.filter(i => i.milestoneId === activeMilestone);
+  }
+
+  // Assignee filter
+  if (activeAssignee) {
+    out = out.filter(i => i.assignee === activeAssignee);
+  }
+
+  // Author filter
+  if (activeAuthor.trim()) {
+    const q = activeAuthor.trim().toLowerCase();
+    out = out.filter(i => (i.author || '').toLowerCase().includes(q));
+  }
+
+  return sortedIssues(out);
 }
 
-// ── Render rows ────────────────────────────────────────────────────────────
+// ── Render issue rows ──────────────────────────────────────────────────────
 function renderRows() {
-  let issues = allIssues;
-  if (activeLabel) {
-    issues = issues.filter(i => (i.labels || []).includes(activeLabel));
-  }
-  issues = sortedIssues(issues);
-
+  const issues = applyFilters(allIssues);
   const container = document.getElementById('issue-rows');
   if (!container) return;
 
   if (issues.length === 0) {
-    container.innerHTML = activeLabel
-      ? `<p class="loading">No issues with label "<strong>${escHtml(activeLabel)}</strong>". <a href="#" onclick="setLabelFilter(null);return false;">Clear filter</a></p>`
+    container.innerHTML = (activeLabels.size > 0 || activeMilestone || activeAssignee || activeAuthor)
+      ? `<p class="loading">No issues match the current filters. <a href="#" onclick="clearAllFilters();return false;">Clear filters</a></p>`
       : '<p class="loading">No issues found.</p>';
     return;
   }
@@ -78,15 +392,29 @@ function renderRows() {
     const rxnPills = topRxns.map(r =>
       `<span style="font-size:11px;color:#8b949e;background:var(--color-surface-2,#21262d);border-radius:4px;padding:1px 5px">${r.emoji}&nbsp;${r.count}</span>`
     ).join('');
+    const isChecked = selectedIssues.has(i.issueId);
     return `
       <div class="issue-row" data-issue-id="${i.issueId}">
+        <input type="checkbox" class="issue-row-check"
+               id="chk-${i.issueId}"
+               ${isChecked ? 'checked' : ''}
+               onchange="toggleIssueSelect(${JSON.stringify(i.issueId)}, this.checked)"/>
         <span class="badge badge-${i.state}">#${i.number}</span>
         <div style="flex:1;min-width:0">
           <a href="${base}/issues/${i.number}">${escHtml(i.title)}</a>
           ${preview ? `<div class="issue-preview">${escHtml(preview)}</div>` : ''}
           <div style="display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;margin-top:4px">
-            ${labels.map(l => `<span class="label label-pill${activeLabel === l ? ' label-active' : ''}" onclick="setLabelFilter(${JSON.stringify(l)})" style="cursor:pointer" title="Filter by ${escHtml(l)}">${escHtml(l)}</span>`).join('')}
+            ${labels.map(l => {
+              const labelObj = allLabels.find(lb => lb.name === l);
+              const dotColor = labelObj ? labelObj.color : '#8b949e';
+              const isActive = activeLabels.has(l);
+              return `<span class="label label-pill${isActive ? ' label-active' : ''}"
+                            onclick="toggleLabelFilter(${JSON.stringify(l)})"
+                            style="cursor:pointer;border:1px solid ${dotColor};color:${dotColor}"
+                            title="Filter by ${escHtml(l)}">${escHtml(l)}</span>`;
+            }).join('')}
             <span style="font-size:11px;color:#8b949e">Opened ${fmtDate(i.createdAt)}</span>
+            ${i.author ? `<span style="font-size:11px;color:#8b949e">by ${escHtml(i.author)}</span>` : ''}
             ${commentBadge}
             ${rxnPills}
           </div>
@@ -94,6 +422,171 @@ function renderRows() {
         <span class="badge badge-${i.state}">${i.state}</span>
       </div>`;
   }).join('');
+}
+
+// ── Label filter helpers ───────────────────────────────────────────────────
+function toggleLabelFilter(label) {
+  if (activeLabels.has(label)) {
+    activeLabels.delete(label);
+  } else {
+    activeLabels.add(label);
+  }
+  syncFilterSidebar();
+  renderRows();
+}
+
+function clearAllFilters() {
+  activeLabels.clear();
+  activeMilestone = null;
+  activeAssignee  = null;
+  activeAuthor    = '';
+  const msEl = document.getElementById('filter-milestone');
+  if (msEl) msEl.value = '';
+  const assigneeEl = document.getElementById('filter-assignee');
+  if (assigneeEl) assigneeEl.value = '';
+  const authorEl = document.getElementById('filter-author');
+  if (authorEl) authorEl.value = '';
+  syncFilterSidebar();
+  renderRows();
+}
+
+// ── Sync filter sidebar active states ─────────────────────────────────────
+function syncFilterSidebar() {
+  document.querySelectorAll('.label-chip[data-label]').forEach(chip => {
+    const lbl = chip.dataset.label;
+    chip.classList.toggle('active', activeLabels.has(lbl));
+  });
+}
+
+// ── Milestone filter ───────────────────────────────────────────────────────
+function setMilestoneFilter(val) {
+  activeMilestone = val || null;
+  renderRows();
+}
+
+// ── Assignee filter ────────────────────────────────────────────────────────
+function setAssigneeFilter(val) {
+  activeAssignee = val || null;
+  renderRows();
+}
+
+// ── Author filter ──────────────────────────────────────────────────────────
+function setAuthorFilter(val) {
+  activeAuthor = val || '';
+  renderRows();
+}
+
+// ── Sort ───────────────────────────────────────────────────────────────────
+async function changeSort(value) {
+  activeSort = value;
+  if (activeSort === 'most-commented' && allIssues.length > 0) {
+    const uncounted = allIssues.filter(i => commentCounts[i.issueId] == null);
+    if (uncounted.length > 0) {
+      const loadEl = document.getElementById('sort-loading');
+      if (loadEl) loadEl.style.display = '';
+      await loadCommentCounts(uncounted);
+      if (loadEl) loadEl.style.display = 'none';
+    }
+  }
+  // Update sort radio buttons
+  document.querySelectorAll('input[name="sort-radio"]').forEach(r => {
+    r.checked = r.value === activeSort;
+  });
+  renderRows();
+}
+
+// ── Selection & bulk actions ───────────────────────────────────────────────
+function toggleIssueSelect(issueId, checked) {
+  if (checked) {
+    selectedIssues.add(issueId);
+  } else {
+    selectedIssues.delete(issueId);
+  }
+  updateBulkToolbar();
+}
+
+function updateBulkToolbar() {
+  const toolbar = document.getElementById('bulk-toolbar');
+  const countEl = document.getElementById('bulk-count');
+  if (!toolbar || !countEl) return;
+  const n = selectedIssues.size;
+  if (n > 0) {
+    toolbar.classList.add('visible');
+    countEl.textContent = n === 1 ? '1 issue selected' : `${n} issues selected`;
+  } else {
+    toolbar.classList.remove('visible');
+  }
+}
+
+async function bulkClose() {
+  if (selectedIssues.size === 0) return;
+  if (!confirm(`Close ${selectedIssues.size} issue(s)?`)) return;
+  const issues = allIssues.filter(i => selectedIssues.has(i.issueId));
+  await Promise.all(issues.map(async i => {
+    try {
+      await apiFetch('/repos/' + repoId + '/issues/' + i.number + '/close', { method: 'POST' });
+    } catch (_) { /* best-effort */ }
+  }));
+  selectedIssues.clear();
+  await load(document.getElementById('tab-open')?.classList.contains('tab-active') ? 'open' : 'closed');
+}
+
+async function bulkReopen() {
+  if (selectedIssues.size === 0) return;
+  if (!confirm(`Reopen ${selectedIssues.size} issue(s)?`)) return;
+  const issues = allIssues.filter(i => selectedIssues.has(i.issueId));
+  await Promise.all(issues.map(async i => {
+    try {
+      await apiFetch('/repos/' + repoId + '/issues/' + i.number + '/reopen', { method: 'POST' });
+    } catch (_) { /* best-effort */ }
+  }));
+  selectedIssues.clear();
+  await load('open');
+}
+
+async function bulkAssignLabel() {
+  const select = document.getElementById('bulk-label-select');
+  if (!select || !select.value) { alert('Please select a label first.'); return; }
+  if (selectedIssues.size === 0) return;
+  const labelName = select.value;
+  const issues = allIssues.filter(i => selectedIssues.has(i.issueId));
+  await Promise.all(issues.map(async i => {
+    const current = new Set(i.labels || []);
+    current.add(labelName);
+    try {
+      await apiFetch('/repos/' + repoId + '/issues/' + i.number + '/labels', {
+        method: 'POST',
+        body: JSON.stringify({ labels: [...current] }),
+      });
+    } catch (_) { /* best-effort */ }
+  }));
+  selectedIssues.clear();
+  const state = document.getElementById('tab-open')?.classList.contains('tab-active') ? 'open' : 'closed';
+  await load(state);
+}
+
+async function bulkAssignMilestone() {
+  const select = document.getElementById('bulk-milestone-select');
+  if (!select || !select.value) { alert('Please select a milestone first.'); return; }
+  if (selectedIssues.size === 0) return;
+  const milestoneId = select.value;
+  const issues = allIssues.filter(i => selectedIssues.has(i.issueId));
+  await Promise.all(issues.map(async i => {
+    try {
+      await apiFetch('/repos/' + repoId + '/issues/' + i.number + '/milestone?milestone_id=' + encodeURIComponent(milestoneId), {
+        method: 'POST',
+      });
+    } catch (_) { /* best-effort */ }
+  }));
+  selectedIssues.clear();
+  const state = document.getElementById('tab-open')?.classList.contains('tab-active') ? 'open' : 'closed';
+  await load(state);
+}
+
+function deselectAll() {
+  selectedIssues.clear();
+  document.querySelectorAll('.issue-row-check').forEach(c => { c.checked = false; });
+  updateBulkToolbar();
 }
 
 // ── Load comment counts ────────────────────────────────────────────────────
@@ -120,30 +613,264 @@ async function loadReactionSummaries(issues) {
   }));
 }
 
-// ── Sort control handler ───────────────────────────────────────────────────
-async function changeSort(value) {
-  activeSort = value;
-  if (activeSort === 'most-commented' && allIssues.length > 0) {
-    // fetch counts only on first request — cache in commentCounts
-    const uncounted = allIssues.filter(i => commentCounts[i.issueId] == null);
-    if (uncounted.length > 0) {
-      document.getElementById('sort-loading').style.display = '';
-      await loadCommentCounts(uncounted);
-      document.getElementById('sort-loading').style.display = 'none';
-    }
+// ── Load labels for sidebars ───────────────────────────────────────────────
+async function loadLabels() {
+  try {
+    const data = await apiFetch('/repos/' + repoId + '/labels');
+    allLabels = data.items || [];
+  } catch (_) {
+    allLabels = [];
   }
-  renderRows();
+}
+
+// ── Load milestones for sidebar ────────────────────────────────────────────
+async function loadMilestones() {
+  try {
+    const data = await apiFetch('/repos/' + repoId + '/milestones?state=open');
+    allMilestones = (data.milestones || []).slice(0, 5); // cap at 5 for sidebar
+  } catch (_) {
+    allMilestones = [];
+  }
+}
+
+// ── Render left filter sidebar ─────────────────────────────────────────────
+function renderFilterSidebar(issues) {
+  const el = document.getElementById('filter-sidebar');
+  if (!el) return;
+
+  // Collect unique assignees from loaded issues
+  const assigneeSet = new Set();
+  for (const i of [...(cachedOpen || []), ...(cachedClosed || [])]) {
+    if (i.assignee) assigneeSet.add(i.assignee);
+  }
+
+  const labelChips = allLabels.map(l => {
+    const isActive = activeLabels.has(l.name);
+    return `<span class="label-chip${isActive ? ' active' : ''}"
+                  data-label="${escHtml(l.name)}"
+                  style="background:${l.color}22;color:${l.color}"
+                  onclick="toggleLabelFilter(${JSON.stringify(l.name)})">
+              <span style="width:6px;height:6px;border-radius:50%;background:${l.color};display:inline-block"></span>
+              ${escHtml(l.name)}
+            </span>`;
+  }).join('');
+
+  const milestoneOptions = allMilestones.map(m =>
+    `<option value="${m.milestoneId}" ${activeMilestone === m.milestoneId ? 'selected' : ''}>${escHtml(m.title)}</option>`
+  ).join('');
+
+  const assigneeOptions = [...assigneeSet].map(a =>
+    `<option value="${escHtml(a)}" ${activeAssignee === a ? 'selected' : ''}>${escHtml(a)}</option>`
+  ).join('');
+
+  el.innerHTML = `
+    <div class="filter-section">
+      <p class="filter-section-title" id="filter-labels-heading">Labels</p>
+      <div id="label-chip-container" style="display:flex;flex-wrap:wrap;gap:2px">
+        ${allLabels.length > 0 ? labelChips : '<span style="font-size:11px;color:#8b949e">No labels yet</span>'}
+      </div>
+    </div>
+
+    <div class="filter-section">
+      <p class="filter-section-title">Milestone</p>
+      <select id="filter-milestone" class="filter-select"
+              onchange="setMilestoneFilter(this.value)">
+        <option value="">All milestones</option>
+        ${milestoneOptions}
+      </select>
+    </div>
+
+    <div class="filter-section">
+      <p class="filter-section-title">Assignee</p>
+      <select id="filter-assignee" class="filter-select"
+              onchange="setAssigneeFilter(this.value)">
+        <option value="">All assignees</option>
+        ${assigneeOptions}
+      </select>
+    </div>
+
+    <div class="filter-section">
+      <p class="filter-section-title">Author</p>
+      <input id="filter-author" class="filter-input" type="text"
+             placeholder="Filter by author…"
+             value="${escHtml(activeAuthor)}"
+             oninput="setAuthorFilter(this.value)"/>
+    </div>
+
+    <div class="filter-section">
+      <p class="filter-section-title">Sort</p>
+      <div class="sort-radio-group" id="sort-radio-group">
+        <label class="sort-radio-label">
+          <input type="radio" name="sort-radio" value="newest" ${activeSort==='newest'?'checked':''} onchange="changeSort('newest')"/>
+          Newest
+        </label>
+        <label class="sort-radio-label">
+          <input type="radio" name="sort-radio" value="oldest" ${activeSort==='oldest'?'checked':''} onchange="changeSort('oldest')"/>
+          Oldest
+        </label>
+        <label class="sort-radio-label">
+          <input type="radio" name="sort-radio" value="most-commented" ${activeSort==='most-commented'?'checked':''} onchange="changeSort('most-commented')"/>
+          Most commented
+        </label>
+      </div>
+      <span id="sort-loading" style="display:none;font-size:11px;color:#8b949e">Loading…</span>
+    </div>
+
+    <button class="filter-clear-btn" onclick="clearAllFilters()">✕ Clear all filters</button>
+  `;
+}
+
+// ── Render right sidebar (milestones progress + labels summary) ────────────
+function renderRightSidebar(issues) {
+  const el = document.getElementById('sidebar-right');
+  if (!el) return;
+
+  // Milestone progress bars
+  const milestoneHTML = allMilestones.length > 0
+    ? allMilestones.map(m => {
+        const total = (m.openIssues || 0) + (m.closedIssues || 0);
+        const pct = total > 0 ? Math.round((m.closedIssues || 0) / total * 100) : 0;
+        return `
+          <div class="milestone-progress-item" id="milestone-progress-${m.milestoneId}">
+            <div class="milestone-progress-title">
+              <a href="${base}/milestones/${m.number}" style="color:var(--color-fg,#e6edf3);text-decoration:none;font-size:12px">
+                ${escHtml(m.title)}
+              </a>
+              <span style="font-size:11px;color:#8b949e">${pct}%</span>
+            </div>
+            <div class="milestone-progress-bar-track">
+              <div class="milestone-progress-bar-fill" style="width:${pct}%"></div>
+            </div>
+            <div class="milestone-progress-counts">
+              ${m.closedIssues || 0} closed · ${m.openIssues || 0} open
+            </div>
+          </div>`;
+      }).join('')
+    : '<span style="font-size:11px;color:#8b949e">No open milestones</span>';
+
+  // Label counts (count against the currently loaded issue list)
+  const allLoadedIssues = [...(cachedOpen || []), ...(cachedClosed || [])];
+  const labelCounts = {};
+  for (const i of allLoadedIssues) {
+    for (const l of (i.labels || [])) labelCounts[l] = (labelCounts[l] || 0) + 1;
+  }
+
+  const topLabels = allLabels
+    .map(l => ({ ...l, count: labelCounts[l.name] || 0 }))
+    .filter(l => l.count > 0)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 8);
+
+  const labelsHTML = topLabels.length > 0
+    ? topLabels.map(l => `
+        <div class="sidebar-label-row" id="sidebar-label-row-${l.label_id}">
+          <span class="sidebar-label-dot" style="background:${l.color}"></span>
+          <span class="sidebar-label-name"
+                onclick="toggleLabelFilter(${JSON.stringify(l.name)})"
+                title="Filter by ${escHtml(l.name)}">
+            ${escHtml(l.name)}
+          </span>
+          <span class="sidebar-label-count">${l.count}</span>
+        </div>`).join('')
+    : '<span style="font-size:11px;color:#8b949e">No labels in use</span>';
+
+  el.innerHTML = `
+    <div class="sidebar-section">
+      <p class="sidebar-section-title" id="milestone-progress-heading">Milestones</p>
+      <div id="milestone-progress-list">${milestoneHTML}</div>
+      ${allMilestones.length > 0 ? `<a href="${base}/milestones" style="font-size:11px;color:var(--color-accent,#1f6feb);display:block;margin-top:var(--space-2)">View all milestones →</a>` : ''}
+    </div>
+
+    <div class="sidebar-section">
+      <p class="sidebar-section-title" id="labels-summary-heading">Labels</p>
+      <div id="labels-summary-list">${labelsHTML}</div>
+      <a href="${base}/labels" style="font-size:11px;color:var(--color-accent,#1f6feb);display:block;margin-top:var(--space-2)">Manage labels →</a>
+    </div>
+  `;
+}
+
+// ── Template selector ──────────────────────────────────────────────────────
+function showTemplatePicker() {
+  const panel = document.getElementById('create-issue-panel');
+  const picker = document.getElementById('template-picker');
+  if (!panel || !picker) return;
+  picker.style.display = '';
+  panel.style.display = 'none';
+}
+
+function selectTemplate(tplId) {
+  const tpl = ISSUE_TEMPLATES.find(t => t.id === tplId);
+  if (!tpl) return;
+  document.getElementById('issue-body').value = tpl.body;
+  document.getElementById('template-picker').style.display = 'none';
+  document.getElementById('create-issue-panel').style.display = '';
+  document.getElementById('issue-title').focus();
+}
+
+// ── Build bulk toolbar HTML ────────────────────────────────────────────────
+function buildBulkToolbar() {
+  const labelOptions = allLabels.map(l =>
+    `<option value="${escHtml(l.name)}">${escHtml(l.name)}</option>`
+  ).join('');
+  const msOptions = allMilestones.map(m =>
+    `<option value="${m.milestoneId}">${escHtml(m.title)}</option>`
+  ).join('');
+
+  return `
+    <div id="bulk-toolbar" aria-live="polite">
+      <span id="bulk-count"></span>
+      <span class="bulk-sep"></span>
+      <select id="bulk-label-select" title="Label to assign">
+        <option value="">Assign label…</option>
+        ${labelOptions}
+      </select>
+      <button class="bulk-action-btn" onclick="bulkAssignLabel()">Apply label</button>
+      <span class="bulk-sep"></span>
+      <select id="bulk-milestone-select" title="Milestone to assign">
+        <option value="">Assign milestone…</option>
+        ${msOptions}
+      </select>
+      <button class="bulk-action-btn" onclick="bulkAssignMilestone()">Apply milestone</button>
+      <span class="bulk-sep"></span>
+      <button class="bulk-action-btn" onclick="bulkClose()">Close</button>
+      <button class="bulk-action-btn" onclick="bulkReopen()">Reopen</button>
+      <button class="bulk-action-btn" style="margin-left:auto" onclick="deselectAll()">✕ Deselect</button>
+    </div>`;
+}
+
+// ── Template picker panel ──────────────────────────────────────────────────
+function buildTemplatePicker() {
+  const cards = ISSUE_TEMPLATES.map(tpl => `
+    <div class="template-card" onclick="selectTemplate(${JSON.stringify(tpl.id)})" id="template-card-${tpl.id}">
+      <div class="template-card-icon">${tpl.icon}</div>
+      <div class="template-card-title">${escHtml(tpl.title)}</div>
+      <div class="template-card-desc">${escHtml(tpl.description)}</div>
+    </div>`).join('');
+
+  return `
+    <div id="template-picker" style="display:none">
+      <div class="card" style="border-color:var(--color-accent)">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-3)">
+          <h2 style="margin:0">Choose a template</h2>
+          <button class="btn btn-ghost btn-sm" onclick="document.getElementById('template-picker').style.display='none'">✕</button>
+        </div>
+        <div class="template-grid" id="template-grid">${cards}</div>
+      </div>
+    </div>`;
 }
 
 // ── Main load ──────────────────────────────────────────────────────────────
 async function load(state) {
   initRepoNav(repoId);
   try {
-    // Fetch only what is not yet cached — both needed on first load for tab counts.
+    // Parallel fetch: issues (both states) + labels + milestones
     const [openData, closedData] = await Promise.all([
       cachedOpen   !== null ? Promise.resolve({ issues: cachedOpen })   : apiFetch('/repos/' + repoId + '/issues?state=open'),
       cachedClosed !== null ? Promise.resolve({ issues: cachedClosed }) : apiFetch('/repos/' + repoId + '/issues?state=closed'),
     ]);
+
+    // Always load labels & milestones (cheap; needed for sidebars)
+    await Promise.all([loadLabels(), loadMilestones()]);
 
     cachedOpen   = openData.issues   || [];
     cachedClosed = closedData.issues || [];
@@ -151,108 +878,114 @@ async function load(state) {
     const openCount   = cachedOpen.length;
     const closedCount = cachedClosed.length;
 
-    allIssues   = state === 'closed' ? cachedClosed : cachedOpen;
-    activeLabel = null;
+    allIssues       = state === 'closed' ? cachedClosed : cachedOpen;
+    selectedIssues  = new Set();  // clear selection on tab switch
 
-    // Eagerly pre-fetch social signals for all issues (open + closed) in parallel
+    // Eager social signal pre-fetch
     const allForSocial = [...cachedOpen, ...cachedClosed];
     const needCounts = allForSocial.filter(i => commentCounts[i.issueId] == null);
     const needRxns   = allForSocial.filter(i => issueReactions[i.issueId] == null);
     await Promise.all([
-      needCounts.length ? loadCommentCounts(needCounts)      : Promise.resolve(),
-      needRxns.length   ? loadReactionSummaries(needRxns)    : Promise.resolve(),
+      needCounts.length ? loadCommentCounts(needCounts)   : Promise.resolve(),
+      needRxns.length   ? loadReactionSummaries(needRxns) : Promise.resolve(),
     ]);
 
     document.getElementById('content').innerHTML = `
-      <div class="card">
-        <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap">
-          <h1 style="margin:0">Issues</h1>
-          <div style="margin-left:auto;display:flex;gap:var(--space-2)">
-            <button class="btn btn-secondary btn-sm" onclick="showCreateIssue()">
-              + New Issue
-            </button>
+      <div style="display:flex;gap:var(--space-4);align-items:flex-start">
+        <!-- Left filter sidebar -->
+        <div class="filter-sidebar" id="filter-sidebar" style="width:220px;flex-shrink:0"></div>
+
+        <!-- Main column -->
+        <div style="flex:1;min-width:0">
+          ${buildBulkToolbar()}
+          <div class="card">
+            <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap">
+              <h1 style="margin:0">Issues</h1>
+              <div style="margin-left:auto;display:flex;gap:var(--space-2)">
+                <button class="btn btn-secondary btn-sm" id="new-issue-btn"
+                        onclick="showTemplatePicker()">
+                  + New Issue
+                </button>
+              </div>
+            </div>
+
+            <!-- Open / Closed tabs -->
+            <div style="display:flex;gap:0;border-bottom:1px solid var(--color-border);margin-bottom:var(--space-3)">
+              <button id="tab-open" class="tab-btn${state !== 'closed' ? ' tab-active' : ''}"
+                      onclick="load('open')">
+                &#9711; Open <span class="tab-count">${openCount}</span>
+              </button>
+              <button id="tab-closed" class="tab-btn${state === 'closed' ? ' tab-active' : ''}"
+                      onclick="load('closed')">
+                &#10003; Closed <span class="tab-count">${closedCount}</span>
+              </button>
+            </div>
+
+            <!-- Issue rows -->
+            <div id="issue-rows"></div>
+
+            ${openCount === 0 && closedCount === 0 ? `
+              <div class="empty-state">
+                <div class="empty-icon">&#128203;</div>
+                <p class="empty-title">No issues yet</p>
+                <p class="empty-desc">Found a musical problem or want to track something? Open an issue.</p>
+                <button class="btn btn-primary" onclick="showTemplatePicker()">Open first issue</button>
+              </div>` : ''}
+          </div>
+
+          <!-- Template picker (hidden until + New Issue clicked) -->
+          ${buildTemplatePicker()}
+
+          <!-- New issue form (hidden until template selected) -->
+          <div id="create-issue-panel" style="display:none">
+            <div class="card" style="border-color:var(--color-accent)">
+              <div style="display:flex;align-items:center;gap:var(--space-2);margin-bottom:var(--space-3)">
+                <button class="btn btn-ghost btn-sm" onclick="showTemplatePicker()" title="Change template">← Templates</button>
+                <h2 style="margin:0">New Issue</h2>
+              </div>
+              <div class="form-group" style="margin-bottom:var(--space-3)">
+                <label class="form-label" for="issue-title">Title</label>
+                <input id="issue-title" class="form-input" type="text" placeholder="Brief description of the issue…"/>
+              </div>
+              <div class="form-group" style="margin-bottom:var(--space-3)">
+                <label class="form-label" for="issue-body">Description</label>
+                <textarea id="issue-body" class="form-input" rows="7"
+                          placeholder="Describe the musical problem or request…"
+                          style="resize:vertical;width:100%;font-family:monospace"></textarea>
+                <button class="btn btn-ghost btn-sm" style="margin-top:var(--space-2)"
+                        onclick="suggestIssueBody()">
+                  &#129504; Suggest musical improvements
+                </button>
+              </div>
+              <div style="display:flex;gap:var(--space-2)">
+                <button class="btn btn-primary" onclick="createIssue()">Submit Issue</button>
+                <button class="btn btn-secondary"
+                        onclick="document.getElementById('create-issue-panel').style.display='none';
+                                 document.getElementById('template-picker').style.display='none'">
+                  Cancel
+                </button>
+              </div>
+            </div>
           </div>
         </div>
 
-        <!-- Open / Closed tabs -->
-        <div style="display:flex;gap:0;border-bottom:1px solid var(--color-border);margin-bottom:var(--space-3)">
-          <button id="tab-open" class="tab-btn${state !== 'closed' ? ' tab-active' : ''}"
-                  onclick="load('open')">
-            &#9711; Open <span class="tab-count">${openCount}</span>
-          </button>
-          <button id="tab-closed" class="tab-btn${state === 'closed' ? ' tab-active' : ''}"
-                  onclick="load('closed')">
-            &#10003; Closed <span class="tab-count">${closedCount}</span>
-          </button>
-        </div>
-
-        <!-- Sort + label-clear bar -->
-        <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap">
-          <span style="font-size:13px;color:#8b949e">Sort by:</span>
-          <div style="display:flex;gap:var(--space-1)">
-            <button class="btn btn-ghost btn-sm sort-btn${activeSort==='newest'?' sort-active':''}" data-sort="newest" onclick="changeSort('newest')">Newest</button>
-            <button class="btn btn-ghost btn-sm sort-btn${activeSort==='oldest'?' sort-active':''}" data-sort="oldest" onclick="changeSort('oldest')">Oldest</button>
-            <button class="btn btn-ghost btn-sm sort-btn${activeSort==='most-commented'?' sort-active':''}" data-sort="most-commented" onclick="changeSort('most-commented')">Most commented</button>
-          </div>
-          <span id="sort-loading" style="display:none;font-size:12px;color:#8b949e">Loading…</span>
-          <div id="label-filter-bar"></div>
-        </div>
-
-        <!-- Issue rows -->
-        <div id="issue-rows"></div>
-
-        ${openCount === 0 && closedCount === 0 ? `
-          <div class="empty-state">
-            <div class="empty-icon">&#128203;</div>
-            <p class="empty-title">No issues yet</p>
-            <p class="empty-desc">Found a musical problem or want to track something? Open an issue.</p>
-            <button class="btn btn-primary" onclick="showCreateIssue()">Open first issue</button>
-          </div>` : ''}
+        <!-- Right sidebar -->
+        <div class="sidebar-right" id="sidebar-right" style="width:220px;flex-shrink:0"></div>
       </div>
-      <div id="create-issue-panel" style="display:none">
-        <div class="card" style="border-color:var(--color-accent)">
-          <h2 style="margin-bottom:var(--space-3)">New Issue</h2>
-          <div class="form-group" style="margin-bottom:var(--space-3)">
-            <label class="form-label" for="issue-title">Title</label>
-            <input id="issue-title" class="form-input" type="text" placeholder="Brief description of the issue…"/>
-          </div>
-          <div class="form-group" style="margin-bottom:var(--space-3)">
-            <label class="form-label" for="issue-body">Description</label>
-            <textarea id="issue-body" class="form-input" rows="5"
-                      placeholder="Describe the musical problem or request…"
-                      style="resize:vertical;width:100%"></textarea>
-            <button class="btn btn-ghost btn-sm" style="margin-top:var(--space-2)"
-                    onclick="suggestIssueBody()">
-              &#129504; Suggest musical improvements
-            </button>
-          </div>
-          <div style="display:flex;gap:var(--space-2)">
-            <button class="btn btn-primary" onclick="createIssue()">Submit Issue</button>
-            <button class="btn btn-secondary" onclick="document.getElementById('create-issue-panel').style.display='none'">Cancel</button>
-          </div>
-        </div>
-      </div>`;
+    `;
 
-    // Initial render
+    // Render sidebars and rows
+    renderFilterSidebar();
+    renderRightSidebar();
     renderRows();
-    updateSortButtons();
   } catch(e) {
     if (e.message !== 'auth')
       document.getElementById('content').innerHTML = '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
   }
 }
 
-// ── Keep sort button active styles in sync ─────────────────────────────────
-// Buttons carry data-sort attributes matching the activeSort values.
-function updateSortButtons() {
-  document.querySelectorAll('.sort-btn[data-sort]').forEach(btn => {
-    btn.classList.toggle('sort-active', btn.dataset.sort === activeSort);
-  });
-}
-
 function showCreateIssue() {
-  document.getElementById('create-issue-panel').style.display = '';
-  document.getElementById('issue-title').focus();
+  showTemplatePicker();
 }
 
 async function createIssue() {

--- a/tests/test_musehub_ui_issue_list_enhanced.py
+++ b/tests/test_musehub_ui_issue_list_enhanced.py
@@ -1,0 +1,663 @@
+"""Regression tests for the enhanced issue list page (issue #445).
+
+Covers five feature areas added to issue_list.html:
+
+Filter sidebar
+- test_issue_list_page_returns_200                  — page renders without auth
+- test_issue_list_no_auth_required                  — GET needs no JWT
+- test_issue_list_unknown_repo_404                  — unknown owner/slug → 404
+- test_issue_list_filter_sidebar_present            — filter-sidebar element present
+- test_issue_list_label_chip_container_present      — label-chip-container element present
+- test_issue_list_filter_milestone_select_present   — filter-milestone <select> present
+- test_issue_list_filter_assignee_select_present    — filter-assignee <select> present
+- test_issue_list_filter_author_input_present       — filter-author <input> present
+- test_issue_list_sort_radio_group_present          — sort-radio-group element present
+- test_issue_list_sort_radio_buttons_present        — radio inputs with name="sort-radio" present
+- test_issue_list_clear_filters_btn_present         — clear-all-filters button present
+- test_issue_list_toggle_label_filter_js_present    — toggleLabelFilter() JS function present
+- test_issue_list_clear_all_filters_js_present      — clearAllFilters() JS function present
+- test_issue_list_apply_filters_js_present          — applyFilters() JS function present
+
+Milestone progress sidebar
+- test_issue_list_milestone_progress_heading_present  — milestone-progress-heading element present
+- test_issue_list_milestone_progress_bar_css_present  — milestone-progress-bar-fill CSS present
+- test_issue_list_right_sidebar_present               — sidebar-right element present
+- test_issue_list_render_right_sidebar_js_present     — renderRightSidebar() JS function present
+- test_issue_list_milestone_progress_list_present     — milestone-progress-list element present
+
+Labels sidebar
+- test_issue_list_labels_summary_heading_present    — labels-summary-heading element present
+- test_issue_list_labels_summary_list_present       — labels-summary-list element present
+- test_issue_list_render_right_sidebar_label_js     — renderRightSidebar contains label sidebar logic
+
+Bulk actions toolbar
+- test_issue_list_bulk_toolbar_present              — bulk-toolbar element present
+- test_issue_list_bulk_count_present               — bulk-count element present
+- test_issue_list_bulk_label_select_present        — bulk-label-select element present
+- test_issue_list_bulk_milestone_select_present    — bulk-milestone-select element present
+- test_issue_list_bulk_close_button_present        — bulkClose() function present
+- test_issue_list_bulk_reopen_button_present       — bulkReopen() function present
+- test_issue_list_bulk_assign_label_js_present     — bulkAssignLabel() JS function present
+- test_issue_list_bulk_assign_milestone_js_present — bulkAssignMilestone() JS function present
+- test_issue_list_toggle_issue_select_js_present   — toggleIssueSelect() JS function present
+- test_issue_list_deselect_all_js_present          — deselectAll() JS function present
+- test_issue_list_issue_row_checkbox_js_present    — issue-row-check checkbox class present
+- test_issue_list_update_bulk_toolbar_js_present   — updateBulkToolbar() JS function present
+
+Issue template selector
+- test_issue_list_template_picker_present          — template-picker element present
+- test_issue_list_template_grid_present            — template-grid element present
+- test_issue_list_template_cards_present           — template-card elements present
+- test_issue_list_show_template_picker_js_present  — showTemplatePicker() JS function present
+- test_issue_list_select_template_js_present       — selectTemplate() JS function present
+- test_issue_list_issue_templates_const_present    — ISSUE_TEMPLATES constant defined
+- test_issue_list_new_issue_btn_calls_template     — new-issue-btn invokes showTemplatePicker
+- test_issue_list_templates_back_btn_present       — ← Templates back button present
+- test_issue_list_blank_template_defined           — blank template in ISSUE_TEMPLATES
+- test_issue_list_bug_template_defined             — bug template in ISSUE_TEMPLATES
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import MusehubIssue, MusehubMilestone, MusehubRepo
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_repo(
+    db: AsyncSession,
+    owner: str = "beatmaker",
+    slug: str = "grooves",
+) -> str:
+    """Seed a public repo and return its repo_id string."""
+    repo = MusehubRepo(
+        name=slug,
+        owner=owner,
+        slug=slug,
+        visibility="public",
+        owner_user_id="uid-beatmaker",
+    )
+    db.add(repo)
+    await db.commit()
+    await db.refresh(repo)
+    return str(repo.repo_id)
+
+
+async def _make_issue(
+    db: AsyncSession,
+    repo_id: str,
+    *,
+    number: int = 1,
+    title: str = "Bass too loud",
+    state: str = "open",
+    labels: list[str] | None = None,
+    author: str = "beatmaker",
+    milestone_id: str | None = None,
+) -> MusehubIssue:
+    """Seed an issue and return it."""
+    issue = MusehubIssue(
+        repo_id=repo_id,
+        number=number,
+        title=title,
+        body="Issue body.",
+        state=state,
+        labels=labels or [],
+        author=author,
+        milestone_id=milestone_id,
+    )
+    db.add(issue)
+    await db.commit()
+    await db.refresh(issue)
+    return issue
+
+
+async def _make_milestone(
+    db: AsyncSession,
+    repo_id: str,
+    *,
+    number: int = 1,
+    title: str = "v1.0",
+    state: str = "open",
+) -> MusehubMilestone:
+    """Seed a milestone and return it."""
+    ms = MusehubMilestone(
+        repo_id=repo_id,
+        number=number,
+        title=title,
+        description="Milestone description.",
+        state=state,
+        author="beatmaker",
+    )
+    db.add(ms)
+    await db.commit()
+    await db.refresh(ms)
+    return ms
+
+
+async def _get_page(client: AsyncClient, owner: str = "beatmaker", slug: str = "grooves") -> str:
+    """Fetch the issue list page and return its text body."""
+    resp = await client.get(f"/musehub/ui/{owner}/{slug}/issues")
+    assert resp.status_code == 200
+    return resp.text
+
+
+# ---------------------------------------------------------------------------
+# Basic page rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_issue_list_page_returns_200(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """GET /musehub/ui/{owner}/{slug}/issues returns 200 HTML."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/beatmaker/grooves/issues")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+@pytest.mark.anyio
+async def test_issue_list_no_auth_required(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Issue list page renders without a JWT token."""
+    await _make_repo(db_session)
+    response = await client.get("/musehub/ui/beatmaker/grooves/issues")
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_issue_list_unknown_repo_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Unknown owner/slug returns 404."""
+    response = await client.get("/musehub/ui/nobody/norepo/issues")
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Filter sidebar
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_issue_list_filter_sidebar_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The filter-sidebar element is present in the page HTML."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "filter-sidebar" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_label_chip_container_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """label-chip-container element is rendered in the filter sidebar."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "label-chip-container" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_filter_milestone_select_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """filter-milestone <select> element is present."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "filter-milestone" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_filter_assignee_select_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """filter-assignee <select> element is present."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "filter-assignee" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_filter_author_input_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """filter-author text input is present."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "filter-author" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_sort_radio_group_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """sort-radio-group element is present in the filter sidebar."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "sort-radio-group" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_sort_radio_buttons_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Radio inputs with name='sort-radio' are present."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert 'name="sort-radio"' in body or "name='sort-radio'" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_clear_filters_btn_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Clear all filters button is present."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "clearAllFilters" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_toggle_label_filter_js_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """toggleLabelFilter() JS function is defined in the page."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "toggleLabelFilter" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_clear_all_filters_js_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """clearAllFilters() JS function is defined in the page."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "clearAllFilters" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_apply_filters_js_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """applyFilters() JS function is defined in the page."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "applyFilters" in body
+
+
+# ---------------------------------------------------------------------------
+# Milestone progress sidebar
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_issue_list_milestone_progress_heading_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """milestone-progress-heading element is present."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "milestone-progress-heading" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_milestone_progress_bar_css_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """milestone-progress-bar-fill CSS class is defined in the page."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "milestone-progress-bar-fill" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_right_sidebar_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """sidebar-right element is present in the page HTML."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "sidebar-right" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_render_right_sidebar_js_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """renderRightSidebar() JS function is defined in the page."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "renderRightSidebar" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_milestone_progress_list_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """milestone-progress-list element is present in the page HTML."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "milestone-progress-list" in body
+
+
+# ---------------------------------------------------------------------------
+# Labels sidebar
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_issue_list_labels_summary_heading_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """labels-summary-heading element is present in the right sidebar."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "labels-summary-heading" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_labels_summary_list_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """labels-summary-list element is present in the right sidebar."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "labels-summary-list" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_render_right_sidebar_label_js(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """renderRightSidebar() references labels-summary-list for the labels sidebar."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "labels-summary-list" in body
+    assert "renderRightSidebar" in body
+
+
+# ---------------------------------------------------------------------------
+# Bulk actions toolbar
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_issue_list_bulk_toolbar_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """bulk-toolbar element is present in the page HTML."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "bulk-toolbar" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_bulk_count_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """bulk-count element is present."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "bulk-count" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_bulk_label_select_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """bulk-label-select element is present."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "bulk-label-select" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_bulk_milestone_select_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """bulk-milestone-select element is present."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "bulk-milestone-select" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_bulk_close_button_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """bulkClose() function is defined in the page JS."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "bulkClose" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_bulk_reopen_button_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """bulkReopen() function is defined in the page JS."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "bulkReopen" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_bulk_assign_label_js_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """bulkAssignLabel() JS function is defined in the page."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "bulkAssignLabel" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_bulk_assign_milestone_js_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """bulkAssignMilestone() JS function is defined in the page."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "bulkAssignMilestone" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_toggle_issue_select_js_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """toggleIssueSelect() JS function is defined in the page."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "toggleIssueSelect" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_deselect_all_js_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """deselectAll() JS function is defined in the page."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "deselectAll" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_issue_row_checkbox_js_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """issue-row-check CSS class is referenced in the page (for selection checkboxes)."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "issue-row-check" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_update_bulk_toolbar_js_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """updateBulkToolbar() JS function is defined in the page."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "updateBulkToolbar" in body
+
+
+# ---------------------------------------------------------------------------
+# Issue template selector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_issue_list_template_picker_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """template-picker element is present in the page HTML."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "template-picker" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_template_grid_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """template-grid element is present in the page HTML."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "template-grid" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_template_cards_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """template-card CSS class is present (one card per template)."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "template-card" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_show_template_picker_js_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """showTemplatePicker() JS function is defined in the page."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "showTemplatePicker" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_select_template_js_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """selectTemplate() JS function is defined in the page."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "selectTemplate" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_issue_templates_const_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """ISSUE_TEMPLATES constant is defined in the page JS."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "ISSUE_TEMPLATES" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_new_issue_btn_calls_template(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """new-issue-btn onclick invokes showTemplatePicker (not showCreateIssue directly)."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "new-issue-btn" in body
+    assert "showTemplatePicker" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_templates_back_btn_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """← Templates back navigation button is present in the new issue form."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "Templates" in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_blank_template_defined(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """'blank' template entry is present in ISSUE_TEMPLATES."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "'blank'" in body or '"blank"' in body
+
+
+@pytest.mark.anyio
+async def test_issue_list_bug_template_defined(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """'bug' template entry is present in ISSUE_TEMPLATES."""
+    await _make_repo(db_session)
+    body = await _get_page(client)
+    assert "'bug'" in body or '"bug"' in body


### PR DESCRIPTION
## Summary

Fully implements the five feature areas from issue #445:

1. **Left filter rail** — label chips (multi-select AND), milestone dropdown, assignee dropdown, author text input, sort radio group (Newest / Oldest / Most commented), and a clear-all button.
2. **Milestone progress sidebar** — right sidebar showing open milestones with title, percentage, progress bar, and open/closed issue counts. Capped at 5 for space. Links to `/milestones`.
3. **Labels sidebar** — right sidebar showing labels that appear in loaded issues, sorted by count (top 8). Clicking a label activates the label filter. Links to `/labels`.
4. **Bulk actions toolbar** — appears reactively when ≥1 issue is selected. Actions: assign label, assign milestone, close, reopen, deselect-all. Uses existing JSON API endpoints.
5. **Issue template selector** — clicking "+ New Issue" opens a template picker card grid (Blank, Bug Report, Feature Request, Arrangement Issue, Music Theory). Selecting a card pre-fills the body textarea and shows the form. A "← Templates" back button lets users switch templates.

## Issue

Closes #445

## Root Cause

The previous issue list page had a single label filter (single-select, inline), no milestones/labels sidebars, no bulk operations, and a flat "New Issue" button that opened a bare form. All five features from the spec were absent.

## Solution

- Rewrote `maestro/templates/musehub/pages/issue_list.html` with a three-column flex layout (left filter sidebar | main column | right sidebar).
- All data (labels, milestones) is fetched in parallel on every tab switch via existing public API endpoints (`/labels`, `/milestones?state=open`).
- Bulk state is maintained in a `selectedIssues` Set; the toolbar shows/hides reactively via `updateBulkToolbar()`.
- Template definitions live as a static JS constant `ISSUE_TEMPLATES` — extendable via PR.
- No backend changes required; all five features are purely frontend within the existing Jinja2/JS template pattern.

## Layers Affected

- [x] Muse Hub UI template (`maestro/templates/musehub/pages/issue_list.html`)
- [ ] Intent Engine
- [ ] Pipeline
- [ ] Maestro Handlers
- [ ] Agent Teams
- [ ] Storpheus Client
- [ ] Muse VCS
- [ ] MCP
- [ ] DAW Adapter
- [ ] Auth / Budget
- [ ] RAG
- [ ] Variation
- [ ] SSE Protocol (handoff required — see below)

## Verification

- [x] `docker compose exec maestro mypy maestro/ tests/` — clean (704 source files, 0 issues)
- [x] `docker compose exec storpheus mypy .` — clean
- [x] 44 new tests pass — `tests/test_musehub_ui_issue_list_enhanced.py` (44/44)
- [x] No warnings in test output
- [x] No protocol changes — no handoff required

## Tests Added

- `test_issue_list_page_returns_200` — regression: page renders
- `test_issue_list_filter_sidebar_present` — left filter rail element present
- `test_issue_list_label_chip_container_present` — label chips in sidebar
- `test_issue_list_filter_milestone_select_present` — milestone dropdown
- `test_issue_list_filter_assignee_select_present` — assignee dropdown
- `test_issue_list_filter_author_input_present` — author text input
- `test_issue_list_sort_radio_group_present` — sort radio group
- `test_issue_list_sort_radio_buttons_present` — radio inputs with name=sort-radio
- `test_issue_list_clear_filters_btn_present` — clear-all filters button
- `test_issue_list_toggle_label_filter_js_present` — toggleLabelFilter() JS
- `test_issue_list_clear_all_filters_js_present` — clearAllFilters() JS
- `test_issue_list_apply_filters_js_present` — applyFilters() JS
- `test_issue_list_milestone_progress_heading_present` — right sidebar heading
- `test_issue_list_milestone_progress_bar_css_present` — progress bar CSS
- `test_issue_list_right_sidebar_present` — sidebar-right element
- `test_issue_list_render_right_sidebar_js_present` — renderRightSidebar() JS
- `test_issue_list_milestone_progress_list_present` — progress list container
- `test_issue_list_labels_summary_heading_present` — labels sidebar heading
- `test_issue_list_labels_summary_list_present` — labels summary list
- `test_issue_list_bulk_toolbar_present` — bulk-toolbar element
- `test_issue_list_bulk_count_present` — selection counter
- `test_issue_list_bulk_label_select_present` — label select in toolbar
- `test_issue_list_bulk_milestone_select_present` — milestone select in toolbar
- `test_issue_list_bulk_close_button_present` — bulkClose() function
- `test_issue_list_bulk_reopen_button_present` — bulkReopen() function
- `test_issue_list_bulk_assign_label_js_present` — bulkAssignLabel() JS
- `test_issue_list_bulk_assign_milestone_js_present` — bulkAssignMilestone() JS
- `test_issue_list_toggle_issue_select_js_present` — toggleIssueSelect() JS
- `test_issue_list_deselect_all_js_present` — deselectAll() JS
- `test_issue_list_issue_row_checkbox_js_present` — issue-row-check class
- `test_issue_list_update_bulk_toolbar_js_present` — updateBulkToolbar() JS
- `test_issue_list_template_picker_present` — template-picker element
- `test_issue_list_template_grid_present` — template-grid element
- `test_issue_list_template_cards_present` — template-card class
- `test_issue_list_show_template_picker_js_present` — showTemplatePicker() JS
- `test_issue_list_select_template_js_present` — selectTemplate() JS
- `test_issue_list_issue_templates_const_present` — ISSUE_TEMPLATES constant
- `test_issue_list_new_issue_btn_calls_template` — new-issue-btn → showTemplatePicker
- `test_issue_list_templates_back_btn_present` — ← Templates back button
- `test_issue_list_blank_template_defined` — blank template defined
- `test_issue_list_bug_template_defined` — bug template defined
- Plus 3 additional coverage tests (unknown repo 404, no-auth, labels sidebar JS)

## Handoff

N/A — no SSE or MCP protocol change. Pure UI template change.