### PR TITLE
fix: move all agentception tests to agentception/tests/ — closes #656

### DIFF
--- a/agentception/tests/conftest.py
+++ b/agentception/tests/conftest.py
@@ -1,0 +1,10 @@
+"""conftest.py for agentception tests.
+
+Deliberately minimal — no maestro imports, no Postgres, no Qdrant, no Redis.
+AgentCeption is a standalone service; its tests must run cleanly in the
+`agentception` Docker container without any maestro infrastructure.
+
+Run the full agentception suite:
+    docker compose exec agentception pytest agentception/tests/ -v
+"""
+from __future__ import annotations

--- a/agentception/tests/test_agentception_github.py
+++ b/agentception/tests/test_agentception_github.py
@@ -6,7 +6,7 @@ interface is thin (``asyncio.create_subprocess_exec``), so patching it at the
 module level gives complete control over return values and exit codes.
 
 Run targeted:
-    pytest tests/test_agentception_github.py -v
+    pytest agentception/tests/test_agentception_github.py -v
 """
 from __future__ import annotations
 

--- a/agentception/tests/test_agentception_poller.py
+++ b/agentception/tests/test_agentception_poller.py
@@ -8,7 +8,7 @@ Coverage:
 - polling_loop() advances state on each iteration (mock sleep)
 
 Run targeted:
-    pytest tests/test_agentception_poller.py -v
+    pytest agentception/tests/test_agentception_poller.py -v
 """
 from __future__ import annotations
 

--- a/agentception/tests/test_agentception_scaffold.py
+++ b/agentception/tests/test_agentception_scaffold.py
@@ -4,7 +4,7 @@ These tests verify the foundational service plumbing — settings, models, and
 the FastAPI app itself — before any reader or poller logic is wired in.
 
 Run targeted:
-    pytest tests/test_agentception_scaffold.py -v
+    pytest agentception/tests/test_agentception_scaffold.py -v
 """
 from __future__ import annotations
 

--- a/agentception/tests/test_agentception_transcripts.py
+++ b/agentception/tests/test_agentception_transcripts.py
@@ -4,7 +4,7 @@ Covers JSONL parsing, role/status heuristics, and AgentNode tree construction.
 All tests use temporary directories — no dependency on live ~/.cursor/projects/.
 
 Run targeted:
-    pytest tests/test_agentception_transcripts.py -v
+    pytest agentception/tests/test_agentception_transcripts.py -v
 """
 from __future__ import annotations
 

--- a/agentception/tests/test_agentception_worktrees.py
+++ b/agentception/tests/test_agentception_worktrees.py
@@ -4,7 +4,7 @@ Verifies that the worktree reader correctly discovers active agent worktrees
 and parses their .agent-task files into TaskFile models.
 
 Run targeted:
-    pytest tests/test_agentception_worktrees.py -v
+    pytest agentception/tests/test_agentception_worktrees.py -v
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Problem (closes #656)

All 5 `test_agentception_*.py` files lived in the maestro `tests/` directory. They import from `agentception.*` which the maestro container doesn't have — they would fail at import in CI. They also require `pytest-asyncio`/`anyio` variants not present in the maestro container.

## Fix

- **Move** all 5 files: `tests/test_agentception_*.py` → `agentception/tests/test_agentception_*.py`
- **Add** `agentception/tests/conftest.py` — deliberately minimal, no maestro imports, no infrastructure fixtures
- **Update** `"Run targeted:"` docstrings to the correct path

## Verified

```
docker compose exec agentception pytest agentception/tests/ -v
73 passed in 0.31s

docker compose exec agentception mypy /app/agentception/
Success: no issues found in 17 source files
```

## Going Forward

All agentception tests live in `agentception/tests/`. The correct command to run them is always:
```bash
docker compose exec agentception pytest agentception/tests/ -v
```
Never run agentception tests in the maestro container.