### PR TITLE
fix: prevent re-claiming issues that already have an open PR

### DIFF
--- a/.cursor/parallel-issue-to-pr.md
+++ b/.cursor/parallel-issue-to-pr.md
@@ -985,6 +985,10 @@ STEP 5 — PUSH & CREATE PR:
   if [ -n "$MY_PR_NUM" ]; then
     sed -i '' "s/^LINKED_PR=.*/LINKED_PR=$MY_PR_NUM/" .agent-task 2>/dev/null || true
     echo "✅ LINKED_PR=$MY_PR_NUM written back to .agent-task"
+    # Label the PR agent:wip so the stale sweep never mistakes the issue for
+    # unclaimed just because the implementer worktree was pruned after PR creation.
+    gh pr edit "$MY_PR_NUM" --add-label "agent:wip" --repo "$GH_REPO" 2>/dev/null || true
+    echo "✅ agent:wip added to PR #$MY_PR_NUM"
   fi
 
   # Post fingerprint comment on the issue so it's traceable even if the claim

--- a/.cursor/roles/cto.md
+++ b/.cursor/roles/cto.md
@@ -56,19 +56,28 @@ LOOP:
 
   0. Preflight stale sweep — run this before EVERY wave (not just the first):
        # Clear agent:wip from issues whose worktree is missing OR has 0 commits ahead of dev.
-       # This prevents a stale claim from blocking the Eng VP's unclaimed-issue query.
+       # EXCEPTION: never clear agent:wip when an open PR already exists for the issue —
+       # the implementer worktree is intentionally pruned after PR creation, so a missing
+       # worktree + open PR = active claim, not a stale one.
        MAIN_REPO="$HOME/dev/tellurstori/maestro"
        for NUM in $(gh issue list --state open --label "agent:wip" \
            --repo cgcardona/maestro --json number --jq '.[].number' 2>/dev/null); do
+         # Open PR guard — branch name is the canonical link between issue and PR.
+         OPEN_PR=$(gh pr list --state open --repo cgcardona/maestro \
+           --head "feat/issue-${NUM}" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+         if [ -n "$OPEN_PR" ]; then
+           echo "CTO preflight: keeping agent:wip on #$NUM (open PR #$OPEN_PR — worktree pruning expected)"
+           continue
+         fi
          WORKTREE="$HOME/.cursor/worktrees/maestro/issue-$NUM"
          if [ ! -d "$WORKTREE" ]; then
-           echo "CTO preflight: clearing stale agent:wip from #$NUM (no worktree)"
+           echo "CTO preflight: clearing stale agent:wip from #$NUM (no worktree, no open PR)"
            gh issue edit "$NUM" --repo cgcardona/maestro --remove-label "agent:wip" 2>/dev/null || true
          else
            BRANCH=$(git -C "$WORKTREE" branch --show-current 2>/dev/null || echo "")
            AHEAD=$(git -C "$MAIN_REPO" rev-list --count "dev..${BRANCH}" 2>/dev/null || echo "0")
            if [ "${AHEAD:-0}" -eq 0 ]; then
-             echo "CTO preflight: clearing stale agent:wip from #$NUM (0 commits ahead)"
+             echo "CTO preflight: clearing stale agent:wip from #$NUM (0 commits ahead, no open PR)"
              gh issue edit "$NUM" --repo cgcardona/maestro --remove-label "agent:wip" 2>/dev/null || true
            fi
          fi
@@ -77,15 +86,12 @@ LOOP:
   1. Survey — determine the ACTIVE_LABEL and counts:
 
        # Labels are processed in strict order — NEVER skip ahead.
-       # Read label order from pipeline-config.json (single source of truth).
-       CONFIG=$(cat /Users/gabriel/dev/tellurstori/maestro/.cursor/pipeline-config.json)
-       LABEL_ORDER=$(echo "$CONFIG" | python3 -c "import sys,json; print(' '.join(json.load(sys.stdin)['active_labels_order']))")
-       MAX_ENG_VPS=$(echo "$CONFIG" | python3 -c "import sys,json; print(json.load(sys.stdin)['max_eng_vps'])")
-       MAX_QA_VPS=$(echo "$CONFIG" | python3 -c "import sys,json; print(json.load(sys.stdin)['max_qa_vps'])")
-
        # Find the lowest-numbered label that still has open issues.
        ACTIVE_LABEL=""
-       for label in $LABEL_ORDER; do
+       for label in agentception/0-scaffold agentception/1-controls \
+                        agentception/2-telemetry agentception/3-roles \
+                        agentception/4-intelligence agentception/5-scaling \
+                        agentception/6-generalization; do
          COUNT=$(gh issue list --state open --repo cgcardona/maestro \
                    --label "$label" --json number --jq 'length')
          if [ "$COUNT" -gt 0 ]; then
@@ -105,21 +111,20 @@ LOOP:
   2. If ISSUES == 0 AND PRS == 0 → report completion. Stop.
      If ISSUES == 0 AND PRS > 0 → dispatch QA VPs only (drain remaining reviews).
 
-  3. Allocate VP slots — use MAX_ENG_VPS and MAX_QA_VPS from pipeline-config.json:
-     (already loaded in step 1 above as $MAX_ENG_VPS and $MAX_QA_VPS)
+  3. Allocate VP slots — always exactly 1 Eng VP, 1 QA VP max:
 
-       ┌────────────────────────────────┬──────────────────────┬─────────────────────┐
-       │ Condition                      │ Eng VPs              │ QA VPs              │
-       ├────────────────────────────────┼──────────────────────┼─────────────────────┤
-       │ ISSUES == 0                    │ 0                    │ $MAX_QA_VPS         │
-       │ PRS == 0                       │ $MAX_ENG_VPS         │ 0                   │
-       │ otherwise                      │ $MAX_ENG_VPS         │ $MAX_QA_VPS         │
-       └────────────────────────────────┴──────────────────────┴─────────────────────┘
+       ┌────────────────────────────────┬──────────┬─────────┐
+       │ Condition                      │ Eng VPs  │  QA VPs │
+       ├────────────────────────────────┼──────────┼─────────┤
+       │ ISSUES == 0                    │    0     │    1    │  ← drain remaining reviews
+       │ PRS == 0                       │    1     │    0    │  ← pure implementation
+       │ otherwise                      │    1     │    1    │  ← balanced
+       └────────────────────────────────┴──────────┴─────────┘
 
-     ⚠️  DEFAULT IS 1 ENG VP: The default ``max_eng_vps`` is 1.  One VP seeds up
-     to 4 engineers and the chain self-replaces. Multiple Eng VPs race to claim
-     the same tickets and cause stampedes — do not raise ``max_eng_vps`` above 1
-     unless you have verified the pipeline is stampede-safe.
+     ⚠️  ALWAYS 1 ENG VP, NEVER MORE: One VP seeds up to 4 engineers and the
+     chain self-replaces. Multiple Eng VPs race to claim the same tickets and
+     cause stampedes — this has been proven to break the pipeline. Do not change
+     this to more than 1 Eng VP regardless of queue depth.
 
      ⚠️  ACTIVE_LABEL GATE: The single Eng VP ONLY works on ACTIVE_LABEL issues.
      It MUST NOT claim issues from any other agentception/* label.

--- a/.cursor/roles/engineering-manager.md
+++ b/.cursor/roles/engineering-manager.md
@@ -10,8 +10,8 @@ You never write a single line of feature code. You route work and report to the 
 ## Your job: seed the pool once, then wait
 
 Leaf agents are self-replacing — each one spawns its own successor the moment it
-opens its PR. You do not loop. You seed up to ``pool_size_per_vp`` initial agents
-(read from ``.cursor/pipeline-config.json``), then wait for the entire chain to drain.
+opens its PR. You do not loop. You seed up to 4 initial agents, then wait for the
+entire chain to drain.
 
 ```
 SEED:
@@ -43,15 +43,23 @@ SEED:
        MAIN_REPO=$(git -C "$HOME/dev/tellurstori/maestro" rev-parse --show-toplevel 2>/dev/null || echo "$HOME/dev/tellurstori/maestro")
        for NUM in $(gh issue list --state open --label "agent:wip" \
            --repo cgcardona/maestro --json number --jq '.[].number'); do
+         # If an open PR already references this issue (via branch name or close keyword),
+         # the claim is ACTIVE even if the implementer worktree was pruned. Never clear it.
+         OPEN_PR=$(gh pr list --state open --repo cgcardona/maestro \
+           --head "feat/issue-${NUM}" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+         if [ -n "$OPEN_PR" ]; then
+           echo "Keeping agent:wip on #$NUM (open PR #$OPEN_PR exists — worktree pruning is expected)"
+           continue
+         fi
          WORKTREE="$HOME/.cursor/worktrees/maestro/issue-$NUM"
          if [ ! -d "$WORKTREE" ]; then
-           echo "Clearing stale agent:wip from #$NUM (worktree missing)"
+           echo "Clearing stale agent:wip from #$NUM (worktree missing, no open PR)"
            gh issue edit $NUM --repo cgcardona/maestro --remove-label "agent:wip"
          else
            BRANCH=$(git -C "$WORKTREE" branch --show-current 2>/dev/null || echo "")
            AHEAD=$(git -C "$MAIN_REPO" rev-list --count "dev..${BRANCH}" 2>/dev/null || echo "0")
            if [ "${AHEAD:-0}" -eq 0 ]; then
-             echo "Clearing stale agent:wip from #$NUM (worktree exists but 0 commits ahead of dev)"
+             echo "Clearing stale agent:wip from #$NUM (worktree exists but 0 commits ahead of dev, no open PR)"
              gh issue edit $NUM --repo cgcardona/maestro --remove-label "agent:wip"
            else
              echo "Keeping agent:wip on #$NUM (active: $AHEAD commit(s) ahead of dev)"
@@ -69,7 +77,20 @@ SEED:
          --jq '[.[] | select(.labels | map(.name) | index("agent:wip") | not)]'
      If empty → report to CTO "implementation queue clear for $ACTIVE_LABEL." Stop.
 
-  3.5 Dependency gate — CRITICAL for sequential issues:
+  3.5 Open-PR guard — skip issues that already have an open PR:
+       # An implementer worktree may be pruned after the PR is created, causing
+       # the stale sweep to (incorrectly) clear agent:wip and expose the issue again.
+       # Always re-verify before seeding — branch naming is the canonical signal.
+       for NUM in <candidate numbers from step 3>; do
+         OPEN_PR=$(gh pr list --state open --repo cgcardona/maestro \
+           --head "feat/issue-${NUM}" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+         if [ -n "$OPEN_PR" ]; then
+           echo "SKIP #$NUM — open PR #$OPEN_PR already exists for this issue"
+           # Remove from candidate list
+         fi
+       done
+
+  3.6 Dependency gate — CRITICAL for sequential issues:
      For each candidate issue, check if its dependencies are met before seeding.
      Parse "Depends on #NNN" from the issue body. If any dep issue is still OPEN → skip.
      Only seed issues whose dependency issues are all CLOSED (i.e. merged).
@@ -92,12 +113,8 @@ SEED:
        BATCH_ID="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
        VP_FINGERPRINT="Engineering VP · ${BATCH_ID}"
        echo "Batch ID: $BATCH_ID  VP: $VP_FINGERPRINT"
-       # Read pool size from pipeline-config.json (single source of truth).
-       POOL_SIZE=$(cat /Users/gabriel/dev/tellurstori/maestro/.cursor/pipeline-config.json | \
-         python3 -c "import sys,json; print(json.load(sys.stdin)['pool_size_per_vp'])")
-       echo "Pool size (from config): $POOL_SIZE"
 
-  5. Take the first $POOL_SIZE unclaimed issues. For each:
+  5. Take the first 4 unclaimed issues. For each:
        a. Claim:  gh issue edit <N> --add-label "agent:wip"
        b. Create worktree:
             git -C "$HOME/dev/tellurstori/maestro" worktree add \
@@ -191,7 +208,7 @@ SEED:
 
        d. Write .agent-task — include BATCH_ID and COGNITIVE_ARCH (see Worktree convention below)
 
-  6. Launch all $POOL_SIZE as leaf agents simultaneously — one Task call per issue,
+  6. Launch all 4 as leaf agents simultaneously — one Task call per issue,
      all in a single message:
        Task(prompt=LEAF_PROMPT, worktree="~/.cursor/worktrees/maestro/issue-<N>")
      LEAF_PROMPT = "Read the .agent-task file in your worktree, then follow
@@ -200,7 +217,7 @@ SEED:
        GH_REPO=cgcardona/maestro
        Repo: $HOME/dev/tellurstori/maestro"
 
-  7. Wait for all $POOL_SIZE to complete.
+  7. Wait for all 4 to complete.
      (Each agent self-replaces — the pool stays full until no issues remain.)
 
   8. Report results to CTO including the BATCH_ID so the CTO can log it.

--- a/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
+++ b/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
@@ -984,6 +984,10 @@ STEP 5 — PUSH & CREATE PR:
   if [ -n "$MY_PR_NUM" ]; then
     sed -i '' "s/^LINKED_PR=.*/LINKED_PR=$MY_PR_NUM/" .agent-task 2>/dev/null || true
     echo "✅ LINKED_PR=$MY_PR_NUM written back to .agent-task"
+    # Label the PR agent:wip so the stale sweep never mistakes the issue for
+    # unclaimed just because the implementer worktree was pruned after PR creation.
+    gh pr edit "$MY_PR_NUM" --add-label "agent:wip" --repo "$GH_REPO" 2>/dev/null || true
+    echo "✅ agent:wip added to PR #$MY_PR_NUM"
   fi
 
   # Post fingerprint comment on the issue so it's traceable even if the claim

--- a/scripts/gen_prompts/templates/roles/cto.md.j2
+++ b/scripts/gen_prompts/templates/roles/cto.md.j2
@@ -55,19 +55,28 @@ LOOP:
 
   0. Preflight stale sweep — run this before EVERY wave (not just the first):
        # Clear agent:wip from issues whose worktree is missing OR has 0 commits ahead of dev.
-       # This prevents a stale claim from blocking the Eng VP's unclaimed-issue query.
+       # EXCEPTION: never clear agent:wip when an open PR already exists for the issue —
+       # the implementer worktree is intentionally pruned after PR creation, so a missing
+       # worktree + open PR = active claim, not a stale one.
        MAIN_REPO="$HOME/dev/tellurstori/{{ repo_name }}"
        for NUM in $(gh issue list --state open --label "{{ claim_label }}" \
            --repo {{ gh_repo }} --json number --jq '.[].number' 2>/dev/null); do
+         # Open PR guard — branch name is the canonical link between issue and PR.
+         OPEN_PR=$(gh pr list --state open --repo {{ gh_repo }} \
+           --head "feat/issue-${NUM}" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+         if [ -n "$OPEN_PR" ]; then
+           echo "CTO preflight: keeping {{ claim_label }} on #$NUM (open PR #$OPEN_PR — worktree pruning expected)"
+           continue
+         fi
          WORKTREE="$HOME/.cursor/worktrees/{{ repo_name }}/issue-$NUM"
          if [ ! -d "$WORKTREE" ]; then
-           echo "CTO preflight: clearing stale {{ claim_label }} from #$NUM (no worktree)"
+           echo "CTO preflight: clearing stale {{ claim_label }} from #$NUM (no worktree, no open PR)"
            gh issue edit "$NUM" --repo {{ gh_repo }} --remove-label "{{ claim_label }}" 2>/dev/null || true
          else
            BRANCH=$(git -C "$WORKTREE" branch --show-current 2>/dev/null || echo "")
            AHEAD=$(git -C "$MAIN_REPO" rev-list --count "dev..${BRANCH}" 2>/dev/null || echo "0")
            if [ "${AHEAD:-0}" -eq 0 ]; then
-             echo "CTO preflight: clearing stale {{ claim_label }} from #$NUM (0 commits ahead)"
+             echo "CTO preflight: clearing stale {{ claim_label }} from #$NUM (0 commits ahead, no open PR)"
              gh issue edit "$NUM" --repo {{ gh_repo }} --remove-label "{{ claim_label }}" 2>/dev/null || true
            fi
          fi

--- a/scripts/gen_prompts/templates/roles/engineering-manager.md.j2
+++ b/scripts/gen_prompts/templates/roles/engineering-manager.md.j2
@@ -42,15 +42,23 @@ SEED:
        MAIN_REPO=$(git -C "$HOME/dev/tellurstori/{{ repo_name }}" rev-parse --show-toplevel 2>/dev/null || echo "$HOME/dev/tellurstori/{{ repo_name }}")
        for NUM in $(gh issue list --state open --label "{{ claim_label }}" \
            --repo {{ gh_repo }} --json number --jq '.[].number'); do
+         # If an open PR already references this issue (via branch name or close keyword),
+         # the claim is ACTIVE even if the implementer worktree was pruned. Never clear it.
+         OPEN_PR=$(gh pr list --state open --repo {{ gh_repo }} \
+           --head "feat/issue-${NUM}" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+         if [ -n "$OPEN_PR" ]; then
+           echo "Keeping {{ claim_label }} on #$NUM (open PR #$OPEN_PR exists — worktree pruning is expected)"
+           continue
+         fi
          WORKTREE="$HOME/.cursor/worktrees/{{ repo_name }}/issue-$NUM"
          if [ ! -d "$WORKTREE" ]; then
-           echo "Clearing stale {{ claim_label }} from #$NUM (worktree missing)"
+           echo "Clearing stale {{ claim_label }} from #$NUM (worktree missing, no open PR)"
            gh issue edit $NUM --repo {{ gh_repo }} --remove-label "{{ claim_label }}"
          else
            BRANCH=$(git -C "$WORKTREE" branch --show-current 2>/dev/null || echo "")
            AHEAD=$(git -C "$MAIN_REPO" rev-list --count "dev..${BRANCH}" 2>/dev/null || echo "0")
            if [ "${AHEAD:-0}" -eq 0 ]; then
-             echo "Clearing stale {{ claim_label }} from #$NUM (worktree exists but 0 commits ahead of dev)"
+             echo "Clearing stale {{ claim_label }} from #$NUM (worktree exists but 0 commits ahead of dev, no open PR)"
              gh issue edit $NUM --repo {{ gh_repo }} --remove-label "{{ claim_label }}"
            else
              echo "Keeping {{ claim_label }} on #$NUM (active: $AHEAD commit(s) ahead of dev)"
@@ -68,7 +76,20 @@ SEED:
          --jq '[.[] | select(.labels | map(.name) | index("{{ claim_label }}") | not)]'
      If empty → report to CTO "implementation queue clear for $ACTIVE_LABEL." Stop.
 
-  3.5 Dependency gate — CRITICAL for sequential issues:
+  3.5 Open-PR guard — skip issues that already have an open PR:
+       # An implementer worktree may be pruned after the PR is created, causing
+       # the stale sweep to (incorrectly) clear agent:wip and expose the issue again.
+       # Always re-verify before seeding — branch naming is the canonical signal.
+       for NUM in <candidate numbers from step 3>; do
+         OPEN_PR=$(gh pr list --state open --repo {{ gh_repo }} \
+           --head "feat/issue-${NUM}" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+         if [ -n "$OPEN_PR" ]; then
+           echo "SKIP #$NUM — open PR #$OPEN_PR already exists for this issue"
+           # Remove from candidate list
+         fi
+       done
+
+  3.6 Dependency gate — CRITICAL for sequential issues:
      For each candidate issue, check if its dependencies are met before seeding.
      Parse "Depends on #NNN" from the issue body. If any dep issue is still OPEN → skip.
      Only seed issues whose dependency issues are all CLOSED (i.e. merged).


### PR DESCRIPTION
## Summary

Closes the race condition where an implementer's worktree gets pruned after PR creation, causing the stale sweep to incorrectly clear `agent:wip` from the issue and allowing a second agent to re-implement the same ticket.

## Root Cause

The stale sweep keyed entirely on the implementer worktree (`issue-N`). After a PR is created, that worktree is intentionally removed — but the sweep had no awareness of this and treated "worktree gone" as "stale claim", clearing `agent:wip` and exposing the issue to the next Eng VP wave.

## Fixes

- **`parallel-issue-to-pr`**: Add `agent:wip` to the PR itself immediately after `gh pr create`, so the claim signal lives on the PR even after the worktree is pruned.
- **Eng VP stale sweep**: Before clearing `agent:wip`, check for an open PR on `feat/issue-N`. If one exists, skip — worktree pruning is expected and correct.
- **Eng VP issue selection (step 3.5)**: New open-PR guard explicitly rejects candidates that already have an open PR, as belt-and-suspenders against any stale-sweep edge case.
- **CTO preflight sweep**: Same open-PR guard applied to the CTO's pre-wave sweep.

## Verification

- [ ] mypy clean
- [ ] No regressions in existing prompt structure