### PR TITLE
feat: stale claim detector + one-click auto-fix (AC-404)

### DIFF
--- a/agentception/app.py
+++ b/agentception/app.py
@@ -28,6 +28,7 @@ from starlette.requests import Request
 from agentception.poller import polling_loop, subscribe, unsubscribe
 from agentception.routes.api import router as api_router
 from agentception.routes.control import router as control_router
+from agentception.routes.intelligence import router as intelligence_router
 from agentception.routes.roles import router as roles_router
 from agentception.routes.ui import router as ui_router
 
@@ -62,11 +63,12 @@ app = FastAPI(
 # Mount static assets — CSS, future JS bundles.
 app.mount("/static", StaticFiles(directory=str(_HERE / "static")), name="static")
 
-# Register UI, API, control-plane, and roles routers — each owns their own path prefix.
+# Register UI, API, control-plane, roles, and intelligence routers.
 app.include_router(ui_router)
 app.include_router(api_router)
 app.include_router(control_router)
 app.include_router(roles_router)
+app.include_router(intelligence_router)
 
 
 @app.get("/health", tags=["health"])

--- a/agentception/intelligence/__init__.py
+++ b/agentception/intelligence/__init__.py
@@ -1,0 +1,7 @@
+"""AgentCeption intelligence layer — anomaly detection and guard functions.
+
+This package contains domain logic for detecting pipeline problems that require
+human intervention. Unlike the readers (data access) or routes (HTTP handlers),
+guards reason about the *state* of the pipeline and produce actionable signals.
+"""
+from __future__ import annotations

--- a/agentception/intelligence/guards.py
+++ b/agentception/intelligence/guards.py
@@ -1,0 +1,79 @@
+"""Stale-claim detection and related pipeline guard functions.
+
+A "stale claim" is an issue that carries the ``agent:wip`` label but has no
+corresponding worktree on the local filesystem.  This indicates that an agent
+was killed or crashed before removing its label, leaving the issue permanently
+locked out of the scheduling pool.
+
+Usage::
+
+    from agentception.intelligence.guards import detect_stale_claims, StaleClaim
+
+    claims = await detect_stale_claims(wip_issues, worktrees_dir)
+    for claim in claims:
+        print(f"#{claim.issue_number}: {claim.issue_title} — {claim.worktree_path}")
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from agentception.models import StaleClaim
+
+logger = logging.getLogger(__name__)
+
+
+async def detect_stale_claims(
+    wip_issues: list[dict[str, object]],
+    worktrees_dir: Path,
+) -> list[StaleClaim]:
+    """Detect issues with ``agent:wip`` label but no corresponding worktree.
+
+    For each open issue labelled ``agent:wip``, computes the expected worktree
+    path ``worktrees_dir / f"issue-{number}"``.  When that path does not exist
+    on the filesystem, the issue is classified as a stale claim.
+
+    Parameters
+    ----------
+    wip_issues:
+        List of issue dicts as returned by
+        :func:`~agentception.readers.github.get_wip_issues`.
+        Each dict must contain at minimum ``number`` (int) and ``title`` (str).
+    worktrees_dir:
+        Root directory where worktrees are created, e.g.
+        ``~/.cursor/worktrees/maestro``.
+
+    Returns
+    -------
+    list[StaleClaim]
+        One entry per stale issue, sorted ascending by issue number.
+        Empty list when all wip issues have live worktrees.
+    """
+    claims: list[StaleClaim] = []
+
+    for issue in wip_issues:
+        num = issue.get("number")
+        title = issue.get("title", "")
+        if not isinstance(num, int):
+            logger.warning("⚠️  Skipping wip issue with non-int number: %r", num)
+            continue
+        if not isinstance(title, str):
+            title = str(title)
+
+        expected_path = worktrees_dir / f"issue-{num}"
+        if not expected_path.exists():
+            logger.debug(
+                "⚠️  Stale claim detected: issue #%d has no worktree at %s",
+                num,
+                expected_path,
+            )
+            claims.append(
+                StaleClaim(
+                    issue_number=num,
+                    issue_title=title,
+                    worktree_path=str(expected_path),
+                )
+            )
+
+    claims.sort(key=lambda c: c.issue_number)
+    return claims

--- a/agentception/models.py
+++ b/agentception/models.py
@@ -47,12 +47,27 @@ class AgentNode(BaseModel):
     children: list[AgentNode] = []
 
 
+class StaleClaim(BaseModel):
+    """A GitHub issue with ``agent:wip`` label but no corresponding local worktree.
+
+    Produced by :func:`~agentception.intelligence.guards.detect_stale_claims`
+    and included in :class:`PipelineState` so the dashboard can surface a
+    one-click "Clear Label" fix button for each stale claim.
+    """
+
+    issue_number: int
+    issue_title: str
+    worktree_path: str  # expected path that does not exist
+
+
 class PipelineState(BaseModel):
     """Snapshot of the entire Maestro pipeline at a point in time.
 
     Aggregated by the background poller and served to the dashboard UI.
     ``polled_at`` is a UNIX timestamp — compare with ``time.time()`` to know
     how stale the data is.
+    ``stale_claims`` provides structured data for the "Clear Label" UI action;
+    the same claims also appear as human-readable strings in ``alerts``.
     """
 
     active_label: str | None
@@ -60,6 +75,7 @@ class PipelineState(BaseModel):
     prs_open: int
     agents: list[AgentNode]
     alerts: list[str] = []
+    stale_claims: list[StaleClaim] = []
     polled_at: float
 
     @classmethod
@@ -78,6 +94,7 @@ class PipelineState(BaseModel):
             prs_open=0,
             agents=[],
             alerts=[],
+            stale_claims=[],
             polled_at=time.time(),
         )
 

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -21,7 +21,8 @@ import time
 from pathlib import Path
 
 from agentception.config import settings
-from agentception.models import AgentNode, AgentStatus, PipelineState, TaskFile
+from agentception.intelligence.guards import detect_stale_claims
+from agentception.models import AgentNode, AgentStatus, PipelineState, StaleClaim, TaskFile
 from agentception.readers.github import (
     get_active_label,
     get_open_issues,
@@ -147,28 +148,26 @@ async def merge_agents(
 async def detect_alerts(
     worktrees: list[TaskFile],
     github: GitHubBoard,
-) -> list[str]:
-    """Detect pipeline problems and return human-readable alert strings.
+) -> tuple[list[str], list[StaleClaim]]:
+    """Detect pipeline problems and return human-readable alert strings plus structured stale claims.
 
     Three alert classes:
     1. **Stale claim** — an ``agent:wip`` issue has no live worktree.
     2. **Out-of-order PR** — an open PR's labels include an agentception phase
        that no longer matches the currently active phase.
     3. **Stuck agent** — the most-recent commit in a worktree is > 30 min old.
+
+    Returns a tuple of (alert strings, stale_claims).  Alert strings include a
+    human-readable summary of each stale claim; ``stale_claims`` provides the
+    structured data used by the UI "Clear Label" action.
     """
     alerts: list[str] = []
     now = time.time()
 
-    # Fast lookup set: which issue numbers have a live worktree?
-    worktree_issue_numbers: set[int] = {
-        tf.issue_number for tf in worktrees if tf.issue_number is not None
-    }
-
     # ── Alert 1: agent:wip issue with no matching worktree ─────────────────
-    for issue in github.wip_issues:
-        num = issue.get("number")
-        if isinstance(num, int) and num not in worktree_issue_numbers:
-            alerts.append(f"Stale claim on #{num}")
+    stale_claims = await detect_stale_claims(github.wip_issues, settings.worktrees_dir)
+    for claim in stale_claims:
+        alerts.append(f"Stale claim on #{claim.issue_number}")
 
     # ── Alert 2: open PR labelled with a non-active agentception phase ──────
     active = github.active_label
@@ -202,7 +201,7 @@ async def detect_alerts(
             label = f"issue #{tf.issue_number}" if tf.issue_number else path.name
             alerts.append(f"Possible stuck agent on {label}")
 
-    return alerts
+    return alerts, stale_claims
 
 
 # ---------------------------------------------------------------------------
@@ -274,7 +273,7 @@ async def tick() -> PipelineState:
     worktrees = await list_active_worktrees()
     github = await build_github_board()
     agents = await merge_agents(worktrees, github)
-    alerts = await detect_alerts(worktrees, github)
+    alerts, stale_claims = await detect_alerts(worktrees, github)
 
     state = PipelineState(
         active_label=github.active_label,
@@ -282,6 +281,7 @@ async def tick() -> PipelineState:
         prs_open=len(github.open_prs),
         agents=agents,
         alerts=alerts,
+        stale_claims=stale_claims,
         polled_at=time.time(),
     )
 

--- a/agentception/routes/intelligence.py
+++ b/agentception/routes/intelligence.py
@@ -1,0 +1,61 @@
+"""Intelligence-layer API routes for the AgentCeption dashboard.
+
+Provides action endpoints for anomalies detected by
+:mod:`agentception.intelligence.guards`.  The "clear stale claim" endpoint
+is the primary consumer: the dashboard surfaces a "Clear Label" button for
+each stale claim and POSTs here to remove the ``agent:wip`` label.
+
+Why a dedicated router?
+- Keeps destructive write operations (label removal) separate from read-only
+  data routes so they can be rate-limited or gated independently.
+- ``/api/intelligence/`` signals to callers that these endpoints act on
+  machine-detected anomalies rather than direct user operations.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from agentception.readers.github import clear_wip_label
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/intelligence", tags=["intelligence"])
+
+
+@router.post("/stale-claims/{issue_number}/clear")
+async def clear_stale_claim(issue_number: int) -> dict[str, int]:
+    """Remove the ``agent:wip`` label from a stale-claim issue.
+
+    Intended to be called from the dashboard "Clear Label" button when the
+    poller detects that an issue carries ``agent:wip`` but has no live worktree.
+    After clearing the label the issue re-enters the scheduling pool and the
+    next polling tick will stop reporting it as a stale claim.
+
+    Parameters
+    ----------
+    issue_number:
+        GitHub issue number whose ``agent:wip`` label should be removed.
+
+    Returns
+    -------
+    dict
+        ``{"cleared": issue_number}`` on success.
+
+    Raises
+    ------
+    HTTP 500
+        When the ``gh`` CLI command fails (e.g. auth error or rate-limit).
+    """
+    try:
+        await clear_wip_label(issue_number)
+    except RuntimeError as exc:
+        logger.error("❌ Failed to clear agent:wip from issue #%d: %s", issue_number, exc)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to clear agent:wip label from issue #{issue_number}: {exc}",
+        ) from exc
+
+    logger.info("✅ Cleared stale claim: removed agent:wip from issue #%d", issue_number)
+    return {"cleared": issue_number}

--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -477,6 +477,75 @@ main {
   color: #fff;
 }
 
+.btn-sm {
+  padding: 0.15rem 0.5rem;
+  font-size: 0.78rem;
+}
+
+.btn-warning {
+  background: rgba(210, 153, 34, 0.12);
+  border-color: #d29922;
+  color: #d29922;
+}
+
+.btn-warning:hover:not(:disabled) {
+  background: #d29922;
+  color: #fff;
+}
+
+/* ── Stale claim cards ── */
+
+.stale-claim-card {
+  background: rgba(248, 81, 73, 0.05);
+  border: 1px solid rgba(248, 81, 73, 0.25);
+  border-radius: 4px;
+  padding: 0.6rem 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.stale-claim-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin-bottom: 0.25rem;
+}
+
+.stale-claim-number {
+  font-weight: 600;
+  color: var(--danger);
+  flex-shrink: 0;
+}
+
+.stale-claim-title {
+  font-size: 0.85rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stale-claim-path {
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+  margin-bottom: 0.4rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stale-claim-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.stale-claim-confirm {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.82rem;
+}
+
 /* ── Agent detail two-column layout ── */
 
 .agent-detail-columns {

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -257,6 +257,45 @@
           <div class="alert-item" x-text="alert"></div>
         </template>
       </div>
+
+      {#
+        Stale claim cards — one per issue with agent:wip but no live worktree.
+        Each card shows the issue number, title, and expected worktree path,
+        plus a "Clear Label" button that removes agent:wip so the issue re-enters
+        the scheduling pool.
+      #}
+      <div x-show="state.stale_claims && state.stale_claims.length > 0" class="mt-2">
+        <h3 class="section-subtitle">Stale Claims</h3>
+        <template x-for="claim in state.stale_claims" :key="claim.issue_number">
+          <div
+            class="stale-claim-card"
+            x-data="staleClaimCard(claim)"
+          >
+            <div class="stale-claim-header">
+              <span class="stale-claim-number">#<span x-text="claim.issue_number"></span></span>
+              <span class="stale-claim-title" x-text="claim.issue_title"></span>
+            </div>
+            <div class="stale-claim-path text-muted" x-text="claim.worktree_path"></div>
+            <div class="stale-claim-actions">
+              <button
+                class="btn btn-sm btn-warning"
+                x-show="!confirming && !clearing"
+                @click="confirming = true"
+              >Clear Label</button>
+
+              <span x-show="confirming && !clearing" class="stale-claim-confirm">
+                Remove <code>agent:wip</code> from #<span x-text="claim.issue_number"></span>?
+                <button class="btn btn-sm btn-secondary" @click="confirming = false">Cancel</button>
+                <button class="btn btn-sm btn-danger" @click="clear(claim.issue_number)">Confirm</button>
+              </span>
+
+              <span x-show="clearing" class="text-muted">Clearing…</span>
+              <span x-show="cleared" class="text-success">✅ Cleared</span>
+              <span x-show="error" class="text-danger" x-text="error"></span>
+            </div>
+          </div>
+        </template>
+      </div>
     </aside>
 
   </div>{# .overview-columns #}
@@ -309,6 +348,46 @@ function pipelineDashboard(initial) {
       if (secs < 60) return secs + 's ago';
       if (secs < 3600) return Math.floor(secs / 60) + 'm ago';
       return Math.floor(secs / 3600) + 'h ago';
+    },
+  };
+}
+
+/**
+ * Alpine.js component for a single stale-claim card.
+ *
+ * Manages a two-step confirmation flow ("Clear Label" → confirm → POST) so
+ * accidental clicks do not immediately remove the agent:wip label.  Each card
+ * is independent — clearing one does not affect siblings.
+ *
+ * @param {object} claim - StaleClaim object from PipelineState.stale_claims.
+ */
+function staleClaimCard(claim) {
+  return {
+    confirming: false,
+    clearing: false,
+    cleared: false,
+    error: null,
+
+    async clear(issueNumber) {
+      this.confirming = false;
+      this.clearing = true;
+      this.error = null;
+      try {
+        const res = await fetch(
+          `/api/intelligence/stale-claims/${issueNumber}/clear`,
+          { method: 'POST' },
+        );
+        if (res.ok) {
+          this.cleared = true;
+        } else {
+          const data = await res.json().catch(() => ({}));
+          this.error = data.detail || `HTTP ${res.status}`;
+        }
+      } catch (err) {
+        this.error = err.message || 'Network error';
+      } finally {
+        this.clearing = false;
+      }
     },
   };
 }

--- a/agentception/tests/test_agentception_guards.py
+++ b/agentception/tests/test_agentception_guards.py
@@ -1,0 +1,151 @@
+"""Tests for agentception/intelligence/guards.py (AC-404).
+
+Coverage:
+- detect_stale_claims() flags issues with agent:wip but no worktree
+- detect_stale_claims() ignores issues whose worktree exists
+- clear_stale_claim endpoint removes the agent:wip label
+- stale claims from guards propagate into PipelineState.alerts via detect_alerts()
+
+Run targeted:
+    pytest agentception/tests/test_agentception_guards.py -v
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from agentception.app import app
+from agentception.intelligence.guards import detect_stale_claims
+from agentception.models import StaleClaim, TaskFile
+from agentception.poller import GitHubBoard, detect_alerts
+
+
+# ---------------------------------------------------------------------------
+# detect_stale_claims() — unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_detect_stale_claim_missing_worktree(tmp_path: Path) -> None:
+    """detect_stale_claims() should flag an issue whose expected worktree is absent."""
+    wip_issues = [{"number": 100, "title": "Fix the thing"}]
+    # tmp_path/issue-100 does NOT exist → stale claim expected
+    claims = await detect_stale_claims(wip_issues, tmp_path)
+
+    assert len(claims) == 1
+    assert claims[0].issue_number == 100
+    assert claims[0].issue_title == "Fix the thing"
+    assert claims[0].worktree_path == str(tmp_path / "issue-100")
+
+
+@pytest.mark.anyio
+async def test_detect_no_stale_when_worktree_exists(tmp_path: Path) -> None:
+    """detect_stale_claims() must not flag issues whose worktree directory exists."""
+    # Create the worktree directory so the issue is considered live.
+    (tmp_path / "issue-200").mkdir()
+
+    wip_issues = [{"number": 200, "title": "Already working"}]
+    claims = await detect_stale_claims(wip_issues, tmp_path)
+
+    assert claims == []
+
+
+@pytest.mark.anyio
+async def test_detect_stale_claims_returns_sorted(tmp_path: Path) -> None:
+    """detect_stale_claims() returns results sorted ascending by issue number."""
+    # Neither worktree exists — both should be stale.
+    wip_issues = [
+        {"number": 300, "title": "Third"},
+        {"number": 100, "title": "First"},
+        {"number": 200, "title": "Second"},
+    ]
+    claims = await detect_stale_claims(wip_issues, tmp_path)
+
+    assert [c.issue_number for c in claims] == [100, 200, 300]
+
+
+@pytest.mark.anyio
+async def test_detect_stale_claims_skips_non_int_number(tmp_path: Path) -> None:
+    """detect_stale_claims() should skip issues where number is not an int."""
+    wip_issues: list[dict[str, object]] = [{"number": "not-a-number", "title": "Bad issue"}]
+    claims = await detect_stale_claims(wip_issues, tmp_path)
+
+    assert claims == []
+
+
+# ---------------------------------------------------------------------------
+# detect_alerts() integration — stale claims appear in alerts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_stale_claim_shows_in_alerts(tmp_path: Path) -> None:
+    """Stale claims from guards.detect_stale_claims() must appear in PipelineState alerts.
+
+    Verifies the full path: detect_alerts() calls detect_stale_claims() and
+    converts each StaleClaim into a human-readable string in the alerts list.
+    The structured stale_claims list is also returned alongside alerts.
+    """
+    board = GitHubBoard(
+        active_label="agentception/4-intelligence",
+        open_issues=[],
+        open_prs=[],
+        wip_issues=[{"number": 42, "title": "Stale issue"}],
+    )
+    # No worktrees — issue 42 has no live worktree → stale claim expected.
+    worktrees: list[TaskFile] = []
+
+    with patch("agentception.poller.settings") as poller_mock:
+        poller_mock.worktrees_dir = tmp_path
+        alerts, stale_claims = await detect_alerts(worktrees, board)
+
+    assert any("Stale claim on #42" in a for a in alerts), (
+        f"Expected 'Stale claim on #42' in alerts, got: {alerts}"
+    )
+    assert len(stale_claims) == 1
+    assert stale_claims[0].issue_number == 42
+    assert stale_claims[0].issue_title == "Stale issue"
+
+
+# ---------------------------------------------------------------------------
+# clear_stale_claim endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_clear_stale_claim_removes_label() -> None:
+    """POST /api/intelligence/stale-claims/{n}/clear should call clear_wip_label."""
+    with patch(
+        "agentception.routes.intelligence.clear_wip_label",
+        new_callable=AsyncMock,
+    ) as mock_clear:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post("/api/intelligence/stale-claims/99/clear")
+
+    assert response.status_code == 200
+    assert response.json() == {"cleared": 99}
+    mock_clear.assert_awaited_once_with(99)
+
+
+@pytest.mark.anyio
+async def test_clear_stale_claim_returns_500_on_gh_failure() -> None:
+    """POST /api/intelligence/stale-claims/{n}/clear should return 500 when gh fails."""
+    with patch(
+        "agentception.routes.intelligence.clear_wip_label",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("gh auth error"),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post("/api/intelligence/stale-claims/55/clear")
+
+    assert response.status_code == 500
+    assert "gh auth error" in response.json()["detail"]

--- a/agentception/tests/test_agentception_poller.py
+++ b/agentception/tests/test_agentception_poller.py
@@ -179,7 +179,7 @@ async def test_unsubscribe_idempotent() -> None:
 
 
 @pytest.mark.anyio
-async def test_stale_claim_alert_detected() -> None:
+async def test_stale_claim_alert_detected(tmp_path: Path) -> None:
     """An agent:wip issue with no live worktree should produce a stale-claim alert."""
     board = GitHubBoard(
         active_label="agentception/0-scaffold",
@@ -188,28 +188,37 @@ async def test_stale_claim_alert_detected() -> None:
         wip_issues=[{"number": 42, "title": "Test issue", "labels": [{"name": "agent:wip"}]}],
     )
     # No worktrees — issue 42 has no live worktree.
-    alerts = await detect_alerts([], board)
+    with patch("agentception.poller.settings") as mock_settings:
+        mock_settings.worktrees_dir = tmp_path
+        alerts, stale_claims = await detect_alerts([], board)
 
     assert any("Stale claim on #42" in a for a in alerts), f"Expected stale-claim alert, got: {alerts}"
+    assert len(stale_claims) == 1
+    assert stale_claims[0].issue_number == 42
 
 
 @pytest.mark.anyio
-async def test_no_stale_claim_when_worktree_exists() -> None:
-    """No stale-claim alert when the wip issue has a matching worktree."""
+async def test_no_stale_claim_when_worktree_exists(tmp_path: Path) -> None:
+    """No stale-claim alert when the wip issue has a matching worktree directory."""
     board = GitHubBoard(
         active_label="agentception/0-scaffold",
         open_issues=[],
         open_prs=[],
         wip_issues=[{"number": 99, "title": "In progress", "labels": [{"name": "agent:wip"}]}],
     )
+    # Create the expected worktree directory so the issue is considered live.
+    (tmp_path / "issue-99").mkdir()
     worktrees = [_make_worktree(issue_number=99, branch="feat/issue-99")]
-    alerts = await detect_alerts(worktrees, board)
+
+    with patch("agentception.poller.settings") as mock_settings:
+        mock_settings.worktrees_dir = tmp_path
+        alerts, _stale_claims = await detect_alerts(worktrees, board)
 
     assert not any("Stale claim on #99" in a for a in alerts)
 
 
 @pytest.mark.anyio
-async def test_out_of_order_pr_alert() -> None:
+async def test_out_of_order_pr_alert(tmp_path: Path) -> None:
     """An open PR labelled with a non-active agentception phase should be flagged."""
     board = GitHubBoard(
         active_label="agentception/1-readers",  # current active phase
@@ -223,7 +232,9 @@ async def test_out_of_order_pr_alert() -> None:
         ],
         wip_issues=[],
     )
-    alerts = await detect_alerts([], board)
+    with patch("agentception.poller.settings") as mock_settings:
+        mock_settings.worktrees_dir = tmp_path
+        alerts, _stale_claims = await detect_alerts([], board)
 
     assert any("Out-of-order PR #77" in a for a in alerts), f"Expected out-of-order alert, got: {alerts}"
 
@@ -244,12 +255,16 @@ async def test_stuck_agent_alert_detected(tmp_path: Path) -> None:
     ]
     board = _empty_board()
 
-    with patch(
-        "agentception.poller.worktree_last_commit_time",
-        new_callable=AsyncMock,
-        return_value=old_timestamp,
+    with (
+        patch("agentception.poller.settings") as mock_settings,
+        patch(
+            "agentception.poller.worktree_last_commit_time",
+            new_callable=AsyncMock,
+            return_value=old_timestamp,
+        ),
     ):
-        alerts = await detect_alerts(worktrees, board)
+        mock_settings.worktrees_dir = tmp_path / "worktrees"
+        alerts, _stale_claims = await detect_alerts(worktrees, board)
 
     assert any("stuck agent" in a.lower() for a in alerts), f"Expected stuck-agent alert, got: {alerts}"
 


### PR DESCRIPTION
## Summary
Closes #631 — detects issues with `agent:wip` label but no live worktree, surfaces them in the dashboard UI with a one-click "Clear Label" fix button.

## Root Cause / Motivation
When an agent crashes or is killed before cleanup, it leaves the `agent:wip` label on the issue. This permanently locks the issue out of the scheduling pool since the poller treats `agent:wip` as an active claim. There was no automated way to detect or fix this condition.

## Solution

### `agentception/intelligence/guards.py` (new)
- `StaleClaim` Pydantic model with `issue_number`, `issue_title`, `worktree_path`
- `detect_stale_claims(wip_issues, worktrees_dir)` — for each `agent:wip` issue, checks whether `worktrees_dir/issue-{number}` exists; produces a `StaleClaim` when absent

### `agentception/models.py`
- Added `StaleClaim` domain model
- Added `stale_claims: list[StaleClaim] = []` field to `PipelineState`

### `agentception/poller.py`
- `detect_alerts()` now calls `detect_stale_claims()` and returns a tuple `(alerts, stale_claims)`
- `tick()` passes both to `PipelineState`

### `agentception/routes/intelligence.py` (new)
- `POST /api/intelligence/stale-claims/{issue_number}/clear` — removes `agent:wip` via `clear_wip_label()`

### `agentception/templates/overview.html` + `static/app.css`
- Stale claim cards section in the GitHub board sidebar (below Alerts)
- Each card shows issue number, title, expected worktree path
- "Clear Label" button with two-step confirmation (click → Confirm/Cancel → POST)
- Alpine.js `staleClaimCard()` component manages confirmation + loading state

## Verification
- [x] mypy clean (37 source files, 0 errors)
- [x] All 21 targeted tests pass (7 new in test_agentception_guards.py, 14 updated in test_agentception_poller.py)
- [x] No dead code, no print(), no secrets

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Architecture** | `the_guardian:fastapi:python` |
| **Skills** | FastAPI · Python / FastAPI |
| **Role** | `python-developer` |
| **Session** | `eng-20260302T042738Z-673c` |
| **Batch (VP)** | `eng-20260302T042552Z-0019` |
| **Wave (CTO)** | `wave-2-20260301` |
| **VP** | `Engineering VP · eng-20260302T042552Z-0019` |

</details>