### PR TITLE
feat: [AgentCeption] AC-004: readers/github.py — gh CLI wrappers, 10s cache

### DIFF
--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -1,0 +1,313 @@
+"""GitHub data reader for AgentCeption.
+
+All GitHub data flows through this module via ``gh`` CLI subprocess calls.
+Results are cached for ``settings.github_cache_seconds`` (default 10 s) to
+avoid hitting the GitHub API rate-limit and keep the dashboard UI snappy.
+
+Write operations (``close_pr``, ``clear_wip_label``) always invalidate the
+entire cache so subsequent reads reflect the new state without waiting for TTL
+expiry.
+
+Usage::
+
+    from agentception.readers.github import get_open_issues, get_active_label
+
+    issues = await get_open_issues(label="agentception/0-scaffold")
+    label  = await get_active_label()
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import cast
+
+from agentception.config import settings
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Internal TTL cache
+# ---------------------------------------------------------------------------
+# Format: {cache_key: (result, expires_at_unix)}
+# ``object`` is intentional — callers are responsible for knowing the shape of
+# what they stored (each public function wraps a specific type).
+_cache: dict[str, tuple[object, float]] = {}
+
+
+def _cache_get(key: str) -> object | None:
+    """Return cached value if it exists and has not expired, else None."""
+    entry = _cache.get(key)
+    if entry is None:
+        return None
+    result, expires_at = entry
+    if time.monotonic() > expires_at:
+        del _cache[key]
+        return None
+    return result
+
+
+def _cache_set(key: str, value: object) -> None:
+    """Store *value* in the cache with a TTL of ``github_cache_seconds``."""
+    expires_at = time.monotonic() + settings.github_cache_seconds
+    _cache[key] = (value, expires_at)
+
+
+def _cache_invalidate() -> None:
+    """Clear the entire cache.
+
+    Called after any write operation so the next read reflects current state
+    rather than serving a stale response that was cached before the mutation.
+    """
+    _cache.clear()
+    logger.debug("⚠️  GitHub cache invalidated after write operation")
+
+
+# ---------------------------------------------------------------------------
+# Low-level subprocess helper
+# ---------------------------------------------------------------------------
+
+async def gh_json(args: list[str], jq: str, cache_key: str) -> object:
+    """Run ``gh`` with ``--json`` + ``--jq`` and cache the result.
+
+    Parameters
+    ----------
+    args:
+        Additional ``gh`` sub-command arguments (e.g. ``["issue", "list",
+        "--repo", "cgcardona/maestro"]``).  Do **not** include ``--json`` or
+        ``--jq`` — those are appended automatically.
+    jq:
+        A ``jq`` filter string passed verbatim to ``--jq``.  The ``gh`` CLI
+        uses its own bundled ``jq`` — no host installation required.
+    cache_key:
+        Opaque string that identifies this particular query.  Use a value that
+        captures all arguments that affect the result so distinct queries never
+        share a cache entry.
+
+    Returns
+    -------
+    object
+        Parsed JSON (list, dict, str, int, …) — shape depends on the ``jq``
+        filter.  Callers must narrow the type themselves.
+
+    Raises
+    ------
+    RuntimeError
+        When ``gh`` exits with a non-zero status.
+    """
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        logger.debug("✅ GitHub cache hit: %s", cache_key)
+        return cached
+
+    cmd = ["gh"] + args + ["--jq", jq]
+    logger.debug("⏱️  gh subprocess: %s", " ".join(cmd))
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh command failed (exit {proc.returncode}): "
+            f"{stderr.decode().strip()!r}  cmd={cmd}"
+        )
+
+    raw = stdout.decode().strip()
+    if not raw:
+        result: object = []
+    else:
+        result = json.loads(raw)
+
+    _cache_set(cache_key, result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public read API
+# ---------------------------------------------------------------------------
+
+async def get_open_issues(label: str | None = None) -> list[dict[str, object]]:
+    """List open issues, optionally filtered by a single label.
+
+    Returns each issue as a dict with at minimum: ``number``, ``title``,
+    ``labels`` (list of label objects), and ``body``.
+
+    Parameters
+    ----------
+    label:
+        When provided, only issues carrying this label are returned.
+    """
+    repo = settings.gh_repo
+    args = [
+        "issue", "list",
+        "--repo", repo,
+        "--state", "open",
+        "--json", "number,title,labels,body",
+    ]
+    if label:
+        args += ["--label", label]
+
+    cache_key = f"get_open_issues:label={label}"
+    result = await gh_json(args, ".", cache_key)
+    return cast(list[dict[str, object]], result)
+
+
+async def get_open_prs() -> list[dict[str, object]]:
+    """List open pull requests targeting the ``dev`` branch.
+
+    Returns each PR as a dict with at minimum: ``number``, ``title``,
+    ``headRefName``, and ``labels``.
+    """
+    repo = settings.gh_repo
+    args = [
+        "pr", "list",
+        "--repo", repo,
+        "--base", "dev",
+        "--state", "open",
+        "--json", "number,title,headRefName,labels",
+    ]
+    result = await gh_json(args, ".", "get_open_prs")
+    return cast(list[dict[str, object]], result)
+
+
+async def get_wip_issues() -> list[dict[str, object]]:
+    """Return issues currently labelled ``agent:wip``.
+
+    An ``agent:wip`` label signals that a pipeline agent has claimed the
+    issue.  The dashboard uses this to detect in-flight work.
+    """
+    return await get_open_issues(label="agent:wip")
+
+
+async def get_active_label() -> str | None:
+    """Find the lowest-numbered ``agentception/*`` label that has open issues.
+
+    Labels follow the pattern ``agentception/<N>-<slug>``.  The «active»
+    label is the one with the smallest ``<N>`` — i.e. the phase currently
+    being worked on.
+
+    Returns ``None`` when no open issues carry an ``agentception/*`` label.
+    """
+    repo = settings.gh_repo
+    args = [
+        "issue", "list",
+        "--repo", repo,
+        "--state", "open",
+        "--json", "labels",
+    ]
+    result = await gh_json(args, "[.[].labels[].name]", "get_active_label")
+    all_label_names = cast(list[str], result)
+
+    agentception_labels: set[str] = {
+        name for name in all_label_names if name.startswith("agentception/")
+    }
+    if not agentception_labels:
+        return None
+
+    def _sort_key(name: str) -> int:
+        """Extract the numeric prefix after the slash for ordering."""
+        suffix = name.split("/", 1)[-1]          # e.g. "0-scaffold"
+        prefix = suffix.split("-", 1)[0]          # e.g. "0"
+        try:
+            return int(prefix)
+        except ValueError:
+            return 999
+
+    return min(agentception_labels, key=_sort_key)
+
+
+async def get_issue_body(number: int) -> str:
+    """Fetch the markdown body of a single issue.
+
+    Used by the ticket analyser and DAG builder to parse dependency
+    declarations (``Depends on #N``) and extract structured metadata.
+
+    Parameters
+    ----------
+    number:
+        GitHub issue number.
+    """
+    repo = settings.gh_repo
+    args = [
+        "issue", "view", str(number),
+        "--repo", repo,
+        "--json", "body",
+    ]
+    result = await gh_json(args, ".body", f"get_issue_body:{number}")
+    return cast(str, result)
+
+
+# ---------------------------------------------------------------------------
+# Write operations (always invalidate cache)
+# ---------------------------------------------------------------------------
+
+async def close_pr(number: int, comment: str) -> None:
+    """Close a pull request and post a comment explaining the closure.
+
+    Invalidates the cache so subsequent reads reflect the updated PR state.
+
+    Parameters
+    ----------
+    number:
+        GitHub PR number.
+    comment:
+        Comment body to post before closing (appears in the PR timeline).
+    """
+    repo = settings.gh_repo
+
+    proc = await asyncio.create_subprocess_exec(
+        "gh", "pr", "close", str(number),
+        "--repo", repo,
+        "--comment", comment,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh pr close failed (exit {proc.returncode}): "
+            f"{stderr.decode().strip()!r}"
+        )
+
+    logger.info("✅ PR #%d closed with comment", number)
+    _cache_invalidate()
+
+
+async def clear_wip_label(issue_number: int) -> None:
+    """Remove the ``agent:wip`` label from an issue.
+
+    Called by the control plane after an agent completes its task so the
+    issue no longer shows up in ``get_wip_issues()``.
+
+    Invalidates the cache so subsequent reads see the updated label set.
+
+    Parameters
+    ----------
+    issue_number:
+        GitHub issue number to remove ``agent:wip`` from.
+    """
+    repo = settings.gh_repo
+
+    proc = await asyncio.create_subprocess_exec(
+        "gh", "issue", "edit", str(issue_number),
+        "--repo", repo,
+        "--remove-label", "agent:wip",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh issue edit failed (exit {proc.returncode}): "
+            f"{stderr.decode().strip()!r}"
+        )
+
+    logger.info("✅ Removed agent:wip from issue #%d", issue_number)
+    _cache_invalidate()

--- a/tests/test_agentception_github.py
+++ b/tests/test_agentception_github.py
@@ -1,0 +1,322 @@
+"""Tests for agentception/readers/github.py.
+
+All GitHub interactions are mocked via ``unittest.mock.AsyncMock`` and
+``patch`` — no real ``gh`` subprocess is ever invoked.  The subprocess
+interface is thin (``asyncio.create_subprocess_exec``), so patching it at the
+module level gives complete control over return values and exit codes.
+
+Run targeted:
+    pytest tests/test_agentception_github.py -v
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import agentception.readers.github as gh_module
+from agentception.readers.github import (
+    _cache,
+    _cache_invalidate,
+    clear_wip_label,
+    close_pr,
+    get_active_label,
+    get_issue_body,
+    get_open_issues,
+    get_open_prs,
+    get_wip_issues,
+    gh_json,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_process(stdout: bytes, returncode: int = 0, stderr: bytes = b"") -> MagicMock:
+    """Return a mock asyncio subprocess with the given stdout/stderr/returncode."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def clear_cache_before_each() -> None:
+    """Ensure a clean cache state for every test.
+
+    Without this, cache hits from earlier tests would contaminate later ones.
+    """
+    _cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# gh_json — caching behaviour
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_cache_hit_skips_subprocess() -> None:
+    """A second call with the same cache_key must NOT invoke the subprocess again."""
+    payload = [{"number": 1, "title": "Example"}]
+
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(json.dumps(payload).encode()),
+    ) as mock_exec:
+        # First call — subprocess runs.
+        result1 = await gh_json(
+            ["issue", "list", "--repo", "cgcardona/maestro", "--json", "number,title"],
+            ".",
+            "test_key",
+        )
+        # Second call — should use cache.
+        result2 = await gh_json(
+            ["issue", "list", "--repo", "cgcardona/maestro", "--json", "number,title"],
+            ".",
+            "test_key",
+        )
+
+    assert mock_exec.call_count == 1
+    assert result1 == payload
+    assert result2 == payload
+
+
+@pytest.mark.anyio
+async def test_cache_invalidated_after_write() -> None:
+    """close_pr / clear_wip_label must empty the cache so next read is fresh."""
+    # Pre-populate cache.
+    _cache["stale_key"] = ("stale_value", time.monotonic() + 30)
+
+    # Patch the subprocess so close_pr succeeds.
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b""),
+    ):
+        await close_pr(42, "closing")
+
+    assert len(_cache) == 0
+
+
+@pytest.mark.anyio
+async def test_gh_json_raises_on_nonzero_exit() -> None:
+    """gh_json must raise RuntimeError when the subprocess exits non-zero."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b"", returncode=1, stderr=b"Not Found"),
+    ):
+        with pytest.raises(RuntimeError, match="gh command failed"):
+            await gh_json(["issue", "list"], ".", "fail_key")
+
+
+# ---------------------------------------------------------------------------
+# get_open_issues
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_get_open_issues_filters_by_label() -> None:
+    """get_open_issues(label=...) must pass --label to gh and return parsed list."""
+    issues = [
+        {"number": 10, "title": "Issue A", "labels": [], "body": ""},
+        {"number": 11, "title": "Issue B", "labels": [], "body": ""},
+    ]
+
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(json.dumps(issues).encode()),
+    ) as mock_exec:
+        result = await get_open_issues(label="batch-01")
+
+    # Verify --label was passed.
+    call_args = mock_exec.call_args[0]  # positional args to create_subprocess_exec
+    assert "--label" in call_args
+    assert "batch-01" in call_args
+
+    assert len(result) == 2
+    assert result[0]["number"] == 10
+
+
+@pytest.mark.anyio
+async def test_get_open_issues_no_label() -> None:
+    """get_open_issues() without a label must NOT pass --label."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b"[]"),
+    ) as mock_exec:
+        result = await get_open_issues()
+
+    call_args = mock_exec.call_args[0]
+    assert "--label" not in call_args
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_wip_issues
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_get_wip_issues_empty() -> None:
+    """get_wip_issues() must return an empty list when no agent:wip issues exist."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b"[]"),
+    ):
+        result = await get_wip_issues()
+
+    assert result == []
+
+
+@pytest.mark.anyio
+async def test_get_wip_issues_passes_label() -> None:
+    """get_wip_issues() must delegate to get_open_issues with label='agent:wip'."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b"[]"),
+    ) as mock_exec:
+        await get_wip_issues()
+
+    call_args = mock_exec.call_args[0]
+    assert "agent:wip" in call_args
+
+
+# ---------------------------------------------------------------------------
+# get_active_label
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_get_active_label_returns_lowest() -> None:
+    """get_active_label() must return the agentception/* label with the lowest numeric prefix."""
+    label_names = [
+        "agentception/2-something",
+        "agentception/0-scaffold",
+        "agentception/1-readers",
+        "enhancement",
+    ]
+
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(json.dumps(label_names).encode()),
+    ):
+        result = await get_active_label()
+
+    assert result == "agentception/0-scaffold"
+
+
+@pytest.mark.anyio
+async def test_get_active_label_returns_none_when_no_agentception_labels() -> None:
+    """get_active_label() must return None when no agentception/* labels are present."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(json.dumps(["enhancement", "batch-01"]).encode()),
+    ):
+        result = await get_active_label()
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_open_prs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_get_open_prs_returns_list() -> None:
+    """get_open_prs() must return a list of PR dicts targeting dev."""
+    prs = [{"number": 5, "title": "feat: something", "headRefName": "feat/x", "labels": []}]
+
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(json.dumps(prs).encode()),
+    ) as mock_exec:
+        result = await get_open_prs()
+
+    call_args = mock_exec.call_args[0]
+    assert "--base" in call_args
+    assert "dev" in call_args
+    assert result == prs
+
+
+# ---------------------------------------------------------------------------
+# get_issue_body
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_get_issue_body_returns_string() -> None:
+    """get_issue_body(N) must return the issue body string from gh output."""
+    expected_body = "This is the issue body."
+
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(json.dumps(expected_body).encode()),
+    ):
+        result = await get_issue_body(42)
+
+    assert result == expected_body
+
+
+# ---------------------------------------------------------------------------
+# close_pr
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_close_pr_passes_comment() -> None:
+    """close_pr() must pass --comment to gh pr close."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b""),
+    ) as mock_exec:
+        await close_pr(99, "closing: no longer needed")
+
+    call_args = mock_exec.call_args[0]
+    assert "pr" in call_args
+    assert "close" in call_args
+    assert "--comment" in call_args
+    assert "closing: no longer needed" in call_args
+
+
+@pytest.mark.anyio
+async def test_close_pr_raises_on_failure() -> None:
+    """close_pr() must raise RuntimeError when gh exits non-zero."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b"", returncode=1, stderr=b"Forbidden"),
+    ):
+        with pytest.raises(RuntimeError, match="gh pr close failed"):
+            await close_pr(1, "test")
+
+
+# ---------------------------------------------------------------------------
+# clear_wip_label
+# ---------------------------------------------------------------------------
+
+@pytest.mark.anyio
+async def test_clear_wip_label_passes_remove_label() -> None:
+    """clear_wip_label() must pass --remove-label agent:wip to gh."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b""),
+    ) as mock_exec:
+        await clear_wip_label(613)
+
+    call_args = mock_exec.call_args[0]
+    assert "--remove-label" in call_args
+    assert "agent:wip" in call_args
+
+
+@pytest.mark.anyio
+async def test_clear_wip_label_invalidates_cache() -> None:
+    """clear_wip_label() must empty the cache as a side effect."""
+    _cache["some_key"] = ("value", time.monotonic() + 60)
+
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b""),
+    ):
+        await clear_wip_label(613)
+
+    assert len(_cache) == 0


### PR DESCRIPTION
## Summary
Closes #613 — implements `agentception/readers/github.py`, the GitHub data layer for the AgentCeption dashboard.

## Root Cause / Motivation
The dashboard poller needed a dedicated, rate-limit-safe layer for all GitHub data. Without it, every component would independently shell out to `gh`, saturating the API and producing inconsistent snapshots.

## Solution
Introduced `agentception/readers/github.py` with:

- **`gh_json(args, jq, cache_key)`** — async subprocess wrapper that runs `gh --json --jq` and stores the result in a per-key TTL cache (`github_cache_seconds`, default 10 s).
- **`get_open_issues(label=None)`** — lists open issues, optionally filtered by label. Returns `number`, `title`, `labels`, `body`.
- **`get_open_prs()`** — lists open PRs targeting `dev`. Returns `number`, `title`, `headRefName`, `labels`.
- **`get_wip_issues()`** — delegates to `get_open_issues(label="agent:wip")`.
- **`get_active_label()`** — finds the lowest-numbered `agentception/*` label that has open issues; returns `None` when none exist.
- **`get_issue_body(number)`** — fetches a single issue body (used by ticket analyser and DAG builder).
- **`close_pr(number, comment)`** — closes a PR with a timeline comment; invalidates cache.
- **`clear_wip_label(issue_number)`** — removes `agent:wip`; invalidates cache.

Cache invalidation on every write ensures subsequent reads reflect the mutation without waiting for TTL expiry.

## Verification
- [x] mypy clean (`Success: no issues found in 2 source files` + `708 source files` full pass)
- [x] 15 tests pass (`tests/test_agentception_github.py`) — all with mocked subprocesses, no real `gh` calls
- [x] All acceptance criteria met: reads cached, writes invalidate, subprocess args verified

---
<!-- maestro-fingerprint
role: python-developer
batch: eng-20260301T214203Z-057d
session: eng-20260301T214252Z-1525
issue: 613
timestamp: 2026-03-01T21:46:03Z
-->
> 🤖 *Opened by Maestro pipeline — batch `eng-20260301T214203Z-057d`, session `eng-20260301T214252Z-1525`*