### PR TITLE
feat: cost estimator — token proxy + Claude Sonnet 4.6 pricing

### DIFF
--- a/agentception/routes/api.py
+++ b/agentception/routes/api.py
@@ -19,7 +19,7 @@ from agentception.poller import get_state
 from agentception.readers.github import add_wip_label, get_issue
 from agentception.readers.transcripts import read_transcript_messages
 from agentception.routes.ui import _find_agent
-from agentception.telemetry import WaveSummary, aggregate_waves
+from agentception.telemetry import WaveSummary, aggregate_waves, estimate_cost
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +72,27 @@ async def waves_api() -> list[WaveSummary]:
     ``BATCH_ID``.  Results are sorted most-recent-first by ``started_at``.
     """
     return await aggregate_waves()
+
+
+@router.get("/telemetry/cost", tags=["telemetry"])
+async def total_cost_api() -> dict[str, float | int]:
+    """Return the aggregate token and cost estimate across all historical waves.
+
+    Sums ``estimated_tokens`` and ``estimated_cost_usd`` from every wave
+    returned by ``aggregate_waves()``.  The result is a stable summary
+    useful for dashboards and budget tracking without iterating wave data
+    on the client side.
+
+    Returns ``{"total_tokens": int, "total_cost_usd": float, "wave_count": int}``.
+    """
+    waves = await aggregate_waves()
+    total_tokens = sum(w.estimated_tokens for w in waves)
+    total_cost_usd = round(sum(w.estimated_cost_usd for w in waves), 4)
+    return {
+        "total_tokens": total_tokens,
+        "total_cost_usd": total_cost_usd,
+        "wave_count": len(waves),
+    }
 
 
 @router.get("/pipeline")

--- a/agentception/routes/api.py
+++ b/agentception/routes/api.py
@@ -19,7 +19,7 @@ from agentception.poller import get_state
 from agentception.readers.github import add_wip_label, get_issue
 from agentception.readers.transcripts import read_transcript_messages
 from agentception.routes.ui import _find_agent
-from agentception.telemetry import WaveSummary, aggregate_waves, estimate_cost
+from agentception.telemetry import WaveSummary, aggregate_waves
 
 logger = logging.getLogger(__name__)
 

--- a/agentception/telemetry.py
+++ b/agentception/telemetry.py
@@ -22,10 +22,35 @@ from agentception.readers.worktrees import list_active_worktrees
 
 logger = logging.getLogger(__name__)
 
-# Placeholder token / cost constants — refined once real usage data is available.
-# These are intentionally conservative estimates based on typical Sonnet runs.
-_TOKENS_PER_AGENT = 80_000
-_COST_PER_TOKEN_USD = 0.000_003  # ~$3 per 1M input tokens (Sonnet 3.5 blended rate)
+# Claude Sonnet 4.6 pricing (per million tokens, as of 2026).
+# Exported so tests and the API layer can reference them without duplication.
+SONNET_INPUT_PER_M: float = 3.0
+SONNET_OUTPUT_PER_M: float = 15.0
+
+# Conservative proxy: transcripts carry no real token counts, so we estimate
+# from message volume.  40 % of traffic is treated as input (prompts/context),
+# 60 % as output (model completions).
+AVG_TOKENS_PER_MSG: int = 800
+AVG_INPUT_RATIO: float = 0.4
+
+
+def estimate_cost(message_count: int) -> tuple[int, float]:
+    """Return ``(estimated_tokens, estimated_cost_usd)`` for a given message count.
+
+    Uses ``AVG_TOKENS_PER_MSG`` as a per-message proxy and Claude Sonnet 4.6
+    pricing constants.  The input/output split follows ``AVG_INPUT_RATIO``.
+
+    Returns ``(0, 0.0)`` when ``message_count`` is zero so callers can treat
+    the zero case uniformly without special-casing.
+    """
+    tokens = message_count * AVG_TOKENS_PER_MSG
+    input_tokens = int(tokens * AVG_INPUT_RATIO)
+    output_tokens = tokens - input_tokens
+    cost = (
+        input_tokens / 1_000_000 * SONNET_INPUT_PER_M
+        + output_tokens / 1_000_000 * SONNET_OUTPUT_PER_M
+    )
+    return tokens, round(cost, 4)
 
 
 class WaveSummary(BaseModel):
@@ -167,12 +192,14 @@ def _build_wave_summaries(
         started_at = min(mtimes) if mtimes else 0.0
         ended_at = None if any_still_active else (max(mtimes) if mtimes else None)
 
-        agent_count = len(members)
-        estimated_tokens = agent_count * _TOKENS_PER_AGENT
-        estimated_cost_usd = estimated_tokens * _COST_PER_TOKEN_USD
-
         # Build minimal AgentNode stubs from TaskFile data.
         agents = [_task_file_to_agent_node(tf) for tf in members]
+
+        # Derive cost from total message count across all agents in this wave.
+        # message_count defaults to 0 until the poller enriches agents from
+        # transcript data; the estimate grows as transcripts are read.
+        total_message_count = sum(a.message_count for a in agents)
+        estimated_tokens, estimated_cost_usd = estimate_cost(total_message_count)
 
         summaries.append(
             WaveSummary(

--- a/agentception/tests/test_agentception_telemetry.py
+++ b/agentception/tests/test_agentception_telemetry.py
@@ -15,10 +15,15 @@ import pytest
 
 from agentception.models import TaskFile
 from agentception.telemetry import (
+    AVG_INPUT_RATIO,
+    AVG_TOKENS_PER_MSG,
+    SONNET_INPUT_PER_M,
+    SONNET_OUTPUT_PER_M,
     WaveSummary,
     _build_wave_summaries,
     aggregate_waves,
     compute_wave_timing,
+    estimate_cost,
 )
 
 
@@ -186,6 +191,76 @@ def test_wave_summary_type_is_wave_summary(tmp_path: Path) -> None:
     tf = _make_task_file(tmp_path, "wt-type", "batch-Z", issue_number=5)
     result = _build_wave_summaries([tf], tmp_path)
     assert isinstance(result[0], WaveSummary)
+
+
+# ── Unit tests for estimate_cost ──────────────────────────────────────────────
+
+
+def test_estimate_cost_zero_messages() -> None:
+    """estimate_cost(0) must return (0, 0.0) — zero messages means zero cost."""
+    tokens, cost = estimate_cost(0)
+    assert tokens == 0
+    assert cost == 0.0
+
+
+def test_estimate_cost_known_input() -> None:
+    """estimate_cost(100) must return tokens and cost within the expected range.
+
+    100 messages × 800 tokens/msg = 80 000 tokens.
+    Input: 80 000 × 0.4 = 32 000 tokens → $0.096 at $3/M
+    Output: 80 000 × 0.6 = 48 000 tokens → $0.72 at $15/M
+    Total cost ≈ $0.816 → rounded to 4 dp.
+    """
+    tokens, cost = estimate_cost(100)
+    expected_tokens = 100 * AVG_TOKENS_PER_MSG
+    assert tokens == expected_tokens
+
+    input_tokens = int(expected_tokens * AVG_INPUT_RATIO)
+    output_tokens = expected_tokens - input_tokens
+    expected_cost = round(
+        input_tokens / 1_000_000 * SONNET_INPUT_PER_M
+        + output_tokens / 1_000_000 * SONNET_OUTPUT_PER_M,
+        4,
+    )
+    assert cost == pytest.approx(expected_cost, abs=1e-4)
+    # Sanity-check range: must be between $0.5 and $2.0 for 100 messages.
+    assert 0.5 <= cost <= 2.0
+
+
+def test_wave_summary_includes_cost(tmp_path: Path) -> None:
+    """Each WaveSummary must expose estimated_tokens and estimated_cost_usd.
+
+    Both fields should be non-negative integers / floats computed by estimate_cost.
+    With no transcript enrichment, message_count defaults to 0, so both are 0.
+    """
+    tf = _make_task_file(tmp_path, "wt-cost", "batch-cost", issue_number=42)
+    result = _build_wave_summaries([tf], tmp_path)
+
+    assert len(result) == 1
+    wave = result[0]
+    assert isinstance(wave.estimated_tokens, int)
+    assert isinstance(wave.estimated_cost_usd, float)
+    assert wave.estimated_tokens >= 0
+    assert wave.estimated_cost_usd >= 0.0
+
+
+def test_total_cost_sums_waves(tmp_path: Path) -> None:
+    """Summing estimated_cost_usd across waves must equal the aggregate total.
+
+    Two independent waves, each with zero message_count (defaults), produce
+    zero cost each — their sum is also zero.  The invariant is that the
+    aggregate matches the per-wave sum, not that costs are non-zero.
+    """
+    tf_a = _make_task_file(tmp_path, "wt-sum-a", "batch-sum-A", issue_number=50)
+    tf_b = _make_task_file(tmp_path, "wt-sum-b", "batch-sum-B", issue_number=51)
+    waves = _build_wave_summaries([tf_a, tf_b], tmp_path)
+
+    assert len(waves) == 2
+    total_cost = round(sum(w.estimated_cost_usd for w in waves), 4)
+    total_tokens = sum(w.estimated_tokens for w in waves)
+    expected_cost = round(waves[0].estimated_cost_usd + waves[1].estimated_cost_usd, 4)
+    assert total_cost == pytest.approx(expected_cost, abs=1e-6)
+    assert total_tokens == waves[0].estimated_tokens + waves[1].estimated_tokens
 
 
 # ── Integration smoke: aggregate_waves (live filesystem) ─────────────────────


### PR DESCRIPTION
## Summary
Closes #621 — Adds a message-count-based cost estimator with Claude Sonnet 4.6 pricing constants to WaveSummary telemetry and exposes a new aggregate cost API endpoint.

## Root Cause / Motivation
WaveSummary used placeholder per-agent token constants that didn't reflect real model pricing or actual transcript volume. The issue required switching to a message-count proxy using real Claude Sonnet 4.6 pricing to surface meaningful cost estimates per wave and in aggregate.

## Solution
- Replaced `_TOKENS_PER_AGENT` / `_COST_PER_TOKEN_USD` with four exported constants: `SONNET_INPUT_PER_M`, `SONNET_OUTPUT_PER_M`, `AVG_TOKENS_PER_MSG`, `AVG_INPUT_RATIO`
- Added `estimate_cost(message_count: int) -> tuple[int, float]` in `telemetry.py` — pure function, no side effects, tested directly
- Updated `_build_wave_summaries()` to sum `message_count` from all AgentNode stubs in a wave, then call `estimate_cost()` — cost grows naturally as the poller enriches agents from transcripts
- Added `GET /api/telemetry/cost` route that sums `estimated_tokens` and `estimated_cost_usd` across all waves and returns `{total_tokens, total_cost_usd, wave_count}`

## Verification
- [x] mypy clean (27 source files, no issues)
- [x] 15 tests pass (11 pre-existing + 4 new: zero-messages, known-input, wave-includes-cost, total-cost-sums-waves)
- [x] No doc changes needed — all public symbols have docstrings

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Architecture** | `turing:fastapi:python` |
| **Skills** | FastAPI · Python / FastAPI |
| **Role** | `python-developer` |
| **Session** | `eng-20260302T024617Z-3b02` |
| **Batch (VP)** | `eng-20260302T024412Z-0d87` |
| **Wave (CTO)** | `wave-3-2026-03-01` |
| **VP** | `Engineering VP · eng-20260302T024412Z-0d87` |

</details>