### PR TITLE
feat: kill endpoint — remove worktree + clear agent:wip label (AC-101)

### DIFF
--- a/agentception/app.py
+++ b/agentception/app.py
@@ -27,6 +27,7 @@ from starlette.requests import Request
 
 from agentception.poller import polling_loop, subscribe, unsubscribe
 from agentception.routes.api import router as api_router
+from agentception.routes.control import router as control_router
 from agentception.routes.ui import router as ui_router
 
 logger = logging.getLogger(__name__)
@@ -60,9 +61,10 @@ app = FastAPI(
 # Mount static assets — CSS, future JS bundles.
 app.mount("/static", StaticFiles(directory=str(_HERE / "static")), name="static")
 
-# Register UI and API routers — each owns their own path prefix.
+# Register UI, API, and control-plane routers — each owns their own path prefix.
 app.include_router(ui_router)
 app.include_router(api_router)
+app.include_router(control_router)
 
 
 @app.get("/health", tags=["health"])

--- a/agentception/routes/control.py
+++ b/agentception/routes/control.py
@@ -1,0 +1,122 @@
+"""Control-plane routes for the AgentCeption dashboard.
+
+These endpoints perform destructive agent operations (kill, future: pause/spawn).
+Each operation is idempotent: calling it on a slug that no longer exists returns
+404 rather than erroring, so UI retries are safe.
+
+Why a separate router?
+- Destructive operations need clear separation from the read-only API and UI
+  routers so they can be reviewed, rate-limited, or gated independently.
+- Prefix ``/api/control`` signals to callers that these are write operations,
+  not reads.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+
+from agentception.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/control", tags=["control"])
+
+
+def _parse_issue_number(worktree: Path) -> int | None:
+    """Read .agent-task in ``worktree`` and return the ISSUE_NUMBER value, or None.
+
+    Parses only KEY=value lines — never evaluates them. Returns ``None`` when
+    the file is absent, unreadable, or contains no ISSUE_NUMBER key.
+    """
+    task_file = worktree / ".agent-task"
+    if not task_file.exists():
+        return None
+    try:
+        for line in task_file.read_text(encoding="utf-8").splitlines():
+            if line.startswith("ISSUE_NUMBER="):
+                raw = line.split("=", 1)[1].strip()
+                return int(raw) if raw.isdigit() else None
+    except OSError:
+        logger.warning("⚠️ Could not read .agent-task at %s", task_file)
+    return None
+
+
+async def _run(cmd: list[str]) -> tuple[int, str, str]:
+    """Run ``cmd`` as a subprocess and return (returncode, stdout, stderr).
+
+    All I/O is captured; nothing is printed to the container console.
+    Raises ``RuntimeError`` only when the process cannot be started at all.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout_bytes, stderr_bytes = await proc.communicate()
+    rc = proc.returncode if proc.returncode is not None else -1
+    return rc, stdout_bytes.decode(errors="replace"), stderr_bytes.decode(errors="replace")
+
+
+@router.post("/kill/{slug}")
+async def kill_agent(slug: str) -> dict[str, str]:
+    """Force-remove an agent worktree and clear the ``agent:wip`` GitHub label.
+
+    Slug is the bare directory name under ``settings.worktrees_dir``, e.g.
+    ``issue-553`` or ``pr-607``.
+
+    Steps:
+    1. Verify the worktree directory exists (404 if not).
+    2. ``git worktree remove --force <path>`` — detaches and removes the directory.
+    3. Parse ``.agent-task`` for ``ISSUE_NUMBER`` and clear ``agent:wip`` on that
+       issue via ``gh issue edit``.
+    4. ``git worktree prune`` — cleans up stale refs in the main repo.
+
+    Returns ``{"killed": slug}`` on success. Any individual step failure is
+    logged as a warning but does not abort the overall operation — the goal is
+    best-effort cleanup rather than strict atomicity.
+    """
+    worktree = settings.worktrees_dir / slug
+    if not worktree.exists():
+        raise HTTPException(status_code=404, detail=f"Worktree '{slug}' not found")
+
+    issue_number = _parse_issue_number(worktree)
+
+    # Step 1: force-remove the worktree.
+    repo_dir = str(settings.repo_dir)
+    rc, stdout, stderr = await _run(
+        ["git", "-C", repo_dir, "worktree", "remove", "--force", str(worktree)]
+    )
+    if rc != 0:
+        logger.warning("⚠️ git worktree remove exited %d: %s", rc, stderr.strip())
+
+    # Step 2: clear agent:wip on the related issue (best-effort).
+    if issue_number is not None:
+        gh_rc, _, gh_err = await _run(
+            [
+                "gh",
+                "issue",
+                "edit",
+                str(issue_number),
+                "--repo",
+                settings.gh_repo,
+                "--remove-label",
+                "agent:wip",
+            ]
+        )
+        if gh_rc != 0:
+            logger.warning("⚠️ gh issue edit exited %d: %s", gh_rc, gh_err.strip())
+        else:
+            logger.info("✅ Cleared agent:wip from issue #%d", issue_number)
+    else:
+        logger.warning("⚠️ No ISSUE_NUMBER in .agent-task for worktree '%s'", slug)
+
+    # Step 3: prune stale worktree refs.
+    prune_rc, _, prune_err = await _run(["git", "-C", repo_dir, "worktree", "prune"])
+    if prune_rc != 0:
+        logger.warning("⚠️ git worktree prune exited %d: %s", prune_rc, prune_err.strip())
+
+    logger.info("✅ Killed agent worktree '%s'", slug)
+    return {"killed": slug}

--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -5,6 +5,7 @@ background poller via ``get_state()`` — routes are intentionally thin.
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from fastapi import APIRouter
@@ -19,6 +20,9 @@ from agentception.readers.transcripts import read_transcript_messages
 
 _HERE = Path(__file__).parent
 _TEMPLATES = Jinja2Templates(directory=str(_HERE.parent / "templates"))
+# Register path filters used by agent.html kill-endpoint modal.
+_TEMPLATES.env.filters["basename"] = os.path.basename
+_TEMPLATES.env.filters["dirname"] = os.path.dirname
 
 router = APIRouter(tags=["ui"])
 

--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -622,3 +622,66 @@ main {
 .message-expand-btn:hover {
   color: var(--accent-hover);
 }
+
+/* ── Kill button (inline ✕ in agent rows) ─────────────────────────────────── */
+
+.btn-kill-inline {
+  margin-left: auto;
+  padding: 0.125rem 0.4rem;
+  background: none;
+  border: 1px solid var(--danger, #e53e3e);
+  border-radius: var(--radius);
+  color: var(--danger, #e53e3e);
+  font-size: 0.6875rem;
+  cursor: pointer;
+  line-height: 1;
+  transition: background 0.15s, color 0.15s;
+  flex-shrink: 0;
+}
+
+.btn-kill-inline:hover {
+  background: var(--danger, #e53e3e);
+  color: #fff;
+}
+
+/* ── Confirmation modal ───────────────────────────────────────────────────── */
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.modal-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  max-width: 26rem;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.modal-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+  color: var(--text-primary);
+}
+
+.modal-body {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  margin: 0 0 1.25rem;
+  line-height: 1.55;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}

--- a/agentception/templates/agent.html
+++ b/agentception/templates/agent.html
@@ -64,7 +64,7 @@
   </div>
 
   {# ── Quick actions ──────────────────────────────────────────────────────── #}
-  <div class="quick-actions">
+  <div class="quick-actions" x-data="{ showKillModal: false }">
     {% if node.issue_number %}
       <a href="https://github.com/cgcardona/maestro/issues/{{ node.issue_number }}"
          target="_blank" rel="noopener" class="btn btn-secondary">
@@ -77,9 +77,49 @@
         View PR on GitHub ↗
       </a>
     {% endif %}
-    <button class="btn btn-danger" disabled title="Kill is a Phase 1 feature — not yet available">
-      Kill Agent (Phase 1)
+
+    {# Kill button — only shown for active agents that have a worktree slug #}
+    {% if node.worktree_path %}
+    <button class="btn btn-danger" @click="showKillModal = true">
+      Kill Agent
     </button>
+
+    {# Confirmation modal — rendered inline so no extra fetch is needed #}
+    <div
+      class="modal-backdrop"
+      x-show="showKillModal"
+      x-cloak
+      @keydown.escape.window="showKillModal = false"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="kill-modal-title"
+    >
+      <div class="modal-box">
+        <h2 id="kill-modal-title" class="modal-title">Kill agent{% if node.issue_number %} for issue #{{ node.issue_number }}{% endif %}?</h2>
+        <p class="modal-body">
+          This removes the worktree at
+          <code>{{ node.worktree_path | replace(node.worktree_path | dirname, '…') }}</code>
+          and clears the <code>agent:wip</code> label.
+          The issue will be available for re-claim.
+        </p>
+        <div class="modal-actions">
+          <button class="btn btn-secondary" @click="showKillModal = false">Cancel</button>
+          <button
+            class="btn btn-danger"
+            hx-post="/api/control/kill/{{ node.worktree_path | basename }}"
+            hx-target="#result"
+            hx-swap="innerHTML"
+            @click="showKillModal = false"
+          >
+            Confirm Kill
+          </button>
+        </div>
+      </div>
+    </div>
+
+    {# Result area — HTMX writes the server response here after kill #}
+    <div id="result"></div>
+    {% endif %}
   </div>
 </div>
 

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -65,7 +65,7 @@
         </div>
 
         <template x-for="agent in state.agents" :key="agent.id">
-          <div class="agent-row">
+          <div class="agent-row" x-data="{ showKillModal: false }">
             <div class="agent-row-header">
               <span
                 class="status-badge"
@@ -93,13 +93,52 @@
                 x-show="agent.last_activity_mtime > 0"
                 x-text="relativeTime(agent.last_activity_mtime)"
               ></span>
+
+              {# Kill button — only for IMPLEMENTING / REVIEWING / STALE agents with a worktree #}
+              <button
+                class="btn-kill-inline"
+                x-show="agent.worktree_path != null && ['implementing','reviewing','stale'].includes(agent.status)"
+                @click.prevent="showKillModal = true"
+                title="Kill agent"
+                aria-label="Kill agent"
+              >✕</button>
+            </div>
+
+            {# Inline kill confirmation for this row #}
+            <div
+              class="modal-backdrop"
+              x-show="showKillModal"
+              x-cloak
+              @keydown.escape.window="showKillModal = false"
+              role="dialog"
+              aria-modal="true"
+            >
+              <div class="modal-box">
+                <h2 class="modal-title">Kill agent<span x-show="agent.issue_number != null"> for issue #<span x-text="agent.issue_number"></span></span>?</h2>
+                <p class="modal-body">
+                  Removes the worktree and clears the <code>agent:wip</code> label.
+                  The issue will be available for re-claim.
+                </p>
+                <div class="modal-actions">
+                  <button class="btn btn-secondary" @click="showKillModal = false">Cancel</button>
+                  <button
+                    class="btn btn-danger"
+                    :hx-post="'/api/control/kill/' + agent.worktree_path.split('/').pop()"
+                    hx-target="closest .agent-row"
+                    hx-swap="outerHTML"
+                    @click="showKillModal = false"
+                  >
+                    Confirm Kill
+                  </button>
+                </div>
+              </div>
             </div>
 
             {# Nested children (one level — recursive nesting deferred to AC-007) #}
             <template x-if="agent.children && agent.children.length > 0">
               <div class="agent-children">
                 <template x-for="child in agent.children" :key="child.id">
-                  <div class="agent-row agent-row--child">
+                  <div class="agent-row agent-row--child" x-data="{ showKillModal: false }">
                     <div class="agent-row-header">
                       <span
                         class="status-badge"
@@ -114,6 +153,44 @@
                       <span class="agent-meta" x-show="child.issue_number != null">
                         #<span x-text="child.issue_number"></span>
                       </span>
+
+                      {# Kill button for child agents #}
+                      <button
+                        class="btn-kill-inline"
+                        x-show="child.worktree_path != null && ['implementing','reviewing','stale'].includes(child.status)"
+                        @click.prevent="showKillModal = true"
+                        title="Kill agent"
+                        aria-label="Kill agent"
+                      >✕</button>
+                    </div>
+
+                    {# Inline kill confirmation for child row #}
+                    <div
+                      class="modal-backdrop"
+                      x-show="showKillModal"
+                      x-cloak
+                      @keydown.escape.window="showKillModal = false"
+                      role="dialog"
+                      aria-modal="true"
+                    >
+                      <div class="modal-box">
+                        <h2 class="modal-title">Kill agent<span x-show="child.issue_number != null"> for issue #<span x-text="child.issue_number"></span></span>?</h2>
+                        <p class="modal-body">
+                          Removes the worktree and clears the <code>agent:wip</code> label.
+                        </p>
+                        <div class="modal-actions">
+                          <button class="btn btn-secondary" @click="showKillModal = false">Cancel</button>
+                          <button
+                            class="btn btn-danger"
+                            :hx-post="'/api/control/kill/' + child.worktree_path.split('/').pop()"
+                            hx-target="closest .agent-row"
+                            hx-swap="outerHTML"
+                            @click="showKillModal = false"
+                          >
+                            Confirm Kill
+                          </button>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </template>

--- a/agentception/tests/test_agentception_control.py
+++ b/agentception/tests/test_agentception_control.py
@@ -1,0 +1,149 @@
+"""Tests for the AgentCeption kill control-plane endpoint (AC-101).
+
+Tests cover:
+- 404 returned for an unknown worktree slug.
+- Successful kill: worktree removal, agent:wip label cleared, prune called.
+- Slug with no .agent-task file (no issue number) — still succeeds.
+
+Run targeted:
+    pytest agentception/tests/test_agentception_control.py -v
+"""
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    """Synchronous test client that handles lifespan correctly."""
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def tmp_worktree(tmp_path: Path) -> Path:
+    """Return a temporary worktree directory with a populated .agent-task file."""
+    worktree = tmp_path / "issue-999"
+    worktree.mkdir()
+    (worktree / ".agent-task").write_text(
+        "WORKFLOW=issue-to-pr\nISSUE_NUMBER=999\nGH_REPO=cgcardona/maestro\n",
+        encoding="utf-8",
+    )
+    return worktree
+
+
+@pytest.fixture()
+def tmp_worktree_no_task(tmp_path: Path) -> Path:
+    """Return a temporary worktree directory WITHOUT an .agent-task file."""
+    worktree = tmp_path / "pr-888"
+    worktree.mkdir()
+    return worktree
+
+
+# ── 404 for unknown slug ──────────────────────────────────────────────────────
+
+
+def test_kill_nonexistent_worktree_returns_404(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """POST /api/control/kill/{slug} must return 404 when the worktree does not exist."""
+    with patch("agentception.routes.control.settings") as mock_settings:
+        mock_settings.worktrees_dir = tmp_path
+        mock_settings.repo_dir = tmp_path
+        mock_settings.gh_repo = "cgcardona/maestro"
+
+        response = client.post("/api/control/kill/nonexistent-slug")
+
+    assert response.status_code == 404
+    assert "nonexistent-slug" in response.json()["detail"]
+
+
+# ── Successful kill ───────────────────────────────────────────────────────────
+
+
+def test_kill_removes_worktree_and_clears_label(
+    client: TestClient,
+    tmp_worktree: Path,
+) -> None:
+    """A successful kill must call git worktree remove, gh issue edit, and git worktree prune."""
+    slug = tmp_worktree.name  # "issue-999"
+    parent = tmp_worktree.parent
+
+    async def fake_run(cmd: list[str]) -> tuple[int, str, str]:
+        return 0, "", ""
+
+    with (
+        patch("agentception.routes.control.settings") as mock_settings,
+        patch("agentception.routes.control._run", side_effect=fake_run) as mock_run,
+    ):
+        mock_settings.worktrees_dir = parent
+        mock_settings.repo_dir = Path("/repo")
+        mock_settings.gh_repo = "cgcardona/maestro"
+
+        response = client.post(f"/api/control/kill/{slug}")
+
+    assert response.status_code == 200
+    assert response.json() == {"killed": slug}
+
+    # Verify the three subprocess calls were made in order.
+    calls = [tuple(call.args[0]) for call in mock_run.call_args_list]
+    assert any("worktree" in c and "remove" in c for c in calls), (
+        "git worktree remove must be called"
+    )
+    assert any("issue" in c and "edit" in c for c in calls), (
+        "gh issue edit must be called to clear agent:wip"
+    )
+    assert any("worktree" in c and "prune" in c for c in calls), (
+        "git worktree prune must be called"
+    )
+
+
+def test_kill_endpoint_requires_existing_slug(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """Killing a slug whose directory does not exist must return 404, not 500."""
+    with patch("agentception.routes.control.settings") as mock_settings:
+        mock_settings.worktrees_dir = tmp_path
+        mock_settings.repo_dir = tmp_path
+        mock_settings.gh_repo = "cgcardona/maestro"
+
+        response = client.post("/api/control/kill/does-not-exist")
+
+    assert response.status_code == 404
+
+
+# ── No .agent-task (no issue number) ─────────────────────────────────────────
+
+
+def test_kill_worktree_without_agent_task_still_succeeds(
+    client: TestClient,
+    tmp_worktree_no_task: Path,
+) -> None:
+    """Kill must succeed even when .agent-task is absent (no issue number to clear)."""
+    slug = tmp_worktree_no_task.name
+    parent = tmp_worktree_no_task.parent
+
+    async def fake_run(cmd: list[str]) -> tuple[int, str, str]:
+        return 0, "", ""
+
+    with (
+        patch("agentception.routes.control.settings") as mock_settings,
+        patch("agentception.routes.control._run", side_effect=fake_run),
+    ):
+        mock_settings.worktrees_dir = parent
+        mock_settings.repo_dir = Path("/repo")
+        mock_settings.gh_repo = "cgcardona/maestro"
+
+        response = client.post(f"/api/control/kill/{slug}")
+
+    assert response.status_code == 200
+    assert response.json() == {"killed": slug}


### PR DESCRIPTION
## Summary
Closes #617 — Implements `POST /api/control/kill/{slug}` control-plane endpoint that force-removes an agent worktree and clears the `agent:wip` GitHub label, then wires up Kill Agent UI in `agent.html` (confirmation modal) and `overview.html` (inline ✕ button per active row).

## Root Cause / Motivation
Phase 0 shipped the AgentCeption scaffold with the Kill Agent button disabled and labelled "Phase 1 feature". This PR activates it: operators can now kill a stale or stuck agent from the dashboard without dropping to the shell.

## Solution

### Backend — `agentception/routes/control.py` (new)
- `POST /api/control/kill/{slug}` — validates the worktree exists (404 if not), runs `git worktree remove --force`, clears `agent:wip` via `gh issue edit`, runs `git worktree prune`. All subprocess calls are async; individual step failures are logged as warnings but do not abort the overall operation (best-effort cleanup).
- `_parse_issue_number(worktree)` — reads `ISSUE_NUMBER=` from `.agent-task` without shell eval.
- `_run(cmd)` — thin async subprocess wrapper; never blocks the event loop.

### `agentception/app.py`
- Registers `control_router` alongside the existing API and UI routers.

### `agentception/templates/agent.html`
- Replaces the disabled "Kill Agent (Phase 1)" button with a live button that opens an Alpine.js confirmation modal.
- Modal shows the worktree path, issue number (if any), and warns that the issue will be available for re-claim.
- On confirm: `hx-post` to `/api/control/kill/{slug}` with the result written to `#result`.

### `agentception/templates/overview.html`
- Each agent row now has an inline `✕` kill button (only visible for IMPLEMENTING / REVIEWING / STALE agents that have a worktree path).
- Button opens an Alpine.js confirmation modal; on confirm sends `hx-post` and swaps the row out.
- Same pattern applied to child rows.

### `agentception/static/app.css`
- Added `.btn-kill-inline`, `.modal-backdrop`, `.modal-box`, `.modal-title`, `.modal-body`, `.modal-actions` styles.

### `agentception/tests/test_agentception_control.py` (new)
- `test_kill_nonexistent_worktree_returns_404`
- `test_kill_removes_worktree_and_clears_label` (mocked subprocess + gh)
- `test_kill_endpoint_requires_existing_slug`
- `test_kill_worktree_without_agent_task_still_succeeds`

## Verification
- [x] mypy clean (23 source files, 0 issues)
- [x] All 4 new tests pass
- [x] Scaffold regression tests (6) still pass
- [x] Pre-push sync: already up to date with origin/dev

## Pre-existing state
Dependency #616 was CLOSED before implementation began. Baseline mypy was clean (21 files, 0 issues).

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Name** | Alan Turing |
| **Architecture** | `turing:htmx:jinja2` |
| **Skills** | HTMX · Jinja2 |
| **Role** | `python-developer` |
| **Session** | `eng-20260302T020135Z-2564` |
| **Batch (VP)** | `eng-20260302T015842Z-02de` |
| **Wave (CTO)** | `wave-1-20260301` |
| **VP** | `Engineering VP · eng-20260302T015842Z-02de` |

</details>