### PR TITLE
feat: cognitive architecture skill domains + ticket taxonomy

### DIFF
--- a/.cursor/PARALLEL_ISSUE_TO_PR.md
+++ b/.cursor/PARALLEL_ISSUE_TO_PR.md
@@ -408,7 +408,7 @@ STEP 0 — READ YOUR TASK FILE:
     git restore --staged <file> for staged undo. Broad undo destroys
     unrelated work. When in doubt: commit, then fix forward.
 
-STEP 0.5 — LOAD YOUR ROLE:
+STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
   REPO=$(git worktree list | head -1 | awk '{print $1}')
   ROLE_FILE="$REPO/.cursor/roles/${ROLE}.md"
@@ -418,8 +418,39 @@ STEP 0.5 — LOAD YOUR ROLE:
   else
     echo "⚠️  No role file found for '$ROLE' — proceeding without role context."
   fi
-  # The decision hierarchy, quality bar, and failure modes in that file govern
-  # all your choices from this point forward.
+
+  # Load cognitive architecture — determines your thinking style AND skill domain
+  COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+  if [ -n "$COGNITIVE_ARCH" ]; then
+    echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
+    echo ""
+    echo "This means:"
+    # Parse figure and skill domain (format: figure+skill_domain or archetype+skill_domain)
+    COGARCH_FIGURE=$(echo "$COGNITIVE_ARCH" | cut -d+ -f1)
+    COGARCH_SKILL=$(echo "$COGNITIVE_ARCH" | cut -d+ -f2)
+    # Load figure/archetype YAML for context (informational — you already have the role file)
+    ARCH_FILE="$REPO/scripts/gen_prompts/cognitive_archetypes/figures/${COGARCH_FIGURE}.yaml"
+    if [ ! -f "$ARCH_FILE" ]; then
+      ARCH_FILE="$REPO/scripts/gen_prompts/cognitive_archetypes/archetypes/${COGARCH_FIGURE}.yaml"
+    fi
+    if [ -f "$ARCH_FILE" ]; then
+      # Print display_name and description for self-awareness
+      grep -A3 "^display_name:" "$ARCH_FILE" | head -4
+      grep -A5 "^description:" "$ARCH_FILE" | head -6
+    fi
+    # Load skill domain context
+    SKILL_FILE="$REPO/scripts/gen_prompts/cognitive_archetypes/skill_domains/${COGARCH_SKILL}.yaml"
+    if [ -f "$SKILL_FILE" ]; then
+      echo "--- Skill domain: $COGARCH_SKILL ---"
+      grep -A3 "^display_name:" "$SKILL_FILE" | head -2
+    fi
+    echo ""
+    echo "Let these govern your approach to this task. See TICKET_TAXONOMY.md for rationale."
+  else
+    echo "⚠️  No COGNITIVE_ARCH set — using default pragmatist+python approach."
+  fi
+  # The cognitive architecture, role file, and .agent-task together form
+  # your full operating context. Honor all three.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only

--- a/.cursor/roles/engineering-manager.md
+++ b/.cursor/roles/engineering-manager.md
@@ -71,7 +71,79 @@ SEED:
               -b feat/issue-<N> \
               "$HOME/.cursor/worktrees/maestro/issue-<N>" \
               origin/dev
-       c. Write .agent-task — include BATCH_ID (see Worktree convention below)
+       c. Select the cognitive architecture for this specific issue:
+
+          Read the issue body once and apply heuristics to set COGNITIVE_ARCH.
+          First match wins. This ensures every leaf agent gets the right skill
+          domain and personality for its task — not just a generic Python engineer.
+
+          ```bash
+          ISSUE_BODY="$(gh issue view <N> --repo cgcardona/maestro --json body -q .body)"
+
+          # --- Skill domain (what tech stack is this issue building?) ---
+          if echo "$ISSUE_BODY" | grep -qiE "monaco|vs/loader|editor.*cdn|cdn.*editor"; then
+            SKILL_DOMAIN="monaco_editor"
+          elif echo "$ISSUE_BODY" | grep -qiE "d3\.js|force-directed|d3\.force|d3\.select"; then
+            SKILL_DOMAIN="d3_js"
+          elif echo "$ISSUE_BODY" | grep -qiE "htmx|hx-|jinja2|\.html|sse-connect|alpine|x-data|hx-ext"; then
+            SKILL_DOMAIN="htmx_jinja2"
+          elif echo "$ISSUE_BODY" | grep -qiE "dockerfile|FROM python|compose.*service|container.*port"; then
+            SKILL_DOMAIN="devops"
+          elif echo "$ISSUE_BODY" | grep -qiE "midi|storpheus|gm.program|tmidix|orpheus"; then
+            SKILL_DOMAIN="audio_midi"
+          elif echo "$ISSUE_BODY" | grep -qiE "llm|embedding|rag|openrouter|claude.*model"; then
+            SKILL_DOMAIN="ml_ai"
+          else
+            SKILL_DOMAIN="python"
+          fi
+
+          # --- Figure/archetype (how should the agent think?) ---
+          if echo "$ISSUE_BODY" | grep -qiE "parse.*body|depends on.*#|DAG|directed.acyclic|formal.*grammar"; then
+            FIGURE="turing"
+          elif echo "$ISSUE_BODY" | grep -qiE "kill|stale.*claim|out-of-order|invariant|correctness.*critical"; then
+            FIGURE="the_guardian"
+          elif echo "$ISSUE_BODY" | grep -qiE "asyncio|SSE|broadcast|subscribe|fanout|information.*flow"; then
+            FIGURE="shannon"
+          elif echo "$ISSUE_BODY" | grep -qiE "readme|explain.*simply|tutorial|document|onboard"; then
+            FIGURE="feynman"
+          elif echo "$ISSUE_BODY" | grep -qiE "dockerfile|FROM |entrypoint|compose.*service"; then
+            FIGURE="ritchie"
+          elif echo "$ISSUE_BODY" | grep -qiE "scaling|advisor|queue.*depth|heuristic.*important"; then
+            FIGURE="hamming"
+          elif echo "$ISSUE_BODY" | grep -qiE "wave|aggregate|batch_id|synthesize|cross.*domain"; then
+            FIGURE="von_neumann"
+          elif echo "$ISSUE_BODY" | grep -qiE "schema|load-bearing|interface.*design|config.*schema|api.*contract"; then
+            FIGURE="the_architect"
+          elif echo "$ISSUE_BODY" | grep -qiE "visualization|force.*directed|D3|beautiful.*graph|render.*graph"; then
+            FIGURE="lovelace"
+          elif echo "$ISSUE_BODY" | grep -qiE "manual.*spawn|tool.*for|direct.*control|bypass.*loop"; then
+            FIGURE="hopper"
+          elif echo "$ISSUE_BODY" | grep -qiE "classify|ticket.*analyze|natural.*language.*parse|formal.*model"; then
+            FIGURE="mccarthy"
+          elif echo "$ISSUE_BODY" | grep -qiE "A/B|variant|experiment|alternate.*role"; then
+            FIGURE="hopper"
+          elif echo "$ISSUE_BODY" | grep -qiE "inspector|transcript.*viewer|detail.*page|make.*visible"; then
+            FIGURE="feynman"
+          elif echo "$ISSUE_BODY" | grep -qiE "overview.*page|live.*tree|pipeline.*dashboard|meta.*view"; then
+            FIGURE="lovelace"
+          elif echo "$ISSUE_BODY" | grep -qiE "recommendation|comparison.*table|teach|mentor.*style"; then
+            FIGURE="the_mentor"
+          elif echo "$ISSUE_BODY" | grep -qiE "pause|resume|sentinel|operational|keep.*running"; then
+            FIGURE="the_operator"
+          elif echo "$ISSUE_BODY" | grep -qiE "diff|version.*track|atomic.*write|history"; then
+            FIGURE="dijkstra"
+          else
+            FIGURE="the_pragmatist"
+          fi
+
+          COGNITIVE_ARCH="${FIGURE}+${SKILL_DOMAIN}"
+          echo "Selected cognitive architecture: $COGNITIVE_ARCH"
+          ```
+
+          See scripts/gen_prompts/TICKET_TAXONOMY.md for the full rationale behind
+          each mapping. The taxonomy also serves as a reference for adding new issues.
+
+       d. Write .agent-task — include BATCH_ID and COGNITIVE_ARCH (see Worktree convention below)
 
   6. Launch all 4 as leaf agents simultaneously — one Task call per issue,
      all in a single message:
@@ -113,9 +185,12 @@ BASE=dev
 GH_REPO=cgcardona/maestro
 CLOSES_ISSUES=<N>
 BATCH_ID=<BATCH_ID>
+COGNITIVE_ARCH=<COGNITIVE_ARCH from step 5c above, e.g. "feynman+htmx_jinja2">
 ```
 
 `ISSUE_LABEL` is the primary scoping label (e.g. `agentception/0-scaffold`). Leaf agents use it to route mypy and tests to the correct codebase container — never cross-run agentception checks on maestro or vice versa.
+
+`COGNITIVE_ARCH` is the selected cognitive architecture for this specific issue (figure+skill_domain or archetype+skill_domain). Leaf agents display it in their opening message and let it guide their approach. See `scripts/gen_prompts/TICKET_TAXONOMY.md` for the full taxonomy and rationale.
 
 If a worktree is missing: `git -C "$HOME/dev/tellurstori/maestro" worktree add -b feat/issue-{N} "$HOME/.cursor/worktrees/maestro/issue-{N}" origin/dev`
 

--- a/scripts/gen_prompts/TICKET_TAXONOMY.md
+++ b/scripts/gen_prompts/TICKET_TAXONOMY.md
@@ -1,0 +1,182 @@
+# AgentCeption Ticket Taxonomy
+
+> Every open issue mapped to its phase, tech stack, and optimal `COGNITIVE_ARCH`.
+> This document drives the auto-selection logic in `engineering-manager.md.j2`.
+> Update when new issues are added or the skill domain library grows.
+
+---
+
+## Tech Stack Analysis
+
+The AgentCeption dashboard is a **FastAPI + Jinja2 + HTMX** application.
+Issues break into five distinct technical stacks:
+
+| Stack | Count | Skill Domain |
+|-------|-------|-------------|
+| Pure Python (async, data processing, REST) | 12 | `python` |
+| **HTMX + Jinja2 + Alpine.js (UI pages)** | **13** | **`htmx_jinja2`** |
+| D3.js (force-directed graph) | 1 | `d3_js` |
+| Monaco editor (in-browser code editor) | 1 | `monaco_editor` |
+| DevOps (Docker, Compose) | 1 | `devops` |
+| Documentation only | 1 | `python` |
+
+**Key insight:** HTMX+Jinja2 is the dominant pattern (45% of all tickets).
+Before this taxonomy existed, every agent was dispatched as a bare Python developer
+with no HTMX/Jinja2 context — this is the bug the taxonomy fixes.
+
+---
+
+## Full Issue Map
+
+### Phase 0 — Scaffold (sequential, foundational)
+
+| # | Title | Primary Stack | Signal Keywords | `COGNITIVE_ARCH` | Rationale |
+|---|-------|--------------|-----------------|------------------|-----------|
+| #648 | Docker runtime — Dockerfile, compose service | DevOps | docker, dockerfile, compose, HOME-relative | `ritchie+devops` | Minimal tools that compose cleanly. Ritchie's Unix philosophy maps directly to Docker service design. |
+| #614 | poller.py — asyncio background task, SSE broadcast | Python | asyncio, SSE, broadcast, PipelineState, subscribe | `shannon+python` | Shannon thinks in information flows and channels. A poller that merges sources and broadcasts is exactly a Shannon problem: latency, throughput, subscriber fanout. |
+| #615 | Pipeline overview UI — live tree, status badges, GitHub board | HTMX+Jinja2 | htmx, sse-swap, hx-ext, template, overview.html | `lovelace+htmx_jinja2` | Lovelace sees the machine behind the machine. The overview page IS the meta-view of the agent pipeline — she would design it to reveal the system's structure, not just display data. |
+| #616 | Agent inspector UI — transcript viewer, .agent-task display | HTMX+Jinja2 | agents/{id}, transcript, agent.html, detail page | `feynman+htmx_jinja2` | Feynman's job is to make the invisible visible. An agent inspector that surfaces what agents are actually doing is a Feynman problem: expose the internals clearly. |
+
+### Phase 1 — Controls
+
+| # | Title | Primary Stack | Signal Keywords | `COGNITIVE_ARCH` | Rationale |
+|---|-------|--------------|-----------------|------------------|-----------|
+| #617 | Kill endpoint — remove worktree + clear agent:wip | Python | kill, worktree, rm -rf, label, correctness | `the_guardian+python` | Kill is irreversible. The Guardian's fail-loud, deductive rigor is exactly right — every edge case (concurrent kill, already-dead agent, missing worktree) must be handled explicitly. |
+| #618 | Pause/resume pipeline sentinel + UI toggle | Python+HTMX | pause, resume, sentinel, .pipeline-pause, toggle | `the_operator+htmx_jinja2` | The Operator keeps the system running reliably. Pause/resume is operational infrastructure — it needs retry-first, probabilistic reasoning, and terse correctness. |
+| #619 | Manual spawn endpoint + issue picker UI | HTMX+Jinja2 | spawn, issue picker, form, POST /api/control/spawn | `hopper+htmx_jinja2` | Hopper built tools that let humans do more. The manual spawn UI is a direct-control tool — she would make it fast, tactile, and clear about what it's doing. |
+
+### Phase 2 — Telemetry
+
+| # | Title | Primary Stack | Signal Keywords | `COGNITIVE_ARCH` | Rationale |
+|---|-------|--------------|-----------------|------------------|-----------|
+| #620 | Wave aggregator — group by BATCH_ID, compute timing | Python | wave, BATCH_ID, aggregate, mtime, timing | `von_neumann+python` | Von Neumann bursts through the entire problem space. Wave aggregation requires holding many correlated data points simultaneously and synthesizing them — his burst+comprehensive style is optimal. |
+| #621 | Cost estimator — token proxy + Claude pricing | Python | cost, token, estimate, pricing, message_count | `hamming+python` | Hamming's heuristic: "work on the important problem." Cost estimation IS the important problem for pipeline economics. He would find the simplest proxy that gives actionable signal. |
+| #622 | Telemetry UI — CSS timeline bar chart + wave table | HTMX+Jinja2 | telemetry, CSS bar chart, wave summary, table | `the_mentor+htmx_jinja2` | The Mentor writes code that teaches. A telemetry dashboard should make complex timing data intuitively legible — the Mentor's visual, expository style produces the most useful dashboards. |
+
+### Phase 3 — Roles (Role Studio)
+
+| # | Title | Primary Stack | Signal Keywords | `COGNITIVE_ARCH` | Rationale |
+|---|-------|--------------|-----------------|------------------|-----------|
+| #623 | Role file reader/writer API — list, read, write, git history | Python | API, REST, /api/roles, read, write, git log | `the_architect+python` | The Architect designs before building. The role file API is load-bearing infrastructure — it must have a clean interface with no path traversal, validated slugs, and a stable contract for the editor above it. |
+| #624 | Monaco editor in browser for role files | Monaco+HTMX | monaco, editor, CDN, vs/loader, markdown, yaml | `lovelace+monaco_editor` | Lovelace sees the machine behind the machine AND the system that creates machines. A tool for editing cognitive architectures in the browser is deeply recursive — she is the right figure to design it. |
+| #625 | Diff preview + Save & Commit flow | Python+HTMX | diff, unified diff, HEAD, git commit, confirm | `dijkstra+python` | Dijkstra: correctness is not optional. A diff-before-commit flow is about preventing irreversible mistakes — his deductive, fail-loud style ensures every save path is provably safe. |
+| #626 | pipeline-config.json — CTO/VP read from file | Python | pipeline-config.json, max_pool_size, phases, read | `the_architect+python` | Another load-bearing design. The pipeline config schema must be forward-compatible, validated, and have a clear migration story. Architect mode. |
+| #627 | Pipeline config UI — sliders for VP count and pool size | HTMX+Jinja2 | sliders, config, pipeline-config.json, one-click | `the_pragmatist+htmx_jinja2` | Pragmatist for a configuration UI: it needs to work cleanly and ship without over-engineering. Simple sliders, immediate feedback, done. |
+
+### Phase 4 — Intelligence
+
+| # | Title | Primary Stack | Signal Keywords | `COGNITIVE_ARCH` | Rationale |
+|---|-------|--------------|-----------------|------------------|-----------|
+| #628 | Dependency DAG builder — parse "Depends on #NNN" | Python | DAG, parse, Depends on, directed, acyclic, graph | `turing+python` | Turing builds formal machines to answer questions. The DAG builder is a formal parsing + graph construction problem — he would define the grammar first, then implement it. |
+| #629 | DAG visualization — D3 force-directed graph | D3.js | D3, force-directed, SVG, node, edge, phase color | `lovelace+d3_js` | Lovelace would be astounded that you can render a live graph of thinking machines in a browser. She would design it beautifully and make the structure self-evident. |
+| #630 | Out-of-order PR guard — detect ordering violations | Python | out-of-order, phase label, alert, ordering, guard | `the_guardian+python` | Guardian is the immune system. Out-of-order detection IS guardian behavior — detect violations, surface loudly, block progression until fixed. |
+| #631 | Stale claim detector + one-click auto-fix | Python+HTMX | stale claim, agent:wip, no worktree, one-click fix | `the_operator+python` | The Operator keeps the lights on. Stale claim detection is operational hygiene — retry-first, empirical, and pragmatic about auto-remediation. |
+| #632 | Ticket analyzer endpoint — parse issue for parallelism/deps | Python | analyze, parse issue body, parallelism, dependency | `mccarthy+python` | McCarthy: formalize first, solve within the formalism. Ticket analysis is a natural language parsing problem that should be expressed as a formal classifier. |
+| #633 | Ticket analyzer UI panel — inline analysis on board | HTMX+Jinja2 | analyze button, dropdown, issue card, inline | `the_pragmatist+htmx_jinja2` | The analysis results panel is a UI concern. Pragmatist: wire up the endpoint, display results clearly, ship. |
+
+### Phase 5 — Scaling
+
+| # | Title | Primary Stack | Signal Keywords | `COGNITIVE_ARCH` | Rationale |
+|---|-------|--------------|-----------------|------------------|-----------|
+| #634 | Auto-scaling advisor engine | Python | scaling, advisor, queue depth, PR backlog, heuristic | `hamming+python` | Hamming again: what is the important metric? Queue depth is the lever. He would find the minimal set of signals that give actionable scaling advice. |
+| #635 | Scaling recommendation UI + one-click apply | HTMX+Jinja2 | recommendation, banner, one-click, apply, dismiss | `the_mentor+htmx_jinja2` | Mentor: the recommendation UI should teach the operator why the scaling advice is being given, not just what to click. |
+| #636 | Role version tracking schema — role-versions.json | Python | role-versions, version, track, A/B, schema | `the_guardian+python` | Version tracking is correctness infrastructure. Guardian ensures the schema is sound, the writes are atomic, and the history is never corrupted. |
+| #637 | A/B mode in Eng VP — alternate role files by BATCH_ID | Python | A/B, variant, even/odd BATCH_ID, role file | `hopper+python` | Hopper: build the experiment, observe, iterate. A/B testing IS her methodology. She would instrument it clearly and make the results easy to read. |
+| #638 | A/B results dashboard — compare role versions | HTMX+Jinja2 | A/B results, comparison table, PR outcomes, mypy | `shannon+htmx_jinja2` | Shannon thinks in information theory. An A/B dashboard is fundamentally about signal vs noise — which role variant produces better outcomes? He would design the comparison to reveal the signal. |
+
+### Phase 6 — Generalization
+
+| # | Title | Primary Stack | Signal Keywords | `COGNITIVE_ARCH` | Rationale |
+|---|-------|--------------|-----------------|------------------|-----------|
+| #639 | Multi-repo config schema + project switcher UI | Python+HTMX | multi-repo, config schema, project, switcher | `the_architect+python` | Generalization requires the cleanest possible interface. Architect mode — design the schema that supports any repo before building the first one. |
+| #640 | Template export/import — .tar.gz packaging | Python | export, import, tar.gz, template, config | `ritchie+python` | Ritchie: the smallest tool that does the job. A tar.gz exporter is a Unix pipe problem — compose existing tools cleanly. |
+| #641 | README, extraction prep, standalone repo scaffold | Documentation | README, pyproject.toml, extraction, standalone | `feynman+python` | Feynman: if you cannot explain it simply, you don't understand it. A README that lets a stranger onboard without asking questions is a Feynman problem. |
+
+---
+
+## Heuristic Rules (implemented in engineering-manager)
+
+The engineering-manager runs these checks against each issue's body + labels
+to auto-select `COGNITIVE_ARCH`. Rules are checked in priority order — first match wins.
+
+### Skill Domain Detection
+
+```bash
+# Read issue body once
+ISSUE_BODY="$(gh issue view $NUM --repo $GH_REPO --json body -q .body)"
+
+if echo "$ISSUE_BODY" | grep -qiE "monaco|vs/loader|editor.*cdn|cdn.*editor"; then
+  SKILL_DOMAIN="monaco_editor"
+elif echo "$ISSUE_BODY" | grep -qiE "d3\.js|force-directed|d3\.forceSimulation|d3\.select"; then
+  SKILL_DOMAIN="d3_js"
+elif echo "$ISSUE_BODY" | grep -qiE "htmx|hx-|jinja2|\.html|sse-connect|alpine|x-data"; then
+  SKILL_DOMAIN="htmx_jinja2"
+elif echo "$ISSUE_BODY" | grep -qiE "dockerfile|docker compose|FROM python|container.*port"; then
+  SKILL_DOMAIN="devops"
+elif echo "$ISSUE_BODY" | grep -qiE "midi|storpheus|gm.program|tmidix|orpheus"; then
+  SKILL_DOMAIN="audio_midi"
+elif echo "$ISSUE_BODY" | grep -qiE "llm|embedding|rag|openrouter|claude.*model"; then
+  SKILL_DOMAIN="ml_ai"
+else
+  SKILL_DOMAIN="python"
+fi
+```
+
+### Figure/Archetype Detection
+
+```bash
+if echo "$ISSUE_BODY" | grep -qiE "parse.*body|depends on|DAG|directed.acyclic|formal"; then
+  FIGURE="turing"
+elif echo "$ISSUE_BODY" | grep -qiE "kill|guard|stale.*claim|out-of-order|correctness|invariant"; then
+  FIGURE="the_guardian"
+elif echo "$ISSUE_BODY" | grep -qiE "asyncio|SSE|broadcast|subscribe|fanout|information flow"; then
+  FIGURE="shannon"
+elif echo "$ISSUE_BODY" | grep -qiE "readme|explain|tutorial|document|onboard"; then
+  FIGURE="feynman"
+elif echo "$ISSUE_BODY" | grep -qiE "docker|compose|FROM|entrypoint|service.*port"; then
+  FIGURE="ritchie"
+elif echo "$ISSUE_BODY" | grep -qiE "scaling|advisor|heuristic|queue.*depth|important.*problem"; then
+  FIGURE="hamming"
+elif echo "$ISSUE_BODY" | grep -qiE "wave|aggregate|batch_id|synthesize|cross.*domain|burst"; then
+  FIGURE="von_neumann"
+elif echo "$ISSUE_BODY" | grep -qiE "diff|version|schema|load-bearing|interface.*design|config.*schema"; then
+  FIGURE="the_architect"
+elif echo "$ISSUE_BODY" | grep -qiE "visualization|render|graph.*beautiful|D3|force.*directed|SVG"; then
+  FIGURE="lovelace"
+elif echo "$ISSUE_BODY" | grep -qiE "spawn|tool.*for|manual.*control|direct.*access"; then
+  FIGURE="hopper"
+elif echo "$ISSUE_BODY" | grep -qiE "classify|analyze|formal.*model|natural.*language|parse.*intent"; then
+  FIGURE="mccarthy"
+elif echo "$ISSUE_BODY" | grep -qiE "A/B|experiment|variant|observe.*iterate"; then
+  FIGURE="hopper"
+elif echo "$ISSUE_BODY" | grep -qiE "inspector|detail.*page|transcript.*viewer|make.*visible"; then
+  FIGURE="feynman"
+elif echo "$ISSUE_BODY" | grep -qiE "overview.*page|live.*tree|dashboard.*main|meta.*view"; then
+  FIGURE="lovelace"
+elif echo "$ISSUE_BODY" | grep -qiE "recommendation|mentor.*style|comparison.*table|teach"; then
+  FIGURE="the_mentor"
+elif echo "$ISSUE_BODY" | grep -qiE "pause|resume|sentinel|operational|keep.*running"; then
+  FIGURE="the_operator"
+else
+  FIGURE="the_pragmatist"
+fi
+
+COGNITIVE_ARCH="${FIGURE}+${SKILL_DOMAIN}"
+```
+
+---
+
+## Skill Domain Coverage by Phase
+
+```
+Phase 0:  devops python htmx_jinja2 htmx_jinja2
+Phase 1:  python htmx_jinja2 htmx_jinja2
+Phase 2:  python python htmx_jinja2
+Phase 3:  python monaco_editor python python htmx_jinja2
+Phase 4:  python d3_js python python python htmx_jinja2
+Phase 5:  python htmx_jinja2 python python htmx_jinja2
+Phase 6:  python python python
+```
+
+**13 of 29 tickets need HTMX+Jinja2 skill domain.**
+Without this taxonomy, all 13 would have been dispatched as generic Python engineers.

--- a/scripts/gen_prompts/cognitive_archetypes/skill_domains/d3_js.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/skill_domains/d3_js.yaml
@@ -1,0 +1,103 @@
+# Skill Domain: D3.js Visualization
+id: d3_js
+display_name: "D3.js / SVG Visualization"
+description: |
+  Data-driven SVG visualizations using D3.js loaded from CDN. Used for the
+  AgentCeption dependency DAG force-directed graph and any future chart needs.
+
+prompt_fragment: |
+  ## Skill Domain: D3.js / SVG Visualization
+
+  You are building an interactive SVG visualization with D3.js loaded from CDN.
+  The visualization lives inside a Jinja2 template served by FastAPI.
+
+  ### CDN Load Pattern
+
+  ```html
+  <!-- In base.html or the specific page template -->
+  <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js"></script>
+  ```
+
+  Always load from CDN — never bundle. Use D3 v7 (latest stable).
+
+  ### Force-Directed Graph Pattern
+
+  ```javascript
+  // Initialize with data from inline JSON (injected by Jinja2 at render time)
+  const graphData = {{ graph_json | tojson }};  // {nodes: [...], links: [...]}
+
+  const width = container.clientWidth;
+  const height = container.clientHeight;
+
+  const svg = d3.select("#dag-container")
+    .append("svg")
+    .attr("width", width)
+    .attr("height", height);
+
+  // Arrow marker for directed edges
+  svg.append("defs").append("marker")
+    .attr("id", "arrowhead")
+    .attr("markerWidth", 10).attr("markerHeight", 7)
+    .attr("refX", 10).attr("refY", 3.5).attr("orient", "auto")
+    .append("polygon").attr("points", "0 0, 10 3.5, 0 7");
+
+  const simulation = d3.forceSimulation(graphData.nodes)
+    .force("link", d3.forceLink(graphData.links).id(d => d.id).distance(80))
+    .force("charge", d3.forceManyBody().strength(-300))
+    .force("center", d3.forceCenter(width / 2, height / 2));
+
+  const link = svg.selectAll(".link")
+    .data(graphData.links).enter().append("line")
+    .attr("class", "link").attr("marker-end", "url(#arrowhead)");
+
+  const node = svg.selectAll(".node")
+    .data(graphData.nodes).enter().append("g")
+    .attr("class", "node")
+    .call(d3.drag()
+      .on("start", dragStarted)
+      .on("drag", dragged)
+      .on("end", dragEnded));
+
+  node.append("circle").attr("r", 20).attr("fill", d => phaseColor(d.label));
+  node.append("text").text(d => `#${d.id}`).attr("text-anchor", "middle").attr("dy", 4);
+  node.on("click", (event, d) => window.location.href = `/agents/${d.id}`);
+
+  simulation.on("tick", () => {
+    link.attr("x1", d => d.source.x).attr("y1", d => d.source.y)
+        .attr("x2", d => d.target.x).attr("y2", d => d.target.y);
+    node.attr("transform", d => `translate(${d.x},${d.y})`);
+  });
+  ```
+
+  ### Data Shape (from FastAPI endpoint)
+
+  ```python
+  # FastAPI returns this; Jinja2 inlines it with | tojson
+  @router.get("/api/dag")
+  async def dag_data() -> dict:
+      return {
+          "nodes": [{"id": 614, "label": "agentception/0-scaffold", "status": "closed"}],
+          "links": [{"source": 610, "target": 614}],
+      }
+  ```
+
+  ### Zoom and Pan
+
+  ```javascript
+  const zoom = d3.zoom().scaleExtent([0.3, 3]).on("zoom", (event) => {
+    svg.select("g.everything").attr("transform", event.transform);
+  });
+  svg.call(zoom);
+  ```
+
+  ### Quality Standards
+
+  - Inline JSON via Jinja2 `| tojson` — never a separate fetch on load.
+  - Graph is responsive: recalculates `width`/`height` on window resize.
+  - Accessible: nodes have `title` elements with full issue title.
+  - Click target is the whole node `<g>`, not just the circle.
+  - Zoom reset button always present.
+
+quality_gates:
+  linter: "docker compose exec agentception mypy /app/agentception/"
+  test_runner: "docker compose exec agentception pytest agentception/tests/ -v -k dag"

--- a/scripts/gen_prompts/cognitive_archetypes/skill_domains/htmx_jinja2.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/skill_domains/htmx_jinja2.yaml
@@ -1,0 +1,118 @@
+# Skill Domain: HTMX + Jinja2 + Alpine.js
+id: htmx_jinja2
+display_name: "HTMX / Jinja2 / Alpine.js"
+description: |
+  Server-side rendering with HTMX for partial updates, Jinja2 templates,
+  and Alpine.js for lightweight client-side reactivity. The primary UI
+  pattern throughout the AgentCeption dashboard.
+
+prompt_fragment: |
+  ## Skill Domain: HTMX / Jinja2 / Alpine.js
+
+  You are building a server-rendered FastAPI application. The UI pattern is:
+  - **HTMX** handles all partial page updates — no full-page refreshes except for
+    initial load. Every interactive element uses `hx-*` attributes.
+  - **Jinja2** templates render HTML on the server. Business logic stays in Python;
+    templates are for presentation only.
+  - **Alpine.js** handles lightweight client-side reactivity (dropdowns, toggles,
+    modal state). Never use Alpine where a pure HTMX solution exists.
+
+  ### HTMX Patterns
+
+  ```html
+  <!-- Polling / live updates -->
+  <div hx-get="/api/pipeline" hx-trigger="every 5s" hx-target="#tree" hx-swap="innerHTML">
+
+  <!-- SSE streaming -->
+  <div hx-ext="sse" sse-connect="/events" sse-swap="message" hx-target="#tree">
+
+  <!-- Form submission without page reload -->
+  <form hx-post="/api/control/kill/{{ worktree_slug }}" hx-target="#alerts" hx-swap="outerHTML">
+
+  <!-- Clicking loads a detail panel -->
+  <button hx-get="/agents/{{ agent_id }}" hx-target="#detail-panel" hx-swap="innerHTML">
+  ```
+
+  ### Jinja2 Template Structure
+
+  ```
+  agentception/templates/
+    base.html          ← base layout (nav, head, scripts)
+    overview.html      ← extends base.html
+    agent.html         ← extends base.html
+    partials/
+      agent_tree.html  ← HTMX target fragment (no base wrapper)
+      alert_banner.html
+  ```
+
+  - `templates/base.html` loads HTMX, Alpine.js, and all CSS from CDN.
+  - Partials (HTMX targets) extend nothing — they are bare HTML fragments.
+  - Macros for reusable UI components: `{% macro status_badge(status) %}`.
+  - Pass `request` as first context key (FastAPI + Jinja2 requirement).
+
+  ### Alpine.js Patterns
+
+  ```html
+  <!-- Toggle panel visibility -->
+  <div x-data="{ open: false }">
+    <button @click="open = !open">Details</button>
+    <div x-show="open">...</div>
+  </div>
+
+  <!-- Bind to API response -->
+  <div x-data="{ count: 0 }" x-init="fetch('/api/count').then(r=>r.json()).then(d=>count=d)">
+    <span x-text="count"></span>
+  </div>
+  ```
+
+  ### FastAPI Route Pattern
+
+  ```python
+  # agentception/routes/ui.py
+  from fastapi import APIRouter, Request
+  from fastapi.responses import HTMLResponse
+  from agentception.templates import templates  # Jinja2Templates instance
+
+  router = APIRouter()
+
+  @router.get("/", response_class=HTMLResponse)
+  async def overview(request: Request) -> HTMLResponse:
+      state = get_state() or PipelineState.empty()
+      return templates.TemplateResponse("overview.html", {
+          "request": request,
+          "state": state,
+      })
+
+  # HTMX partial (returns fragment, not full page)
+  @router.get("/partials/tree", response_class=HTMLResponse)
+  async def tree_partial(request: Request) -> HTMLResponse:
+      state = get_state() or PipelineState.empty()
+      return templates.TemplateResponse("partials/agent_tree.html", {
+          "request": request,
+          "state": state,
+      })
+  ```
+
+  ### CDN Versions (use these — do not bundle)
+
+  - HTMX: `https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js`
+  - HTMX SSE ext: `https://unpkg.com/htmx-ext-sse@2.2.2/sse.js`
+  - Alpine.js: `https://unpkg.com/alpinejs@3.14.1/dist/cdn.min.js`
+
+  ### CSS Convention
+
+  No CSS framework. Use a single `agentception/static/style.css` with:
+  - CSS custom properties for colors (dark theme: `--bg: #0d1117`, `--fg: #e6edf3`)
+  - Flexbox for layout, CSS Grid for dashboards
+  - Status colors: implementing=`#3b82f6`, reviewing=`#f59e0b`, done=`#22c55e`, stale=`#ef4444`
+
+  ### Quality Standards
+
+  - Templates have no business logic — only conditionals and loops over data passed in.
+  - Every HTMX target has a stable `id`. No anonymous targets.
+  - Partials are tested by requesting them directly with `pytest` + `httpx`.
+  - `hx-indicator` on every non-trivial HTMX request (loading state).
+
+quality_gates:
+  linter: "docker compose exec agentception mypy /app/agentception/"
+  test_runner: "docker compose exec agentception pytest agentception/tests/ -v"

--- a/scripts/gen_prompts/cognitive_archetypes/skill_domains/monaco_editor.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/skill_domains/monaco_editor.yaml
@@ -1,0 +1,134 @@
+# Skill Domain: Monaco Editor
+id: monaco_editor
+display_name: "Monaco Editor (CDN)"
+description: |
+  In-browser code editor (the same engine as VS Code) loaded from CDN.
+  Used for the AgentCeption role studio — live editing of Markdown/YAML files.
+
+prompt_fragment: |
+  ## Skill Domain: Monaco Editor (CDN)
+
+  You are integrating Monaco Editor into a Jinja2/HTMX page. Monaco is loaded
+  from CDN using the AMD loader pattern (required by Monaco's module system).
+
+  ### CDN Load Pattern (AMD — required by Monaco)
+
+  ```html
+  <!-- In the page template (NOT in base.html — Monaco is heavy) -->
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs/loader.js"></script>
+  <script>
+    require.config({ paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs' } });
+    require(['vs/editor/editor.main'], function () {
+      window._editor = monaco.editor.create(document.getElementById('editor-container'), {
+        value: '',
+        language: 'markdown',   // or 'yaml' for cognitive archetype files
+        theme: 'vs-dark',
+        automaticLayout: true,  // REQUIRED — resizes with container
+        minimap: { enabled: false },
+        wordWrap: 'on',
+        scrollBeyondLastLine: false,
+      });
+    });
+  </script>
+  ```
+
+  Use `monaco-editor@0.52.0` — do not use a newer untested version.
+
+  ### Loading File Content into Monaco
+
+  ```javascript
+  // Called when a file is selected in the sidebar
+  async function loadFile(slug) {
+    const res = await fetch(`/api/roles/${slug}`);
+    const data = await res.json();   // {slug, content, language, path}
+    window._editor.setValue(data.content);
+    // Set language based on file extension
+    const lang = data.path.endsWith('.yaml') ? 'yaml' : 'markdown';
+    monaco.editor.setModelLanguage(window._editor.getModel(), lang);
+    document.getElementById('current-file').textContent = data.path;
+  }
+  ```
+
+  ### Saving Back to the Server
+
+  ```javascript
+  async function saveFile(slug) {
+    const content = window._editor.getValue();
+    const res = await fetch(`/api/roles/${slug}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    });
+    if (!res.ok) {
+      document.getElementById('save-status').textContent = '❌ Save failed';
+      return;
+    }
+    document.getElementById('save-status').textContent = '✅ Saved';
+  }
+  ```
+
+  ### Keyboard Shortcut: Cmd+S / Ctrl+S to Save
+
+  ```javascript
+  require(['vs/editor/editor.main'], function () {
+    const editor = monaco.editor.create(...);
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
+      saveFile(currentSlug);
+    });
+  });
+  ```
+
+  ### Layout Pattern
+
+  ```html
+  <div class="roles-layout">
+    <!-- Sidebar: file list (pure HTML, HTMX to load content) -->
+    <aside class="roles-sidebar">
+      {% for role in roles %}
+      <button class="role-item" onclick="loadFile('{{ role.slug }}')">
+        {{ role.name }}
+        <span class="line-count">{{ role.line_count }}L</span>
+      </button>
+      {% endfor %}
+    </aside>
+
+    <!-- Editor: full-height Monaco container -->
+    <div class="editor-area">
+      <div class="editor-toolbar">
+        <span id="current-file" class="breadcrumb">No file loaded</span>
+        <span id="save-status"></span>
+        <button onclick="saveFile(currentSlug)">Save</button>
+      </div>
+      <div id="editor-container" style="height: calc(100vh - 60px);"></div>
+    </div>
+  </div>
+  ```
+
+  ### FastAPI Backend Endpoints
+
+  ```python
+  @router.get("/api/roles/{slug}")
+  async def get_role(slug: str) -> dict:
+      path = resolve_role_path(slug)   # validates slug, no path traversal
+      return {"slug": slug, "content": path.read_text(), "path": str(path)}
+
+  @router.put("/api/roles/{slug}")
+  async def put_role(slug: str, body: RoleWriteRequest) -> dict:
+      path = resolve_role_path(slug)
+      path.write_text(body.content)
+      return {"slug": slug, "saved": True}
+  ```
+
+  Never allow path traversal in `resolve_role_path` — validate against an allowlist
+  of known role file paths.
+
+  ### Quality Standards
+
+  - `automaticLayout: true` is mandatory — Monaco must resize with its container.
+  - Never expose `resolve_role_path` to arbitrary paths. Allowlist only.
+  - Save button is disabled (greyed) when no file is loaded.
+  - Test the PUT endpoint to ensure it round-trips content correctly.
+
+quality_gates:
+  linter: "docker compose exec agentception mypy /app/agentception/"
+  test_runner: "docker compose exec agentception pytest agentception/tests/ -v -k roles"

--- a/scripts/gen_prompts/templates/PARALLEL_ISSUE_TO_PR.md.j2
+++ b/scripts/gen_prompts/templates/PARALLEL_ISSUE_TO_PR.md.j2
@@ -407,7 +407,7 @@ STEP 0 — READ YOUR TASK FILE:
     git restore --staged <file> for staged undo. Broad undo destroys
     unrelated work. When in doubt: commit, then fix forward.
 
-STEP 0.5 — LOAD YOUR ROLE:
+STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
   REPO=$(git worktree list | head -1 | awk '{print $1}')
   ROLE_FILE="$REPO/.cursor/roles/${ROLE}.md"
@@ -417,8 +417,39 @@ STEP 0.5 — LOAD YOUR ROLE:
   else
     echo "⚠️  No role file found for '$ROLE' — proceeding without role context."
   fi
-  # The decision hierarchy, quality bar, and failure modes in that file govern
-  # all your choices from this point forward.
+
+  # Load cognitive architecture — determines your thinking style AND skill domain
+  COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+  if [ -n "$COGNITIVE_ARCH" ]; then
+    echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
+    echo ""
+    echo "This means:"
+    # Parse figure and skill domain (format: figure+skill_domain or archetype+skill_domain)
+    COGARCH_FIGURE=$(echo "$COGNITIVE_ARCH" | cut -d+ -f1)
+    COGARCH_SKILL=$(echo "$COGNITIVE_ARCH" | cut -d+ -f2)
+    # Load figure/archetype YAML for context (informational — you already have the role file)
+    ARCH_FILE="$REPO/scripts/gen_prompts/cognitive_archetypes/figures/${COGARCH_FIGURE}.yaml"
+    if [ ! -f "$ARCH_FILE" ]; then
+      ARCH_FILE="$REPO/scripts/gen_prompts/cognitive_archetypes/archetypes/${COGARCH_FIGURE}.yaml"
+    fi
+    if [ -f "$ARCH_FILE" ]; then
+      # Print display_name and description for self-awareness
+      grep -A3 "^display_name:" "$ARCH_FILE" | head -4
+      grep -A5 "^description:" "$ARCH_FILE" | head -6
+    fi
+    # Load skill domain context
+    SKILL_FILE="$REPO/scripts/gen_prompts/cognitive_archetypes/skill_domains/${COGARCH_SKILL}.yaml"
+    if [ -f "$SKILL_FILE" ]; then
+      echo "--- Skill domain: $COGARCH_SKILL ---"
+      grep -A3 "^display_name:" "$SKILL_FILE" | head -2
+    fi
+    echo ""
+    echo "Let these govern your approach to this task. See TICKET_TAXONOMY.md for rationale."
+  else
+    echo "⚠️  No COGNITIVE_ARCH set — using default pragmatist+python approach."
+  fi
+  # The cognitive architecture, role file, and .agent-task together form
+  # your full operating context. Honor all three.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only

--- a/scripts/gen_prompts/templates/roles/engineering-manager.md.j2
+++ b/scripts/gen_prompts/templates/roles/engineering-manager.md.j2
@@ -70,7 +70,79 @@ SEED:
               -b feat/issue-<N> \
               "$HOME/.cursor/worktrees/{{ repo_name }}/issue-<N>" \
               origin/dev
-       c. Write .agent-task — include BATCH_ID (see Worktree convention below)
+       c. Select the cognitive architecture for this specific issue:
+
+          Read the issue body once and apply heuristics to set COGNITIVE_ARCH.
+          First match wins. This ensures every leaf agent gets the right skill
+          domain and personality for its task — not just a generic Python engineer.
+
+          ```bash
+          ISSUE_BODY="$(gh issue view <N> --repo {{ gh_repo }} --json body -q .body)"
+
+          # --- Skill domain (what tech stack is this issue building?) ---
+          if echo "$ISSUE_BODY" | grep -qiE "monaco|vs/loader|editor.*cdn|cdn.*editor"; then
+            SKILL_DOMAIN="monaco_editor"
+          elif echo "$ISSUE_BODY" | grep -qiE "d3\.js|force-directed|d3\.force|d3\.select"; then
+            SKILL_DOMAIN="d3_js"
+          elif echo "$ISSUE_BODY" | grep -qiE "htmx|hx-|jinja2|\.html|sse-connect|alpine|x-data|hx-ext"; then
+            SKILL_DOMAIN="htmx_jinja2"
+          elif echo "$ISSUE_BODY" | grep -qiE "dockerfile|FROM python|compose.*service|container.*port"; then
+            SKILL_DOMAIN="devops"
+          elif echo "$ISSUE_BODY" | grep -qiE "midi|storpheus|gm.program|tmidix|orpheus"; then
+            SKILL_DOMAIN="audio_midi"
+          elif echo "$ISSUE_BODY" | grep -qiE "llm|embedding|rag|openrouter|claude.*model"; then
+            SKILL_DOMAIN="ml_ai"
+          else
+            SKILL_DOMAIN="python"
+          fi
+
+          # --- Figure/archetype (how should the agent think?) ---
+          if echo "$ISSUE_BODY" | grep -qiE "parse.*body|depends on.*#|DAG|directed.acyclic|formal.*grammar"; then
+            FIGURE="turing"
+          elif echo "$ISSUE_BODY" | grep -qiE "kill|stale.*claim|out-of-order|invariant|correctness.*critical"; then
+            FIGURE="the_guardian"
+          elif echo "$ISSUE_BODY" | grep -qiE "asyncio|SSE|broadcast|subscribe|fanout|information.*flow"; then
+            FIGURE="shannon"
+          elif echo "$ISSUE_BODY" | grep -qiE "readme|explain.*simply|tutorial|document|onboard"; then
+            FIGURE="feynman"
+          elif echo "$ISSUE_BODY" | grep -qiE "dockerfile|FROM |entrypoint|compose.*service"; then
+            FIGURE="ritchie"
+          elif echo "$ISSUE_BODY" | grep -qiE "scaling|advisor|queue.*depth|heuristic.*important"; then
+            FIGURE="hamming"
+          elif echo "$ISSUE_BODY" | grep -qiE "wave|aggregate|batch_id|synthesize|cross.*domain"; then
+            FIGURE="von_neumann"
+          elif echo "$ISSUE_BODY" | grep -qiE "schema|load-bearing|interface.*design|config.*schema|api.*contract"; then
+            FIGURE="the_architect"
+          elif echo "$ISSUE_BODY" | grep -qiE "visualization|force.*directed|D3|beautiful.*graph|render.*graph"; then
+            FIGURE="lovelace"
+          elif echo "$ISSUE_BODY" | grep -qiE "manual.*spawn|tool.*for|direct.*control|bypass.*loop"; then
+            FIGURE="hopper"
+          elif echo "$ISSUE_BODY" | grep -qiE "classify|ticket.*analyze|natural.*language.*parse|formal.*model"; then
+            FIGURE="mccarthy"
+          elif echo "$ISSUE_BODY" | grep -qiE "A/B|variant|experiment|alternate.*role"; then
+            FIGURE="hopper"
+          elif echo "$ISSUE_BODY" | grep -qiE "inspector|transcript.*viewer|detail.*page|make.*visible"; then
+            FIGURE="feynman"
+          elif echo "$ISSUE_BODY" | grep -qiE "overview.*page|live.*tree|pipeline.*dashboard|meta.*view"; then
+            FIGURE="lovelace"
+          elif echo "$ISSUE_BODY" | grep -qiE "recommendation|comparison.*table|teach|mentor.*style"; then
+            FIGURE="the_mentor"
+          elif echo "$ISSUE_BODY" | grep -qiE "pause|resume|sentinel|operational|keep.*running"; then
+            FIGURE="the_operator"
+          elif echo "$ISSUE_BODY" | grep -qiE "diff|version.*track|atomic.*write|history"; then
+            FIGURE="dijkstra"
+          else
+            FIGURE="the_pragmatist"
+          fi
+
+          COGNITIVE_ARCH="${FIGURE}+${SKILL_DOMAIN}"
+          echo "Selected cognitive architecture: $COGNITIVE_ARCH"
+          ```
+
+          See scripts/gen_prompts/TICKET_TAXONOMY.md for the full rationale behind
+          each mapping. The taxonomy also serves as a reference for adding new issues.
+
+       d. Write .agent-task — include BATCH_ID and COGNITIVE_ARCH (see Worktree convention below)
 
   6. Launch all 4 as leaf agents simultaneously — one Task call per issue,
      all in a single message:
@@ -112,9 +184,12 @@ BASE=dev
 GH_REPO={{ gh_repo }}
 CLOSES_ISSUES=<N>
 BATCH_ID=<BATCH_ID>
+COGNITIVE_ARCH=<COGNITIVE_ARCH from step 5c above, e.g. "feynman+htmx_jinja2">
 ```
 
 `ISSUE_LABEL` is the primary scoping label (e.g. `{{ active_label_prefix }}0-scaffold`). Leaf agents use it to route mypy and tests to the correct codebase container — never cross-run {{ active_name }} checks on maestro or vice versa.
+
+`COGNITIVE_ARCH` is the selected cognitive architecture for this specific issue (figure+skill_domain or archetype+skill_domain). Leaf agents display it in their opening message and let it guide their approach. See `scripts/gen_prompts/TICKET_TAXONOMY.md` for the full taxonomy and rationale.
 
 If a worktree is missing: `git -C "$HOME/dev/tellurstori/{{ repo_name }}" worktree add -b feat/issue-{N} "$HOME/.cursor/worktrees/{{ repo_name }}/issue-{N}" origin/dev`
 


### PR DESCRIPTION
## Summary

- **3 new skill domains** covering the actual tech stack of AgentCeption tickets:
  - `htmx_jinja2` — HTMX + Jinja2 + Alpine.js (needed by 13 of 29 tickets, 45%)
  - `d3_js` — D3 force-directed graph (DAG visualization, #629)
  - `monaco_editor` — Monaco editor via CDN (role studio, #624)
  
- **`TICKET_TAXONOMY.md`** — maps all 29 open issues to optimal `COGNITIVE_ARCH` with rationale. Key finding: before this, every HTMX/UI ticket was dispatched as a generic Python engineer with no template/HTMX context.

- **Engineering manager now auto-selects `COGNITIVE_ARCH`** per issue by running keyword heuristics on the issue body — detects tech stack (monaco? d3? htmx? devops?) then selects figure/archetype (turing for DAG parsers, dijkstra for correctness-critical, lovelace for visualizations, feynman for inspectors/docs, etc.)

- **Leaf agents read + announce their architecture** at startup (Step 0.5 in PARALLEL_ISSUE_TO_PR), loading the figure YAML for self-context.

## Test plan

- [ ] Engineering manager dispatches issue #615 (overview UI) → `COGNITIVE_ARCH=lovelace+htmx_jinja2`
- [ ] Engineering manager dispatches issue #617 (kill endpoint) → `COGNITIVE_ARCH=the_guardian+python`
- [ ] Engineering manager dispatches issue #629 (D3 DAG) → `COGNITIVE_ARCH=lovelace+d3_js`
- [ ] Leaf agent reads COGNITIVE_ARCH from .agent-task and announces it in opening message