### PR TITLE
fix: pipeline ordering gate + gh pr checkout prohibition

### DIFF
--- a/.cursor/AGENT_COMMAND_POLICY.md
+++ b/.cursor/AGENT_COMMAND_POLICY.md
@@ -432,6 +432,17 @@ git push origin dev             ← NEVER push directly to dev
 git push origin main            ← NEVER push directly to main
 ```
 
+### Checking out PR branches in the main repo
+```
+gh pr checkout <N>              ← FORBIDDEN in any context
+```
+`gh pr checkout` runs `git checkout` against the main repo's working directory, not
+against the current worktree. This silently moves the main repo onto the feature branch,
+poisoning every subsequent `git worktree list` result and leaving dirty state that
+cascades across all concurrent agents. **Always use `git checkout "$BRANCH"` from within
+your worktree directory instead.** If you think you need `gh pr checkout`, you don't —
+the reviewer worktree is already at the correct branch tip when it is created.
+
 ### Hard reset (discards history / working state)
 ```
 git reset --hard <anything>

--- a/.cursor/PARALLEL_PR_REVIEW.md
+++ b/.cursor/PARALLEL_PR_REVIEW.md
@@ -364,8 +364,15 @@ STEP 3 — CHECKOUT & SYNC (only if STEP 2 shows the PR is open and unreviewed):
   git add -A
   git diff --cached --quiet || git commit -m "chore: stage worktree before dev sync"
 
-  # 1. Checkout the PR branch into this worktree
-  gh pr checkout <N>
+  # 1. Checkout the PR branch in this worktree.
+  #
+  # ⚠️  NEVER use `gh pr checkout <N>` — it runs `git checkout` against the MAIN repo's
+  #    working directory, not this worktree. This is what causes feat/* branches to appear
+  #    checked out in the main repo. It is a known, recurring failure mode.
+  #
+  # ALWAYS use plain git inside this worktree directory:
+  git fetch origin "$BRANCH"
+  git checkout -b "$BRANCH" --track "origin/$BRANCH" 2>/dev/null || git checkout "$BRANCH"
 
   # 2. Fetch ALL remote refs (other agents may have merged PRs while you work)
   git fetch origin

--- a/.cursor/roles/cto.md
+++ b/.cursor/roles/cto.md
@@ -27,17 +27,31 @@ The pool stays at 4 concurrent workers continuously until the queue drains.
 
 ```
 LOOP:
-  1. Survey — run both queries simultaneously:
-       # Issues: count only htmx-tagged ones (htmx/0-foundation, htmx/1-independent, etc.)
-       # PRs: all open PRs against dev are always in scope
-       # (PRs do not carry htmx labels — their scope comes from the issue they close).
-       ISSUES=$(gh issue list --state open --repo cgcardona/maestro \
-                  --json number,labels \
-                  --jq '[.[] | select(.labels | map(.name) | any(startswith("htmx/")))] | length')
+  1. Survey — determine the ACTIVE_LABEL and counts:
+
+       # Labels are processed in strict order — NEVER skip ahead.
+       # Find the lowest-numbered htmx label that still has open issues.
+       ACTIVE_LABEL=""
+       for label in htmx/0-foundation htmx/1-independent htmx/2-main-ui \
+                    htmx/3-analysis htmx/4-canvas htmx/5-cleanup; do
+         COUNT=$(gh issue list --state open --repo cgcardona/maestro \
+                   --label "$label" --json number --jq 'length')
+         if [ "$COUNT" -gt 0 ]; then
+           ACTIVE_LABEL="$label"
+           ISSUES=$COUNT
+           break
+         fi
+       done
+
+       # PRs: all open PRs against dev are always in scope.
        PRS=$(gh pr list --base dev --state open --repo cgcardona/maestro \
                --json number --jq 'length')
 
+       # If no active label found, all issues are closed — check PRs only.
+       [ -z "$ACTIVE_LABEL" ] && ISSUES=0
+
   2. If ISSUES == 0 AND PRS == 0 → report completion. Stop.
+     If ISSUES == 0 AND PRS > 0 → dispatch QA VPs only (drain remaining reviews).
 
   3. Allocate VP slots dynamically (VP_BUDGET = 4 total):
 
@@ -51,16 +65,21 @@ LOOP:
        │ otherwise                      │    2     │    2    │  ← balanced
        └────────────────────────────────┴──────────┴─────────┘
 
+     ⚠️  ACTIVE_LABEL GATE: Engineering VPs ONLY work on ACTIVE_LABEL issues.
+     They MUST NOT claim issues from any other htmx/* label, even if those issues
+     have no unmet dependencies. The label ordering is the sequencing contract.
+
   4. Dispatch all allocated VPs simultaneously in ONE message
      (one Task call per VP, all in the same response):
        - Each Engineering VP → reads engineering-manager.md, seeds 4 leaf engineers
+         (pass ACTIVE_LABEL so the VP only queries that label)
        - Each QA VP          → reads qa-manager.md, seeds 4 leaf reviewers
        - VPs do NOT loop — they seed once and wait for their pool to drain
 
   5. Wait for all dispatched VPs to report back.
 
   6. Log the allocation decision and results:
-       "Wave N: ISSUES=X PRS=Y → dispatched ENG_VPs engineering VPs,
+       "Wave N: ACTIVE_LABEL=X ISSUES=Y PRS=Z → dispatched ENG_VPs engineering VPs,
         QA_VPs QA VPs. Results: [summary]"
 
   7. GOTO 1
@@ -68,10 +87,11 @@ LOOP:
 
 ## VP dispatch context
 
-Pass each VP its role file path and a `CTO_WAVE` identifier so it can tag its batch:
+Pass each VP its role file path, a `CTO_WAVE` identifier, and the **ACTIVE_LABEL**:
 
 > Engineering VP prompt: "Read /Users/gabriel/dev/tellurstori/maestro/.cursor/roles/engineering-manager.md.
-> CTO_WAVE=<wave-N-timestamp>. Seed your pool and wait for it to drain."
+> CTO_WAVE=<wave-N-timestamp>. ACTIVE_LABEL=<htmx/X-label>. Seed your pool and wait for it to drain.
+> You MUST only query and claim issues labeled exactly '<htmx/X-label>' — no other htmx/* labels."
 
 > QA VP prompt: "Read /Users/gabriel/dev/tellurstori/maestro/.cursor/roles/qa-manager.md.
 > CTO_WAVE=<wave-N-timestamp>. Seed your pool and wait for it to drain."

--- a/.cursor/roles/engineering-manager.md
+++ b/.cursor/roles/engineering-manager.md
@@ -25,13 +25,15 @@ SEED:
          --json number --jq '.[].number' | \
          xargs -r -I{} gh issue edit {} --remove-label "agent:wip"
 
-  3. Query open unclaimed issues — htmx-tagged only (htmx/0-foundation, htmx/1-independent, etc.):
-       gh issue list --state open --repo cgcardona/maestro --json number,title,labels \
-         --jq '[.[] | select(
-                 (.labels | map(.name) | any(startswith("htmx/"))) and
-                 (.labels | map(.name) | index("agent:wip") | not)
-               )]'
-     If empty → report to CTO "implementation queue clear." Stop.
+  3. Query open unclaimed issues — ACTIVE_LABEL only (passed by CTO in your dispatch prompt):
+       # ACTIVE_LABEL is the single htmx/* label the CTO assigned to you (e.g. htmx/0-foundation).
+       # NEVER query all htmx/* labels — you are scoped to exactly one label per VP run.
+       # This prevents you from accidentally claiming issues from a later phase.
+       ACTIVE_LABEL="<from CTO dispatch prompt>"
+       gh issue list --state open --repo cgcardona/maestro --label "$ACTIVE_LABEL" \
+         --json number,title,labels \
+         --jq '[.[] | select(.labels | map(.name) | index("agent:wip") | not)]'
+     If empty → report to CTO "implementation queue clear for $ACTIVE_LABEL." Stop.
 
   3.5 Dependency gate — CRITICAL for htmx/0-foundation (sequential issues):
      For each candidate issue, check if its dependencies are met before seeding.


### PR DESCRIPTION
## What changed

**cto.md** — Added ACTIVE_LABEL derivation. The CTO now finds the lowest-numbered htmx/* label with open issues and passes it to Eng VPs. VPs cannot claim issues from any later label, even if those issues have no unmet dependencies. The label sequence (0-foundation → 1-independent → …) is the ordering contract.

**engineering-manager.md** — Eng VP now queries only the ACTIVE_LABEL passed by the CTO, not all htmx/* labels. This is the enforcement point that prevented the first run from racing into htmx/5-cleanup while htmx/0-foundation was still in progress.

**PARALLEL_PR_REVIEW.md** — Replaced `gh pr checkout <N>` with `git fetch origin "$BRANCH" && git checkout -b "$BRANCH" --track "origin/$BRANCH" 2>/dev/null || git checkout "$BRANCH"`. The old command ran git checkout against the main repo working directory (not the worktree), which is what caused feat/* branches to repeatedly appear checked out in the main repo.

**AGENT_COMMAND_POLICY.md** — Added `gh pr checkout` to the RED tier with a full explanation of why it is forbidden and what to use instead.

## No regressions
- No Python files changed — mypy/pytest not required
- All existing worktree creation patterns preserved
- Dependency gate (Depends on[^#]*#[0-9]+) unchanged