### PR TITLE
feat: [AgentCeption] AC-001: Scaffold agentception/ directory, app.py, config.py, models.py

### DIFF
--- a/agentception/__init__.py
+++ b/agentception/__init__.py
@@ -1,0 +1,2 @@
+"""AgentCeption — standalone dashboard service for monitoring Maestro pipeline agents."""
+from __future__ import annotations

--- a/agentception/app.py
+++ b/agentception/app.py
@@ -1,0 +1,87 @@
+"""AgentCeption FastAPI application factory.
+
+Entry point: ``uvicorn agentception.app:app --port 7777 --reload``
+
+Architecture:
+- ``lifespan`` starts a background poller task that periodically refreshes
+  the ``PipelineState`` from the filesystem and GitHub API.
+- Static files are served from ``agentception/static/``.
+- HTML pages are rendered via Jinja2 from ``agentception/templates/``.
+- JSON API routes live in ``agentception/routes/`` (stubbed for now).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from starlette.requests import Request
+
+from agentception.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Resolve paths relative to this file so the app works regardless of cwd.
+_HERE = Path(__file__).parent
+_TEMPLATES = Jinja2Templates(directory=str(_HERE / "templates"))
+
+
+async def _poll_loop() -> None:
+    """Background task: refresh pipeline state on a fixed interval.
+
+    The initial implementation is a stub — subsequent issues will fill in the
+    actual GitHub + filesystem collection logic. The loop runs until cancelled.
+    """
+    while True:
+        try:
+            await asyncio.sleep(settings.poll_interval_seconds)
+            logger.debug("⏱️  Poll tick (stub — no readers wired yet)")
+        except asyncio.CancelledError:
+            logger.info("✅ Poller stopped cleanly")
+            return
+        except Exception as exc:
+            logger.warning("⚠️  Poller error: %s", exc)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    """Start the background poller on startup; cancel it on shutdown."""
+    poller = asyncio.create_task(_poll_loop(), name="agentception-poller")
+    logger.info("✅ AgentCeption poller started (interval=%ds)", settings.poll_interval_seconds)
+    try:
+        yield
+    finally:
+        poller.cancel()
+        try:
+            await poller
+        except asyncio.CancelledError:
+            pass
+
+
+app = FastAPI(
+    title="AgentCeption",
+    description="Maestro pipeline agent dashboard",
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+# Mount static assets — CSS, future JS bundles.
+app.mount("/static", StaticFiles(directory=str(_HERE / "static")), name="static")
+
+
+@app.get("/health", tags=["health"])
+async def health() -> dict[str, str]:
+    """Liveness probe — returns ``{"status": "ok"}`` when the service is up."""
+    return {"status": "ok"}
+
+
+@app.get("/", response_class=HTMLResponse, tags=["ui"])
+async def index(request: Request) -> HTMLResponse:
+    """Dashboard home — renders the base template with nav skeleton."""
+    return _TEMPLATES.TemplateResponse(request, "base.html")

--- a/agentception/config.py
+++ b/agentception/config.py
@@ -1,0 +1,26 @@
+"""AgentCeption service configuration.
+
+All settings are prefixed with ``AC_`` so they never collide with Maestro's
+``STORI_*`` namespace. Defaults work for local development without any env vars set.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AgentCeptionSettings(BaseSettings):
+    """Runtime configuration for the AgentCeption dashboard service."""
+
+    model_config = SettingsConfigDict(env_prefix="AC_")
+
+    cursor_projects_dir: Path = Path.home() / ".cursor/projects"
+    worktrees_dir: Path = Path.home() / ".cursor/worktrees/maestro"
+    repo_dir: Path = Path("/Users/gabriel/dev/tellurstori/maestro")
+    gh_repo: str = "cgcardona/maestro"
+    poll_interval_seconds: int = 5
+    github_cache_seconds: int = 10
+
+
+settings = AgentCeptionSettings()

--- a/agentception/models.py
+++ b/agentception/models.py
@@ -1,0 +1,80 @@
+"""Domain models for the AgentCeption dashboard.
+
+These types are the shared contract between the background poller, the API
+routes, and the frontend templates. Keep them flat — no nested Pydantic
+models that reference external services.
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class AgentStatus(str, Enum):
+    """Lifecycle state of a single pipeline agent, derived from filesystem + GitHub signals."""
+
+    IMPLEMENTING = "implementing"
+    REVIEWING = "reviewing"
+    DONE = "done"
+    STALE = "stale"
+    UNKNOWN = "unknown"
+
+
+class AgentNode(BaseModel):
+    """A single agent in the pipeline tree.
+
+    Represents one Cursor/Claude agent instance that is either actively working
+    or has completed its assigned task. Children are spawned sub-agents.
+    """
+
+    id: str
+    role: str
+    status: AgentStatus
+    issue_number: int | None = None
+    pr_number: int | None = None
+    branch: str | None = None
+    batch_id: str | None = None
+    worktree_path: str | None = None
+    transcript_path: str | None = None
+    message_count: int = 0
+    last_activity_mtime: float = 0.0
+    children: list[AgentNode] = []
+
+
+class PipelineState(BaseModel):
+    """Snapshot of the entire Maestro pipeline at a point in time.
+
+    Aggregated by the background poller and served to the dashboard UI.
+    ``polled_at`` is a UNIX timestamp — compare with ``time.time()`` to know
+    how stale the data is.
+    """
+
+    active_label: str | None
+    issues_open: int
+    prs_open: int
+    agents: list[AgentNode]
+    alerts: list[str] = []
+    polled_at: float
+
+
+class TaskFile(BaseModel):
+    """Parsed content of a ``.agent-task`` file from a worktree.
+
+    Every field maps 1-to-1 with a ``KEY=value`` line in the task file.
+    Unknown keys are silently ignored.
+    """
+
+    task: str | None = None
+    gh_repo: str | None = None
+    issue_number: int | None = None
+    branch: str | None = None
+    worktree: str | None = None
+    role: str | None = None
+    base: str | None = None
+    batch_id: str | None = None
+    closes_issues: str | None = None
+    spawn_sub_agents: bool = False
+    attempt_n: int = 0
+    required_output: str | None = None
+    on_block: str | None = None

--- a/agentception/readers/__init__.py
+++ b/agentception/readers/__init__.py
@@ -1,0 +1,7 @@
+"""Readers sub-package for AgentCeption.
+
+Each reader is responsible for collecting raw data from a specific source
+(filesystem worktrees, Cursor transcript files, GitHub API). The poller
+orchestrates them into a unified ``PipelineState``.
+"""
+from __future__ import annotations

--- a/agentception/requirements.txt
+++ b/agentception/requirements.txt
@@ -1,0 +1,11 @@
+fastapi>=0.115.0
+uvicorn[standard]>=0.30.0
+jinja2>=3.1.4
+aiofiles>=23.2.1
+pydantic>=2.7.0
+pydantic-settings>=2.3.0
+sse-starlette>=2.1.0
+httpx>=0.27.0
+pytest>=8.0.0
+pytest-anyio>=0.0.0
+anyio>=4.0.0

--- a/agentception/routes/__init__.py
+++ b/agentception/routes/__init__.py
@@ -1,0 +1,9 @@
+"""Routes sub-package for AgentCeption.
+
+Split into two routers:
+- ``api``:  JSON endpoints consumed by HTMX and future clients.
+- ``ui``:   HTML endpoints rendered via Jinja2 templates.
+
+Both are registered in ``app.py`` via ``app.include_router()``.
+"""
+from __future__ import annotations

--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -1,0 +1,131 @@
+/* AgentCeption — dark-mode base styles.
+   No framework dependencies. Colours match GitHub Dark + Maestro purple accent. */
+
+:root {
+  --bg-primary:   #0d1117;
+  --bg-secondary: #161b22;
+  --bg-tertiary:  #21262d;
+  --border:       #30363d;
+  --text-primary: #e6edf3;
+  --text-muted:   #8b949e;
+  --accent:       #7c3aed;
+  --accent-hover: #9461fb;
+  --success:      #3fb950;
+  --warning:      #d29922;
+  --danger:       #f85149;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  min-height: 100vh;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--accent-hover);
+  text-decoration: underline;
+}
+
+/* ── Layout ── */
+
+.layout {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+}
+
+/* ── Nav ── */
+
+nav.topnav {
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  padding: 0 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  height: 48px;
+}
+
+nav.topnav .brand {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+nav.topnav a {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+nav.topnav a:hover,
+nav.topnav a.active {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  text-decoration: none;
+}
+
+/* ── Main content ── */
+
+main {
+  padding: 2rem 1.5rem;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+/* ── Cards ── */
+
+.card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+}
+
+/* ── Status badges ── */
+
+.badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.125rem 0.5rem;
+  border-radius: 2em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.badge-implementing { background: #1e40af; color: #93c5fd; }
+.badge-reviewing    { background: #713f12; color: #fde68a; }
+.badge-done         { background: #14532d; color: #86efac; }
+.badge-stale        { background: #3d1f00; color: #fdba74; }
+.badge-unknown      { background: var(--bg-tertiary); color: var(--text-muted); }
+
+/* ── Utility ── */
+
+.text-muted   { color: var(--text-muted); }
+.text-success { color: var(--success); }
+.text-warning { color: var(--warning); }
+.text-danger  { color: var(--danger); }
+
+.mt-1 { margin-top: 0.5rem; }
+.mt-2 { margin-top: 1rem; }
+.mt-3 { margin-top: 1.5rem; }

--- a/agentception/templates/base.html
+++ b/agentception/templates/base.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{% block title %}AgentCeption{% endblock %}</title>
+
+  <!-- Dark-mode base styles — no external CSS framework -->
+  <link rel="stylesheet" href="/static/app.css" />
+
+  <!-- HTMX 2.x — server-driven hypermedia from CDN -->
+  <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.min.js"
+          integrity="sha256-YADM5XNYL2VfHKqKBCPhwQlEGr8vG3FkFTzlECr/KIM="
+          crossorigin="anonymous" defer></script>
+
+  <!-- Alpine.js 3.x — lightweight reactivity from CDN -->
+  <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.3/dist/cdn.min.js"
+          defer></script>
+
+  {% block head %}{% endblock %}
+</head>
+<body class="layout">
+
+  <nav class="topnav" role="navigation" aria-label="Main navigation">
+    <span class="brand">⚡ AgentCeption</span>
+    <a href="/"
+       class="{% if request.url.path == '/' %}active{% endif %}">
+      Overview
+    </a>
+    <a href="/agents"
+       class="{% if request.url.path.startswith('/agents') %}active{% endif %}">
+      Agents
+    </a>
+    <a href="/telemetry"
+       class="{% if request.url.path.startswith('/telemetry') %}active{% endif %}">
+      Telemetry
+    </a>
+    <a href="/roles"
+       class="{% if request.url.path.startswith('/roles') %}active{% endif %}">
+      Roles
+    </a>
+    <a href="/controls"
+       class="{% if request.url.path.startswith('/controls') %}active{% endif %}">
+      Controls
+    </a>
+  </nav>
+
+  <main role="main">
+    {% block content %}
+    <div class="card">
+      <p class="text-muted">Welcome to <strong>AgentCeption</strong> — the Maestro pipeline dashboard.</p>
+      <p class="mt-1 text-muted">Select a section from the navigation above to get started.</p>
+    </div>
+    {% endblock %}
+  </main>
+
+</body>
+</html>

--- a/tests/test_agentception_scaffold.py
+++ b/tests/test_agentception_scaffold.py
@@ -1,0 +1,117 @@
+"""Tests for the AgentCeption scaffold (AC-001).
+
+These tests verify the foundational service plumbing — settings, models, and
+the FastAPI app itself — before any reader or poller logic is wired in.
+
+Run targeted:
+    pytest tests/test_agentception_scaffold.py -v
+"""
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+from agentception.config import AgentCeptionSettings
+from agentception.models import AgentNode, AgentStatus, PipelineState, TaskFile
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    """Synchronous test client that handles lifespan correctly."""
+    with TestClient(app) as c:
+        yield c
+
+
+# ── /health ──────────────────────────────────────────────────────────────────
+
+
+def test_health_returns_200(client: TestClient) -> None:
+    """GET /health must return 200 with ``{"status": "ok"}``."""
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+
+def test_settings_loads_defaults() -> None:
+    """AgentCeptionSettings must load without errors and expose expected defaults."""
+    s = AgentCeptionSettings()
+    assert s.gh_repo == "cgcardona/maestro"
+    assert s.poll_interval_seconds == 5
+    assert s.github_cache_seconds == 10
+    assert s.worktrees_dir.name == "maestro"
+
+
+# ── Models ────────────────────────────────────────────────────────────────────
+
+
+def test_agent_node_serializes_roundtrip() -> None:
+    """AgentNode must survive a JSON serialise → deserialise roundtrip without data loss."""
+    node = AgentNode(
+        id="eng-20260301T000000Z-abcd",
+        role="python-developer",
+        status=AgentStatus.IMPLEMENTING,
+        issue_number=609,
+        branch="feat/issue-609",
+        batch_id="eng-20260301T211956Z-741f",
+        message_count=42,
+    )
+    restored = AgentNode.model_validate(node.model_dump())
+    assert restored.id == node.id
+    assert restored.status == AgentStatus.IMPLEMENTING
+    assert restored.issue_number == 609
+    assert restored.message_count == 42
+    assert restored.children == []
+
+
+def test_pipeline_state_empty_valid() -> None:
+    """PipelineState with no agents and no alerts must be valid and serialisable."""
+    import time
+
+    state = PipelineState(
+        active_label="batch-01",
+        issues_open=0,
+        prs_open=0,
+        agents=[],
+        alerts=[],
+        polled_at=time.time(),
+    )
+    assert state.issues_open == 0
+    assert state.agents == []
+    data = state.model_dump()
+    assert "polled_at" in data
+
+
+# ── UI ────────────────────────────────────────────────────────────────────────
+
+
+def test_index_returns_html_with_agentception(client: TestClient) -> None:
+    """GET / must return 200 HTML containing the string 'AgentCeption'."""
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "AgentCeption" in response.text
+
+
+# ── TaskFile ──────────────────────────────────────────────────────────────────
+
+
+def test_task_file_model_parses_known_fields() -> None:
+    """TaskFile must parse a representative .agent-task payload correctly."""
+    tf = TaskFile(
+        task="issue-to-pr",
+        gh_repo="cgcardona/maestro",
+        issue_number=609,
+        branch="feat/issue-609",
+        role="python-developer",
+        batch_id="eng-20260301T211956Z-741f",
+        spawn_sub_agents=False,
+        attempt_n=0,
+    )
+    assert tf.issue_number == 609
+    assert tf.spawn_sub_agents is False
+    assert tf.attempt_n == 0


### PR DESCRIPTION
## Summary
Closes #609 — Bootstrap the AgentCeption dashboard service with a complete directory scaffold, FastAPI app factory, Pydantic v2 models, dark-mode CSS, and Jinja2/HTMX/Alpine.js template.

## Root Cause / Motivation
Every subsequent AgentCeption issue depends on this foundation. Without the `agentception/` package existing, later issues (readers, poller, dashboard UI) have no imports to build on.

## Solution
Created the full scaffold as specified in the issue:

- **`agentception/app.py`** — FastAPI factory with `lifespan` background poller stub, `GET /health` → `{"status": "ok"}`, `GET /` HTML index, static file mount at `/static`
- **`agentception/config.py`** — `AgentCeptionSettings` via `pydantic-settings` with `AC_` env prefix; sane local defaults
- **`agentception/models.py`** — `AgentStatus` enum, `AgentNode`, `PipelineState`, `TaskFile` Pydantic v2 models
- **`agentception/readers/__init__.py`** — readers sub-package skeleton (source readers added in later issues)
- **`agentception/routes/__init__.py`** — routes sub-package skeleton (api + ui routers added in later issues)
- **`agentception/static/app.css`** — dark-mode base styles: bg `#0d1117`, accent `#7c3aed`, no framework
- **`agentception/templates/base.html`** — HTMX 2.x + Alpine.js 3.x from jsDelivr CDN; nav skeleton with 5 links
- **`agentception/requirements.txt`** — standalone service dependencies (separate from the main Maestro `requirements.txt`)
- **`tests/test_agentception_scaffold.py`** — 6 tests: health 200, settings defaults, AgentNode round-trip, PipelineState empty, index HTML, TaskFile parse

## Verification
- [x] mypy clean (707 source files, 0 errors)
- [x] 6/6 tests pass (no warnings)
- [x] `uvicorn agentception.app:app --port 7777` starts without error (verified via TestClient lifespan)
- [x] `GET /health` returns `{"status": "ok"}`
- [x] `GET /` returns HTML containing `AgentCeption`

---
<!-- maestro-fingerprint
role: python-developer
batch: eng-20260301T211956Z-741f
session: eng-20260301T212047Z-5ee3
issue: 609
timestamp: 2026-03-01T21:24:58Z
-->
> 🤖 *Opened by Maestro pipeline — batch `eng-20260301T211956Z-741f`, session `eng-20260301T212047Z-5ee3`*