### PR TITLE
feat: [AgentCeption] AC-002: readers/worktrees.py — parse git worktrees + .agent-task files

### DIFF
--- a/agentception/models.py
+++ b/agentception/models.py
@@ -62,19 +62,23 @@ class TaskFile(BaseModel):
     """Parsed content of a ``.agent-task`` file from a worktree.
 
     Every field maps 1-to-1 with a ``KEY=value`` line in the task file.
-    Unknown keys are silently ignored.
+    Unknown keys are silently ignored. All fields are optional to ensure
+    graceful handling of missing or malformed task files.
     """
 
     task: str | None = None
     gh_repo: str | None = None
     issue_number: int | None = None
+    pr_number: int | None = None
     branch: str | None = None
     worktree: str | None = None
     role: str | None = None
     base: str | None = None
     batch_id: str | None = None
-    closes_issues: str | None = None
+    closes_issues: list[int] = []
     spawn_sub_agents: bool = False
+    spawn_mode: str | None = None
+    merge_after: str | None = None
     attempt_n: int = 0
     required_output: str | None = None
     on_block: str | None = None

--- a/agentception/readers/worktrees.py
+++ b/agentception/readers/worktrees.py
@@ -66,7 +66,7 @@ async def parse_agent_task(worktree_path: Path) -> TaskFile | None:
         return None
 
     try:
-        content = await asyncio.get_event_loop().run_in_executor(
+        content = await asyncio.get_running_loop().run_in_executor(
             None, task_file_path.read_text, "utf-8"
         )
     except OSError as exc:
@@ -127,7 +127,7 @@ def _build_task_file(fields: dict[str, str], worktree_path: Path) -> TaskFile:
     """
     closes_issues = _parse_int_list(fields.get("CLOSES_ISSUES", ""))
 
-    raw: dict[str, object] = {
+    raw: dict[str, str | int | bool | list[int] | None] = {
         "task": fields.get("TASK") or fields.get("WORKFLOW"),
         "gh_repo": fields.get("GH_REPO"),
         "issue_number": _parse_int(fields.get("ISSUE_NUMBER")),

--- a/agentception/readers/worktrees.py
+++ b/agentception/readers/worktrees.py
@@ -1,0 +1,174 @@
+"""Worktree reader for AgentCeption.
+
+Scans ``~/.cursor/worktrees/maestro/`` for active git worktrees and parses
+the ``.agent-task`` file in each one to derive live agent metadata.
+
+This is the primary filesystem signal for the poller — it tells the dashboard
+which agents are actively working and what they are working on. Combine with
+transcript data for richer status information.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from agentception.config import settings
+from agentception.models import TaskFile
+
+logger = logging.getLogger(__name__)
+
+
+async def list_active_worktrees() -> list[TaskFile]:
+    """Scan the worktrees directory and return one TaskFile per active checkout.
+
+    A worktree is considered active if it contains a ``.agent-task`` file.
+    Directories without that file are silently skipped (they may be stale
+    or manually created). Returns an empty list when the worktrees directory
+    does not exist.
+    """
+    worktrees_dir: Path = settings.worktrees_dir
+    if not worktrees_dir.exists():
+        logger.debug("⚠️  Worktrees dir does not exist: %s", worktrees_dir)
+        return []
+
+    results: list[TaskFile] = []
+    try:
+        entries = list(worktrees_dir.iterdir())
+    except OSError as exc:
+        logger.warning("⚠️  Cannot read worktrees dir %s: %s", worktrees_dir, exc)
+        return []
+
+    for entry in entries:
+        if not entry.is_dir():
+            continue
+        task = await parse_agent_task(entry)
+        if task is not None:
+            results.append(task)
+
+    logger.debug("✅ Found %d active worktree(s)", len(results))
+    return results
+
+
+async def parse_agent_task(worktree_path: Path) -> TaskFile | None:
+    """Parse a ``KEY=VALUE`` ``.agent-task`` file into a TaskFile model.
+
+    Returns ``None`` when the file is absent, unreadable, or so malformed
+    that no valid TaskFile can be constructed. Missing individual fields
+    default gracefully — only a complete read failure returns ``None``.
+
+    The parser is intentionally lenient: blank lines and lines without ``=``
+    are silently skipped. This matches how agents write task files via heredoc
+    (which may include trailing blank lines or comments).
+    """
+    task_file_path = worktree_path / ".agent-task"
+    if not task_file_path.exists():
+        return None
+
+    try:
+        content = await asyncio.get_event_loop().run_in_executor(
+            None, task_file_path.read_text, "utf-8"
+        )
+    except OSError as exc:
+        logger.warning("⚠️  Cannot read %s: %s", task_file_path, exc)
+        return None
+
+    fields: dict[str, str] = {}
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        fields[key.strip().upper()] = value.strip()
+
+    try:
+        return _build_task_file(fields, worktree_path)
+    except Exception as exc:
+        logger.warning("⚠️  Failed to build TaskFile from %s: %s", task_file_path, exc)
+        return None
+
+
+async def worktree_last_commit_time(worktree_path: Path) -> float:
+    """Return the UNIX timestamp of the most recent commit in the worktree.
+
+    Used for stuck-agent detection: if this value has not advanced in a
+    configurable number of minutes, the agent is likely hung and should be
+    flagged in the dashboard. Returns 0.0 when the worktree has no commits
+    or git is unavailable.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "log",
+            "-1",
+            "--format=%ct",
+            cwd=str(worktree_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        if proc.returncode != 0 or not stdout.strip():
+            return 0.0
+        return float(stdout.strip())
+    except (OSError, ValueError) as exc:
+        logger.debug("⚠️  worktree_last_commit_time(%s) error: %s", worktree_path, exc)
+        return 0.0
+
+
+# ── Private helpers ────────────────────────────────────────────────────────────
+
+
+def _build_task_file(fields: dict[str, str], worktree_path: Path) -> TaskFile:
+    """Construct a TaskFile from the parsed KEY=VALUE map.
+
+    Field names in .agent-task files are UPPER_SNAKE_CASE. We map them to
+    the lower_snake_case Pydantic model fields here. PR review task files use
+    ``PR=<number>`` for the PR number instead of ``ISSUE_NUMBER``.
+    """
+    closes_issues = _parse_int_list(fields.get("CLOSES_ISSUES", ""))
+
+    raw: dict[str, object] = {
+        "task": fields.get("TASK") or fields.get("WORKFLOW"),
+        "gh_repo": fields.get("GH_REPO"),
+        "issue_number": _parse_int(fields.get("ISSUE_NUMBER")),
+        "pr_number": _parse_int(fields.get("PR")),
+        "branch": fields.get("BRANCH"),
+        "worktree": str(worktree_path),
+        "role": fields.get("ROLE"),
+        "base": fields.get("BASE"),
+        "batch_id": fields.get("BATCH_ID"),
+        "closes_issues": closes_issues,
+        "spawn_sub_agents": _parse_bool(fields.get("SPAWN_SUB_AGENTS", "false")),
+        "spawn_mode": fields.get("SPAWN_MODE"),
+        "merge_after": fields.get("MERGE_AFTER"),
+        "attempt_n": _parse_int(fields.get("ATTEMPT_N")) or 0,
+        "required_output": fields.get("REQUIRED_OUTPUT"),
+        "on_block": fields.get("ON_BLOCK"),
+    }
+    cleaned = {k: v for k, v in raw.items() if v is not None}
+    return TaskFile.model_validate(cleaned)
+
+
+def _parse_int(value: str | None) -> int | None:
+    """Convert a string to int, returning None on failure."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _parse_int_list(value: str) -> list[int]:
+    """Parse a comma-separated string of integers, skipping invalid tokens."""
+    result: list[int] = []
+    for token in value.split(","):
+        token = token.strip()
+        if token.isdigit():
+            result.append(int(token))
+    return result
+
+
+def _parse_bool(value: str) -> bool:
+    """Interpret 'true'/'false' (case-insensitive) as bool."""
+    return value.strip().lower() == "true"

--- a/tests/test_agentception_worktrees.py
+++ b/tests/test_agentception_worktrees.py
@@ -1,0 +1,290 @@
+"""Tests for agentception/readers/worktrees.py (AC-002).
+
+Verifies that the worktree reader correctly discovers active agent worktrees
+and parses their .agent-task files into TaskFile models.
+
+Run targeted:
+    pytest tests/test_agentception_worktrees.py -v
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agentception.models import TaskFile
+from agentception.readers.worktrees import (
+    list_active_worktrees,
+    parse_agent_task,
+    worktree_last_commit_time,
+)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def issue_task_content() -> str:
+    """Minimal .agent-task content for an issue-to-pr workflow."""
+    return (
+        "TASK=issue-to-pr\n"
+        "GH_REPO=cgcardona/maestro\n"
+        "ISSUE_NUMBER=610\n"
+        "BRANCH=feat/issue-610\n"
+        "WORKTREE=/Users/gabriel/.cursor/worktrees/maestro/issue-610\n"
+        "ROLE=python-developer\n"
+        "BASE=dev\n"
+        "BATCH_ID=eng-20260301T214203Z-057d\n"
+        "CLOSES_ISSUES=610\n"
+        "SPAWN_SUB_AGENTS=false\n"
+        "ATTEMPT_N=0\n"
+        "REQUIRED_OUTPUT=pr_url\n"
+        "ON_BLOCK=stop\n"
+    )
+
+
+@pytest.fixture()
+def pr_review_task_content() -> str:
+    """Minimal .agent-task content for a pr-review workflow."""
+    return (
+        "TASK=pr-review\n"
+        "PR=642\n"
+        "BRANCH=feat/issue-609\n"
+        "WORKTREE=/Users/gabriel/.cursor/worktrees/maestro/pr-642\n"
+        "ROLE=pr-reviewer\n"
+        "BASE=dev\n"
+        "GH_REPO=cgcardona/maestro\n"
+        "BATCH_ID=eng-20260301T211956Z-741f\n"
+        "SPAWN_MODE=chain\n"
+    )
+
+
+@pytest.fixture()
+def worktree_with_issue_task(tmp_path: Path, issue_task_content: str) -> Path:
+    """Temporary worktree directory with a valid issue-to-pr .agent-task file."""
+    task_file = tmp_path / ".agent-task"
+    task_file.write_text(issue_task_content)
+    return tmp_path
+
+
+@pytest.fixture()
+def worktree_with_pr_review_task(tmp_path: Path, pr_review_task_content: str) -> Path:
+    """Temporary worktree directory with a valid pr-review .agent-task file."""
+    task_file = tmp_path / ".agent-task"
+    task_file.write_text(pr_review_task_content)
+    return tmp_path
+
+
+# ── parse_agent_task ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_parse_agent_task_issue(worktree_with_issue_task: Path) -> None:
+    """parse_agent_task correctly extracts all fields from an issue-to-pr task file."""
+    result = await parse_agent_task(worktree_with_issue_task)
+
+    assert result is not None
+    assert result.task == "issue-to-pr"
+    assert result.gh_repo == "cgcardona/maestro"
+    assert result.issue_number == 610
+    assert result.branch == "feat/issue-610"
+    assert result.role == "python-developer"
+    assert result.base == "dev"
+    assert result.batch_id == "eng-20260301T214203Z-057d"
+    assert result.closes_issues == [610]
+    assert result.spawn_sub_agents is False
+    assert result.attempt_n == 0
+    assert result.required_output == "pr_url"
+    assert result.on_block == "stop"
+    assert result.pr_number is None
+
+
+@pytest.mark.anyio
+async def test_parse_agent_task_pr_review(worktree_with_pr_review_task: Path) -> None:
+    """parse_agent_task correctly extracts all fields from a pr-review task file."""
+    result = await parse_agent_task(worktree_with_pr_review_task)
+
+    assert result is not None
+    assert result.task == "pr-review"
+    assert result.pr_number == 642
+    assert result.branch == "feat/issue-609"
+    assert result.role == "pr-reviewer"
+    assert result.gh_repo == "cgcardona/maestro"
+    assert result.batch_id == "eng-20260301T211956Z-741f"
+    assert result.spawn_mode == "chain"
+    assert result.issue_number is None
+    assert result.closes_issues == []
+
+
+@pytest.mark.anyio
+async def test_parse_agent_task_missing_returns_none(tmp_path: Path) -> None:
+    """parse_agent_task returns None when the .agent-task file does not exist."""
+    result = await parse_agent_task(tmp_path)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_parse_agent_task_blank_lines_and_comments_ignored(tmp_path: Path) -> None:
+    """parse_agent_task silently skips blank lines and comment-like lines."""
+    task_file = tmp_path / ".agent-task"
+    task_file.write_text(
+        "\n"
+        "# This is a comment-like line\n"
+        "TASK=issue-to-pr\n"
+        "\n"
+        "ROLE=python-developer\n"
+        "not_a_key_value_pair\n"
+    )
+    result = await parse_agent_task(tmp_path)
+    assert result is not None
+    assert result.task == "issue-to-pr"
+    assert result.role == "python-developer"
+
+
+@pytest.mark.anyio
+async def test_parse_agent_task_closes_issues_multi(tmp_path: Path) -> None:
+    """parse_agent_task parses comma-separated CLOSES_ISSUES into list[int]."""
+    task_file = tmp_path / ".agent-task"
+    task_file.write_text("TASK=issue-to-pr\nCLOSES_ISSUES=610,611,612\n")
+    result = await parse_agent_task(tmp_path)
+    assert result is not None
+    assert result.closes_issues == [610, 611, 612]
+
+
+@pytest.mark.anyio
+async def test_parse_agent_task_workflow_alias(tmp_path: Path) -> None:
+    """parse_agent_task accepts WORKFLOW= as an alias for TASK= (legacy format)."""
+    task_file = tmp_path / ".agent-task"
+    task_file.write_text("WORKFLOW=issue-to-pr\nROLE=python-developer\n")
+    result = await parse_agent_task(tmp_path)
+    assert result is not None
+    assert result.task == "issue-to-pr"
+
+
+# ── list_active_worktrees ──────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_list_active_worktrees_empty(tmp_path: Path) -> None:
+    """list_active_worktrees returns an empty list when no worktrees have task files."""
+    with patch("agentception.readers.worktrees.settings") as mock_settings:
+        mock_settings.worktrees_dir = tmp_path
+        result = await list_active_worktrees()
+    assert result == []
+
+
+@pytest.mark.anyio
+async def test_list_active_worktrees_nonexistent_dir() -> None:
+    """list_active_worktrees returns an empty list when the worktrees directory is absent."""
+    with patch("agentception.readers.worktrees.settings") as mock_settings:
+        mock_settings.worktrees_dir = Path("/nonexistent/worktrees/dir")
+        result = await list_active_worktrees()
+    assert result == []
+
+
+@pytest.mark.anyio
+async def test_list_active_worktrees_one_active(tmp_path: Path, issue_task_content: str) -> None:
+    """list_active_worktrees returns one TaskFile for a single worktree with a task file."""
+    wt_dir = tmp_path / "issue-610"
+    wt_dir.mkdir()
+    (wt_dir / ".agent-task").write_text(issue_task_content)
+
+    with patch("agentception.readers.worktrees.settings") as mock_settings:
+        mock_settings.worktrees_dir = tmp_path
+        result = await list_active_worktrees()
+
+    assert len(result) == 1
+    assert result[0].issue_number == 610
+    assert result[0].task == "issue-to-pr"
+
+
+@pytest.mark.anyio
+async def test_list_active_worktrees_skips_dirs_without_task(tmp_path: Path) -> None:
+    """list_active_worktrees silently skips subdirectories that lack .agent-task."""
+    (tmp_path / "stale-worktree").mkdir()
+    (tmp_path / "other-dir").mkdir()
+
+    with patch("agentception.readers.worktrees.settings") as mock_settings:
+        mock_settings.worktrees_dir = tmp_path
+        result = await list_active_worktrees()
+
+    assert result == []
+
+
+@pytest.mark.anyio
+async def test_list_active_worktrees_multiple(
+    tmp_path: Path, issue_task_content: str, pr_review_task_content: str
+) -> None:
+    """list_active_worktrees returns one entry per valid worktree."""
+    wt1 = tmp_path / "issue-610"
+    wt1.mkdir()
+    (wt1 / ".agent-task").write_text(issue_task_content)
+
+    wt2 = tmp_path / "pr-642"
+    wt2.mkdir()
+    (wt2 / ".agent-task").write_text(pr_review_task_content)
+
+    with patch("agentception.readers.worktrees.settings") as mock_settings:
+        mock_settings.worktrees_dir = tmp_path
+        result = await list_active_worktrees()
+
+    assert len(result) == 2
+    issue_numbers = {tf.issue_number for tf in result}
+    pr_numbers = {tf.pr_number for tf in result}
+    assert 610 in issue_numbers
+    assert 642 in pr_numbers
+
+
+# ── worktree_last_commit_time ──────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_worktree_last_commit_time_no_git_returns_zero(tmp_path: Path) -> None:
+    """worktree_last_commit_time returns 0.0 for a non-git directory."""
+    result = await worktree_last_commit_time(tmp_path)
+    assert result == 0.0
+
+
+@pytest.mark.anyio
+async def test_worktree_last_commit_time_git_output_parsed(tmp_path: Path) -> None:
+    """worktree_last_commit_time parses git log --format=%ct output into a float."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate = AsyncMock(return_value=(b"1740000000\n", b""))
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        result = await worktree_last_commit_time(tmp_path)
+
+    assert isinstance(result, float)
+    assert result == 1_740_000_000.0
+
+
+# ── TaskFile model ─────────────────────────────────────────────────────────────
+
+
+def test_task_file_closes_issues_defaults_to_empty_list() -> None:
+    """TaskFile.closes_issues defaults to [] when not provided."""
+    tf = TaskFile(task="issue-to-pr")
+    assert tf.closes_issues == []
+
+
+def test_task_file_pr_number_field() -> None:
+    """TaskFile.pr_number is available and optional."""
+    tf = TaskFile(task="pr-review", pr_number=642)
+    assert tf.pr_number == 642
+
+
+def test_task_file_spawn_mode_field() -> None:
+    """TaskFile.spawn_mode is available and optional."""
+    tf = TaskFile(task="pr-review", spawn_mode="chain")
+    assert tf.spawn_mode == "chain"
+
+
+def test_task_file_merge_after_field() -> None:
+    """TaskFile.merge_after is available and optional."""
+    tf = TaskFile(task="issue-to-pr", merge_after="other-branch")
+    assert tf.merge_after == "other-branch"


### PR DESCRIPTION
## Summary
Closes #610 — implement `agentception/readers/worktrees.py` to scan active git worktrees and parse their `.agent-task` files into typed `TaskFile` models.

## Root Cause / Motivation
The AgentCeption dashboard poller had no way to discover which pipeline agents are actively working. This reader provides the primary filesystem signal by scanning `~/.cursor/worktrees/maestro/` and parsing the structured `KEY=VALUE` task files each agent writes at startup.

## Solution
- **`agentception/readers/worktrees.py`**: Three async public functions:
  - `list_active_worktrees()` — scans the worktrees directory, returns one `TaskFile` per active checkout (skips dirs without `.agent-task`)
  - `parse_agent_task(worktree_path)` — parses `KEY=VALUE` task file into a `TaskFile` model; returns `None` on missing/malformed files
  - `worktree_last_commit_time(worktree_path)` — runs `git log -1 --format=%ct` to get last commit timestamp for stuck-agent detection
- **`agentception/models.py`**: Extended `TaskFile` with missing fields from the spec: `pr_number`, `spawn_mode`, `merge_after`; updated `closes_issues` from `str | None` to `list[int]`
- **`tests/test_agentception_worktrees.py`**: 17 tests covering all public functions, edge cases (blank lines, WORKFLOW alias, multi-issue closes, nonexistent dirs), and the updated TaskFile model

## Verification
- [x] mypy clean (9 source files, 0 issues)
- [x] 17 new tests pass + 6 scaffold tests still pass (23/23)
- [x] Docs: docstrings on all public functions explain why + contract

---
<!-- maestro-fingerprint
role: python-developer
batch: eng-20260301T214203Z-057d
session: eng-20260301T214259Z-096d
issue: 610
timestamp: 2026-03-01T21:48:06Z
-->
> 🤖 *Opened by Maestro pipeline — batch `eng-20260301T214203Z-057d`, session `eng-20260301T214259Z-096d`*