### PR TITLE
fix: agent prompt sweep — stale htmx refs, hardcoded paths, missing ISSUE_LABEL in chain

### DIFF
--- a/.cursor/PARALLEL_ISSUE_TO_PR.md
+++ b/.cursor/PARALLEL_ISSUE_TO_PR.md
@@ -863,7 +863,7 @@ PR=$MY_PR
 BRANCH=$MY_BRANCH
 WORKTREE=$REVIEW_WORKTREE
 ROLE=pr-reviewer
-ROLE_FILE=/Users/gabriel/dev/tellurstori/maestro/.cursor/roles/pr-reviewer.md
+ROLE_FILE=$HOME/dev/tellurstori/maestro/.cursor/roles/pr-reviewer.md
 BASE=dev
 GH_REPO=cgcardona/maestro
 BATCH_ID=${BATCH_ID:-none}
@@ -873,8 +873,8 @@ TASK
     echo "✅ Spawning QA reviewer for PR #$MY_PR (chain mode — reviewer will spawn next engineer)"
     # AGENT INSTRUCTION: call Task(prompt="Read the .agent-task file in your worktree,
     # then follow the complete Kickoff Prompt in
-    # /Users/gabriel/dev/tellurstori/maestro/.cursor/PARALLEL_PR_REVIEW.md.
-    # GH_REPO=cgcardona/maestro  Repo: /Users/gabriel/dev/tellurstori/maestro",
+    # $HOME/dev/tellurstori/maestro/.cursor/PARALLEL_PR_REVIEW.md.
+    # GH_REPO=cgcardona/maestro  Repo: $HOME/dev/tellurstori/maestro",
     # worktree="$REVIEW_WORKTREE")
   else
     echo "⚠️  Could not find open PR for branch $MY_BRANCH — skipping reviewer spawn."

--- a/.cursor/PARALLEL_PR_REVIEW.md
+++ b/.cursor/PARALLEL_PR_REVIEW.md
@@ -1072,7 +1072,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     NEXT_ISSUE=""
     if [ -z "$ACTIVE_LABEL" ]; then
-      echo "ℹ️  No open htmx issues remain — chain complete."
+      echo "ℹ️  No open agentception issues remain — chain complete."
     else
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       NEXT_ISSUE=$(gh issue list \
@@ -1111,17 +1111,23 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       NEXT_WORKTREE="$HOME/.cursor/worktrees/maestro/issue-$NEXT_ISSUE"
       git -C "$REPO" worktree add -b "feat/issue-$NEXT_ISSUE" "$NEXT_WORKTREE" origin/dev
 
+      # Resolve the primary label so the engineer can route mypy/tests correctly.
+      NEXT_ISSUE_LABEL=$(gh issue view "$NEXT_ISSUE" --repo "$GH_REPO" \
+        --json labels --jq '[.labels[].name | select(startswith("agentception/"))] | first // ""')
+
       cat > "$NEXT_WORKTREE/.agent-task" <<TASK
 TASK=issue-to-pr
 ISSUE_NUMBER=$NEXT_ISSUE
+ISSUE_LABEL=$NEXT_ISSUE_LABEL
 BRANCH=feat/issue-$NEXT_ISSUE
 WORKTREE=$NEXT_WORKTREE
 ROLE=python-developer
-ROLE_FILE=/Users/gabriel/dev/tellurstori/maestro/.cursor/roles/python-developer.md
+ROLE_FILE=$HOME/dev/tellurstori/maestro/.cursor/roles/python-developer.md
 BASE=dev
 GH_REPO=cgcardona/maestro
 CLOSES_ISSUES=$NEXT_ISSUE
 BATCH_ID=${BATCH_ID:-none}
+SPAWN_MODE=chain
 TASK
 
       echo "✅ Chain: spawning engineer for issue #$NEXT_ISSUE (will spawn its own reviewer when done)"
@@ -1157,7 +1163,7 @@ PR=$NEXT_PR
 BRANCH=$NEXT_BRANCH
 WORKTREE=$NEXT_WORKTREE
 ROLE=pr-reviewer
-ROLE_FILE=/Users/gabriel/dev/tellurstori/maestro/.cursor/roles/pr-reviewer.md
+ROLE_FILE=$HOME/dev/tellurstori/maestro/.cursor/roles/pr-reviewer.md
 BASE=dev
 GH_REPO=cgcardona/maestro
 BATCH_ID=${BATCH_ID:-none}

--- a/.cursor/roles/cto.md
+++ b/.cursor/roles/cto.md
@@ -30,10 +30,12 @@ LOOP:
   1. Survey — determine the ACTIVE_LABEL and counts:
 
        # Labels are processed in strict order — NEVER skip ahead.
-       # Find the lowest-numbered htmx label that still has open issues.
+       # Find the lowest-numbered agentception label that still has open issues.
        ACTIVE_LABEL=""
-       for label in htmx/0-foundation htmx/1-independent htmx/2-main-ui \
-                    htmx/3-analysis htmx/4-canvas htmx/5-cleanup; do
+       for label in agentception/0-scaffold agentception/1-controls \
+                    agentception/2-telemetry agentception/3-roles \
+                    agentception/4-intelligence agentception/5-scaling \
+                    agentception/6-generalization; do
          COUNT=$(gh issue list --state open --repo cgcardona/maestro \
                    --label "$label" --json number --jq 'length')
          if [ "$COUNT" -gt 0 ]; then
@@ -69,7 +71,7 @@ LOOP:
      this to more than 1 Eng VP regardless of queue depth.
 
      ⚠️  ACTIVE_LABEL GATE: The single Eng VP ONLY works on ACTIVE_LABEL issues.
-     It MUST NOT claim issues from any other htmx/* label.
+     It MUST NOT claim issues from any other agentception/* label.
 
   4. Dispatch all allocated VPs simultaneously in ONE message
      (one Task call per VP, all in the same response):
@@ -91,11 +93,11 @@ LOOP:
 
 Pass each VP its role file path, a `CTO_WAVE` identifier, and the **ACTIVE_LABEL**:
 
-> Engineering VP prompt: "Read /Users/gabriel/dev/tellurstori/maestro/.cursor/roles/engineering-manager.md.
-> CTO_WAVE=<wave-N-timestamp>. ACTIVE_LABEL=<htmx/X-label>. Seed your pool and wait for it to drain.
-> You MUST only query and claim issues labeled exactly '<htmx/X-label>' — no other htmx/* labels."
+> Engineering VP prompt: "Read $HOME/dev/tellurstori/maestro/.cursor/roles/engineering-manager.md.
+> CTO_WAVE=<wave-N-timestamp>. ACTIVE_LABEL=<agentception/X-label>. Seed your pool and wait for it to drain.
+> You MUST only query and claim issues labeled exactly '<agentception/X-label>' — no other agentception/* labels."
 
-> QA VP prompt: "Read /Users/gabriel/dev/tellurstori/maestro/.cursor/roles/qa-manager.md.
+> QA VP prompt: "Read $HOME/dev/tellurstori/maestro/.cursor/roles/qa-manager.md.
 > CTO_WAVE=<wave-N-timestamp>. Seed your pool and wait for it to drain."
 
 ## Gating
@@ -105,11 +107,11 @@ CTO and VPs do not track dependencies. The canonical prompts handle it.
 
 ## Label scoping rules (critical)
 
-- **Issues:** only htmx-tagged issues are in scope. Filter every query:
-  `--jq '[.[] | select(.labels | map(.name) | any(startswith("htmx/")))]'`
-- **PRs:** ALL open PRs against `dev` are in scope — PRs never carry `htmx/*` labels.
-  Never add an htmx label to a PR. Never filter PRs by label.
-- The QA VP must NOT require htmx labels on PRs — it reviews every open PR, full stop.
+- **Issues:** only agentception-tagged issues are in scope. Filter every query:
+  `--jq '[.[] | select(.labels | map(.name) | any(startswith("agentception/")))]'`
+- **PRs:** ALL open PRs against `dev` are in scope — PRs never carry `agentception/*` labels.
+  Never add an agentception label to a PR. Never filter PRs by label.
+- The QA VP must NOT require agentception labels on PRs — it reviews every open PR, full stop.
 
 ## What you never do
 

--- a/.cursor/roles/engineering-manager.md
+++ b/.cursor/roles/engineering-manager.md
@@ -25,7 +25,7 @@ SEED:
        # If the worktree exists, the claim is ACTIVE — do NOT touch it.
        for NUM in $(gh issue list --state open --label "agent:wip" \
            --repo cgcardona/maestro --json number --jq '.[].number'); do
-         WORKTREE="/Users/gabriel/.cursor/worktrees/maestro/issue-$NUM"
+         WORKTREE="$HOME/.cursor/worktrees/maestro/issue-$NUM"
          if [ ! -d "$WORKTREE" ]; then
            echo "Clearing stale agent:wip from #$NUM (no worktree)"
            gh issue edit $NUM --repo cgcardona/maestro --remove-label "agent:wip"
@@ -67,9 +67,9 @@ SEED:
   5. Take the first 4 unclaimed issues. For each:
        a. Claim:  gh issue edit <N> --add-label "agent:wip"
        b. Create worktree:
-            git -C /Users/gabriel/dev/tellurstori/maestro worktree add \
+            git -C "$HOME/dev/tellurstori/maestro" worktree add \
               -b feat/issue-<N> \
-              ~/.cursor/worktrees/maestro/issue-<N> \
+              "$HOME/.cursor/worktrees/maestro/issue-<N>" \
               origin/dev
        c. Write .agent-task — include BATCH_ID (see Worktree convention below)
 
@@ -97,18 +97,18 @@ SEED:
 
 ## Worktree convention
 
-Worktrees live at: `/Users/gabriel/.cursor/worktrees/maestro/issue-{N}/`
+Worktrees live at: `$HOME/.cursor/worktrees/maestro/issue-{N}/`
 
 `.agent-task` format (include ALL fields — leaf agents read these):
 
 ```
 TASK=issue-to-pr
 ISSUE_NUMBER=<N>
-ISSUE_LABEL=<primary agentception/* or maestro/* label from gh issue view>
+ISSUE_LABEL=<primary agentception/* label from: gh issue view <N> --json labels --jq '[.labels[].name | select(startswith("agentception/"))] | first'>
 BRANCH=feat/issue-<N>
-WORKTREE=/Users/gabriel/.cursor/worktrees/maestro/issue-<N>
+WORKTREE=$HOME/.cursor/worktrees/maestro/issue-<N>
 ROLE=python-developer
-ROLE_FILE=/Users/gabriel/dev/tellurstori/maestro/.cursor/roles/python-developer.md
+ROLE_FILE=$HOME/dev/tellurstori/maestro/.cursor/roles/python-developer.md
 BASE=dev
 GH_REPO=cgcardona/maestro
 CLOSES_ISSUES=<N>
@@ -117,7 +117,7 @@ BATCH_ID=<BATCH_ID>
 
 `ISSUE_LABEL` is the primary scoping label (e.g. `agentception/0-scaffold`). Leaf agents use it to route mypy and tests to the correct codebase container — never cross-run agentception checks on maestro or vice versa.
 
-If a worktree is missing: `git worktree add -b feat/issue-{N} ~/.cursor/worktrees/maestro/issue-{N} origin/dev`
+If a worktree is missing: `git -C "$HOME/dev/tellurstori/maestro" worktree add -b feat/issue-{N} "$HOME/.cursor/worktrees/maestro/issue-{N}" origin/dev`
 
 ## What you never do
 

--- a/.cursor/roles/pr-reviewer.md
+++ b/.cursor/roles/pr-reviewer.md
@@ -27,10 +27,16 @@ You do not negotiate on type safety. You do not ship dirty mypy. You do not igno
 
 ## Baseline Discipline
 
-Before checking out the PR branch, record the pre-existing mypy state on `dev`:
+Before checking out the PR branch, record the pre-existing mypy state on `dev`.
+Route by codebase — agentception and maestro are independent; never cross-run:
 ```
-docker compose exec maestro mypy maestro/ tests/ 2>&1 | tail -5   # error count baseline
+# agentception PRs (label starts with agentception/):
+docker compose exec agentception mypy /app/agentception/ 2>&1 | tail -5
+
+# maestro PRs:
+docker compose exec maestro mypy maestro/ tests/ 2>&1 | tail -5
 ```
+Full routing logic is in PARALLEL_PR_REVIEW.md STEP 4 (IS_AC detection).
 
 Do **not** run the full test suite as a baseline. Run only the targeted test files for this PR (derived below), and only after checkout. Your job is to ensure the PR does not *introduce* new errors — not to inherit all pre-existing debt. But if your PR touches a file with pre-existing errors, you own them.
 

--- a/.cursor/roles/qa-manager.md
+++ b/.cursor/roles/qa-manager.md
@@ -51,19 +51,20 @@ SEED:
        a. Claim:  gh pr edit <N> --add-label "agent:wip"
        b. Get branch: BRANCH=$(gh pr view <N> --json headRefName --jq .headRefName)
        c. Create worktree:
-            git -C /Users/gabriel/dev/tellurstori/maestro worktree add \
-              ~/.cursor/worktrees/maestro/pr-<N> \
+            git -C "$HOME/dev/tellurstori/maestro" worktree add \
+              "$HOME/.cursor/worktrees/maestro/pr-<N>" \
               origin/$BRANCH
        d. Write .agent-task — include BATCH_ID:
             TASK=pr-review
             PR=<N>
             BRANCH=$BRANCH
-            WORKTREE=~/.cursor/worktrees/maestro/pr-<N>
+            WORKTREE=$HOME/.cursor/worktrees/maestro/pr-<N>
             ROLE=pr-reviewer
-            ROLE_FILE=/Users/gabriel/dev/tellurstori/maestro/.cursor/roles/pr-reviewer.md
+            ROLE_FILE=$HOME/dev/tellurstori/maestro/.cursor/roles/pr-reviewer.md
             BASE=dev
             GH_REPO=cgcardona/maestro
             BATCH_ID=$BATCH_ID
+            SPAWN_MODE=chain
 
   6. Launch all 4 as leaf reviewers simultaneously — one Task call per PR,
      all in a single message:
@@ -82,11 +83,11 @@ SEED:
 
 ## Worktree convention
 
-Worktrees live at: `/Users/gabriel/.cursor/worktrees/maestro/pr-{N}/`
+Worktrees live at: `$HOME/.cursor/worktrees/maestro/pr-{N}/`
 .agent-task files are pre-written in each worktree.
 If a worktree is missing for a new PR:
   `BRANCH=$(gh pr view {N} --json headRefName --jq '.headRefName')`
-  `git worktree add ~/.cursor/worktrees/maestro/pr-{N} origin/$BRANCH`
+  `git -C "$HOME/dev/tellurstori/maestro" worktree add "$HOME/.cursor/worktrees/maestro/pr-{N}" origin/$BRANCH`
   Then write a .agent-task file with TASK=pr-review, PR={N}, BRANCH=..., ROLE=..., etc.
 
 ## MERGE_AFTER protocol


### PR DESCRIPTION
Pre-launch sweep caught five bugs across six files:

| # | File | Bug | Fix |
|---|------|-----|-----|
| 1 | `cto.md` | Two `htmx/*` refs in VP dispatch templates | → `agentception/*`; paths → `$HOME` |
| 2 | `pr-reviewer.md` | Mypy baseline hardcoded to maestro | → codebase-aware routing note |
| 3 | `PARALLEL_PR_REVIEW.md` | Chain spawn `.agent-task` missing `ISSUE_LABEL` | → resolves label from `gh issue view`; adds `SPAWN_MODE=chain` |
| 4 | `engineering-manager.md` | All `/Users/gabriel` hardcoded paths | → `$HOME` |
| 5 | `qa-manager.md` | All `/Users/gabriel` hardcoded paths; missing `SPAWN_MODE=chain` | → `$HOME`; adds field |