### PR TITLE
feat: [AgentCeption] AC-003 — transcript reader, AgentNode tree builder

### DIFF
--- a/agentception/readers/transcripts.py
+++ b/agentception/readers/transcripts.py
@@ -1,0 +1,231 @@
+"""Transcript reader for AgentCeption (AC-003).
+
+Walks ``~/.cursor/projects/.../agent-transcripts/`` to build the parent/child
+``AgentNode`` tree. Hierarchy is derived from the ``subagents/`` folder
+structure that Cursor creates when an agent spawns sub-agents.
+
+Public API:
+    find_transcript_root()        → locate the transcripts directory
+    build_agent_tree()            → parse one root UUID into an AgentNode tree
+    read_transcript_messages()    → parse a JSONL file into [{role, text}]
+    infer_role_from_messages()    → keyword heuristic → role string
+    infer_status_from_messages()  → PR-URL heuristic → AgentStatus
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+
+from agentception.config import settings
+from agentception.models import AgentNode, AgentStatus
+
+logger = logging.getLogger(__name__)
+
+# Ordered priority table: first matching keyword wins.
+_ROLE_KEYWORDS: list[tuple[str, str]] = [
+    ("CTO", "cto"),
+    ("Engineering VP", "engineering-vp"),
+    ("Engineering Manager", "engineering-manager"),
+    ("QA VP", "qa-vp"),
+    ("muse-specialist", "muse-specialist"),
+    ("database-architect", "database-architect"),
+    ("python-developer", "python-developer"),
+    ("pr-reviewer", "pr-reviewer"),
+]
+
+_PR_URL_RE = re.compile(r"github\.com/[^/\s]+/[^/\s]+/pull/\d+")
+
+
+async def find_transcript_root() -> Path | None:
+    """Find the agent-transcripts/ directory for the current Cursor project.
+
+    Strategy: derive the expected project-directory name from ``settings.repo_dir``
+    by stripping the leading slash and replacing ``/`` with ``-``. If that exact
+    directory exists under ``cursor_projects_dir``, return it. Otherwise fall back
+    to the most-recently-modified ``agent-transcripts/`` found in any project
+    directory — useful when the repo is opened under an unexpected path.
+
+    Returns ``None`` if no transcript directory can be found at all.
+    """
+    base = settings.cursor_projects_dir
+    if not base.exists():
+        logger.warning("⚠️  cursor_projects_dir does not exist: %s", base)
+        return None
+
+    # Derive expected project dir name: /Users/gabriel/dev/…/maestro
+    #   → Users-gabriel-dev-…-maestro
+    repo_slug = str(settings.repo_dir).lstrip("/").replace("/", "-")
+    exact = base / repo_slug / "agent-transcripts"
+    if exact.exists():
+        return exact
+
+    # Fall back to the most recently modified agent-transcripts/ anywhere.
+    best_mtime: float = -1.0
+    best_path: Path | None = None
+    for project_dir in base.iterdir():
+        if not project_dir.is_dir():
+            continue
+        transcripts = project_dir / "agent-transcripts"
+        if not transcripts.exists():
+            continue
+        mtime = transcripts.stat().st_mtime
+        if mtime > best_mtime:
+            best_mtime = mtime
+            best_path = transcripts
+
+    if best_path is None:
+        logger.warning("⚠️  No agent-transcripts directory found under %s", base)
+    return best_path
+
+
+async def read_transcript_messages(jsonl_path: Path) -> list[dict[str, str]]:
+    """Parse a Cursor JSONL transcript file into a flat list of ``{role, text}`` dicts.
+
+    Each line is a JSON object with the shape::
+
+        {"role": "user"|"assistant",
+         "message": {"content": [{"type": "text", "text": "..."}]}}
+
+    Only ``type == "text"`` content blocks are included. Lines that fail JSON
+    parsing are silently skipped to tolerate partial writes. Returns ``[]`` for
+    an empty or missing file.
+    """
+    if not jsonl_path.exists():
+        return []
+
+    try:
+        raw = jsonl_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        logger.warning("⚠️  Cannot read transcript %s: %s", jsonl_path, exc)
+        return []
+
+    messages: list[dict[str, str]] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            entry = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+
+        role: str = entry.get("role", "")
+        content_parts: list[dict[str, str]] = (
+            entry.get("message", {}).get("content", [])
+        )
+        for part in content_parts:
+            if isinstance(part, dict) and part.get("type") == "text":
+                messages.append({"role": role, "text": part.get("text", "")})
+
+    return messages
+
+
+def infer_role_from_messages(messages: list[dict[str, str]]) -> str:
+    """Derive a role string from the first assistant message in the transcript.
+
+    Scans ``_ROLE_KEYWORDS`` in order; returns the role for the first keyword
+    found in the text. Returns ``"unknown"`` when no keyword matches.
+
+    The first assistant message is the one most likely to contain a system
+    prompt or role-declaration preamble, so only it is examined.
+    """
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        text = msg.get("text", "")
+        for keyword, role in _ROLE_KEYWORDS:
+            if keyword in text:
+                return role
+        # Only inspect the first assistant message.
+        break
+    return "unknown"
+
+
+def infer_status_from_messages(messages: list[dict[str, str]]) -> AgentStatus:
+    """Derive lifecycle status from the last assistant message.
+
+    Heuristic: if the most-recent assistant message contains a GitHub pull-request
+    URL (``github.com/<owner>/<repo>/pull/<n>``), the agent successfully opened
+    a PR and is considered ``DONE``. Any other ending state maps to ``UNKNOWN``.
+    """
+    for msg in reversed(messages):
+        if msg.get("role") == "assistant":
+            if _PR_URL_RE.search(msg.get("text", "")):
+                return AgentStatus.DONE
+            break
+    return AgentStatus.UNKNOWN
+
+
+async def build_agent_tree(
+    root_uuid: str,
+    transcripts_dir: Path,
+) -> AgentNode | None:
+    """Recursively build an ``AgentNode`` tree rooted at ``root_uuid``.
+
+    Cursor stores transcripts in one of two layouts:
+
+    * **Leaf agent** (no sub-agents spawned)::
+
+        <transcripts_dir>/<root_uuid>/<root_uuid>.jsonl
+
+    * **Coordinator agent** (spawned sub-agents)::
+
+        <transcripts_dir>/<root_uuid>/subagents/<child-uuid>.jsonl
+        ...
+
+      The coordinator may or may not have its own ``<root_uuid>.jsonl``;
+      children are always leaf ``.jsonl`` files (the structure does not
+      nest deeper in practice).
+
+    Returns ``None`` if the root directory does not exist.
+    """
+    root_dir = transcripts_dir / root_uuid
+    if not root_dir.exists():
+        logger.warning("⚠️  Transcript directory not found: %s", root_dir)
+        return None
+
+    # Own transcript — may be absent for pure-coordinator agents.
+    parent_jsonl = root_dir / f"{root_uuid}.jsonl"
+    messages = await read_transcript_messages(parent_jsonl)
+
+    # Use directory mtime as fallback when the JSONL file is absent.
+    mtime = (
+        parent_jsonl.stat().st_mtime
+        if parent_jsonl.exists()
+        else root_dir.stat().st_mtime
+    )
+
+    role = infer_role_from_messages(messages)
+    status = infer_status_from_messages(messages)
+
+    # Build children from subagents/ if present.
+    children: list[AgentNode] = []
+    subagents_dir = root_dir / "subagents"
+    if subagents_dir.is_dir():
+        for child_jsonl in sorted(subagents_dir.glob("*.jsonl")):
+            child_uuid = child_jsonl.stem
+            child_messages = await read_transcript_messages(child_jsonl)
+            child_role = infer_role_from_messages(child_messages)
+            child_status = infer_status_from_messages(child_messages)
+            children.append(
+                AgentNode(
+                    id=child_uuid,
+                    role=child_role,
+                    status=child_status,
+                    message_count=len(child_messages),
+                    last_activity_mtime=child_jsonl.stat().st_mtime,
+                    transcript_path=str(child_jsonl),
+                )
+            )
+
+    return AgentNode(
+        id=root_uuid,
+        role=role,
+        status=status,
+        message_count=len(messages),
+        last_activity_mtime=mtime,
+        transcript_path=str(parent_jsonl) if parent_jsonl.exists() else None,
+        children=children,
+    )

--- a/tests/test_agentception_transcripts.py
+++ b/tests/test_agentception_transcripts.py
@@ -1,0 +1,355 @@
+"""Tests for agentception/readers/transcripts.py (AC-003).
+
+Covers JSONL parsing, role/status heuristics, and AgentNode tree construction.
+All tests use temporary directories — no dependency on live ~/.cursor/projects/.
+
+Run targeted:
+    pytest tests/test_agentception_transcripts.py -v
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentception.models import AgentStatus
+from agentception.readers.transcripts import (
+    build_agent_tree,
+    infer_role_from_messages,
+    infer_status_from_messages,
+    read_transcript_messages,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_entry(role: str, text: str) -> str:
+    """Serialise one JSONL transcript line."""
+    return json.dumps(
+        {
+            "role": role,
+            "message": {
+                "content": [{"type": "text", "text": text}],
+            },
+        }
+    )
+
+
+def _write_jsonl(path: Path, entries: list[tuple[str, str]]) -> None:
+    """Write a list of (role, text) pairs to a JSONL file."""
+    path.write_text(
+        "\n".join(_make_entry(role, text) for role, text in entries),
+        encoding="utf-8",
+    )
+
+
+# ── read_transcript_messages ──────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_read_transcript_messages_valid_jsonl(tmp_path: Path) -> None:
+    """Valid JSONL with two entries is parsed into two {role, text} dicts."""
+    jsonl = tmp_path / "test.jsonl"
+    _write_jsonl(
+        jsonl,
+        [
+            ("user", "Hello, agent!"),
+            ("assistant", "I am your assistant."),
+        ],
+    )
+
+    messages = await read_transcript_messages(jsonl)
+
+    assert len(messages) == 2
+    assert messages[0] == {"role": "user", "text": "Hello, agent!"}
+    assert messages[1] == {"role": "assistant", "text": "I am your assistant."}
+
+
+@pytest.mark.anyio
+async def test_read_transcript_messages_empty_file(tmp_path: Path) -> None:
+    """An empty JSONL file returns an empty list without raising."""
+    jsonl = tmp_path / "empty.jsonl"
+    jsonl.write_text("", encoding="utf-8")
+
+    messages = await read_transcript_messages(jsonl)
+
+    assert messages == []
+
+
+@pytest.mark.anyio
+async def test_read_transcript_messages_missing_file(tmp_path: Path) -> None:
+    """A path that does not exist returns [] without raising."""
+    messages = await read_transcript_messages(tmp_path / "nonexistent.jsonl")
+    assert messages == []
+
+
+@pytest.mark.anyio
+async def test_read_transcript_messages_skips_malformed_lines(tmp_path: Path) -> None:
+    """Malformed JSON lines are silently skipped; valid lines are returned."""
+    jsonl = tmp_path / "mixed.jsonl"
+    jsonl.write_text(
+        "\n".join(
+            [
+                _make_entry("user", "good line"),
+                "{this is not json",
+                _make_entry("assistant", "another good line"),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    messages = await read_transcript_messages(jsonl)
+
+    assert len(messages) == 2
+    assert messages[0]["text"] == "good line"
+    assert messages[1]["text"] == "another good line"
+
+
+@pytest.mark.anyio
+async def test_read_transcript_messages_non_text_content_ignored(
+    tmp_path: Path,
+) -> None:
+    """Content blocks with type != 'text' are excluded from the result."""
+    jsonl = tmp_path / "tool.jsonl"
+    entry = {
+        "role": "assistant",
+        "message": {
+            "content": [
+                {"type": "tool_use", "name": "Shell", "input": {}},
+                {"type": "text", "text": "Done."},
+            ]
+        },
+    }
+    jsonl.write_text(json.dumps(entry), encoding="utf-8")
+
+    messages = await read_transcript_messages(jsonl)
+
+    assert len(messages) == 1
+    assert messages[0] == {"role": "assistant", "text": "Done."}
+
+
+# ── infer_role_from_messages ──────────────────────────────────────────────────
+
+
+def test_infer_role_cto() -> None:
+    """An assistant message containing 'CTO' maps to role 'cto'."""
+    messages = [
+        {"role": "user", "text": "What is your role?"},
+        {"role": "assistant", "text": "I am operating as CTO for this session."},
+    ]
+    assert infer_role_from_messages(messages) == "cto"
+
+
+def test_infer_role_python_developer() -> None:
+    """An assistant message containing 'python-developer' maps to that role."""
+    messages = [
+        {
+            "role": "assistant",
+            "text": "You are a python-developer on the Maestro project.",
+        },
+    ]
+    assert infer_role_from_messages(messages) == "python-developer"
+
+
+def test_infer_role_pr_reviewer() -> None:
+    """An assistant message containing 'pr-reviewer' maps to that role."""
+    messages = [
+        {"role": "assistant", "text": "Operating as pr-reviewer for PR #42."},
+    ]
+    assert infer_role_from_messages(messages) == "pr-reviewer"
+
+
+def test_infer_role_muse_specialist() -> None:
+    """An assistant message containing 'muse-specialist' maps to that role."""
+    messages = [
+        {"role": "assistant", "text": "You are a muse-specialist agent."},
+    ]
+    assert infer_role_from_messages(messages) == "muse-specialist"
+
+
+def test_infer_role_unknown_when_no_keywords() -> None:
+    """A message with no known keywords returns 'unknown'."""
+    messages = [
+        {"role": "assistant", "text": "Let me help you with that."},
+    ]
+    assert infer_role_from_messages(messages) == "unknown"
+
+
+def test_infer_role_only_checks_first_assistant_message() -> None:
+    """Only the first assistant message is examined; later ones are ignored."""
+    messages = [
+        {"role": "user", "text": "hello"},
+        {"role": "assistant", "text": "General assistant here."},
+        {"role": "assistant", "text": "Now acting as CTO."},
+    ]
+    # First assistant message has no keyword → unknown, even though second has CTO.
+    assert infer_role_from_messages(messages) == "unknown"
+
+
+def test_infer_role_empty_messages() -> None:
+    """Empty message list returns 'unknown' without raising."""
+    assert infer_role_from_messages([]) == "unknown"
+
+
+# ── infer_status_from_messages ────────────────────────────────────────────────
+
+
+def test_infer_status_done_when_last_assistant_has_pr_url() -> None:
+    """Last assistant message containing a GitHub PR URL → DONE."""
+    messages = [
+        {"role": "user", "text": "Did you open a PR?"},
+        {
+            "role": "assistant",
+            "text": "Yes! https://github.com/cgcardona/maestro/pull/42",
+        },
+    ]
+    assert infer_status_from_messages(messages) == AgentStatus.DONE
+
+
+def test_infer_status_unknown_without_pr_url() -> None:
+    """Last assistant message with no PR URL → UNKNOWN."""
+    messages = [
+        {"role": "user", "text": "Status?"},
+        {"role": "assistant", "text": "Still implementing."},
+    ]
+    assert infer_status_from_messages(messages) == AgentStatus.UNKNOWN
+
+
+def test_infer_status_unknown_empty_messages() -> None:
+    """Empty message list returns UNKNOWN without raising."""
+    assert infer_status_from_messages([]) == AgentStatus.UNKNOWN
+
+
+def test_infer_status_uses_last_assistant_message() -> None:
+    """Only the last assistant message matters; earlier PR URLs are ignored."""
+    messages = [
+        {
+            "role": "assistant",
+            "text": "Opened https://github.com/cgcardona/maestro/pull/10",
+        },
+        {"role": "user", "text": "That was reverted. Can you redo it?"},
+        {"role": "assistant", "text": "Re-implementing now."},
+    ]
+    assert infer_status_from_messages(messages) == AgentStatus.UNKNOWN
+
+
+# ── build_agent_tree ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_build_agent_tree_missing_directory(tmp_path: Path) -> None:
+    """A root_uuid whose directory doesn't exist returns None."""
+    result = await build_agent_tree("nonexistent-uuid", tmp_path)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_build_agent_tree_single_node(tmp_path: Path) -> None:
+    """Single JSONL with no subagents/ produces a leaf AgentNode."""
+    uuid = "aaaaaaaa-0000-0000-0000-000000000001"
+    node_dir = tmp_path / uuid
+    node_dir.mkdir()
+    _write_jsonl(
+        node_dir / f"{uuid}.jsonl",
+        [
+            ("user", "Implement issue #42"),
+            ("assistant", "python-developer here. Starting implementation."),
+        ],
+    )
+
+    node = await build_agent_tree(uuid, tmp_path)
+
+    assert node is not None
+    assert node.id == uuid
+    assert node.role == "python-developer"
+    assert node.message_count == 2
+    assert node.children == []
+    assert node.transcript_path is not None
+
+
+@pytest.mark.anyio
+async def test_build_agent_tree_parent_child(tmp_path: Path) -> None:
+    """Parent UUID with one subagent produces a tree of depth 2."""
+    parent_uuid = "bbbbbbbb-0000-0000-0000-000000000001"
+    child_uuid = "cccccccc-0000-0000-0000-000000000001"
+
+    parent_dir = tmp_path / parent_uuid
+    subagents_dir = parent_dir / "subagents"
+    subagents_dir.mkdir(parents=True)
+
+    # Parent has no own JSONL (coordinator pattern).
+    _write_jsonl(
+        subagents_dir / f"{child_uuid}.jsonl",
+        [
+            ("user", "Review PR #99"),
+            (
+                "assistant",
+                "Operating as pr-reviewer. "
+                "PR merged: https://github.com/cgcardona/maestro/pull/99",
+            ),
+        ],
+    )
+
+    node = await build_agent_tree(parent_uuid, tmp_path)
+
+    assert node is not None
+    assert node.id == parent_uuid
+    assert len(node.children) == 1
+
+    child = node.children[0]
+    assert child.id == child_uuid
+    assert child.role == "pr-reviewer"
+    assert child.status == AgentStatus.DONE
+    assert child.message_count == 2
+
+
+@pytest.mark.anyio
+async def test_build_agent_tree_coordinator_no_own_jsonl(tmp_path: Path) -> None:
+    """Coordinator without own JSONL still returns a valid parent AgentNode."""
+    uuid = "dddddddd-0000-0000-0000-000000000001"
+    node_dir = tmp_path / uuid
+    sub_dir = node_dir / "subagents"
+    sub_dir.mkdir(parents=True)
+
+    child_uuid = "eeeeeeee-0000-0000-0000-000000000001"
+    _write_jsonl(
+        sub_dir / f"{child_uuid}.jsonl",
+        [("assistant", "I am a python-developer agent.")],
+    )
+
+    node = await build_agent_tree(uuid, tmp_path)
+
+    assert node is not None
+    assert node.id == uuid
+    # No own JSONL → role falls back to "unknown", status to UNKNOWN.
+    assert node.role == "unknown"
+    assert node.status == AgentStatus.UNKNOWN
+    assert node.message_count == 0
+    assert node.transcript_path is None
+    assert len(node.children) == 1
+
+
+@pytest.mark.anyio
+async def test_build_agent_tree_multiple_children_sorted(tmp_path: Path) -> None:
+    """Multiple subagents are returned sorted by filename (deterministic order)."""
+    parent_uuid = "ffffffff-0000-0000-0000-000000000001"
+    sub_dir = tmp_path / parent_uuid / "subagents"
+    sub_dir.mkdir(parents=True)
+
+    child_uuids = [
+        "cccccccc-0000-0000-0000-000000000003",
+        "aaaaaaaa-0000-0000-0000-000000000003",
+        "bbbbbbbb-0000-0000-0000-000000000003",
+    ]
+    for cu in child_uuids:
+        _write_jsonl(sub_dir / f"{cu}.jsonl", [("assistant", f"Agent {cu}")])
+
+    node = await build_agent_tree(parent_uuid, tmp_path)
+
+    assert node is not None
+    assert len(node.children) == 3
+    # Should be alphabetically sorted by child UUID.
+    actual_ids = [c.id for c in node.children]
+    assert actual_ids == sorted(child_uuids)


### PR DESCRIPTION
## Summary
Closes #612 — implements `agentception/readers/transcripts.py` with JSONL parsing, role/status heuristics, and recursive AgentNode tree construction from Cursor's `agent-transcripts/` folder layout.

## Root Cause / Motivation
AgentCeption needs to read Cursor transcript files and build a hierarchical view of the agent pipeline. Without this reader, the dashboard has no way to introspect agent activity from the filesystem.

## Solution
Implemented five public async/sync functions in `agentception/readers/transcripts.py`:

- **`find_transcript_root()`** — derives the expected project directory name from `settings.repo_dir` (path → slug conversion), falls back to most-recently-modified `agent-transcripts/` directory.
- **`read_transcript_messages()`** — parses JSONL lines into `{role, text}` dicts; skips malformed lines; ignores non-text content blocks.
- **`infer_role_from_messages()`** — keyword scan of the first assistant message against an ordered priority table (CTO, Engineering VP, python-developer, pr-reviewer, etc.).
- **`infer_status_from_messages()`** — GitHub PR URL regex on the last assistant message → `DONE`; otherwise `UNKNOWN`.
- **`build_agent_tree()`** — constructs an `AgentNode` tree: reads parent JSONL, then walks `subagents/*.jsonl` for children (the actual Cursor structure is at most 2 levels deep).

## Verification
- [x] mypy clean — `Success: no issues found in 2 source files`
- [x] 21 targeted tests pass — all required cases plus extras (malformed lines, non-text content, multi-child sorted order, coordinator with no own JSONL)
- [x] Scaffold regression tests still pass (6/6)
- [x] No live filesystem dependency — all tests use `tmp_path`

---
<!-- maestro-fingerprint
role: python-developer
batch: eng-20260301T214203Z-057d
session: eng-20260301T214303Z-0239
issue: 612
timestamp: 2026-03-01T21:48:27Z
-->
> 🤖 *Opened by Maestro pipeline — batch `eng-20260301T214203Z-057d`, session `eng-20260301T214303Z-0239`*