### PR TITLE
feat: migrate harmony_analysis_page from inline Python HTML to Jinja2 SSR template

### DIFF
--- a/maestro/templates/musehub/fragments/analysis/harmony_content.html
+++ b/maestro/templates/musehub/fragments/analysis/harmony_content.html
@@ -1,0 +1,108 @@
+{# Harmony analysis content fragment.
+   Rendered server-side from HarmonyAnalysisResponse.
+   Included by the full page (harmony.html) and returned directly for
+   HTMX partial updates (HX-Request: true). #}
+
+<div style="margin-bottom:12px;display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+  <a href="{{ base_url }}">&larr; Back to repo</a>
+  <span style="color:#8b949e;font-size:13px">
+    Analysis for <code style="background:#161b22;padding:2px 6px;border-radius:4px">{{ ref[:12] }}</code>
+  </span>
+</div>
+
+{# Key summary card #}
+<div class="card" style="border-color:#1f6feb;margin-bottom:16px">
+  <div style="display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:12px">
+    <div>
+      <h1 style="margin:0;font-size:26px">
+        🎹 {{ harmony_data.key }}
+      </h1>
+      <div style="font-size:14px;color:#8b949e;margin-top:4px">
+        Mode: <strong style="color:#58a6ff">{{ harmony_data.mode }}</strong>
+        &bull; Harmonic rhythm: <strong>{{ "%.2f"|format(harmony_data.harmonic_rhythm_bpm) }} chords/min</strong>
+      </div>
+    </div>
+  </div>
+</div>
+
+{# Roman numeral events #}
+{% if harmony_data.roman_numerals %}
+<div class="card" style="margin-bottom:16px">
+  <h2 style="margin-bottom:12px">🎵 Roman Numeral Analysis</h2>
+  <div style="overflow-x:auto">
+    <table style="width:100%;border-collapse:collapse;font-size:13px">
+      <thead>
+        <tr style="border-bottom:2px solid #30363d">
+          <th style="padding:8px 12px;text-align:left;color:#8b949e;font-weight:600">Beat</th>
+          <th style="padding:8px 12px;text-align:left;color:#8b949e;font-weight:600">Chord</th>
+          <th style="padding:8px 12px;text-align:left;color:#8b949e;font-weight:600">Root</th>
+          <th style="padding:8px 12px;text-align:left;color:#8b949e;font-weight:600">Quality</th>
+          <th style="padding:8px 12px;text-align:left;color:#8b949e;font-weight:600">Function</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for rn in harmony_data.roman_numerals %}
+        <tr style="border-bottom:1px solid #21262d">
+          <td style="padding:8px 12px;font-family:monospace;color:#e6edf3">{{ rn.beat | int }}</td>
+          <td style="padding:8px 12px;font-weight:700;color:#58a6ff">{{ rn.chord }}</td>
+          <td style="padding:8px 12px;color:#e6edf3">{{ rn.root }}</td>
+          <td style="padding:8px 12px;color:#8b949e">{{ rn.quality }}</td>
+          <td style="padding:8px 12px">
+            {% if rn.function == "tonic" %}
+              <span style="color:#3fb950">{{ rn.function }}</span>
+            {% elif rn.function == "dominant" %}
+              <span style="color:#f85149">{{ rn.function }}</span>
+            {% elif rn.function == "subdominant" %}
+              <span style="color:#58a6ff">{{ rn.function }}</span>
+            {% else %}
+              <span style="color:#8b949e">{{ rn.function }}</span>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endif %}
+
+{# Cadence analysis #}
+{% if harmony_data.cadences %}
+<div class="card" style="margin-bottom:16px">
+  <h2 style="margin-bottom:12px">🎼 Cadences</h2>
+  <div style="display:flex;flex-wrap:wrap;gap:var(--space-2)">
+    {% for cadence in harmony_data.cadences %}
+    <div style="padding:var(--space-2) var(--space-3);background:var(--color-surface-2,#161b22);border-radius:6px;border:1px solid #30363d">
+      <div style="font-size:12px;color:#8b949e;margin-bottom:2px">Beat {{ cadence.beat | int }}</div>
+      <div style="font-weight:700;color:#e6edf3">{{ cadence.from_ }} &rarr; {{ cadence.to }}</div>
+      <div style="font-size:11px;color:#8b949e;margin-top:2px">{{ cadence.type }}</div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
+
+{# Modulations #}
+{% if harmony_data.modulations %}
+<div class="card" style="margin-bottom:16px">
+  <h2 style="margin-bottom:12px">🔀 Modulations</h2>
+  {% for mod in harmony_data.modulations %}
+  <div style="display:flex;align-items:center;gap:12px;padding:8px 0;border-bottom:1px solid #21262d">
+    <span style="font-family:monospace;font-size:13px;color:#f0883e;min-width:60px">
+      Beat {{ mod.beat | int }}
+    </span>
+    <span style="font-size:13px">
+      {{ mod.from_key }} &rarr; <strong style="color:#58a6ff">{{ mod.to_key }}</strong>
+    </span>
+    {% if mod.pivot_chord %}
+    <span style="font-size:11px;color:#8b949e">via {{ mod.pivot_chord }}</span>
+    {% endif %}
+  </div>
+  {% endfor %}
+</div>
+{% else %}
+<div class="card" style="margin-bottom:16px">
+  <h2 style="margin-bottom:8px">🔀 Modulations</h2>
+  <p style="color:#3fb950;font-size:13px;margin:0">No modulations detected — piece remains in one key.</p>
+</div>
+{% endif %}

--- a/maestro/templates/musehub/pages/analysis/harmony.html
+++ b/maestro/templates/musehub/pages/analysis/harmony.html
@@ -1,0 +1,30 @@
+{% extends "musehub/base.html" %}
+
+{% block title %}Harmony Analysis {{ ref[:8] }} · {{ owner }}/{{ repo_slug }}{% endblock %}
+
+{% block breadcrumb %}
+  <a href="/musehub/ui/{{ owner }}">{{ owner }}</a> /
+  <a href="{{ base_url }}">{{ repo_slug }}</a> /
+  analysis /
+  <a href="{{ base_url }}/analysis/{{ ref }}">{{ ref[:8] }}</a> /
+  harmony
+{% endblock %}
+
+{% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
+
+{% block content %}
+{% include "musehub/fragments/analysis/harmony_content.html" %}
+{% endblock %}
+
+{% block page_data %}
+const repoId   = {{ repo_id | tojson }};
+const ref      = {{ ref | tojson }};
+const base     = {{ base_url | tojson }};
+const apiBase  = '/api/v1/musehub/repos/' + repoId;
+{% endblock %}
+
+{% block page_script %}
+{% raw %}
+initRepoNav(repoId);
+{% endraw %}
+{% endblock %}

--- a/tests/test_musehub_ui_analysis_harmony_ssr.py
+++ b/tests/test_musehub_ui_analysis_harmony_ssr.py
@@ -1,0 +1,203 @@
+"""SSR tests for the Muse Hub harmony analysis page (issue #585).
+
+Verifies that :func:`~maestro.api.routes.musehub.ui.harmony_analysis_page`
+renders data server-side via a Jinja2 template — not via the former inline
+Python HTML builder.
+
+All assertions are made against the raw HTML returned by the server, without
+running JavaScript.  The page uses
+:func:`~maestro.services.musehub_analysis.compute_harmony_analysis` which
+returns deterministic stub data seeded by the ``ref`` hash, so no musical data
+needs to be inserted into the database.
+
+Covers:
+- test_harmony_page_uses_jinja2_template
+- test_harmony_page_renders_key_server_side
+- test_harmony_page_no_python_html_builder_in_module
+- test_harmony_page_htmx_fragment_path
+- test_harmony_page_renders_roman_numerals_server_side
+- test_harmony_page_renders_cadences_server_side
+- test_harmony_page_unknown_repo_returns_404
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.api.routes.musehub import ui as ui_module
+from maestro.db.musehub_models import MusehubRepo
+from maestro.services import musehub_analysis
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_repo(
+    db: AsyncSession,
+    owner: str = "harmony_artist",
+    slug: str = "harmony-album",
+) -> str:
+    """Seed a public repo and return its repo_id string."""
+    repo = MusehubRepo(
+        name=slug,
+        owner=owner,
+        slug=slug,
+        visibility="public",
+        owner_user_id="uid-harmony-artist",
+    )
+    db.add(repo)
+    await db.commit()
+    await db.refresh(repo)
+    return str(repo.repo_id)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_harmony_page_uses_jinja2_template(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Harmony page is rendered by Jinja2 — not an inline HTML string.
+
+    Asserts that the response is valid HTML from the base template (contains
+    the Muse Hub branding and breadcrumb structure) rather than the former
+    bare HTMLResponse built by Python f-string concatenation.
+    """
+    repo_id = await _make_repo(db_session)
+    response = await client.get(
+        "/musehub/ui/harmony_artist/harmony-album/analysis/abc12345/harmony"
+    )
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    # Base template landmarks confirm Jinja2 rendered the page
+    assert "Muse Hub" in response.text
+    assert "harmony_artist" in response.text
+    assert "harmony-album" in response.text
+
+
+@pytest.mark.anyio
+async def test_harmony_page_renders_key_server_side(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Detected key label appears in the HTML without JavaScript execution.
+
+    compute_harmony_analysis returns deterministic data for any ref — the key
+    label (e.g. "C major") must be present in the raw server response.
+    """
+    repo_id = await _make_repo(db_session)
+    ref = "abc12345"
+    harmony = musehub_analysis.compute_harmony_analysis(repo_id=repo_id, ref=ref)
+
+    response = await client.get(
+        f"/musehub/ui/harmony_artist/harmony-album/analysis/{ref}/harmony"
+    )
+    assert response.status_code == 200
+    # The server-computed key label must appear verbatim in the SSR output
+    assert harmony.key in response.text
+
+
+@pytest.mark.anyio
+async def test_harmony_page_no_python_html_builder_in_module(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The _render_harmony_html inline HTML builder must not exist in ui.py.
+
+    Confirms that the migration removed the Python-based HTML builder entirely.
+    Neither the function definition nor any call site should remain.
+    """
+    source = inspect.getsource(ui_module)
+    assert "_render_harmony_html" not in source
+    # The old approach built an inline 'html = f"""..."""' block within the handler
+    assert "HTMLResponse(content=html)" not in source or "harmony" not in source
+
+
+@pytest.mark.anyio
+async def test_harmony_page_htmx_fragment_path(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """HTMX request (HX-Request: true) receives only the fragment — no <html> tag.
+
+    When HTMX sends a partial-page request for the harmony view, the server
+    returns only the inner content fragment, not the full base.html shell.
+    """
+    repo_id = await _make_repo(db_session)
+    response = await client.get(
+        "/musehub/ui/harmony_artist/harmony-album/analysis/abc12345/harmony",
+        headers={"HX-Request": "true"},
+    )
+    assert response.status_code == 200
+    # Fragment must NOT contain the full-page HTML wrapper
+    assert "<html" not in response.text
+    assert "<!DOCTYPE" not in response.text
+    # But it must contain the harmony content
+    assert "harmony" in response.text.lower()
+
+
+@pytest.mark.anyio
+async def test_harmony_page_renders_roman_numerals_server_side(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Roman Numeral Analysis section and table headers appear in the HTML.
+
+    The Roman numeral table (Beat / Chord / Root / Quality / Function columns)
+    is rendered server-side — no JavaScript required.
+    """
+    repo_id = await _make_repo(db_session)
+    response = await client.get(
+        "/musehub/ui/harmony_artist/harmony-album/analysis/abc12345/harmony"
+    )
+    assert response.status_code == 200
+    assert "Roman Numeral Analysis" in response.text
+    # Table column headers from the Jinja2 template
+    assert "Beat" in response.text
+    assert "Chord" in response.text
+    assert "Function" in response.text
+
+
+@pytest.mark.anyio
+async def test_harmony_page_renders_cadences_server_side(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Cadences section is rendered server-side with cadence type and beat.
+
+    compute_harmony_analysis always returns at least one cadence; the cadence
+    type (e.g. 'authentic') and beat position must appear in the raw HTML.
+    """
+    repo_id = await _make_repo(db_session)
+    ref = "abc12345"
+    harmony = musehub_analysis.compute_harmony_analysis(repo_id=repo_id, ref=ref)
+
+    response = await client.get(
+        f"/musehub/ui/harmony_artist/harmony-album/analysis/{ref}/harmony"
+    )
+    assert response.status_code == 200
+    assert "Cadences" in response.text
+    # At least one cadence type must appear server-rendered
+    assert harmony.cadences, "Test expects at least one cadence in stub data"
+    assert harmony.cadences[0].type in response.text
+
+
+@pytest.mark.anyio
+async def test_harmony_page_unknown_repo_returns_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Non-existent repo slug returns HTTP 404 (resolved via DB lookup)."""
+    response = await client.get(
+        "/musehub/ui/nobody/no-such-repo/analysis/abc12345/harmony"
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
Closes #585 — replaces the 407-line inline Python HTML/JS builder in `harmony_analysis_page()` with a proper Jinja2 SSR template, matching the pattern established by all other analysis sub-pages.

## Root Cause / Motivation
`harmony_analysis_page()` was the last route handler in `ui.py` that built HTML by concatenating Python f-strings (a `script = f\"\"\"...\"\"\"` block containing 400+ lines of JavaScript followed by an `html = f\"\"\"...\"\"\"` block). All other analysis pages (contour, tempo, dynamics, key, meter, chord-map, groove, emotion, form, motifs) already use `TemplateResponse`. This was also using the wrong route pattern (`/{repo_id}/...` instead of `/{owner}/{repo_slug}/...`).

## Solution
- **Route fixed**: `/{repo_id}/analysis/{ref}/harmony` → `/{owner}/{repo_slug}/analysis/{ref}/harmony` (matches module docstring and all sibling routes)
- **SSR migration**: calls `compute_harmony_analysis()` server-side and passes `HarmonyAnalysisResponse` to Jinja2 templates
- **Two templates created**:
  - `maestro/templates/musehub/pages/analysis/harmony.html` — full page extending `base.html`
  - `maestro/templates/musehub/fragments/analysis/harmony_content.html` — inner content fragment for HTMX partial updates
- **Old inline HTML builder deleted** (407 lines removed)
- **Import added**: `musehub_analysis` added to `ui.py` imports
- **HTMX support**: uses `htmx_fragment_or_full()` so `HX-Request: true` returns only the fragment

## Verification
- [x] mypy clean (714 source files, no issues)
- [x] 7 new SSR tests pass (`tests/test_musehub_ui_analysis_harmony_ssr.py`)
- [x] 10 existing harmony tests in `test_musehub_ui.py` updated and passing
- [x] Pre-push sync with `origin/dev` — no conflicts

## Files Changed
| File | Change |
|------|--------|
| `maestro/api/routes/musehub/ui.py` | Replace inline HTML builder with Jinja2 SSR handler; fix route path; add import |
| `maestro/templates/musehub/pages/analysis/harmony.html` | New full page template |
| `maestro/templates/musehub/fragments/analysis/harmony_content.html` | New HTMX fragment template |
| `tests/test_musehub_ui_analysis_harmony_ssr.py` | New SSR test file (7 tests) |
| `tests/test_musehub_ui.py` | Update 10 harmony tests to new URL pattern and SSR assertions |

---
<!-- maestro-fingerprint
role: python-developer
batch: eng-20260301T192713Z-2e06
session: eng-20260301T194742Z-2696
issue: 585
timestamp: 2026-03-01T20:01:13Z
-->
> 🤖 *Opened by Maestro pipeline — batch `eng-20260301T192713Z-2e06`, session `eng-20260301T194742Z-2696`*