### PR TITLE
feat: manual spawn endpoint + issue-picker UI (AC-103)

### DIFF
--- a/agentception/models.py
+++ b/agentception/models.py
@@ -8,7 +8,12 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
+
+#: Roles that can be assigned to a spawned agent.
+VALID_ROLES: frozenset[str] = frozenset(
+    {"python-developer", "database-architect", "pr-reviewer"}
+)
 
 
 class AgentStatus(str, Enum):
@@ -101,3 +106,38 @@ class TaskFile(BaseModel):
     attempt_n: int = 0
     required_output: str | None = None
     on_block: str | None = None
+
+
+class SpawnRequest(BaseModel):
+    """Request body for ``POST /api/control/spawn``.
+
+    Callers provide the issue number they want an agent to tackle and an
+    optional role override. The endpoint verifies the issue is open and
+    unclaimed before creating the worktree.
+    """
+
+    issue_number: int
+    role: str = "python-developer"
+
+    @field_validator("role")
+    @classmethod
+    def validate_role(cls, v: str) -> str:
+        """Reject unknown roles early so errors surface at the boundary, not in git."""
+        if v not in VALID_ROLES:
+            raise ValueError(f"role must be one of {sorted(VALID_ROLES)}, got {v!r}")
+        return v
+
+
+class SpawnResult(BaseModel):
+    """Response for a successful ``POST /api/control/spawn``.
+
+    Contains enough information for the user (or a future automation layer)
+    to launch a Cursor Task pointed at the new worktree.
+    ``agent_task`` is the raw text of the ``.agent-task`` file that was
+    written — callers can display it or pass it directly to the Task tool.
+    """
+
+    spawned: int
+    worktree: str
+    branch: str
+    agent_task: str

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -225,6 +225,38 @@ async def get_active_label() -> str | None:
     return min(agentception_labels, key=_sort_key)
 
 
+async def get_issue(number: int) -> dict[str, object]:
+    """Fetch state, title, and labels for a single issue.
+
+    Returns a dict with at minimum: ``number``, ``state``, ``title``,
+    and ``labels`` (list of label-name strings).
+
+    Parameters
+    ----------
+    number:
+        GitHub issue number.
+
+    Raises
+    ------
+    RuntimeError
+        When ``gh`` exits with a non-zero status (e.g. issue not found).
+    """
+    repo = settings.gh_repo
+    args = [
+        "issue", "view", str(number),
+        "--repo", repo,
+        "--json", "number,state,title,labels",
+    ]
+    result = await gh_json(
+        args,
+        "{number: .number, state: .state, title: .title, labels: [.labels[].name]}",
+        f"get_issue:{number}",
+    )
+    if not isinstance(result, dict):
+        raise RuntimeError(f"get_issue: expected dict from gh, got {type(result).__name__}")
+    return result
+
+
 async def get_issue_body(number: int) -> str:
     """Fetch the markdown body of a single issue.
 
@@ -282,6 +314,43 @@ async def close_pr(number: int, comment: str) -> None:
         )
 
     logger.info("✅ PR #%d closed with comment", number)
+    _cache_invalidate()
+
+
+async def add_wip_label(issue_number: int) -> None:
+    """Add the ``agent:wip`` label to an issue to claim it for a pipeline agent.
+
+    Invalidates the cache so subsequent ``get_wip_issues()`` calls immediately
+    reflect the new label without waiting for TTL expiry.
+
+    Parameters
+    ----------
+    issue_number:
+        GitHub issue number to label.
+
+    Raises
+    ------
+    RuntimeError
+        When ``gh`` exits with a non-zero status.
+    """
+    repo = settings.gh_repo
+
+    proc = await asyncio.create_subprocess_exec(
+        "gh", "issue", "edit", str(issue_number),
+        "--repo", repo,
+        "--add-label", "agent:wip",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh issue edit (add label) failed (exit {proc.returncode}): "
+            f"{stderr.decode().strip()!r}"
+        )
+
+    logger.info("✅ Added agent:wip to issue #%d", issue_number)
     _cache_invalidate()
 
 

--- a/agentception/routes/api.py
+++ b/agentception/routes/api.py
@@ -6,14 +6,21 @@ can choose their preferred serialisation format.
 """
 from __future__ import annotations
 
+import asyncio
+import logging
+from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 
-from agentception.models import AgentNode, PipelineState
+from agentception.config import settings
+from agentception.models import AgentNode, PipelineState, SpawnRequest, SpawnResult
 from agentception.poller import get_state
+from agentception.readers.github import add_wip_label, get_issue
 from agentception.readers.transcripts import read_transcript_messages
 from agentception.routes.ui import _find_agent
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["api"])
 
@@ -69,3 +76,161 @@ async def transcript_api(agent_id: str) -> list[dict[str, str]]:
     if not node.transcript_path:
         return []
     return await read_transcript_messages(Path(node.transcript_path))
+
+
+def _build_agent_task(
+    issue_number: int,
+    title: str,
+    role: str,
+    worktree: Path,
+    branch: str,
+) -> str:
+    """Build the raw text content of a ``.agent-task`` file.
+
+    The format mirrors what the parallel-batch coordinator writes so that
+    agents spawned via the control plane behave identically to batch-spawned
+    agents.
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    repo = settings.gh_repo
+    role_file = settings.repo_dir / ".cursor" / "roles" / f"{role}.md"
+    return (
+        f"WORKFLOW=issue-to-pr\n"
+        f"GH_REPO={repo}\n"
+        f"ISSUE_NUMBER={issue_number}\n"
+        f"ISSUE_TITLE={title}\n"
+        f"ISSUE_URL=https://github.com/{repo}/issues/{issue_number}\n"
+        f"ROLE={role}\n"
+        f"ROLE_FILE={role_file}\n"
+        f"WORKTREE={worktree}\n"
+        f"BASE=dev\n"
+        f"CLOSES_ISSUES={issue_number}\n"
+        f"BATCH_ID=manual\n"
+        f"CREATED_AT={now}\n"
+        f"SPAWN_MODE=chain\n"
+        f"LINKED_PR=none\n"
+        f"SPAWN_SUB_AGENTS=false\n"
+        f"ATTEMPT_N=0\n"
+        f"REQUIRED_OUTPUT=pr_url\n"
+        f"ON_BLOCK=stop\n"
+    )
+
+
+@router.post("/control/spawn")
+async def spawn_agent(body: SpawnRequest) -> SpawnResult:
+    """Manually seed a new engineer agent for an open, unclaimed issue.
+
+    This endpoint bypasses the CTO/VP polling loop for direct human
+    intervention — useful when an issue needs immediate attention or when
+    the automated batch scheduler hasn't picked it up yet.
+
+    The caller is responsible for launching the Cursor Task pointed at the
+    returned ``worktree`` path.  This endpoint only prepares the worktree
+    and ``.agent-task`` file; it does NOT start the agent automatically.
+
+    Raises
+    ------
+    HTTP 404
+        When the issue number does not exist on GitHub or the issue is not
+        open (already closed or merged).
+    HTTP 409
+        When the issue already carries an ``agent:wip`` label, indicating
+        another agent has already claimed it.
+    HTTP 500
+        When the git worktree creation fails (e.g. directory already exists).
+    """
+    issue_number = body.issue_number
+
+    # ── 1. Fetch issue state from GitHub ──────────────────────────────────────
+    try:
+        issue = await get_issue(issue_number)
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Issue #{issue_number} not found on GitHub: {exc}",
+        ) from exc
+
+    state = issue.get("state", "")
+    if state != "OPEN":
+        raise HTTPException(
+            status_code=404,
+            detail=f"Issue #{issue_number} is not open (state={state!r})",
+        )
+
+    # ── 2. Check whether the issue is already claimed ─────────────────────────
+    raw_labels = issue.get("labels")
+    # narrow from object to list before iterating — get() returns object
+    label_names: list[str] = (
+        [lbl for lbl in raw_labels if isinstance(lbl, str)]
+        if isinstance(raw_labels, list)
+        else []
+    )
+    if "agent:wip" in label_names:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Issue #{issue_number} is already claimed (agent:wip label present)",
+        )
+
+    # ── 3. Add agent:wip label ────────────────────────────────────────────────
+    await add_wip_label(issue_number)
+
+    # ── 4. Create git worktree ────────────────────────────────────────────────
+    branch = f"feat/issue-{issue_number}"
+    worktree_path = settings.worktrees_dir / f"issue-{issue_number}"
+
+    if worktree_path.exists():
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Worktree directory already exists: {worktree_path}. "
+                "Remove it manually and retry."
+            ),
+        )
+
+    repo_dir = str(settings.repo_dir)
+    proc = await asyncio.create_subprocess_exec(
+        "git", "-C", repo_dir,
+        "worktree", "add", "-b", branch,
+        str(worktree_path), "origin/dev",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"git worktree add failed (exit {proc.returncode}): "
+                f"{stderr.decode().strip()!r}"
+            ),
+        )
+
+    logger.info(
+        "✅ Created worktree %s on branch %s for issue #%d",
+        worktree_path,
+        branch,
+        issue_number,
+    )
+
+    # ── 5. Write .agent-task ──────────────────────────────────────────────────
+    title_raw = issue.get("title", "")
+    title: str = title_raw if isinstance(title_raw, str) else str(title_raw)
+    agent_task_content = _build_agent_task(
+        issue_number=issue_number,
+        title=title,
+        role=body.role,
+        worktree=worktree_path,
+        branch=branch,
+    )
+    task_file = worktree_path / ".agent-task"
+    task_file.write_text(agent_task_content, encoding="utf-8")
+
+    logger.info("✅ Wrote .agent-task to %s", task_file)
+
+    return SpawnResult(
+        spawned=issue_number,
+        worktree=str(worktree_path),
+        branch=branch,
+        agent_task=agent_task_content,
+    )

--- a/agentception/routes/api.py
+++ b/agentception/routes/api.py
@@ -89,7 +89,8 @@ def _build_agent_task(
 
     The format mirrors what the parallel-batch coordinator writes so that
     agents spawned via the control plane behave identically to batch-spawned
-    agents.
+    agents.  ``BRANCH`` is included so the engineer kickoff prompt can derive
+    the feature branch name without re-computing it.
     """
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     repo = settings.gh_repo
@@ -100,6 +101,7 @@ def _build_agent_task(
         f"ISSUE_NUMBER={issue_number}\n"
         f"ISSUE_TITLE={title}\n"
         f"ISSUE_URL=https://github.com/{repo}/issues/{issue_number}\n"
+        f"BRANCH={branch}\n"
         f"ROLE={role}\n"
         f"ROLE_FILE={role_file}\n"
         f"WORKTREE={worktree}\n"
@@ -171,10 +173,10 @@ async def spawn_agent(body: SpawnRequest) -> SpawnResult:
             detail=f"Issue #{issue_number} is already claimed (agent:wip label present)",
         )
 
-    # ── 3. Add agent:wip label ────────────────────────────────────────────────
-    await add_wip_label(issue_number)
-
-    # ── 4. Create git worktree ────────────────────────────────────────────────
+    # ── 3. Pre-flight: check for an existing worktree BEFORE claiming ─────────
+    # Claiming (add_wip_label) is irreversible in the short term; checking the
+    # worktree path first prevents leaving an issue permanently labelled
+    # agent:wip with no agent actually working on it.
     branch = f"feat/issue-{issue_number}"
     worktree_path = settings.worktrees_dir / f"issue-{issue_number}"
 
@@ -186,6 +188,9 @@ async def spawn_agent(body: SpawnRequest) -> SpawnResult:
                 "Remove it manually and retry."
             ),
         )
+
+    # ── 4. Add agent:wip label ────────────────────────────────────────────────
+    await add_wip_label(issue_number)
 
     repo_dir = str(settings.repo_dir)
     proc = await asyncio.create_subprocess_exec(

--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -13,14 +13,34 @@ from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
 from starlette.responses import Response
 
-from agentception.models import AgentNode, PipelineState
+from agentception.models import AgentNode, PipelineState, VALID_ROLES
 from agentception.poller import get_state
+from agentception.readers.github import get_open_issues
 from agentception.readers.transcripts import read_transcript_messages
 
 _HERE = Path(__file__).parent
 _TEMPLATES = Jinja2Templates(directory=str(_HERE.parent / "templates"))
 
 router = APIRouter(tags=["ui"])
+
+
+def _issue_is_claimed(iss: dict[str, object]) -> bool:
+    """Return True when an issue carries the ``agent:wip`` label.
+
+    Handles both list-of-strings and list-of-label-objects shapes so the
+    helper works correctly regardless of which GitHub reader format is used.
+    """
+    raw = iss.get("labels")
+    if not isinstance(raw, list):
+        return False
+    for lbl in raw:
+        if isinstance(lbl, str) and lbl == "agent:wip":
+            return True
+        if isinstance(lbl, dict):
+            name = lbl.get("name")
+            if name == "agent:wip":
+                return True
+    return False
 
 
 def _find_agent(state: PipelineState | None, agent_id: str) -> AgentNode | None:
@@ -76,4 +96,36 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
         request,
         "agent.html",
         {"node": node, "agent_id": agent_id, "messages": messages},
+    )
+
+
+@router.get("/control/spawn", response_class=HTMLResponse)
+async def spawn_form(request: Request) -> HTMLResponse:
+    """Issue picker form for manually spawning a new engineer agent.
+
+    Fetches all open, unclaimed issues (those without ``agent:wip``) from
+    GitHub and renders a form that posts to ``POST /api/control/spawn``.
+    On any GitHub read error the page renders with an empty issue list and
+    an error banner — it never raises HTTP 500 so the controls page stays
+    accessible even when GitHub is unreachable.
+    """
+    error: str | None = None
+    issues: list[dict[str, object]] = []
+    try:
+        all_open = await get_open_issues()
+        issues = [
+            iss for iss in all_open
+            if not _issue_is_claimed(iss)
+        ]
+    except Exception as exc:  # pragma: no cover — network failure path
+        error = f"Could not load issues from GitHub: {exc}"
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "spawn.html",
+        {
+            "issues": issues,
+            "roles": sorted(VALID_ROLES),
+            "error": error,
+        },
     )

--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -622,3 +622,85 @@ main {
 .message-expand-btn:hover {
   color: var(--accent-hover);
 }
+
+/* ── Spawn page ─────────────────────────────────────────────────────────── */
+
+.spawn-page {
+  max-width: 640px;
+}
+
+.spawn-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.form-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.form-select {
+  width: 100%;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  padding: 0.5rem 0.625rem;
+  appearance: none;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.form-select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.btn-primary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.spawn-result {
+  border-left: 3px solid var(--success, #22c55e);
+}
+
+.agent-task-pre {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  white-space: pre;
+  overflow-x: auto;
+  margin: 0;
+}

--- a/agentception/templates/spawn.html
+++ b/agentception/templates/spawn.html
@@ -1,0 +1,181 @@
+{% extends "base.html" %}
+
+{% block title %}AgentCeption — Spawn Agent{% endblock %}
+
+{% block content %}
+
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">← Overview</a>
+  <span class="breadcrumb-sep">/</span>
+  <span class="breadcrumb-current">Spawn Agent</span>
+</nav>
+
+{% if error %}
+<div class="alert-banner" role="alert">
+  <span>⚠️</span>
+  <span>{{ error }}</span>
+</div>
+{% endif %}
+
+{#
+  Alpine.js component manages the form submission and result/error display.
+  HTMX is not used here because we need to handle both success and error
+  states with structured JSON from POST /api/control/spawn.
+#}
+<div
+  x-data="spawnForm()"
+  class="spawn-page"
+>
+
+  <h1 class="section-title">Spawn Agent</h1>
+  <p class="text-muted">
+    Manually seed a new engineer agent for an open, unclaimed issue.
+    The agent worktree and <code>.agent-task</code> file will be created;
+    you must then launch the Cursor Task pointed at the worktree path shown below.
+  </p>
+
+  <div class="card mt-2">
+    <form @submit.prevent="submit" class="spawn-form" novalidate>
+
+      {# Issue picker #}
+      <div class="form-group">
+        <label class="form-label" for="issue_number">Issue</label>
+        {% if issues %}
+        <select
+          id="issue_number"
+          name="issue_number"
+          class="form-select"
+          x-model="issueNumber"
+          required
+        >
+          <option value="">— select an issue —</option>
+          {% for iss in issues %}
+          <option value="{{ iss.number }}">
+            #{{ iss.number }} — {{ iss.title }}
+          </option>
+          {% endfor %}
+        </select>
+        {% else %}
+        <p class="text-muted">
+          No open, unclaimed issues found{% if not error %} on GitHub{% endif %}.
+          All open issues may already have the <code>agent:wip</code> label.
+        </p>
+        {% endif %}
+      </div>
+
+      {# Role selector #}
+      <div class="form-group mt-1">
+        <label class="form-label" for="role">Role</label>
+        <select
+          id="role"
+          name="role"
+          class="form-select"
+          x-model="role"
+        >
+          {% for r in roles %}
+          <option value="{{ r }}" {% if r == "python-developer" %}selected{% endif %}>
+            {{ r }}
+          </option>
+          {% endfor %}
+        </select>
+      </div>
+
+      <div class="form-actions mt-2">
+        <button
+          type="submit"
+          class="btn btn-primary"
+          :disabled="loading || !issueNumber"
+          x-text="loading ? 'Spawning…' : 'Spawn Agent'"
+        ></button>
+      </div>
+
+    </form>
+  </div>
+
+  {# Error state #}
+  <template x-if="formError">
+    <div class="alert-banner mt-2" role="alert">
+      <span>❌</span>
+      <span x-text="formError"></span>
+    </div>
+  </template>
+
+  {# Success state #}
+  <template x-if="result">
+    <div class="card mt-2 spawn-result" role="region" aria-label="Spawn result">
+      <h2 class="section-title">✅ Agent spawned for issue #<span x-text="result.spawned"></span></h2>
+
+      <table class="task-table mt-1">
+        <tbody>
+          <tr>
+            <td class="task-key">Worktree</td>
+            <td class="task-value task-value--path"><code x-text="result.worktree"></code></td>
+          </tr>
+          <tr>
+            <td class="task-key">Branch</td>
+            <td class="task-value"><code x-text="result.branch"></code></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="mt-2">
+        <h3 class="section-subtitle">.agent-task</h3>
+        <pre class="agent-task-pre" x-text="result.agent_task"></pre>
+      </div>
+
+      <p class="text-muted mt-1">
+        Launch a Cursor Task rooted in the worktree path above to start the agent.
+      </p>
+    </div>
+  </template>
+
+</div>
+
+<script>
+/**
+ * Alpine.js component for the manual spawn form.
+ *
+ * Posts to POST /api/control/spawn and displays either a success card with
+ * the worktree path + .agent-task contents, or an error banner.
+ */
+function spawnForm() {
+  return {
+    issueNumber: '',
+    role: 'python-developer',
+    loading: false,
+    result: null,
+    formError: null,
+
+    async submit() {
+      this.result = null;
+      this.formError = null;
+      this.loading = true;
+
+      try {
+        const resp = await fetch('/api/control/spawn', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            issue_number: parseInt(this.issueNumber, 10),
+            role: this.role,
+          }),
+        });
+
+        const data = await resp.json();
+
+        if (!resp.ok) {
+          this.formError = data.detail ?? `HTTP ${resp.status}`;
+        } else {
+          this.result = data;
+        }
+      } catch (err) {
+        this.formError = `Network error: ${err.message}`;
+      } finally {
+        this.loading = false;
+      }
+    },
+  };
+}
+</script>
+
+{% endblock %}

--- a/agentception/tests/test_agentception_github.py
+++ b/agentception/tests/test_agentception_github.py
@@ -21,9 +21,11 @@ import agentception.readers.github as gh_module
 from agentception.readers.github import (
     _cache,
     _cache_invalidate,
+    add_wip_label,
     clear_wip_label,
     close_pr,
     get_active_label,
+    get_issue,
     get_issue_body,
     get_open_issues,
     get_open_prs,
@@ -320,3 +322,78 @@ async def test_clear_wip_label_invalidates_cache() -> None:
         await clear_wip_label(613)
 
     assert len(_cache) == 0
+
+
+# ---------------------------------------------------------------------------
+# get_issue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_issue_returns_dict() -> None:
+    """get_issue() must return a dict with state, title, and labels for a valid issue."""
+    payload = json.dumps({"number": 42, "state": "OPEN", "title": "Fix it", "labels": ["enhancement"]})
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(payload.encode()),
+    ):
+        result = await get_issue(42)
+
+    assert isinstance(result, dict)
+    assert result["state"] == "OPEN"
+    assert result["title"] == "Fix it"
+
+
+@pytest.mark.anyio
+async def test_get_issue_raises_on_failure() -> None:
+    """get_issue() must raise RuntimeError when gh exits with a non-zero status."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b"", returncode=1),
+    ):
+        with pytest.raises(RuntimeError, match="gh command failed"):
+            await get_issue(9999)
+
+
+# ---------------------------------------------------------------------------
+# add_wip_label
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_add_wip_label_passes_add_label() -> None:
+    """add_wip_label() must pass --add-label agent:wip to gh."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b""),
+    ) as mock_exec:
+        await add_wip_label(42)
+
+    call_args = mock_exec.call_args[0]
+    assert "--add-label" in call_args
+    assert "agent:wip" in call_args
+
+
+@pytest.mark.anyio
+async def test_add_wip_label_invalidates_cache() -> None:
+    """add_wip_label() must empty the cache as a side effect."""
+    _cache["some_key"] = ("value", time.monotonic() + 60)
+
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b""),
+    ):
+        await add_wip_label(42)
+
+    assert len(_cache) == 0
+
+
+@pytest.mark.anyio
+async def test_add_wip_label_raises_on_failure() -> None:
+    """add_wip_label() must raise RuntimeError when gh exits with a non-zero status."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b"", returncode=1),
+    ):
+        with pytest.raises(RuntimeError, match="gh issue edit"):
+            await add_wip_label(42)

--- a/agentception/tests/test_agentception_spawn.py
+++ b/agentception/tests/test_agentception_spawn.py
@@ -1,0 +1,285 @@
+"""Tests for the manual spawn endpoint and issue-picker UI (AC-103).
+
+Covers POST /api/control/spawn and GET /control/spawn.
+All GitHub calls and git operations are mocked — no live network, no
+filesystem side-effects.
+
+Run targeted:
+    pytest agentception/tests/test_agentception_spawn.py -v
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+from agentception.models import SpawnRequest, VALID_ROLES
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    """Synchronous test client with full lifespan."""
+    with TestClient(app) as c:
+        yield c
+
+
+# ── Helper: build a fake open issue dict ──────────────────────────────────────
+
+def _open_issue(
+    number: int,
+    title: str = "Test issue",
+    labels: list[str] | None = None,
+) -> dict[str, object]:
+    """Return a minimal open-issue dict as returned by get_issue()."""
+    return {
+        "number": number,
+        "state": "OPEN",
+        "title": title,
+        "labels": labels or [],
+    }
+
+
+def _open_issue_list(
+    number: int,
+    title: str = "Test issue",
+    label_names: list[str] | None = None,
+) -> dict[str, object]:
+    """Return a minimal open-issue dict as returned by get_open_issues()."""
+    label_objs: list[object] = [
+        {"name": name} for name in (label_names or [])
+    ]
+    return {
+        "number": number,
+        "title": title,
+        "labels": label_objs,
+        "body": "",
+    }
+
+
+# ── POST /api/control/spawn — success ─────────────────────────────────────────
+
+
+def test_spawn_creates_worktree_and_task_file(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """POST /api/control/spawn must create a worktree and return SpawnResult on success."""
+    worktree_dir = tmp_path / "worktrees" / "maestro"
+    worktree_dir.mkdir(parents=True)
+    # Simulate what `git worktree add` would do: create the directory.
+    expected_worktree = worktree_dir / "issue-42"
+
+    proc_mock = MagicMock()
+    proc_mock.returncode = 0
+
+    async def _fake_communicate() -> tuple[bytes, bytes]:
+        # Simulate git creating the worktree directory on communicate().
+        expected_worktree.mkdir(parents=True, exist_ok=True)
+        return (b"", b"")
+
+    proc_mock.communicate = _fake_communicate
+
+    async def _fake_exec(*args: object, **kwargs: object) -> MagicMock:
+        return proc_mock
+
+    with (
+        patch(
+            "agentception.routes.api.get_issue",
+            return_value=_open_issue(42, "Fix the thing"),
+        ),
+        patch("agentception.routes.api.add_wip_label", new_callable=AsyncMock),
+        patch(
+            "agentception.routes.api.settings.worktrees_dir",
+            worktree_dir,
+        ),
+        patch(
+            "agentception.routes.api.settings.repo_dir",
+            Path("/fake/repo"),
+        ),
+        patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_fake_exec,
+        ),
+    ):
+        response = client.post(
+            "/api/control/spawn",
+            json={"issue_number": 42, "role": "python-developer"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["spawned"] == 42
+    assert "issue-42" in data["worktree"]
+    assert data["branch"] == "feat/issue-42"
+    assert "ISSUE_NUMBER=42" in data["agent_task"]
+    assert "ROLE=python-developer" in data["agent_task"]
+    # Verify the .agent-task file was actually written to disk.
+    task_file = expected_worktree / ".agent-task"
+    assert task_file.exists()
+    assert "ISSUE_NUMBER=42" in task_file.read_text()
+
+
+# ── POST /api/control/spawn — already claimed → 409 ──────────────────────────
+
+
+def test_spawn_already_claimed_returns_409(client: TestClient) -> None:
+    """POST /api/control/spawn must return 409 when the issue already has agent:wip."""
+    with patch(
+        "agentception.routes.api.get_issue",
+        return_value=_open_issue(42, "Fix the thing", labels=["agent:wip", "enhancement"]),
+    ):
+        response = client.post(
+            "/api/control/spawn",
+            json={"issue_number": 42},
+        )
+
+    assert response.status_code == 409
+    assert "already claimed" in response.json()["detail"]
+
+
+# ── POST /api/control/spawn — issue not found → 404 ──────────────────────────
+
+
+def test_spawn_invalid_issue_returns_404(client: TestClient) -> None:
+    """POST /api/control/spawn must return 404 when gh cannot find the issue."""
+    with patch(
+        "agentception.routes.api.get_issue",
+        side_effect=RuntimeError("issue not found"),
+    ):
+        response = client.post(
+            "/api/control/spawn",
+            json={"issue_number": 99999},
+        )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"]
+
+
+def test_spawn_closed_issue_returns_404(client: TestClient) -> None:
+    """POST /api/control/spawn must return 404 when the issue is closed."""
+    closed = _open_issue(42)
+    closed["state"] = "CLOSED"
+
+    with patch("agentception.routes.api.get_issue", return_value=closed):
+        response = client.post(
+            "/api/control/spawn",
+            json={"issue_number": 42},
+        )
+
+    assert response.status_code == 404
+    assert "not open" in response.json()["detail"]
+
+
+# ── POST /api/control/spawn — invalid role → 422 ─────────────────────────────
+
+
+def test_spawn_invalid_role_returns_422(client: TestClient) -> None:
+    """POST /api/control/spawn must return 422 for an unrecognised role."""
+    response = client.post(
+        "/api/control/spawn",
+        json={"issue_number": 42, "role": "chaos-monkey"},
+    )
+    assert response.status_code == 422
+
+
+# ── POST /api/control/spawn — worktree already exists → 409 ──────────────────
+
+
+def test_spawn_existing_worktree_returns_409(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """POST /api/control/spawn must return 409 when the worktree directory already exists."""
+    worktrees = tmp_path / "worktrees" / "maestro"
+    # Pre-create the issue worktree so the endpoint sees it exists
+    existing = worktrees / "issue-42"
+    existing.mkdir(parents=True)
+
+    with (
+        patch(
+            "agentception.routes.api.get_issue",
+            return_value=_open_issue(42),
+        ),
+        patch("agentception.routes.api.add_wip_label", new_callable=AsyncMock),
+        patch("agentception.routes.api.settings.worktrees_dir", worktrees),
+    ):
+        response = client.post(
+            "/api/control/spawn",
+            json={"issue_number": 42},
+        )
+
+    assert response.status_code == 409
+    assert "already exists" in response.json()["detail"]
+
+
+# ── GET /control/spawn — form renders ────────────────────────────────────────
+
+
+def test_spawn_form_renders_issue_list(client: TestClient) -> None:
+    """GET /control/spawn must render a form containing open, unclaimed issues."""
+    fake_issues = [
+        _open_issue_list(100, "Issue Alpha"),
+        _open_issue_list(101, "Issue Beta"),
+        _open_issue_list(102, "Issue Gamma — already claimed", ["agent:wip"]),
+    ]
+
+    with patch(
+        "agentception.routes.ui.get_open_issues",
+        return_value=fake_issues,
+    ):
+        response = client.get("/control/spawn")
+
+    assert response.status_code == 200
+    html = response.text
+    assert "#100" in html
+    assert "Issue Alpha" in html
+    assert "#101" in html
+    assert "Issue Beta" in html
+    # Claimed issue must NOT appear in the picker
+    assert "#102" not in html
+    assert "Issue Gamma" not in html
+
+
+def test_spawn_form_renders_role_options(client: TestClient) -> None:
+    """GET /control/spawn form must include all valid role options."""
+    with patch("agentception.routes.ui.get_open_issues", return_value=[]):
+        response = client.get("/control/spawn")
+
+    assert response.status_code == 200
+    html = response.text
+    for role in VALID_ROLES:
+        assert role in html
+
+
+def test_spawn_form_renders_empty_state_gracefully(client: TestClient) -> None:
+    """GET /control/spawn must render without error when there are no unclaimed issues."""
+    with patch("agentception.routes.ui.get_open_issues", return_value=[]):
+        response = client.get("/control/spawn")
+
+    assert response.status_code == 200
+    assert "AgentCeption" in response.text
+
+
+# ── SpawnRequest model validation ─────────────────────────────────────────────
+
+
+def test_spawn_request_default_role() -> None:
+    """SpawnRequest must default the role to python-developer."""
+    req = SpawnRequest(issue_number=1)
+    assert req.role == "python-developer"
+
+
+def test_spawn_request_accepts_all_valid_roles() -> None:
+    """SpawnRequest must accept every role in VALID_ROLES."""
+    for role in VALID_ROLES:
+        req = SpawnRequest(issue_number=1, role=role)
+        assert req.role == role
+
+
+def test_spawn_request_rejects_unknown_role() -> None:
+    """SpawnRequest must raise ValueError for an unrecognised role."""
+    with pytest.raises(Exception):
+        SpawnRequest(issue_number=1, role="hacker")

--- a/agentception/tests/test_agentception_spawn.py
+++ b/agentception/tests/test_agentception_spawn.py
@@ -116,6 +116,7 @@ def test_spawn_creates_worktree_and_task_file(
     assert "issue-42" in data["worktree"]
     assert data["branch"] == "feat/issue-42"
     assert "ISSUE_NUMBER=42" in data["agent_task"]
+    assert "BRANCH=feat/issue-42" in data["agent_task"]
     assert "ROLE=python-developer" in data["agent_task"]
     # Verify the .agent-task file was actually written to disk.
     task_file = expected_worktree / ".agent-task"
@@ -281,5 +282,5 @@ def test_spawn_request_accepts_all_valid_roles() -> None:
 
 def test_spawn_request_rejects_unknown_role() -> None:
     """SpawnRequest must raise ValueError for an unrecognised role."""
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         SpawnRequest(issue_number=1, role="hacker")


### PR DESCRIPTION
## Summary
Closes #619 — adds `POST /api/control/spawn` for manual agent seeding and a `GET /control/spawn` issue-picker UI.

## Root Cause / Motivation
The CTO/VP polling loop handles batched parallel dispatch, but operators need a direct escape hatch to seed a single agent on any open, unclaimed issue without waiting for the next batch cycle.

## Solution
- **`POST /api/control/spawn`** — verifies the issue is open and not already labelled `agent:wip`, adds the claim label, creates a git worktree at `~/.cursor/worktrees/maestro/issue-<N>`, writes a conformant `.agent-task` file, and returns the worktree path + task content. The caller (human or future automation) launches the Cursor Task.
- **`GET /control/spawn`** — renders an Alpine.js + HTMX-ready form populated with open, unclaimed issues (filtered from `get_open_issues()`) and a role selector. On submit it calls the API endpoint and shows the result card or error banner inline.
- **Models**: `SpawnRequest` (issue_number + validated role) and `SpawnResult` added to `models.py`.
- **GitHub readers**: `get_issue()` and `add_wip_label()` added to `readers/github.py`, following the existing cache-invalidation pattern.

## Verification
- [x] mypy clean (22 source files, 0 errors)
- [x] 32 tests pass — 12 new in `test_agentception_spawn.py`, 5 new in `test_agentception_github.py`, 0 regressions
- [x] All issue acceptance criteria covered:
  - POST creates worktree + .agent-task ✅
  - 409 returned if issue has agent:wip ✅
  - 409 returned if worktree already exists ✅
  - 404 returned if issue not found or closed ✅
  - 422 returned for invalid role ✅
  - Issue picker shows only open, unclaimed issues ✅
- [x] No secrets, no print(), no dead code
- [x] Docs: docstrings on all public functions and models

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Name** | Alan Turing |
| **Architecture** | `turing:fastapi:python` |
| **Skills** | FastAPI · Python / FastAPI |
| **Role** | `python-developer` |
| **Session** | `eng-20260302T020137Z-0804` |
| **Batch (VP)** | `eng-20260302T015842Z-02de` |
| **Wave (CTO)** | `wave-1-20260301` |
| **VP** | `Engineering VP · eng-20260302T015842Z-02de` |

</details>