### PR TITLE
fix: replace hardcoded paths with ${HOME} in docker-compose.override.yml

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -36,7 +36,7 @@ services:
       - ./pyproject.toml:/app/pyproject.toml
       # Cursor worktrees — agents run mypy/pytest directly against their worktree
       # via PYTHONPATH=/worktrees/<id>. No file copies needed. See .cursor/PARALLEL_ISSUE_TO_PR.md.
-      - /Users/gabriel/.cursor/worktrees/maestro:/worktrees
+      - ${HOME}/.cursor/worktrees/maestro:/worktrees
 
   storpheus:
     volumes:
@@ -44,11 +44,11 @@ services:
       - ./storpheus:/app
       # Cursor worktrees — parallel review agents need this to run mypy/pytest
       # against their worktree storpheus files via "cd /worktrees/<id> && mypy ."
-      - /Users/gabriel/.cursor/worktrees/maestro:/worktrees
+      - ${HOME}/.cursor/worktrees/maestro:/worktrees
 
   agentception:
     volumes:
       # Live code — host edits are instantly visible; no rebuild needed
       - ./agentception:/app/agentception
       # agentception tests live under agentception/tests/ (isolated from maestro conftest)
-      - /Users/gabriel/.cursor/worktrees/maestro:/worktrees
+      - ${HOME}/.cursor/worktrees/maestro:/worktrees


### PR DESCRIPTION
All three worktree volume mounts in `docker-compose.override.yml` were hardcoded to `/Users/gabriel`. Replaced with `${HOME}` so the override works for any user/machine.