### PR TITLE
feat: add Role Studio UI with Monaco editor (AC-302)

### DIFF
--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -15,10 +15,11 @@ from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
 from starlette.responses import Response
 
-from agentception.models import AgentNode, PipelineState, VALID_ROLES
+from agentception.models import AgentNode, PipelineState, RoleMeta, VALID_ROLES
 from agentception.poller import get_state
 from agentception.readers.github import get_open_issues
 from agentception.readers.transcripts import read_transcript_messages
+from agentception.routes.roles import list_roles
 from agentception.telemetry import WaveSummary, aggregate_waves
 
 _HERE = Path(__file__).parent
@@ -158,6 +159,33 @@ async def telemetry_page(request: Request) -> HTMLResponse:
             "total_cost_usd": total_cost_usd,
             "total_agents": total_agents,
         },
+    )
+
+
+@router.get("/roles", response_class=HTMLResponse)
+async def roles_page(request: Request) -> HTMLResponse:
+    """Role Studio — Monaco editor for live editing of managed role and cursor files.
+
+    Renders the Role Studio UI (AC-302): a two-panel layout with a file list
+    on the left and a Monaco editor on the right. File content is loaded into
+    the editor via ``GET /api/roles/{slug}`` when a file row is clicked.
+    Save triggers ``PUT /api/roles/{slug}`` with the editor content.
+
+    On any API read error the page renders with an empty roles list and a
+    visible error banner — the editor chrome always mounts so Monaco can
+    load and the UI stays accessible.
+    """
+    roles: list[RoleMeta] = []
+    error: str | None = None
+    try:
+        roles = await list_roles()
+    except Exception as exc:  # pragma: no cover — filesystem error path
+        error = f"Could not load role file list: {exc}"
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "roles.html",
+        {"roles": roles, "error": error},
     )
 
 

--- a/agentception/templates/roles.html
+++ b/agentception/templates/roles.html
@@ -1,0 +1,315 @@
+{% extends "base.html" %}
+
+{% block title %}Role Studio — AgentCeption{% endblock %}
+
+{% block head %}
+<!-- Monaco Editor AMD loader — loaded only on this page (Monaco is heavy) -->
+<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs/loader.js"></script>
+<style>
+  .roles-layout {
+    display: flex;
+    gap: var(--gap, 1rem);
+    height: calc(100vh - 5rem);
+    overflow: hidden;
+  }
+
+  /* Left panel — file list */
+  .roles-sidebar {
+    flex: 0 0 30%;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .roles-sidebar h2 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-muted, #888);
+    margin: 0 0 0.5rem 0;
+    padding: 0 0.5rem;
+  }
+
+  .role-row {
+    display: flex;
+    flex-direction: column;
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    background: var(--color-card, #1e1e2e);
+    transition: background 0.1s, border-color 0.1s;
+  }
+
+  .role-row:hover {
+    background: var(--color-card-hover, #2a2a3e);
+    border-color: var(--color-border, #444);
+  }
+
+  .role-row.active {
+    border-color: var(--color-accent, #7c6af7);
+    background: var(--color-card-active, #252540);
+  }
+
+  .role-row__slug {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--color-text, #e0e0e0);
+  }
+
+  .role-row__meta {
+    font-size: 0.75rem;
+    color: var(--color-muted, #888);
+    margin-top: 0.15rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /* Right panel — editor area */
+  .roles-editor-panel {
+    flex: 1 1 70%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* Header bar above the editor */
+  .editor-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--color-card, #1e1e2e);
+    border-radius: 4px 4px 0 0;
+    border-bottom: 1px solid var(--color-border, #333);
+    min-height: 2.5rem;
+    flex-shrink: 0;
+  }
+
+  .editor-breadcrumb {
+    flex: 1;
+    font-size: 0.8rem;
+    color: var(--color-muted, #888);
+    font-family: var(--font-mono, monospace);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .editor-header button {
+    font-size: 0.8rem;
+    padding: 0.3rem 0.75rem;
+    border-radius: 4px;
+    border: 1px solid var(--color-border, #444);
+    cursor: pointer;
+    background: var(--color-card, #1e1e2e);
+    color: var(--color-text, #e0e0e0);
+    transition: background 0.1s;
+  }
+
+  .editor-header button:hover {
+    background: var(--color-card-hover, #2a2a3e);
+  }
+
+  .editor-header button.btn-save {
+    background: var(--color-accent, #7c6af7);
+    border-color: var(--color-accent, #7c6af7);
+    color: #fff;
+  }
+
+  .editor-header button.btn-save:hover {
+    opacity: 0.85;
+  }
+
+  .editor-header button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  #editor-container {
+    flex: 1 1 0;
+    overflow: hidden;
+    border-radius: 0 0 4px 4px;
+  }
+
+  /* Status bar below header */
+  .editor-status {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.75rem;
+    min-height: 1.5rem;
+    color: var(--color-muted, #888);
+    background: var(--color-card, #1e1e2e);
+    border-top: 1px solid var(--color-border, #333);
+    flex-shrink: 0;
+  }
+
+  .editor-status.ok { color: #4caf50; }
+  .editor-status.err { color: #f44336; }
+
+  /* Placeholder when nothing is selected */
+  .editor-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: var(--color-muted, #888);
+    font-size: 0.9rem;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+{% if error %}
+<div class="alert-banner" role="alert" style="margin-bottom:0.75rem">
+  ⚠️ {{ error }}
+</div>
+{% endif %}
+
+<div class="roles-layout">
+
+  <!-- ── Left panel: file list ────────────────────────────────────────────── -->
+  <aside class="roles-sidebar" aria-label="Role file list">
+    <h2>Managed Files ({{ roles | length }})</h2>
+    {% if roles %}
+      {% for role in roles %}
+      <div class="role-row"
+           id="row-{{ role.slug }}"
+           data-slug="{{ role.slug }}"
+           data-path="{{ role.path }}"
+           onclick="loadRole('{{ role.slug }}', '{{ role.path }}')"
+           role="button"
+           tabindex="0"
+           onkeydown="if(event.key==='Enter'||event.key===' ')loadRole('{{ role.slug }}','{{ role.path }}')">
+        <span class="role-row__slug">{{ role.slug }}</span>
+        <span class="role-row__meta">
+          {{ role.line_count }} lines
+          {% if role.last_commit_message %}· {{ role.last_commit_message | truncate(50) }}{% endif %}
+        </span>
+      </div>
+      {% endfor %}
+    {% else %}
+      <p class="text-muted" style="padding:0.5rem">No managed files found on disk.</p>
+    {% endif %}
+  </aside>
+
+  <!-- ── Right panel: Monaco editor ──────────────────────────────────────── -->
+  <section class="roles-editor-panel" aria-label="Monaco editor">
+    <div class="editor-header">
+      <span class="editor-breadcrumb" id="editor-breadcrumb">
+        ← select a file to edit
+      </span>
+      <button id="btn-diff" disabled title="Preview Diff (AC-303)">Preview Diff</button>
+      <button id="btn-save" class="btn-save" disabled onclick="saveRole()">Save</button>
+    </div>
+
+    <div id="editor-container">
+      <div class="editor-placeholder" id="editor-placeholder">
+        Select a file on the left to begin editing.
+      </div>
+    </div>
+
+    <div class="editor-status" id="editor-status" aria-live="polite"></div>
+  </section>
+
+</div>
+
+<script>
+  // ── Monaco AMD bootstrap ──────────────────────────────────────────────────
+  require.config({
+    paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs' }
+  });
+
+  let _editor = null;
+  let _currentSlug = null;
+  let _currentPath = null;
+
+  require(['vs/editor/editor.main'], function () {
+    // Hide the placeholder once Monaco has loaded.
+    document.getElementById('editor-placeholder').style.display = 'none';
+
+    _editor = monaco.editor.create(document.getElementById('editor-container'), {
+      value: '',
+      language: 'markdown',
+      theme: 'vs-dark',
+      automaticLayout: true,  // required — resizes correctly when parent flexes
+      minimap: { enabled: false },
+      wordWrap: 'on',
+      scrollBeyondLastLine: false,
+      readOnly: true,          // read-only until a file is loaded
+    });
+  });
+
+  // ── File loading ──────────────────────────────────────────────────────────
+
+  function _setStatus(msg, cls) {
+    var el = document.getElementById('editor-status');
+    el.textContent = msg;
+    el.className = 'editor-status' + (cls ? ' ' + cls : '');
+  }
+
+  function _setActive(slug) {
+    document.querySelectorAll('.role-row').forEach(function (row) {
+      row.classList.toggle('active', row.dataset.slug === slug);
+    });
+  }
+
+  function loadRole(slug, path) {
+    if (!_editor) {
+      _setStatus('⚠️  Monaco has not finished loading — try again in a moment.', 'err');
+      return;
+    }
+    _setStatus('Loading ' + path + ' …');
+    _setActive(slug);
+
+    fetch('/api/roles/' + encodeURIComponent(slug))
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status + ' — ' + r.statusText);
+        return r.json();
+      })
+      .then(function (data) {
+        _editor.setValue(data.content);
+        _editor.updateOptions({ readOnly: false });
+        _currentSlug = slug;
+        _currentPath = path;
+        document.getElementById('editor-breadcrumb').textContent = path;
+        document.getElementById('btn-save').disabled = false;
+        _setStatus('Loaded ' + data.meta.line_count + ' lines · last commit: ' +
+          (data.meta.last_commit_message || '(none)'), 'ok');
+      })
+      .catch(function (err) {
+        _setStatus('Failed to load file: ' + err.message, 'err');
+      });
+  }
+
+  // ── Save ──────────────────────────────────────────────────────────────────
+
+  function saveRole() {
+    if (!_editor || !_currentSlug) return;
+    var content = _editor.getValue();
+    var btn = document.getElementById('btn-save');
+    btn.disabled = true;
+    _setStatus('Saving …');
+
+    fetch('/api/roles/' + encodeURIComponent(_currentSlug), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: content }),
+    })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status + ' — ' + r.statusText);
+        return r.json();
+      })
+      .then(function (data) {
+        btn.disabled = false;
+        var diffLines = data.diff ? data.diff.split('\n').length : 0;
+        _setStatus('✅ Saved — diff is ' + diffLines + ' line(s).', 'ok');
+      })
+      .catch(function (err) {
+        btn.disabled = false;
+        _setStatus('Save failed: ' + err.message, 'err');
+      });
+  }
+</script>
+{% endblock %}

--- a/agentception/tests/test_agentception_roles.py
+++ b/agentception/tests/test_agentception_roles.py
@@ -1,4 +1,4 @@
-"""Tests for the Role file reader/writer API (AC-301).
+"""Tests for the Role file reader/writer API (AC-301) and Role Studio UI (AC-302).
 
 Covers:
 - list_roles returns all managed files that exist on disk
@@ -6,6 +6,7 @@ Covers:
 - get_role returns 404 for an unknown slug
 - update_role writes new content to disk
 - role_history returns a list of commit dicts
+- GET /roles page returns 200 with file list and Monaco CDN script
 
 Run targeted:
     pytest agentception/tests/test_agentception_roles.py -v
@@ -181,3 +182,71 @@ def test_role_history_returns_commits(
     assert history[0]["sha"] == "aaa111"
     assert history[0]["subject"] == "feat: role update"
     assert "date" in history[0]
+
+
+# ── GET /roles — Role Studio UI (AC-302) ──────────────────────────────────────
+
+
+def test_roles_page_returns_200(
+    client: TestClient,
+    tmp_repo: Path,
+) -> None:
+    """GET /roles must return HTTP 200 with valid HTML."""
+    with patch("agentception.routes.roles.settings") as mock_settings:
+        mock_settings.repo_dir = tmp_repo
+
+        with patch(
+            "agentception.routes.roles._git_log_one",
+            new=AsyncMock(return_value=("abc123", "initial commit")),
+        ):
+            response = client.get("/roles")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+def test_roles_page_lists_all_files(
+    client: TestClient,
+    tmp_repo: Path,
+) -> None:
+    """GET /roles HTML must list all managed files that exist on disk.
+
+    Uses the same tmp_repo fixture that creates cto.md, python-developer.md,
+    and PARALLEL_ISSUE_TO_PR.md — so those three slugs must appear in the page.
+    """
+    with patch("agentception.routes.roles.settings") as mock_settings:
+        mock_settings.repo_dir = tmp_repo
+
+        with patch(
+            "agentception.routes.roles._git_log_one",
+            new=AsyncMock(return_value=("abc123", "initial commit")),
+        ):
+            response = client.get("/roles")
+
+    assert response.status_code == 200
+    html = response.text
+    assert "cto" in html
+    assert "python-developer" in html
+    assert "PARALLEL_ISSUE_TO_PR" in html
+
+
+def test_roles_page_includes_monaco_cdn(
+    client: TestClient,
+    tmp_repo: Path,
+) -> None:
+    """GET /roles HTML must include the Monaco Editor CDN loader script tag.
+
+    The Monaco AMD loader URL must appear verbatim — frontend consumers
+    depend on this exact CDN path for Monaco to initialise.
+    """
+    with patch("agentception.routes.roles.settings") as mock_settings:
+        mock_settings.repo_dir = tmp_repo
+
+        with patch(
+            "agentception.routes.roles._git_log_one",
+            new=AsyncMock(return_value=("", "")),
+        ):
+            response = client.get("/roles")
+
+    assert response.status_code == 200
+    assert "cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs/loader.js" in response.text


### PR DESCRIPTION
## Summary
Closes #624 — Adds the `GET /roles` Role Studio page with a Monaco editor for live in-browser editing of managed role and cursor files.

## Root Cause / Motivation
Issue #624 (AC-302) required a browser-based editor for the 9 managed `.cursor/roles/*.md` and `.cursor/PARALLEL_*.md` files. The API layer (AC-301, #623) was already in place — this PR wires the UI on top of it.

## Solution
- **`agentception/routes/ui.py`**: added `roles_page()` route (`GET /roles`). It calls `list_roles()` from the API layer to populate the file list, then renders `roles.html`. On any read error it degrades gracefully: the page renders with an empty list and an error banner.
- **`agentception/templates/roles.html`**: two-panel flex layout. Left panel (30%) lists all managed files with slug, line count, and last-commit message. Right panel (70%) hosts a Monaco editor loaded from the jsdelivr CDN (`monaco-editor@0.52.0`). Clicking a file row fetches its content via `GET /api/roles/{slug}` and loads it into the editor; the Save button calls `PUT /api/roles/{slug}`. A status bar below the editor shows load/save status. The breadcrumb in the header bar shows the current file path.
- **`agentception/tests/test_agentception_roles.py`**: three new UI tests:
  - `test_roles_page_returns_200`
  - `test_roles_page_lists_all_files`
  - `test_roles_page_includes_monaco_cdn`

## Verification
- [x] mypy clean (Success: no issues found in 32 source files)
- [x] 8/8 tests pass (`test_agentception_roles.py`)
- [x] 10/10 UI overview regression tests pass
- [x] Pre-push sync with origin/dev — already up to date

## Notes
- The "Preview Diff" button is intentionally disabled (labelled AC-303) — its implementation is the next issue in the sequence.
- The `revert scenario` flag was set: a prior merged PR (#285) closed this issue, but the issue was reopened. This is a clean re-implementation.

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Architecture** | `turing:monaco` |
| **Skills** | Monaco Editor (CDN) |
| **Role** | `python-developer` |
| **Session** | `eng-20260302T033425Z-742b` |
| **Batch (VP)** | `eng-20260302T033242Z-5d41` |
| **Wave (CTO)** | `wave-7-2026-03-01` |
| **VP** | `Engineering VP · eng-20260302T033242Z-5d41` |

</details>