### PR TITLE
feat(agentception): telemetry UI — CSS timeline bar chart + wave summary table

### DIFF
--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -5,6 +5,7 @@ background poller via ``get_state()`` — routes are intentionally thin.
 """
 from __future__ import annotations
 
+import datetime
 import os
 from pathlib import Path
 
@@ -18,12 +19,30 @@ from agentception.models import AgentNode, PipelineState, VALID_ROLES
 from agentception.poller import get_state
 from agentception.readers.github import get_open_issues
 from agentception.readers.transcripts import read_transcript_messages
+from agentception.telemetry import WaveSummary, aggregate_waves
 
 _HERE = Path(__file__).parent
 _TEMPLATES = Jinja2Templates(directory=str(_HERE.parent / "templates"))
 # Register path filters used by agent.html kill-endpoint modal.
 _TEMPLATES.env.filters["basename"] = os.path.basename
 _TEMPLATES.env.filters["dirname"] = os.path.dirname
+
+
+def _format_ts(ts: float) -> str:
+    """Format a UNIX timestamp as a short UTC datetime string for the telemetry table."""
+    try:
+        return datetime.datetime.utcfromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
+    except (OSError, OverflowError, ValueError):
+        return "—"
+
+
+def _format_number(n: int) -> str:
+    """Format an integer with thousands separators for readability."""
+    return f"{n:,}"
+
+
+_TEMPLATES.env.filters["format_ts"] = _format_ts
+_TEMPLATES.env.filters["format_number"] = _format_number
 
 router = APIRouter(tags=["ui"])
 
@@ -100,6 +119,45 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
         request,
         "agent.html",
         {"node": node, "agent_id": agent_id, "messages": messages},
+    )
+
+
+@router.get("/telemetry", response_class=HTMLResponse)
+async def telemetry_page(request: Request) -> HTMLResponse:
+    """Telemetry dashboard — wave history as a CSS bar chart and summary table.
+
+    Aggregates all ``.agent-task`` files grouped by BATCH_ID into WaveSummary
+    objects. The chart is CSS-only (no JS charting library): bar widths are
+    computed server-side as percentages of the longest wave duration.
+    Returns an empty-wave view when no wave data is present.
+    """
+    waves: list[WaveSummary] = await aggregate_waves()
+
+    # Compute bar widths as percentages of the longest wave duration so all
+    # bars are proportional and the chart fills its container.
+    max_duration_s: float = 0.0
+    for wave in waves:
+        if wave.ended_at is not None:
+            max_duration_s = max(max_duration_s, wave.ended_at - wave.started_at)
+
+    # Pre-compute summary totals in Python so the template stays logic-free.
+    all_issues: set[int] = set()
+    for wave in waves:
+        all_issues.update(wave.issues_worked)
+    total_issues = len(all_issues)
+    total_cost_usd = round(sum(w.estimated_cost_usd for w in waves), 4)
+    total_agents = sum(len(w.agents) for w in waves)
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "telemetry.html",
+        {
+            "waves": waves,
+            "max_duration_s": max_duration_s,
+            "total_issues": total_issues,
+            "total_cost_usd": total_cost_usd,
+            "total_agents": total_agents,
+        },
     )
 
 

--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -766,3 +766,167 @@ main {
   gap: 0.5rem;
   justify-content: flex-end;
 }
+
+/* ── Telemetry page ───────────────────────────────────────────────────────── */
+
+/* Chart section */
+
+.telemetry-chart-section {
+  /* section wrapper — uses existing .card and .mt-2 utilities */
+}
+
+.telemetry-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+}
+
+.telemetry-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: default;
+}
+
+.telemetry-bar-label {
+  flex: 0 0 220px;
+  font-size: 0.6875rem;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
+}
+
+.telemetry-bar-track {
+  flex: 1;
+  background: var(--bg-tertiary);
+  border-radius: 3px;
+  height: 22px;
+  overflow: hidden;
+}
+
+.telemetry-bar {
+  height: 100%;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  min-width: 4px;
+  transition: opacity 0.15s;
+}
+
+.telemetry-bar:hover {
+  opacity: 0.8;
+}
+
+.telemetry-bar--complete {
+  background: var(--success);
+}
+
+.telemetry-bar--active {
+  background: var(--warning);
+  /* pulse animation indicates the wave is still running */
+  animation: bar-pulse 2s ease-in-out infinite;
+}
+
+.telemetry-bar--short {
+  background: var(--text-muted);
+}
+
+@keyframes bar-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.6; }
+}
+
+.telemetry-bar-text {
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: #0d1117;
+  padding: 0 0.4rem;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+/* Wave table */
+
+.telemetry-table-wrap {
+  overflow-x: auto;
+  padding: 0;
+}
+
+.telemetry-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.telemetry-th {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding: 0.5rem 0.875rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.telemetry-td {
+  padding: 0.5rem 0.875rem;
+  vertical-align: middle;
+  border-bottom: 1px solid var(--border);
+}
+
+.telemetry-row:last-child .telemetry-td {
+  border-bottom: none;
+}
+
+.telemetry-td--batch {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.telemetry-batch-id {
+  font-size: 0.6875rem;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  color: var(--accent-hover);
+}
+
+.telemetry-expand-btn {
+  font-size: 0.75rem;
+  padding: 0.1875rem 0.5rem;
+  white-space: nowrap;
+}
+
+/* Agent details sub-row */
+
+.telemetry-agents-row {
+  background: var(--bg-tertiary);
+}
+
+.telemetry-agents-cell {
+  padding: 0.625rem 0.875rem 0.625rem 2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.telemetry-agents-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.telemetry-agent-item {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.telemetry-agent-role {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}

--- a/agentception/templates/telemetry.html
+++ b/agentception/templates/telemetry.html
@@ -1,0 +1,182 @@
+{% extends "base.html" %}
+
+{% block title %}AgentCeption — Telemetry{% endblock %}
+
+{% block content %}
+{#
+  Telemetry page: wave history as a CSS-only horizontal bar chart and a
+  summary table with per-wave timing, cost, and agent details expandable
+  via Alpine x-show.  No JS charting library — all bar widths are
+  percentages computed by the route handler.
+#}
+
+{# ── Summary stats bar ───────────────────────────────────────────────────── #}
+{# Totals are pre-computed by the route handler and passed as context variables. #}
+
+<div class="pipeline-summary-bar" role="status" aria-label="Telemetry summary">
+  <div class="summary-item">
+    <span class="summary-label">Waves run</span>
+    <span class="summary-value">{{ waves | length }}</span>
+  </div>
+  <div class="summary-item">
+    <span class="summary-label">Issues worked</span>
+    <span class="summary-value">{{ total_issues }}</span>
+  </div>
+  <div class="summary-item">
+    <span class="summary-label">Est. cost (USD)</span>
+    <span class="summary-value">${{ "%.4f" | format(total_cost_usd) }}</span>
+  </div>
+  <div class="summary-item">
+    <span class="summary-label">All-time agents</span>
+    <span class="summary-value">{{ total_agents }}</span>
+  </div>
+</div>
+
+{# ── Empty state ─────────────────────────────────────────────────────────── #}
+{% if not waves %}
+<div class="card mt-2">
+  <p class="text-muted empty-state">No wave history available yet. Waves appear once agents start running.</p>
+</div>
+{% else %}
+
+{# ── CSS timeline bar chart ──────────────────────────────────────────────── #}
+<section class="telemetry-chart-section mt-2" aria-label="Wave timeline">
+  <h2 class="section-title">Timeline</h2>
+  <div class="telemetry-chart card">
+    {% for wave in waves %}
+    {%   set duration_s = (wave.ended_at - wave.started_at) if wave.ended_at is not none else 0 %}
+    {%   if max_duration_s > 0 and wave.ended_at is not none %}
+    {%     set pct = ((duration_s / max_duration_s) * 100) | round(1) %}
+    {%   else %}
+    {%     set pct = 100 %}
+    {%   endif %}
+    {#   Colour: active → yellow, very short (<10 s) → grey, complete → green #}
+    {%   if wave.ended_at is none %}
+    {%     set bar_class = "telemetry-bar--active" %}
+    {%   elif duration_s < 10 %}
+    {%     set bar_class = "telemetry-bar--short" %}
+    {%   else %}
+    {%     set bar_class = "telemetry-bar--complete" %}
+    {%   endif %}
+    <div class="telemetry-bar-row" title="Batch: {{ wave.batch_id }} | Duration: {{ duration_s | int }}s | Issues: {{ wave.issues_worked | join(', ') }} | Cost: ${{ '%.4f' | format(wave.estimated_cost_usd) }}">
+      <span class="telemetry-bar-label text-muted">{{ wave.batch_id }}</span>
+      <div class="telemetry-bar-track">
+        <div class="telemetry-bar {{ bar_class }}" style="width: {{ pct }}%">
+          {% if pct > 15 %}
+          <span class="telemetry-bar-text">{{ duration_s | int }}s · {{ wave.issues_worked | length }} issue{{ 's' if wave.issues_worked | length != 1 else '' }}</span>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+
+{# ── Wave summary table ───────────────────────────────────────────────────── #}
+<section class="mt-3" aria-label="Wave table">
+  <h2 class="section-title">Wave History</h2>
+  <div class="telemetry-table-wrap card">
+    <table class="telemetry-table" role="table">
+      <thead>
+        <tr>
+          <th class="telemetry-th">Batch ID</th>
+          <th class="telemetry-th">Start</th>
+          <th class="telemetry-th">Duration</th>
+          <th class="telemetry-th">Issues</th>
+          <th class="telemetry-th">PRs opened</th>
+          <th class="telemetry-th">PRs merged</th>
+          <th class="telemetry-th">Est. tokens</th>
+          <th class="telemetry-th">Est. cost</th>
+          <th class="telemetry-th"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for wave in waves %}
+        {%   set row_id = "wave-" ~ loop.index %}
+        {%   set duration_s = (wave.ended_at - wave.started_at) | int if wave.ended_at is not none else none %}
+        <tr
+          class="telemetry-row"
+          x-data="{ open: false }"
+        >
+          <td class="telemetry-td telemetry-td--batch">
+            <code class="telemetry-batch-id">{{ wave.batch_id }}</code>
+          </td>
+          <td class="telemetry-td text-muted">
+            {% if wave.started_at %}
+              {{ wave.started_at | format_ts }}
+            {% else %}
+              —
+            {% endif %}
+          </td>
+          <td class="telemetry-td text-muted">
+            {% if duration_s is not none %}
+              {{ duration_s }}s
+            {% elif wave.ended_at is none %}
+              <span class="text-warning">active</span>
+            {% else %}
+              —
+            {% endif %}
+          </td>
+          <td class="telemetry-td">
+            {% if wave.issues_worked %}
+              <span class="text-muted">{{ wave.issues_worked | join(', ') }}</span>
+            {% else %}
+              <span class="text-muted">—</span>
+            {% endif %}
+          </td>
+          <td class="telemetry-td text-muted">{{ wave.prs_opened }}</td>
+          <td class="telemetry-td text-muted">{{ wave.prs_merged }}</td>
+          <td class="telemetry-td text-muted">{{ wave.estimated_tokens | int | format_number }}</td>
+          <td class="telemetry-td text-muted">${{ "%.4f" | format(wave.estimated_cost_usd) }}</td>
+          <td class="telemetry-td">
+            {% if wave.agents %}
+            <button
+              class="btn btn-secondary telemetry-expand-btn"
+              @click="open = !open"
+              :aria-expanded="open.toString()"
+              aria-label="Toggle agent details"
+              x-text="open ? 'Hide' : 'Agents (' + {{ wave.agents | length }} + ')'"
+            ></button>
+            {% endif %}
+          </td>
+        </tr>
+
+        {# Expandable agent details row #}
+        {% if wave.agents %}
+        <tr x-show="open" x-cloak class="telemetry-agents-row">
+          <td colspan="9" class="telemetry-agents-cell">
+            <div class="telemetry-agents-list">
+              {% for agent in wave.agents %}
+              <div class="telemetry-agent-item">
+                <span
+                  class="status-badge status-badge--{{ agent.status.value }}"
+                >{{ agent.status.value }}</span>
+                <a
+                  href="/agents/{{ agent.id }}"
+                  class="telemetry-agent-role"
+                >{{ agent.role }}</a>
+                {% if agent.issue_number is not none %}
+                <span class="agent-meta">#{{ agent.issue_number }}</span>
+                {% endif %}
+                {% if agent.pr_number is not none %}
+                <span class="agent-meta">PR {{ agent.pr_number }}</span>
+                {% endif %}
+                {% if agent.branch %}
+                <span class="agent-meta text-muted">{{ agent.branch }}</span>
+                {% endif %}
+              </div>
+              {% endfor %}
+            </div>
+          </td>
+        </tr>
+        {% endif %}
+
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+
+{% endif %}{# if not waves #}
+
+{% endblock %}

--- a/agentception/tests/test_agentception_ui_telemetry.py
+++ b/agentception/tests/test_agentception_ui_telemetry.py
@@ -1,0 +1,139 @@
+"""Tests for the AgentCeption telemetry UI page (AC-203).
+
+Covers the three acceptance criteria from issue #622:
+- GET /telemetry returns HTTP 200 for both empty and non-empty wave history
+- The page renders a wave table when waves are present
+- The page renders gracefully with an empty wave list
+
+Run targeted:
+    pytest agentception/tests/test_agentception_ui_telemetry.py -v
+"""
+from __future__ import annotations
+
+import time
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+from agentception.models import AgentNode, AgentStatus
+from agentception.telemetry import WaveSummary
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    """Synchronous test client with full lifespan (poller starts and is immediately cancelled)."""
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def empty_waves() -> list[WaveSummary]:
+    """Empty wave list — simulates a fresh deployment with no history."""
+    return []
+
+
+@pytest.fixture()
+def populated_waves() -> list[WaveSummary]:
+    """Two WaveSummary objects covering completed and active waves."""
+    now = time.time()
+    agent = AgentNode(
+        id="issue-615",
+        role="python-developer",
+        status=AgentStatus.DONE,
+        issue_number=615,
+        batch_id="eng-batch-A",
+    )
+    return [
+        WaveSummary(
+            batch_id="eng-batch-A",
+            started_at=now - 3600,
+            ended_at=now - 3000,
+            issues_worked=[615, 616],
+            prs_opened=2,
+            prs_merged=2,
+            estimated_tokens=160000,
+            estimated_cost_usd=1.632,
+            agents=[agent],
+        ),
+        WaveSummary(
+            batch_id="eng-batch-B",
+            started_at=now - 900,
+            ended_at=None,  # still active
+            issues_worked=[620],
+            prs_opened=0,
+            prs_merged=0,
+            estimated_tokens=0,
+            estimated_cost_usd=0.0,
+            agents=[],
+        ),
+    ]
+
+
+# ── test_telemetry_page_returns_200 ──────────────────────────────────────────
+
+
+def test_telemetry_page_returns_200(
+    client: TestClient, populated_waves: list[WaveSummary]
+) -> None:
+    """GET /telemetry must return HTTP 200 when wave history is present."""
+    with patch(
+        "agentception.routes.ui.aggregate_waves",
+        new_callable=AsyncMock,
+        return_value=populated_waves,
+    ):
+        response = client.get("/telemetry")
+    assert response.status_code == 200
+
+
+# ── test_telemetry_page_shows_wave_table ─────────────────────────────────────
+
+
+def test_telemetry_page_shows_wave_table(
+    client: TestClient, populated_waves: list[WaveSummary]
+) -> None:
+    """GET /telemetry must render the wave table with batch IDs and chart bars."""
+    with patch(
+        "agentception.routes.ui.aggregate_waves",
+        new_callable=AsyncMock,
+        return_value=populated_waves,
+    ):
+        response = client.get("/telemetry")
+
+    assert response.status_code == 200
+    html = response.text
+    # Table must be present
+    assert "telemetry-table" in html
+    # Both batch IDs must appear
+    assert "eng-batch-A" in html
+    assert "eng-batch-B" in html
+    # Chart bar track must be rendered
+    assert "telemetry-bar-track" in html
+    # Summary stats bar must be present
+    assert "pipeline-summary-bar" in html
+
+
+# ── test_telemetry_page_empty_waves ──────────────────────────────────────────
+
+
+def test_telemetry_page_empty_waves(
+    client: TestClient, empty_waves: list[WaveSummary]
+) -> None:
+    """GET /telemetry must return HTTP 200 and an empty-state message when there are no waves."""
+    with patch(
+        "agentception.routes.ui.aggregate_waves",
+        new_callable=AsyncMock,
+        return_value=empty_waves,
+    ):
+        response = client.get("/telemetry")
+
+    assert response.status_code == 200
+    html = response.text
+    # Empty-state text must be shown
+    assert "No wave history" in html
+    # The table must NOT be rendered for an empty list
+    assert "telemetry-table" not in html
+    # Summary stats bar is still shown even with no waves
+    assert "pipeline-summary-bar" in html


### PR DESCRIPTION
## Summary
Closes #622 — adds `GET /telemetry` page showing wave history as a CSS-only horizontal bar chart and a summary table with timing, cost, agent counts, and expandable agent detail rows.

## Root Cause / Motivation
The AgentCeption dashboard had no historical view of wave activity. Operators could see live agents on the overview page but had no way to review past waves, costs, or throughput across batches.

## Solution

**New route** (`agentception/routes/ui.py`):
- `GET /telemetry` calls `aggregate_waves()` from `telemetry.py` (implemented in #620/#621)
- Pre-computes per-wave bar widths as percentages of the longest completed wave, and summary totals (issues, cost, agents)
- Registers two Jinja2 filters: `format_ts` (UNIX → UTC string) and `format_number` (integer thousands separator)

**Template** (`agentception/templates/telemetry.html`):
- Summary stats bar: waves run · issues worked · est. cost · all-time agents
- CSS-only timeline bar chart: one bar per wave, width proportional to duration; green=complete, yellow=active (pulsing), grey=very short (<10s)
- Wave table: batch ID · start · duration · issues · PRs opened/merged · est. tokens · est. cost
- Each wave row expands (Alpine `x-show`) to list its agent nodes linking to `/agents/{id}`
- Empty-state message when no wave history exists

**CSS** (`agentception/static/app.css`):
- `telemetry-bar-track` / `telemetry-bar` variants (complete/active/short), `@keyframes bar-pulse` for active bars
- `telemetry-table`, `telemetry-row`, `telemetry-agents-row` sub-row styling

**Tests** (`agentception/tests/test_agentception_ui_telemetry.py`):
- `test_telemetry_page_returns_200`
- `test_telemetry_page_shows_wave_table`
- `test_telemetry_page_empty_waves`

## Verification
- [x] mypy clean (28 source files, 0 errors)
- [x] 3 new tests pass
- [x] 25 existing tests pass (telemetry + overview + api)
- [x] No JS charting library — CSS only
- [x] Depends-on #620 (CLOSED) + #621 (CLOSED) ✅

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Architecture** | `turing:jinja2:alpine` |
| **Skills** | Jinja2 · Alpine.js |
| **Role** | `python-developer` |
| **Session** | `eng-20260302T025825Z-433b` |
| **Batch (VP)** | `eng-20260302T024412Z-0d87` |
| **Wave (CTO)** | `wave-3-2026-03-01` |
| **VP** | `Engineering VP · eng-20260302T024412Z-0d87` |

</details>