### PR TITLE
feat: agent inspector UI — transcript viewer and .agent-task display (AC-007)

### DIFF
--- a/agentception/routes/api.py
+++ b/agentception/routes/api.py
@@ -6,10 +6,14 @@ can choose their preferred serialisation format.
 """
 from __future__ import annotations
 
-from fastapi import APIRouter
+from pathlib import Path
 
-from agentception.models import PipelineState
+from fastapi import APIRouter, HTTPException
+
+from agentception.models import AgentNode, PipelineState
 from agentception.poller import get_state
+from agentception.readers.transcripts import read_transcript_messages
+from agentception.routes.ui import _find_agent
 
 router = APIRouter(prefix="/api", tags=["api"])
 
@@ -23,3 +27,45 @@ async def pipeline_api() -> PipelineState:
     not as "no agents exist".
     """
     return get_state() or PipelineState.empty()
+
+
+@router.get("/agents")
+async def agents_api() -> list[AgentNode]:
+    """Return the flat list of root-level AgentNodes from the current pipeline state.
+
+    Children are embedded inside each AgentNode's ``children`` field.
+    Returns an empty list before the first polling tick completes.
+    """
+    state = get_state() or PipelineState.empty()
+    return state.agents
+
+
+@router.get("/agents/{agent_id}")
+async def agent_api(agent_id: str) -> AgentNode:
+    """Return a single AgentNode by ID from the current pipeline state.
+
+    Searches root agents and their children (one level deep). Raises HTTP 404
+    when the agent ID is not found in the current state.
+    """
+    state = get_state()
+    node = _find_agent(state, agent_id)
+    if node is None:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
+    return node
+
+
+@router.get("/agents/{agent_id}/transcript")
+async def transcript_api(agent_id: str) -> list[dict[str, str]]:
+    """Return the parsed transcript messages for a given agent.
+
+    Each element is ``{"role": "user"|"assistant", "text": "..."}``.
+    Returns an empty list when the agent has no transcript file.
+    Raises HTTP 404 when the agent ID is not found in the current state.
+    """
+    state = get_state()
+    node = _find_agent(state, agent_id)
+    if node is None:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
+    if not node.transcript_path:
+        return []
+    return await read_transcript_messages(Path(node.transcript_path))

--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -11,14 +11,34 @@ from fastapi import APIRouter
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
+from starlette.responses import Response
 
-from agentception.models import PipelineState
+from agentception.models import AgentNode, PipelineState
 from agentception.poller import get_state
+from agentception.readers.transcripts import read_transcript_messages
 
 _HERE = Path(__file__).parent
 _TEMPLATES = Jinja2Templates(directory=str(_HERE.parent / "templates"))
 
 router = APIRouter(tags=["ui"])
+
+
+def _find_agent(state: PipelineState | None, agent_id: str) -> AgentNode | None:
+    """Search the agent tree for an AgentNode matching ``agent_id``.
+
+    Searches root agents first, then their children (one level deep, matching
+    the current tree depth supported by the poller). Returns ``None`` when the
+    state is empty or the ID is not found.
+    """
+    if state is None:
+        return None
+    for agent in state.agents:
+        if agent.id == agent_id:
+            return agent
+        for child in agent.children:
+            if child.id == agent_id:
+                return child
+    return None
 
 
 @router.get("/", response_class=HTMLResponse)
@@ -30,3 +50,30 @@ async def overview(request: Request) -> HTMLResponse:
     """
     state = get_state() or PipelineState.empty()
     return _TEMPLATES.TemplateResponse(request, "overview.html", {"state": state})
+
+
+@router.get("/agents/{agent_id}", response_class=HTMLResponse)
+async def agent_detail(request: Request, agent_id: str) -> Response:
+    """Agent detail page — transcript viewer and .agent-task fields.
+
+    Renders the full conversation transcript (user/assistant messages),
+    parsed .agent-task key/value table, and quick-action buttons.
+    Returns HTTP 404 when the agent ID is not in the current pipeline state.
+    """
+    state = get_state()
+    node = _find_agent(state, agent_id)
+    if node is None:
+        return _TEMPLATES.TemplateResponse(
+            request,
+            "agent.html",
+            {"node": None, "agent_id": agent_id, "messages": []},
+            status_code=404,
+        )
+    messages: list[dict[str, str]] = []
+    if node.transcript_path:
+        messages = await read_transcript_messages(Path(node.transcript_path))
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "agent.html",
+        {"node": node, "agent_id": agent_id, "messages": messages},
+    )

--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -340,3 +340,285 @@ main {
   border-radius: 0 4px 4px 0;
   margin-bottom: 0.25rem;
 }
+
+/* ── Breadcrumb ── */
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+
+.breadcrumb a {
+  color: var(--accent);
+}
+
+.breadcrumb a:hover {
+  color: var(--accent-hover);
+}
+
+.breadcrumb-sep {
+  color: var(--border);
+}
+
+.breadcrumb-current {
+  color: var(--text-primary);
+}
+
+/* ── Agent detail header ── */
+
+.agent-detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.agent-detail-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.agent-detail-role {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.agent-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.1875rem 0.5rem;
+  font-size: 0.75rem;
+}
+
+.meta-label {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.6875rem;
+}
+
+.meta-value {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.meta-value a {
+  color: var(--accent);
+}
+
+/* ── Quick actions ── */
+
+.quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.btn:hover:not(:disabled) {
+  text-decoration: none;
+}
+
+.btn-secondary {
+  background: var(--bg-tertiary);
+  border-color: var(--border);
+  color: var(--text-primary);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.btn-danger {
+  background: rgba(248, 81, 73, 0.12);
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: var(--danger);
+  color: #fff;
+}
+
+/* ── Agent detail two-column layout ── */
+
+.agent-detail-columns {
+  display: grid;
+  grid-template-columns: 40fr 60fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .agent-detail-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── .agent-task table ── */
+
+.agent-task-panel {
+  position: sticky;
+  top: 1rem;
+}
+
+.task-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.task-table tr + tr {
+  border-top: 1px solid var(--border);
+}
+
+.task-key {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding: 0.4375rem 0.5rem 0.4375rem 0;
+  vertical-align: top;
+  width: 38%;
+  white-space: nowrap;
+}
+
+.task-value {
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  padding: 0.4375rem 0;
+  vertical-align: top;
+  word-break: break-word;
+}
+
+.task-value--path code {
+  font-size: 0.6875rem;
+  word-break: break-all;
+}
+
+/* ── Transcript ── */
+
+.transcript-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 70vh;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.message {
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.message--user {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+}
+
+.message--assistant {
+  background: rgba(124, 58, 237, 0.1);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+}
+
+.message-role {
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.message--user .message-role {
+  color: var(--text-muted);
+  background: var(--bg-tertiary);
+}
+
+.message--assistant .message-role {
+  color: var(--accent-hover);
+  background: rgba(124, 58, 237, 0.15);
+}
+
+.message-body {
+  cursor: pointer;
+  padding: 0.5rem 0.75rem 0;
+}
+
+.message-body--collapsed {
+  max-height: 5rem;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+  mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+}
+
+.message-body--expanded {
+  max-height: none;
+}
+
+.message-text {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, sans-serif;
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
+
+.message-expand-btn {
+  display: block;
+  width: 100%;
+  text-align: center;
+  background: none;
+  border: none;
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  padding: 0.25rem;
+  cursor: pointer;
+  margin-top: 0.25rem;
+  transition: color 0.15s;
+}
+
+.message-expand-btn:hover {
+  color: var(--accent-hover);
+}

--- a/agentception/templates/agent.html
+++ b/agentception/templates/agent.html
@@ -1,0 +1,214 @@
+{% extends "base.html" %}
+
+{% block title %}
+  {% if node %}AgentCeption — {{ node.role }} ({{ node.id[:8] }}){% else %}AgentCeption — Agent Not Found{% endif %}
+{% endblock %}
+
+{% block content %}
+
+{# ── Breadcrumb ─────────────────────────────────────────────────────────── #}
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">← Overview</a>
+  <span class="breadcrumb-sep">/</span>
+  <span class="breadcrumb-current">
+    {% if node %}{{ node.role }}{% else %}Not Found{% endif %}
+  </span>
+</nav>
+
+{% if not node %}
+{# ── 404 state ──────────────────────────────────────────────────────────── #}
+<div class="card mt-2">
+  <p class="text-danger">Agent <code>{{ agent_id }}</code> not found in the current pipeline state.</p>
+  <p class="text-muted mt-1">The agent may have completed and removed its worktree, or the ID is invalid.</p>
+</div>
+
+{% else %}
+{# ── Agent header ────────────────────────────────────────────────────────── #}
+<div class="agent-detail-header card">
+  <div class="agent-detail-title">
+    <span class="status-badge status-badge--{{ node.status.value }}" aria-label="Status">{{ node.status.value }}</span>
+    <h1 class="agent-detail-role">{{ node.role }}</h1>
+  </div>
+
+  <div class="agent-detail-meta">
+    {% if node.batch_id %}
+      <span class="meta-chip">
+        <span class="meta-label">Batch</span>
+        <code class="meta-value">{{ node.batch_id }}</code>
+      </span>
+    {% endif %}
+    {% if node.issue_number %}
+      <span class="meta-chip">
+        <span class="meta-label">Issue</span>
+        <a href="https://github.com/cgcardona/maestro/issues/{{ node.issue_number }}"
+           target="_blank" rel="noopener" class="meta-value">#{{ node.issue_number }}</a>
+      </span>
+    {% endif %}
+    {% if node.pr_number %}
+      <span class="meta-chip">
+        <span class="meta-label">PR</span>
+        <a href="https://github.com/cgcardona/maestro/pull/{{ node.pr_number }}"
+           target="_blank" rel="noopener" class="meta-value">#{{ node.pr_number }}</a>
+      </span>
+    {% endif %}
+    {% if node.branch %}
+      <span class="meta-chip">
+        <span class="meta-label">Branch</span>
+        <code class="meta-value">{{ node.branch }}</code>
+      </span>
+    {% endif %}
+    <span class="meta-chip">
+      <span class="meta-label">Messages</span>
+      <span class="meta-value">{{ node.message_count }}</span>
+    </span>
+  </div>
+
+  {# ── Quick actions ──────────────────────────────────────────────────────── #}
+  <div class="quick-actions">
+    {% if node.issue_number %}
+      <a href="https://github.com/cgcardona/maestro/issues/{{ node.issue_number }}"
+         target="_blank" rel="noopener" class="btn btn-secondary">
+        View Issue on GitHub ↗
+      </a>
+    {% endif %}
+    {% if node.pr_number %}
+      <a href="https://github.com/cgcardona/maestro/pull/{{ node.pr_number }}"
+         target="_blank" rel="noopener" class="btn btn-secondary">
+        View PR on GitHub ↗
+      </a>
+    {% endif %}
+    <button class="btn btn-danger" disabled title="Kill is a Phase 1 feature — not yet available">
+      Kill Agent (Phase 1)
+    </button>
+  </div>
+</div>
+
+{# ── Two-column body ─────────────────────────────────────────────────────── #}
+<div class="agent-detail-columns mt-2">
+
+  {# ── Left: .agent-task table (40%) ──────────────────────────────────────── #}
+  <section class="agent-task-panel" aria-label="Agent task fields">
+    <h2 class="section-title">.agent-task</h2>
+    <div class="card">
+      <table class="task-table">
+        <tbody>
+          <tr>
+            <td class="task-key">id</td>
+            <td class="task-value"><code>{{ node.id }}</code></td>
+          </tr>
+          <tr>
+            <td class="task-key">role</td>
+            <td class="task-value">{{ node.role }}</td>
+          </tr>
+          <tr>
+            <td class="task-key">status</td>
+            <td class="task-value">
+              <span class="status-badge status-badge--{{ node.status.value }}">{{ node.status.value }}</span>
+            </td>
+          </tr>
+          {% if node.issue_number %}
+          <tr>
+            <td class="task-key">issue_number</td>
+            <td class="task-value">
+              <a href="https://github.com/cgcardona/maestro/issues/{{ node.issue_number }}"
+                 target="_blank" rel="noopener">#{{ node.issue_number }}</a>
+            </td>
+          </tr>
+          {% endif %}
+          {% if node.pr_number %}
+          <tr>
+            <td class="task-key">pr_number</td>
+            <td class="task-value">
+              <a href="https://github.com/cgcardona/maestro/pull/{{ node.pr_number }}"
+                 target="_blank" rel="noopener">#{{ node.pr_number }}</a>
+            </td>
+          </tr>
+          {% endif %}
+          {% if node.branch %}
+          <tr>
+            <td class="task-key">branch</td>
+            <td class="task-value"><code>{{ node.branch }}</code></td>
+          </tr>
+          {% endif %}
+          {% if node.batch_id %}
+          <tr>
+            <td class="task-key">batch_id</td>
+            <td class="task-value"><code>{{ node.batch_id }}</code></td>
+          </tr>
+          {% endif %}
+          {% if node.worktree_path %}
+          <tr>
+            <td class="task-key">worktree_path</td>
+            <td class="task-value task-value--path"><code>{{ node.worktree_path }}</code></td>
+          </tr>
+          {% endif %}
+          {% if node.transcript_path %}
+          <tr>
+            <td class="task-key">transcript_path</td>
+            <td class="task-value task-value--path"><code>{{ node.transcript_path }}</code></td>
+          </tr>
+          {% endif %}
+          <tr>
+            <td class="task-key">message_count</td>
+            <td class="task-value">{{ node.message_count }}</td>
+          </tr>
+          <tr>
+            <td class="task-key">children</td>
+            <td class="task-value">{{ node.children | length }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  {# ── Right: Transcript (60%) ─────────────────────────────────────────────── #}
+  <section class="transcript-panel" aria-label="Agent transcript">
+    <h2 class="section-title">Transcript ({{ messages | length }} messages)</h2>
+
+    {% if messages %}
+    <div class="transcript-container" id="transcript">
+      {% for msg in messages %}
+      <div
+        class="message message--{{ msg.role }}"
+        x-data="{ expanded: false }"
+      >
+        <div class="message-role">{{ msg.role }}</div>
+        <div
+          class="message-body"
+          :class="expanded ? 'message-body--expanded' : 'message-body--collapsed'"
+          @click="expanded = !expanded"
+        >
+          <pre class="message-text">{{ msg.text | truncate(400, True, '…') }}</pre>
+        </div>
+        <button
+          class="message-expand-btn"
+          @click.stop="expanded = !expanded"
+          aria-label="Toggle full message"
+          x-text="expanded ? '▲ Collapse' : '▼ Expand'"
+        ></button>
+      </div>
+      {% endfor %}
+    </div>
+
+    <script>
+    // Auto-scroll to the last message on page load so users see the most recent activity.
+    document.addEventListener('DOMContentLoaded', function () {
+      const container = document.getElementById('transcript');
+      if (container) {
+        const last = container.lastElementChild;
+        if (last) last.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    });
+    </script>
+
+    {% else %}
+    <div class="card">
+      <p class="text-muted empty-state">No transcript available for this agent.</p>
+    </div>
+    {% endif %}
+  </section>
+
+</div>{# .agent-detail-columns #}
+{% endif %}{# node #}
+
+{% endblock %}

--- a/agentception/tests/test_agentception_ui_agent.py
+++ b/agentception/tests/test_agentception_ui_agent.py
@@ -1,0 +1,320 @@
+"""Tests for the AgentCeption agent detail UI and API endpoints (AC-007).
+
+Covers:
+- ``GET /agents/{id}`` — HTML agent detail page
+- ``GET /api/agents`` — list of root-level AgentNodes
+- ``GET /api/agents/{id}`` — single AgentNode by ID
+- ``GET /api/agents/{id}/transcript`` — parsed transcript messages
+
+All tests are synchronous with mocked state — no live GitHub calls, no
+background polling, no filesystem reads.
+
+Run targeted:
+    docker compose exec agentception pytest agentception/tests/test_agentception_ui_agent.py -v
+"""
+from __future__ import annotations
+
+import time
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+from agentception.models import AgentNode, AgentStatus, PipelineState
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    """Synchronous test client with lifespan (poller started then immediately cancelled)."""
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def agent_node() -> AgentNode:
+    """A single AgentNode with known transcript path for testing."""
+    return AgentNode(
+        id="issue-616",
+        role="python-developer",
+        status=AgentStatus.IMPLEMENTING,
+        issue_number=616,
+        branch="feat/issue-616-agent-inspector-ui",
+        batch_id="eng-20260302T013317Z-4e62",
+        worktree_path="/worktrees/issue-616",
+        transcript_path="/tmp/fake-transcript.jsonl",
+        message_count=3,
+    )
+
+
+@pytest.fixture()
+def pipeline_with_agent(agent_node: AgentNode) -> PipelineState:
+    """PipelineState with one root agent and one child agent."""
+    child = AgentNode(
+        id="child-abc",
+        role="pr-reviewer",
+        status=AgentStatus.REVIEWING,
+        message_count=1,
+        transcript_path=None,
+    )
+    parent = AgentNode(
+        id="issue-616",
+        role="python-developer",
+        status=AgentStatus.IMPLEMENTING,
+        issue_number=616,
+        message_count=3,
+        transcript_path="/tmp/fake-616.jsonl",
+        children=[child],
+    )
+    return PipelineState(
+        active_label="agentception/0-scaffold",
+        issues_open=1,
+        prs_open=0,
+        agents=[parent],
+        alerts=[],
+        polled_at=time.time(),
+    )
+
+
+# ── GET /agents/{id} — HTML detail page ───────────────────────────────────────
+
+
+def test_agent_detail_404_unknown_id(client: TestClient) -> None:
+    """GET /agents/<unknown> must return HTTP 404 when the agent ID is not in state."""
+    state = PipelineState(
+        active_label=None,
+        issues_open=0,
+        prs_open=0,
+        agents=[],
+        alerts=[],
+        polled_at=time.time(),
+    )
+    with patch("agentception.routes.ui.get_state", return_value=state):
+        response = client.get("/agents/does-not-exist")
+    assert response.status_code == 404
+    assert "does-not-exist" in response.text
+
+
+def test_agent_detail_renders_transcript(
+    client: TestClient, pipeline_with_agent: PipelineState
+) -> None:
+    """GET /agents/<id> must render HTTP 200 with transcript for a known agent ID."""
+    fake_messages = [
+        {"role": "user", "text": "Implement issue 616 now."},
+        {"role": "assistant", "text": "On it. Reading the issue..."},
+    ]
+    with (
+        patch("agentception.routes.ui.get_state", return_value=pipeline_with_agent),
+        patch(
+            "agentception.routes.ui.read_transcript_messages",
+            new_callable=AsyncMock,
+            return_value=fake_messages,
+        ),
+    ):
+        response = client.get("/agents/issue-616")
+    assert response.status_code == 200
+    assert "python-developer" in response.text
+    assert "Implement issue 616 now." in response.text
+    assert "On it. Reading the issue" in response.text
+
+
+def test_agent_detail_renders_child_agent(
+    client: TestClient, pipeline_with_agent: PipelineState
+) -> None:
+    """GET /agents/<child-id> must resolve child agents one level deep."""
+    with (
+        patch("agentception.routes.ui.get_state", return_value=pipeline_with_agent),
+        patch(
+            "agentception.routes.ui.read_transcript_messages",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        response = client.get("/agents/child-abc")
+    assert response.status_code == 200
+    assert "pr-reviewer" in response.text
+
+
+def test_agent_detail_no_transcript_path(client: TestClient) -> None:
+    """GET /agents/<id> must render 200 and show empty transcript when transcript_path is None."""
+    node = AgentNode(
+        id="no-transcript",
+        role="unknown",
+        status=AgentStatus.UNKNOWN,
+        transcript_path=None,
+        message_count=0,
+    )
+    state = PipelineState(
+        active_label=None,
+        issues_open=0,
+        prs_open=0,
+        agents=[node],
+        alerts=[],
+        polled_at=time.time(),
+    )
+    with patch("agentception.routes.ui.get_state", return_value=state):
+        response = client.get("/agents/no-transcript")
+    assert response.status_code == 200
+    assert "No transcript available" in response.text
+
+
+def test_agent_detail_contains_task_table(
+    client: TestClient, pipeline_with_agent: PipelineState
+) -> None:
+    """GET /agents/<id> HTML must include the .agent-task key/value table."""
+    with (
+        patch("agentception.routes.ui.get_state", return_value=pipeline_with_agent),
+        patch(
+            "agentception.routes.ui.read_transcript_messages",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        response = client.get("/agents/issue-616")
+    assert response.status_code == 200
+    assert "task-table" in response.text
+    assert "agent-task" in response.text
+
+
+def test_agent_detail_contains_breadcrumb(
+    client: TestClient, pipeline_with_agent: PipelineState
+) -> None:
+    """GET /agents/<id> HTML must include a breadcrumb link back to overview."""
+    with (
+        patch("agentception.routes.ui.get_state", return_value=pipeline_with_agent),
+        patch(
+            "agentception.routes.ui.read_transcript_messages",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        response = client.get("/agents/issue-616")
+    assert response.status_code == 200
+    assert "← Overview" in response.text
+    assert 'href="/"' in response.text
+
+
+# ── GET /api/agents — list endpoint ───────────────────────────────────────────
+
+
+def test_agents_list_api_returns_array(
+    client: TestClient, pipeline_with_agent: PipelineState
+) -> None:
+    """GET /api/agents must return a JSON array of AgentNodes."""
+    with patch("agentception.routes.api.get_state", return_value=pipeline_with_agent):
+        response = client.get("/api/agents")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    assert data[0]["id"] == "issue-616"
+    assert data[0]["role"] == "python-developer"
+
+
+def test_agents_list_api_empty_state(client: TestClient) -> None:
+    """GET /api/agents must return an empty array when no agents are active."""
+    with patch("agentception.routes.api.get_state", return_value=None):
+        response = client.get("/api/agents")
+    assert response.status_code == 200
+    data = response.json()
+    assert data == []
+
+
+# ── GET /api/agents/{id} — single agent ───────────────────────────────────────
+
+
+def test_agent_api_returns_node(
+    client: TestClient, pipeline_with_agent: PipelineState
+) -> None:
+    """GET /api/agents/<id> must return the matching AgentNode as JSON."""
+    with patch("agentception.routes.api.get_state", return_value=pipeline_with_agent):
+        response = client.get("/api/agents/issue-616")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == "issue-616"
+    assert data["status"] == "implementing"
+
+
+def test_agent_api_404_unknown(client: TestClient) -> None:
+    """GET /api/agents/<unknown> must return HTTP 404."""
+    state = PipelineState(
+        active_label=None,
+        issues_open=0,
+        prs_open=0,
+        agents=[],
+        alerts=[],
+        polled_at=time.time(),
+    )
+    with patch("agentception.routes.api.get_state", return_value=state):
+        response = client.get("/api/agents/not-real")
+    assert response.status_code == 404
+
+
+# ── GET /api/agents/{id}/transcript — transcript endpoint ─────────────────────
+
+
+def test_transcript_api_returns_list(
+    client: TestClient, pipeline_with_agent: PipelineState
+) -> None:
+    """GET /api/agents/<id>/transcript must return a JSON list of message dicts."""
+    fake_messages = [
+        {"role": "user", "text": "Start implementing."},
+        {"role": "assistant", "text": "Starting now."},
+    ]
+    with (
+        patch("agentception.routes.api.get_state", return_value=pipeline_with_agent),
+        patch(
+            "agentception.routes.api.read_transcript_messages",
+            new_callable=AsyncMock,
+            return_value=fake_messages,
+        ),
+    ):
+        response = client.get("/api/agents/issue-616/transcript")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]["role"] == "user"
+    assert data[1]["role"] == "assistant"
+
+
+def test_transcript_api_404_unknown(client: TestClient) -> None:
+    """GET /api/agents/<unknown>/transcript must return HTTP 404."""
+    state = PipelineState(
+        active_label=None,
+        issues_open=0,
+        prs_open=0,
+        agents=[],
+        alerts=[],
+        polled_at=time.time(),
+    )
+    with patch("agentception.routes.api.get_state", return_value=state):
+        response = client.get("/api/agents/ghost/transcript")
+    assert response.status_code == 404
+
+
+def test_transcript_api_empty_when_no_path(
+    client: TestClient,
+) -> None:
+    """GET /api/agents/<id>/transcript must return [] when the agent has no transcript_path."""
+    node = AgentNode(
+        id="notranscript",
+        role="unknown",
+        status=AgentStatus.UNKNOWN,
+        transcript_path=None,
+        message_count=0,
+    )
+    state = PipelineState(
+        active_label=None,
+        issues_open=0,
+        prs_open=0,
+        agents=[node],
+        alerts=[],
+        polled_at=time.time(),
+    )
+    with patch("agentception.routes.api.get_state", return_value=state):
+        response = client.get("/api/agents/notranscript/transcript")
+    assert response.status_code == 200
+    assert response.json() == []


### PR DESCRIPTION
## Summary
Closes #616 — implements the agent detail page (`GET /agents/{id}`) with transcript viewer, .agent-task fields table, and three new JSON API endpoints.

## Root Cause / Motivation
The AgentCeption dashboard had no way to inspect individual agents. Clicking an agent in the overview tree led to a dead URL. Phase 0 required a detail view showing the full conversation transcript and task metadata so operators can understand what each agent is doing.

## Solution
Added `GET /agents/{agent_id}` HTML route that renders `agent.html` — a two-column layout with the .agent-task key/value table (40%) and the full transcript conversation view (60%). Unknown IDs return HTTP 404.

Three new JSON API endpoints added to `routes/api.py`:
- `GET /api/agents` — list all root AgentNodes
- `GET /api/agents/{id}` — single node by ID (404 on miss)
- `GET /api/agents/{id}/transcript` — parsed `{role, text}` messages (404 on miss)

The `_find_agent` helper in `routes/ui.py` searches root agents and their children (one level deep, matching current poller depth). Imported by both ui.py and api.py to avoid duplication.

Template features:
- Breadcrumb ← Overview link
- Role badge, status badge (correct `.value` rendering), batch ID, issue/PR GitHub links
- Status-keyed CSS classes (`status-badge--implementing`, etc.)
- Transcript messages: user=grey, assistant=purple accent; click-to-expand via Alpine.js
- Auto-scroll to last message on DOMContentLoaded
- Quick actions: View on GitHub (issue + PR), Kill Agent (disabled — Phase 1 stub)

## Verification
- [x] mypy clean (21 source files, 0 errors)
- [x] 13 new tests pass, 10 existing overview tests pass (zero regressions)
- [x] No new dependencies introduced

---
<!-- maestro-fingerprint
role: python-developer
batch: eng-20260302T013317Z-4e62
session: eng-20260302T013428Z-6e6e
issue: 616
timestamp: 2026-03-02T01:39:29Z
-->
> 🤖 *Opened by Maestro pipeline — batch `eng-20260302T013317Z-4e62`, session `eng-20260302T013428Z-6e6e`*