### PR TITLE
feat: add pause/resume pipeline sentinel and UI toggle [AC-102]

### DIFF
--- a/.cursor/roles/cto.md
+++ b/.cursor/roles/cto.md
@@ -48,6 +48,12 @@ The pool stays at 4 concurrent workers continuously until the queue drains.
 
 ```
 LOOP:
+  -1. Pipeline-pause sentinel — check BEFORE every wave, every iteration:
+       # The AgentCeption dashboard writes .cursor/.pipeline-pause to request a pause.
+       # When the file exists, wait 30 s and restart the loop without dispatching agents.
+       [ -f /Users/gabriel/dev/tellurstori/maestro/.cursor/.pipeline-pause ] && \
+         echo "⏸ Pipeline paused by AgentCeption dashboard." && sleep 30 && continue
+
   0. Preflight stale sweep — run this before EVERY wave (not just the first):
        # Clear agent:wip from issues whose worktree is missing OR has 0 commits ahead of dev.
        # This prevents a stale claim from blocking the Eng VP's unclaimed-issue query.

--- a/.cursor/roles/engineering-manager.md
+++ b/.cursor/roles/engineering-manager.md
@@ -15,6 +15,12 @@ entire chain to drain.
 
 ```
 SEED:
+  0. Pipeline-pause sentinel — check BEFORE seeding any agents:
+       # The AgentCeption dashboard writes .cursor/.pipeline-pause to request a pause.
+       # When the file exists, wait 30 s and restart the SEED block without spawning.
+       [ -f /Users/gabriel/dev/tellurstori/maestro/.cursor/.pipeline-pause ] && \
+         echo "⏸ Pipeline paused by AgentCeption dashboard." && sleep 30 && continue
+
   1. Ensure the claim label exists with canonical color (idempotent):
        # create first; if it already exists, edit to enforce the canonical color.
        # Never rely on create alone — it fails silently if the label exists, leaving

--- a/agentception/routes/api.py
+++ b/agentception/routes/api.py
@@ -10,12 +10,49 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 
+from agentception.config import settings
 from agentception.models import AgentNode, PipelineState
 from agentception.poller import get_state
 from agentception.readers.transcripts import read_transcript_messages
 from agentception.routes.ui import _find_agent
 
 router = APIRouter(prefix="/api", tags=["api"])
+
+# Path to the sentinel file that pauses the agent pipeline.
+# Writing this file tells CTO and Eng VP loops to wait rather than spawn agents.
+_SENTINEL: Path = settings.repo_dir / ".cursor" / ".pipeline-pause"
+
+
+@router.post("/control/pause", tags=["control"])
+async def pause_pipeline() -> dict[str, bool]:
+    """Create the pipeline-pause sentinel file, halting agent spawning.
+
+    Idempotent — calling pause when already paused is a no-op.
+    The CTO and Eng VP role files check for this sentinel at the top of
+    every loop iteration and sleep instead of dispatching new agents.
+    """
+    _SENTINEL.touch()
+    return {"paused": True}
+
+
+@router.post("/control/resume", tags=["control"])
+async def resume_pipeline() -> dict[str, bool]:
+    """Remove the pipeline-pause sentinel file, allowing agent spawning to continue.
+
+    Idempotent — calling resume when not paused is a no-op.
+    """
+    _SENTINEL.unlink(missing_ok=True)
+    return {"paused": False}
+
+
+@router.get("/control/status", tags=["control"])
+async def control_status() -> dict[str, bool]:
+    """Return the current pause state of the agent pipeline.
+
+    Returns ``{"paused": true}`` when the sentinel file exists,
+    ``{"paused": false}`` otherwise.
+    """
+    return {"paused": _SENTINEL.exists()}
 
 
 @router.get("/pipeline")

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -42,6 +42,33 @@
         x-text="connected ? '● Live' : '○ Reconnecting…'"
       ></span>
     </div>
+
+    {#
+      Pause/resume toggle — issues a POST via HTMX and swaps only this element
+      so the rest of the dashboard stays live.  The paused flag is polled from
+      /api/control/status on page load and updated optimistically on click.
+    #}
+    <div
+      class="summary-item summary-item--control"
+      id="pipeline-control"
+      x-data="pipelineControl()"
+      x-init="fetchStatus()"
+    >
+      <span
+        class="pipeline-status-badge"
+        :class="paused ? 'pipeline-status-badge--paused' : 'pipeline-status-badge--running'"
+        x-text="paused ? 'PAUSED' : 'RUNNING'"
+        role="status"
+        :aria-label="paused ? 'Pipeline paused' : 'Pipeline running'"
+      ></span>
+      <button
+        class="control-btn"
+        :class="paused ? 'control-btn--resume' : 'control-btn--pause'"
+        x-text="paused ? 'Resume' : 'Pause'"
+        @click="toggle()"
+        :aria-label="paused ? 'Resume pipeline' : 'Pause pipeline'"
+      ></button>
+    </div>
   </div>
 
   {# ── Alert banners ─────────────────────────────────────────────────────── #}
@@ -205,6 +232,44 @@ function pipelineDashboard(initial) {
       if (secs < 60) return secs + 's ago';
       if (secs < 3600) return Math.floor(secs / 60) + 'm ago';
       return Math.floor(secs / 3600) + 'h ago';
+    },
+  };
+}
+
+/**
+ * Alpine.js component for the pipeline pause/resume control.
+ *
+ * Fetches current pause state from GET /api/control/status on init.
+ * Toggle sends a POST to /api/control/pause or /api/control/resume and
+ * updates the badge optimistically — no page reload needed.
+ */
+function pipelineControl() {
+  return {
+    paused: false,
+
+    async fetchStatus() {
+      try {
+        const res = await fetch('/api/control/status');
+        if (res.ok) {
+          const data = await res.json();
+          this.paused = data.paused;
+        }
+      } catch (_) {
+        // Network error — keep current state, will retry on next toggle.
+      }
+    },
+
+    async toggle() {
+      const endpoint = this.paused ? '/api/control/resume' : '/api/control/pause';
+      try {
+        const res = await fetch(endpoint, { method: 'POST' });
+        if (res.ok) {
+          const data = await res.json();
+          this.paused = data.paused;
+        }
+      } catch (_) {
+        // Network error — leave state unchanged so the badge stays accurate.
+      }
     },
   };
 }

--- a/agentception/tests/test_agentception_controls.py
+++ b/agentception/tests/test_agentception_controls.py
@@ -1,0 +1,148 @@
+"""Tests for the AgentCeption pipeline pause/resume control endpoints (AC-102).
+
+Covers:
+  POST /api/control/pause   → creates sentinel, returns {paused: true}
+  POST /api/control/resume  → deletes sentinel, returns {paused: false}
+  GET  /api/control/status  → reflects current sentinel state
+
+All tests are synchronous and use a temporary directory for the sentinel file
+so they never touch the real repository filesystem.
+
+Run targeted:
+    pytest agentception/tests/test_agentception_controls.py -v
+"""
+from __future__ import annotations
+
+import importlib
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+
+
+@pytest.fixture()
+def client(tmp_path: Path) -> Generator[TestClient, None, None]:
+    """Test client with a temporary repo_dir so sentinel writes stay isolated."""
+    # Patch _SENTINEL in the api module to point into tmp_path.
+    sentinel = tmp_path / ".pipeline-pause"
+    with patch("agentception.routes.api._SENTINEL", sentinel):
+        with TestClient(app) as c:
+            yield c
+
+
+@pytest.fixture()
+def client_paused(tmp_path: Path) -> Generator[TestClient, None, None]:
+    """Test client with the sentinel file pre-created (pipeline already paused)."""
+    sentinel = tmp_path / ".pipeline-pause"
+    sentinel.touch()
+    with patch("agentception.routes.api._SENTINEL", sentinel):
+        with TestClient(app) as c:
+            yield c
+
+
+# ── POST /api/control/pause ───────────────────────────────────────────────────
+
+
+def test_pause_creates_sentinel_file(tmp_path: Path, client: TestClient) -> None:
+    """POST /api/control/pause must create the sentinel file on disk."""
+    sentinel = tmp_path / ".pipeline-pause"
+    assert not sentinel.exists(), "Sentinel must not exist before pause"
+    with patch("agentception.routes.api._SENTINEL", sentinel):
+        response = client.post("/api/control/pause")
+    assert response.status_code == 200
+    assert sentinel.exists(), "Sentinel must be created after pause"
+
+
+def test_pause_returns_paused_true(tmp_path: Path, client: TestClient) -> None:
+    """POST /api/control/pause must return {paused: true}."""
+    sentinel = tmp_path / ".pipeline-pause"
+    with patch("agentception.routes.api._SENTINEL", sentinel):
+        response = client.post("/api/control/pause")
+    assert response.status_code == 200
+    assert response.json() == {"paused": True}
+
+
+def test_pause_idempotent(tmp_path: Path, client_paused: TestClient) -> None:
+    """POST /api/control/pause when already paused must succeed without error."""
+    sentinel = tmp_path / ".pipeline-pause"
+    with patch("agentception.routes.api._SENTINEL", sentinel):
+        response = client_paused.post("/api/control/pause")
+    assert response.status_code == 200
+    assert response.json() == {"paused": True}
+
+
+# ── POST /api/control/resume ──────────────────────────────────────────────────
+
+
+def test_resume_deletes_sentinel_file(tmp_path: Path, client_paused: TestClient) -> None:
+    """POST /api/control/resume must remove the sentinel file when it exists."""
+    sentinel = tmp_path / ".pipeline-pause"
+    assert sentinel.exists(), "Sentinel must exist before resume"
+    with patch("agentception.routes.api._SENTINEL", sentinel):
+        response = client_paused.post("/api/control/resume")
+    assert response.status_code == 200
+    assert not sentinel.exists(), "Sentinel must be gone after resume"
+
+
+def test_resume_returns_paused_false(tmp_path: Path, client_paused: TestClient) -> None:
+    """POST /api/control/resume must return {paused: false}."""
+    sentinel = tmp_path / ".pipeline-pause"
+    with patch("agentception.routes.api._SENTINEL", sentinel):
+        response = client_paused.post("/api/control/resume")
+    assert response.status_code == 200
+    assert response.json() == {"paused": False}
+
+
+def test_resume_idempotent_when_not_paused(tmp_path: Path, client: TestClient) -> None:
+    """POST /api/control/resume when not paused must succeed without error."""
+    sentinel = tmp_path / ".pipeline-pause"
+    assert not sentinel.exists()
+    with patch("agentception.routes.api._SENTINEL", sentinel):
+        response = client.post("/api/control/resume")
+    assert response.status_code == 200
+    assert response.json() == {"paused": False}
+
+
+# ── GET /api/control/status ───────────────────────────────────────────────────
+
+
+def test_status_reflects_sentinel_state_running(tmp_path: Path, client: TestClient) -> None:
+    """GET /api/control/status must return {paused: false} when sentinel is absent."""
+    sentinel = tmp_path / ".pipeline-pause"
+    assert not sentinel.exists()
+    with patch("agentception.routes.api._SENTINEL", sentinel):
+        response = client.get("/api/control/status")
+    assert response.status_code == 200
+    assert response.json() == {"paused": False}
+
+
+def test_status_reflects_sentinel_state_paused(tmp_path: Path, client_paused: TestClient) -> None:
+    """GET /api/control/status must return {paused: true} when sentinel is present."""
+    sentinel = tmp_path / ".pipeline-pause"
+    assert sentinel.exists()
+    with patch("agentception.routes.api._SENTINEL", sentinel):
+        response = client_paused.get("/api/control/status")
+    assert response.status_code == 200
+    assert response.json() == {"paused": True}
+
+
+def test_status_updates_after_pause(tmp_path: Path, client: TestClient) -> None:
+    """GET /api/control/status must reflect paused=true immediately after a pause call."""
+    sentinel = tmp_path / ".pipeline-pause"
+    with patch("agentception.routes.api._SENTINEL", sentinel):
+        client.post("/api/control/pause")
+        response = client.get("/api/control/status")
+    assert response.json() == {"paused": True}
+
+
+def test_status_updates_after_resume(tmp_path: Path, client_paused: TestClient) -> None:
+    """GET /api/control/status must reflect paused=false immediately after a resume call."""
+    sentinel = tmp_path / ".pipeline-pause"
+    with patch("agentception.routes.api._SENTINEL", sentinel):
+        client_paused.post("/api/control/resume")
+        response = client_paused.get("/api/control/status")
+    assert response.json() == {"paused": False}


### PR DESCRIPTION
## Summary
Closes #618 — Pause/resume pipeline sentinel with UI toggle in the AgentCeption dashboard.

## Root Cause / Motivation
The pipeline had no way to halt agent spawning without terminating the CTO/Eng VP loops entirely. Operators needed a lightweight, reversible mechanism to pause the pipeline during debugging, incident response, or manual intervention.

## Solution

### Sentinel file
Writing `.cursor/.pipeline-pause` pauses the pipeline. Deleting it resumes. The CTO and Eng VP role files now check for this sentinel at the top of every loop iteration and sleep 30 s instead of dispatching new agents.

### API endpoints (agentception/routes/api.py)
- `POST /api/control/pause` — touches the sentinel, returns `{"paused": true}`
- `POST /api/control/resume` — removes the sentinel, returns `{"paused": false}`
- `GET  /api/control/status` — returns current sentinel state

Both pause and resume are idempotent — calling them when already in that state is safe.

### UI (agentception/templates/overview.html)
Added a RUNNING/PAUSED badge and Pause/Resume button to the pipeline summary bar. Uses Alpine.js `fetch()` to call the control endpoints and update the badge in-place — no page reload, no HTMX dependency.

### Role files
- `.cursor/roles/cto.md`: sentinel guard added as step -1 at the top of `LOOP`
- `.cursor/roles/engineering-manager.md`: sentinel guard added as step 0 at the top of `SEED`

### Tests (agentception/tests/test_agentception_controls.py)
10 tests covering:
- `test_pause_creates_sentinel_file`
- `test_pause_returns_paused_true`
- `test_pause_idempotent`
- `test_resume_deletes_sentinel_file`
- `test_resume_returns_paused_false`
- `test_resume_idempotent_when_not_paused`
- `test_status_reflects_sentinel_state_running`
- `test_status_reflects_sentinel_state_paused`
- `test_status_updates_after_pause`
- `test_status_updates_after_resume`

## Verification
- [x] mypy clean (22 source files, 0 issues)
- [x] 10 new tests pass, 0 warnings
- [x] Existing UI overview tests (10) still pass
- [x] Pre-push sync with origin/dev — already up to date, no conflicts

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Name** | Alan Turing |
| **Architecture** | `turing:htmx:jinja2` |
| **Skills** | HTMX · Jinja2 |
| **Role** | `python-developer` |
| **Session** | `eng-20260302T020141Z-42c7` |
| **Batch (VP)** | `eng-20260302T015842Z-02de` |
| **Wave (CTO)** | `wave-1-20260301` |
| **VP** | `Engineering VP · eng-20260302T015842Z-02de` |

</details>