### PR TITLE
feat: [AgentCeption] AC-000 — Docker runtime, Dockerfile, compose service, HOME-relative mounts

### DIFF
--- a/agentception/Dockerfile
+++ b/agentception/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install git + gh CLI (needed for subprocess calls to git/gh)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY agentception/requirements.txt /app/agentception/requirements.txt
+RUN pip install --no-cache-dir -r /app/agentception/requirements.txt
+
+COPY agentception/ /app/agentception/
+
+CMD ["uvicorn", "agentception.app:app", "--host", "0.0.0.0", "--port", "7777"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -45,3 +45,10 @@ services:
       # Cursor worktrees — parallel review agents need this to run mypy/pytest
       # against their worktree storpheus files via "cd /worktrees/<id> && mypy ."
       - /Users/gabriel/.cursor/worktrees/maestro:/worktrees
+
+  agentception:
+    volumes:
+      # Live code — host edits are instantly visible; no rebuild needed
+      - ./agentception:/app/agentception
+      # agentception tests live under agentception/tests/ (isolated from maestro conftest)
+      - /Users/gabriel/.cursor/worktrees/maestro:/worktrees

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,6 +204,34 @@ services:
       - no-new-privileges:true
 
   # ==========================================================================
+  # AgentCeption — Multi-tier agent pipeline dashboard (port 7777)
+  # ==========================================================================
+  agentception:
+    build:
+      context: .
+      dockerfile: agentception/Dockerfile
+    container_name: maestro-agentception
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:7777:7777"
+    environment:
+      HOME: ${HOME}
+    volumes:
+      # Mount cursor dir at same absolute path so worktree paths match
+      - ${HOME}/.cursor:${HOME}/.cursor
+      # gh CLI auth (read-only)
+      - ${HOME}/.config/gh:${HOME}/.config/gh:ro
+      # Repo itself (for git operations)
+      - ./:${HOME}/dev/tellurstori/maestro
+    networks:
+      - maestro-net
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7777/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # ==========================================================================
   # Certbot for Let's Encrypt SSL
   # ==========================================================================
   certbot:


### PR DESCRIPTION
Closes #648

## What
- `agentception/Dockerfile` — python:3.11-slim with git + gh CLI
- `docker-compose.yml` — new `agentception` service on port 7777 with `${HOME}`-relative mounts (no hardcoded paths)
- `docker-compose.override.yml` — live bind-mounts for dev
- `agentception/tests/` — isolated test dir (no maestro conftest conflict)
- `PARALLEL_PR_REVIEW.md` — agentception tests now run via `docker compose exec agentception`

## Test
`docker compose up agentception` and verify port 7777 comes up.