### PR TITLE
fix: switch pipeline to htmx/* labels and fix dependency gate regex

### DIFF
--- a/.cursor/PARALLEL_ISSUE_TO_PR.md
+++ b/.cursor/PARALLEL_ISSUE_TO_PR.md
@@ -248,7 +248,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   # Write rich .agent-task — agent reads ALL context from this file
   # Extract DEPENDS_ON from issue body (looks for "Depends on #NNN" patterns)
   ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
-  DEPENDS_ON=$(echo "$ISSUE_BODY" | grep -oE 'Depends on #[0-9]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
+  DEPENDS_ON=$(echo "$ISSUE_BODY" | grep -oE 'Depends on[^#]*#[0-9]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   [ -z "$DEPENDS_ON" ] && DEPENDS_ON=none
 
   # FILE_OWNERSHIP: coordinator should fill this in manually from the taxonomy

--- a/.cursor/roles/cto.md
+++ b/.cursor/roles/cto.md
@@ -28,12 +28,12 @@ The pool stays at 4 concurrent workers continuously until the queue drains.
 ```
 LOOP:
   1. Survey — run both queries simultaneously:
-       # Issues: count only phase-tagged ones — never count agent-identity, blockchain,
-       # or other non-phase issues. PRs: all open PRs against dev are always in scope
-       # (PRs do not carry phase labels — their scope comes from the issue they close).
+       # Issues: count only htmx-tagged ones (htmx/0-foundation, htmx/1-independent, etc.)
+       # PRs: all open PRs against dev are always in scope
+       # (PRs do not carry htmx labels — their scope comes from the issue they close).
        ISSUES=$(gh issue list --state open --repo cgcardona/maestro \
                   --json number,labels \
-                  --jq '[.[] | select(.labels | map(.name) | any(startswith("phase-")))] | length')
+                  --jq '[.[] | select(.labels | map(.name) | any(startswith("htmx/")))] | length')
        PRS=$(gh pr list --base dev --state open --repo cgcardona/maestro \
                --json number --jq 'length')
 
@@ -83,11 +83,11 @@ CTO and VPs do not track dependencies. The canonical prompts handle it.
 
 ## Label scoping rules (critical)
 
-- **Issues:** only phase-tagged issues are in scope. Filter every query:
-  `--jq '[.[] | select(.labels | map(.name) | any(startswith("phase-")))]'`
-- **PRs:** ALL open PRs against `dev` are in scope — PRs never carry `phase-*` labels.
-  Never add a phase label to a PR. Never filter PRs by label.
-- The QA VP must NOT require phase labels on PRs — it reviews every open PR, full stop.
+- **Issues:** only htmx-tagged issues are in scope. Filter every query:
+  `--jq '[.[] | select(.labels | map(.name) | any(startswith("htmx/")))]'`
+- **PRs:** ALL open PRs against `dev` are in scope — PRs never carry `htmx/*` labels.
+  Never add an htmx label to a PR. Never filter PRs by label.
+- The QA VP must NOT require htmx labels on PRs — it reviews every open PR, full stop.
 
 ## What you never do
 


### PR DESCRIPTION
## Summary
Closes no issue — pipeline infrastructure fix needed before htmx agents can run correctly.

## What Changed
- `.cursor/roles/cto.md` — issue filter changed from `startswith("phase-")` to `startswith("htmx/")`
- `.cursor/roles/engineering-manager.md` — same filter + added dependency gate (step 3.5) that checks "Depends on #NNN" before seeding an engineer
- `.cursor/PARALLEL_ISSUE_TO_PR.md` — fixed dependency regex from `Depends on #[0-9]+` to `Depends on[^#]*#[0-9]+` to match `**Depends on:** #NNN` markdown format
- `.cursor/PARALLEL_PR_REVIEW.md` — same regex fix in chain-spawn step 8

## Why
The old `phase-*` labels were deleted. Agents were bypassing the dependency gate because the regex didn't match the bold-markdown format used in issue bodies (`**Depends on:** #555` not `Depends on #555`). This caused rogue engineers for issues that depend on unmerged work.

## Verification
- [ ] No Python files changed — mypy/pytest not required
- [ ] Manual verification: `grep -oE 'Depends on[^#]*#[0-9]+' <issue_body>` matches correctly