### PR TITLE
feat: [HTMX] Infrastructure — fragment response helpers + HX-Request detection

### DIFF
--- a/maestro/api/routes/musehub/htmx_helpers.py
+++ b/maestro/api/routes/musehub/htmx_helpers.py
@@ -1,13 +1,29 @@
-"""HTMX request detection helpers for MuseHub route handlers.
+"""HTMX request detection and fragment response helpers for MuseHub route handlers.
 
 These thin utilities read HTMX-specific request headers so handlers can
 return either a full-page response or a partial fragment without duplicating
 header-inspection logic across every route.
+
+Usage pattern for migrated route handlers::
+
+    return await htmx_fragment_or_full(
+        request, templates, ctx,
+        full_template="musehub/pages/issue_list.html",
+        fragment_template="musehub/fragments/issue_rows.html",
+    )
+
+Priority order when a request arrives:
+1. HTMX partial request (HX-Request: true) + fragment_template → return fragment
+2. No HTMX header, or no fragment_template provided → return full page
 """
 
 from __future__ import annotations
 
+import json
+
 from fastapi import Request
+from fastapi.templating import Jinja2Templates
+from starlette.responses import Response
 
 
 def is_htmx(request: Request) -> bool:
@@ -18,3 +34,69 @@ def is_htmx(request: Request) -> bool:
 def is_htmx_boosted(request: Request) -> bool:
     """Return True when the request came from an hx-boost link (HX-Boosted header present)."""
     return request.headers.get("HX-Boosted") == "true"
+
+
+async def htmx_fragment_or_full(
+    request: Request,
+    templates: Jinja2Templates,
+    ctx: dict[str, object],
+    full_template: str,
+    fragment_template: str | None = None,
+) -> Response:
+    """Return a fragment for HTMX requests, full page for direct navigation.
+
+    When HTMX sends ``HX-Request: true`` and a ``fragment_template`` is provided,
+    the response contains only the fragment — no ``<html>``, ``<head>``, or nav.
+    Direct browser navigation (bookmark, refresh, first load) always receives
+    the complete page that extends ``base.html``.
+
+    Args:
+        request: The incoming FastAPI request.
+        templates: The ``Jinja2Templates`` instance from the route module.
+        ctx: Template context dict shared by both full and fragment templates.
+        full_template: Jinja2 path to the full-page template (extends base.html).
+        fragment_template: Jinja2 path to the bare fragment template (no extends).
+            When ``None``, always returns the full page regardless of request type.
+
+    Returns:
+        ``TemplateResponse`` using either ``fragment_template`` or ``full_template``.
+    """
+    if is_htmx(request) and fragment_template is not None:
+        return templates.TemplateResponse(request, fragment_template, ctx)
+    return templates.TemplateResponse(request, full_template, ctx)
+
+
+def htmx_trigger(response: Response, event: str, detail: dict[str, object] | None = None) -> None:
+    """Set ``HX-Trigger`` header to fire a client-side event after the swap.
+
+    Use for toast notifications, badge refreshes, and other side effects that
+    should happen after HTMX swaps the response into the DOM::
+
+        htmx_trigger(response, "toast", {"message": "Issue closed", "type": "success"})
+
+    Args:
+        response: The Starlette/FastAPI response object to mutate.
+        event: The client-side event name HTMX will dispatch.
+        detail: Optional payload attached to the event. When ``None``, the
+            event fires with ``True`` as its value (a simple signal).
+    """
+    payload: dict[str, object] = {event: detail} if detail is not None else {event: True}
+    response.headers["HX-Trigger"] = json.dumps(payload)
+
+
+def htmx_redirect(url: str) -> Response:
+    """Return an ``HX-Redirect`` response that redirects HTMX without a full page reload.
+
+    The browser URL bar updates and HTMX fetches the target page, but the
+    navigation happens client-side rather than issuing a 302 that the browser
+    follows before HTMX can intercept.
+
+    Args:
+        url: The target URL the client should navigate to.
+
+    Returns:
+        A 200 response with the ``HX-Redirect`` header set; HTMX performs the redirect.
+    """
+    r = Response(status_code=200)
+    r.headers["HX-Redirect"] = url
+    return r

--- a/maestro/api/routes/musehub/negotiate.py
+++ b/maestro/api/routes/musehub/negotiate.py
@@ -3,15 +3,21 @@
 Every MuseHub URL can serve two audiences from the same path:
 - HTML to browsers (default, ``Accept: text/html``)
 - JSON to agents/scripts (``Accept: application/json`` or ``?format=json``)
+- HTMX fragment to HTMX requests (``HX-Request: true``)
 
 This module provides ``negotiate_response()`` — a single function that route
 handlers call after preparing both a Pydantic data model and a Jinja2 template
-context.  The function inspects the ``Accept`` header and an optional
-``?format`` query parameter, then dispatches to the correct serialiser.
+context.  The function inspects headers and an optional ``?format`` query
+parameter, then dispatches to the correct serialiser.
+
+Priority order (first match wins):
+1. ``HX-Request: true`` + ``fragment_template`` provided → return bare fragment
+2. ``?format=json`` or ``Accept: application/json`` → return JSON
+3. Default → return full HTML page
 
 Design rationale:
-- One URL, two audiences — agents get structured JSON, humans get rich HTML.
-- No separate ``/api/v1/...`` endpoint needed; one handler serves both.
+- One URL, three audiences — HTMX gets fragments, agents get JSON, humans get HTML.
+- No separate ``/api/v1/...`` endpoint needed; one handler serves all.
 - ``?format=json`` as a fallback for clients that cannot set ``Accept`` headers
   (e.g. browser ``<a>`` links, ``curl`` without ``-H``).
 - JSON keys use camelCase via Pydantic ``by_alias=True``, matching the existing
@@ -27,6 +33,8 @@ from fastapi.responses import JSONResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 from starlette.responses import Response
+
+from maestro.api.routes.musehub.htmx_helpers import is_htmx
 
 logger = logging.getLogger(__name__)
 
@@ -53,13 +61,22 @@ async def negotiate_response(
     templates: Jinja2Templates,
     json_data: BaseModel | None = None,
     format_param: str | None = None,
+    fragment_template: str | None = None,
 ) -> Response:
-    """Return an HTML or JSON response based on the caller's preference.
+    """Return an HTML, fragment, or JSON response based on the caller's preference.
 
     Route handlers should call this instead of constructing responses directly.
     The handler prepares:
-    - ``context``   — Jinja2 template variables for the HTML path.
-    - ``json_data`` — Pydantic model for the JSON path (camelCase serialised).
+    - ``context``           — Jinja2 template variables for both HTML paths.
+    - ``json_data``         — Pydantic model for the JSON path (camelCase serialised).
+    - ``fragment_template`` — Bare fragment template for HTMX partial updates.
+
+    Priority order (first match wins):
+    1. HTMX request (``HX-Request: true``) + ``fragment_template`` provided
+       → returns bare fragment (no ``<html>``, ``<head>``, or nav).
+    2. JSON requested (``?format=json`` or ``Accept: application/json``)
+       → returns ``JSONResponse`` with camelCase keys.
+    3. Default → returns full ``TemplateResponse`` using ``template_name``.
 
     When ``json_data`` is ``None`` and JSON is requested, ``context`` is
     serialised as-is.  This is a fallback for pages that have no structured
@@ -67,15 +84,22 @@ async def negotiate_response(
 
     Args:
         request: The incoming FastAPI request (needed for template rendering).
-        template_name: Jinja2 template path relative to the templates dir.
+        template_name: Jinja2 template path for the full-page HTML response.
         context: Template context dict (also used as fallback JSON payload).
         templates: The ``Jinja2Templates`` instance from the route module.
         json_data: Optional Pydantic model to serialise for the JSON path.
         format_param: Value of the ``?format`` query parameter, or ``None``.
+        fragment_template: Optional Jinja2 path to a bare fragment template
+            (no ``{% extends %}``). When provided, HTMX requests receive this
+            fragment instead of the full page.
 
     Returns:
-        ``JSONResponse`` with camelCase keys, or ``TemplateResponse`` for HTML.
+        ``TemplateResponse`` (fragment or full page), or ``JSONResponse``.
     """
+    if is_htmx(request) and fragment_template is not None:
+        logger.debug("✅ negotiate_response: HTMX fragment path — %s", fragment_template)
+        return templates.TemplateResponse(request, fragment_template, context)
+
     if _wants_json(request, format_param):
         if json_data is not None:
             payload: dict[str, Any] = json_data.model_dump(by_alias=True, mode="json")

--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -77,6 +77,7 @@ from sqlalchemy import func, select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import Response as StarletteResponse
 
+from maestro.api.routes.musehub.htmx_helpers import htmx_fragment_or_full, htmx_trigger, is_htmx
 from maestro.api.routes.musehub.json_alternate import json_or_html
 from maestro.api.routes.musehub.negotiate import negotiate_response
 from maestro.api.routes.musehub.ui_jsonld import jsonld_release, jsonld_repo, render_jsonld_script

--- a/tests/test_musehub_htmx_helpers.py
+++ b/tests/test_musehub_htmx_helpers.py
@@ -1,0 +1,203 @@
+"""Tests for HTMX fragment response helpers in maestro/api/routes/musehub/htmx_helpers.py.
+
+Verifies that is_htmx(), is_htmx_boosted(), htmx_fragment_or_full(), htmx_trigger(),
+and htmx_redirect() behave correctly for all expected request shapes.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import Request
+from starlette.datastructures import Headers
+from starlette.responses import Response
+from starlette.testclient import TestClient
+
+from maestro.api.routes.musehub.htmx_helpers import (
+    htmx_fragment_or_full,
+    htmx_redirect,
+    htmx_trigger,
+    is_htmx,
+    is_htmx_boosted,
+)
+
+
+def _make_request(headers: dict[str, str] | None = None) -> Request:
+    """Construct a minimal Starlette Request with the given headers."""
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "query_string": b"",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
+    }
+    return Request(scope)
+
+
+def _make_templates(rendered_name: str | None = None) -> MagicMock:
+    """Return a mock Jinja2Templates that records which template was rendered."""
+    templates = MagicMock()
+    response = MagicMock(spec=Response)
+
+    def template_response(request: Request, name: str, ctx: dict[str, object]) -> MagicMock:
+        response.template_name = name
+        return response
+
+    templates.TemplateResponse.side_effect = template_response
+    return templates
+
+
+# ---------------------------------------------------------------------------
+# is_htmx
+# ---------------------------------------------------------------------------
+
+
+def test_is_htmx_returns_true_with_header() -> None:
+    request = _make_request({"HX-Request": "true"})
+    assert is_htmx(request) is True
+
+
+def test_is_htmx_returns_false_without_header() -> None:
+    request = _make_request()
+    assert is_htmx(request) is False
+
+
+def test_is_htmx_returns_false_wrong_value() -> None:
+    request = _make_request({"HX-Request": "false"})
+    assert is_htmx(request) is False
+
+
+def test_is_htmx_returns_false_on_arbitrary_value() -> None:
+    request = _make_request({"HX-Request": "1"})
+    assert is_htmx(request) is False
+
+
+# ---------------------------------------------------------------------------
+# is_htmx_boosted
+# ---------------------------------------------------------------------------
+
+
+def test_is_htmx_boosted_with_header() -> None:
+    request = _make_request({"HX-Boosted": "true"})
+    assert is_htmx_boosted(request) is True
+
+
+def test_is_htmx_boosted_returns_false_without_header() -> None:
+    request = _make_request()
+    assert is_htmx_boosted(request) is False
+
+
+# ---------------------------------------------------------------------------
+# htmx_fragment_or_full
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_htmx_fragment_or_full_returns_fragment_on_htmx_request() -> None:
+    request = _make_request({"HX-Request": "true"})
+    templates = _make_templates()
+    ctx: dict[str, object] = {"key": "value"}
+
+    response = await htmx_fragment_or_full(
+        request,
+        templates,
+        ctx,
+        full_template="musehub/pages/full.html",
+        fragment_template="musehub/fragments/partial.html",
+    )
+
+    templates.TemplateResponse.assert_called_once_with(
+        request, "musehub/fragments/partial.html", ctx
+    )
+
+
+@pytest.mark.anyio
+async def test_htmx_fragment_or_full_returns_full_on_direct_request() -> None:
+    request = _make_request()
+    templates = _make_templates()
+    ctx: dict[str, object] = {"key": "value"}
+
+    response = await htmx_fragment_or_full(
+        request,
+        templates,
+        ctx,
+        full_template="musehub/pages/full.html",
+        fragment_template="musehub/fragments/partial.html",
+    )
+
+    templates.TemplateResponse.assert_called_once_with(
+        request, "musehub/pages/full.html", ctx
+    )
+
+
+@pytest.mark.anyio
+async def test_htmx_fragment_or_full_returns_full_when_no_fragment_template() -> None:
+    """HTMX request without a fragment_template must still return the full page."""
+    request = _make_request({"HX-Request": "true"})
+    templates = _make_templates()
+    ctx: dict[str, object] = {}
+
+    response = await htmx_fragment_or_full(
+        request,
+        templates,
+        ctx,
+        full_template="musehub/pages/full.html",
+        fragment_template=None,
+    )
+
+    templates.TemplateResponse.assert_called_once_with(
+        request, "musehub/pages/full.html", ctx
+    )
+
+
+# ---------------------------------------------------------------------------
+# htmx_trigger
+# ---------------------------------------------------------------------------
+
+
+def test_htmx_trigger_sets_header_with_detail() -> None:
+    response = Response(status_code=200)
+    htmx_trigger(response, "toast", {"message": "Issue closed", "type": "success"})
+
+    raw = response.headers["HX-Trigger"]
+    payload = json.loads(raw)
+    assert payload == {"toast": {"message": "Issue closed", "type": "success"}}
+
+
+def test_htmx_trigger_sets_header_without_detail() -> None:
+    response = Response(status_code=200)
+    htmx_trigger(response, "refresh")
+
+    raw = response.headers["HX-Trigger"]
+    payload = json.loads(raw)
+    assert payload == {"refresh": True}
+
+
+def test_htmx_trigger_overwrites_existing_header() -> None:
+    response = Response(status_code=200)
+    htmx_trigger(response, "first", {"x": 1})
+    htmx_trigger(response, "second", {"y": 2})
+
+    raw = response.headers["HX-Trigger"]
+    payload = json.loads(raw)
+    assert payload == {"second": {"y": 2}}
+
+
+# ---------------------------------------------------------------------------
+# htmx_redirect
+# ---------------------------------------------------------------------------
+
+
+def test_htmx_redirect_sets_hx_redirect_header() -> None:
+    response = htmx_redirect("/musehub/ui/some/path")
+
+    assert response.status_code == 200
+    assert response.headers["HX-Redirect"] == "/musehub/ui/some/path"
+
+
+def test_htmx_redirect_absolute_url() -> None:
+    url = "https://example.com/path"
+    response = htmx_redirect(url)
+
+    assert response.headers["HX-Redirect"] == url

--- a/tests/test_musehub_negotiate.py
+++ b/tests/test_musehub_negotiate.py
@@ -3,6 +3,9 @@
 Covers issue #200 — negotiate_response() dispatches HTML vs JSON based on
 Accept header and ?format query param.
 
+Covers issue #554 — negotiate_response() dispatches HTMX fragment when
+HX-Request header is present and fragment_template is provided.
+
 Tests:
 - test_negotiate_wants_json_format_param         — ?format=json → JSON path
 - test_negotiate_wants_json_accept_header        — Accept: application/json → JSON path
@@ -11,6 +14,9 @@ Tests:
 - test_negotiate_json_uses_pydantic_by_alias     — camelCase keys in JSON output
 - test_negotiate_json_fallback_to_context        — no json_data → context dict as JSON
 - test_negotiate_accept_partial_match            — mixed Accept header containing json
+- test_negotiate_htmx_fragment_path              — HX-Request + fragment_template → fragment
+- test_negotiate_htmx_no_fragment_template       — HX-Request but no fragment_template → HTML
+- test_negotiate_htmx_fragment_beats_json        — HX-Request takes priority over JSON Accept
 """
 from __future__ import annotations
 
@@ -171,3 +177,86 @@ async def test_negotiate_format_param_overrides_html_accept() -> None:
     )
     assert isinstance(resp, JSONResponse)
     templates.TemplateResponse.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# negotiate_response — HTMX fragment path (added in issue #554)
+# ---------------------------------------------------------------------------
+
+
+def _make_htmx_request(accept: str = "") -> Any:
+    """Build a minimal mock Request with the HX-Request: true header set."""
+    req = MagicMock()
+    headers: dict[str, str] = {"HX-Request": "true"}
+    if accept:
+        headers["accept"] = accept
+    req.headers = headers
+    return req
+
+
+@pytest.mark.anyio
+async def test_negotiate_htmx_fragment_path() -> None:
+    """HTMX request + fragment_template → TemplateResponse with fragment template."""
+    req = _make_htmx_request()
+    mock_fragment_resp = MagicMock()
+    templates = MagicMock()
+    templates.TemplateResponse.return_value = mock_fragment_resp
+
+    resp = await negotiate_response(
+        request=req,
+        template_name="musehub/pages/repo.html",
+        context={"owner": "alice"},
+        templates=templates,
+        fragment_template="musehub/fragments/repo_card.html",
+    )
+
+    templates.TemplateResponse.assert_called_once_with(
+        req, "musehub/fragments/repo_card.html", {"owner": "alice"}
+    )
+    assert resp is mock_fragment_resp
+
+
+@pytest.mark.anyio
+async def test_negotiate_htmx_no_fragment_template() -> None:
+    """HTMX request with no fragment_template falls through to full HTML page."""
+    req = _make_htmx_request()
+    mock_full_resp = MagicMock()
+    templates = MagicMock()
+    templates.TemplateResponse.return_value = mock_full_resp
+
+    resp = await negotiate_response(
+        request=req,
+        template_name="musehub/pages/repo.html",
+        context={"owner": "alice"},
+        templates=templates,
+        fragment_template=None,
+    )
+
+    templates.TemplateResponse.assert_called_once_with(
+        req, "musehub/pages/repo.html", {"owner": "alice"}
+    )
+    assert resp is mock_full_resp
+
+
+@pytest.mark.anyio
+async def test_negotiate_htmx_fragment_beats_json() -> None:
+    """HTMX fragment path takes priority over Accept: application/json."""
+    req = _make_htmx_request(accept="application/json")
+    mock_fragment_resp = MagicMock()
+    templates = MagicMock()
+    templates.TemplateResponse.return_value = mock_fragment_resp
+
+    model = _SampleModel(repo_id="xyz", star_count=7)
+    resp = await negotiate_response(
+        request=req,
+        template_name="musehub/pages/repo.html",
+        context={"owner": "alice"},
+        templates=templates,
+        json_data=model,
+        fragment_template="musehub/fragments/repo_card.html",
+    )
+
+    templates.TemplateResponse.assert_called_once_with(
+        req, "musehub/fragments/repo_card.html", {"owner": "alice"}
+    )
+    assert not isinstance(resp, JSONResponse)


### PR DESCRIPTION
## Summary
Closes #554 — creates the fragment response infrastructure that lets every MuseHub route handler return either a full HTML page (direct browser navigation) or a bare fragment (HTMX partial update) without duplicating logic.

## Root Cause / Motivation
Issue #552 added HTMX + Alpine.js to the static layer. Issue #554 is the response layer: every route handler needs a single helper that detects `HX-Request: true` and picks the right template to render. Without this plumbing, every migrated handler would inline the same header check and call the same two `TemplateResponse` paths independently.

## Solution

### `maestro/api/routes/musehub/htmx_helpers.py` (extended)
Added three new functions to the existing detection helpers:

- **`htmx_fragment_or_full()`** — async helper used by every migrated route. Returns the bare fragment template for HTMX requests, the full page otherwise.
- **`htmx_trigger()`** — sets the `HX-Trigger` response header so the client fires a DOM event after the swap (toast notifications, badge refreshes, etc.).
- **`htmx_redirect()`** — returns a 200 response with `HX-Redirect` so HTMX navigates client-side without a 302.

### `maestro/api/routes/musehub/negotiate.py` (updated)
Added `fragment_template` parameter to `negotiate_response()`. Priority order:
1. HTMX request + `fragment_template` → return bare fragment
2. JSON requested (`?format=json` / `Accept: application/json`) → return JSON
3. Default → return full HTML page

### `maestro/templates/musehub/fragments/` (new directory)
Created with `.gitkeep`. Subsequent issues (page migrations) add fragment templates here. Naming convention: fragment file name matches the `id` of the `<div>` it targets.

### `maestro/api/routes/musehub/ui.py`
Added imports for `htmx_fragment_or_full`, `htmx_trigger`, and `is_htmx` so migrated handlers have immediate access.

### `tests/test_musehub_htmx_helpers.py` (new — 14 tests)
Covers all specified scenarios: `is_htmx`/`is_htmx_boosted` header detection, fragment vs. full dispatch, `htmx_trigger` header payload, and `htmx_redirect` header.

## Dependency Note
Issue #553 (Jinja2 macros library) is still open. This PR does not depend on macros — the helpers are pure Python and template-agnostic. Fragment templates using macros from #553 will be added by subsequent page-migration issues.

## Verification
- [x] mypy clean (707 source files, no issues)
- [x] 14/14 tests pass
- [x] Docs updated (module docstrings, inline arg docs)

---
<!-- maestro-fingerprint
role: python-developer
batch: eng-20260301T192750Z-1815
session: eng-20260301T192840Z-7378
issue: 554
timestamp: 2026-03-01T19:33:07Z
-->
> 🤖 *Opened by Maestro pipeline — batch `eng-20260301T192750Z-1815`, session `eng-20260301T192840Z-7378`*