### PR TITLE
feat: out-of-order PR guard with one-click close action (AC-403)

### DIFF
--- a/agentception/intelligence/__init__.py
+++ b/agentception/intelligence/__init__.py
@@ -1,0 +1,2 @@
+"""AgentCeption intelligence layer — automated pipeline guards and analysis."""
+from __future__ import annotations

--- a/agentception/intelligence/guards.py
+++ b/agentception/intelligence/guards.py
@@ -1,0 +1,137 @@
+"""Out-of-order PR guard for the AgentCeption intelligence layer.
+
+Detects open PRs whose linked issue belongs to a phase label that no longer
+matches the currently active pipeline phase. Surfaces violations so operators
+can close stale PRs before they create merge conflicts or pollute the dev
+branch with work from the wrong batch.
+
+Depends on: #616 (GitHub reader layer must be present).
+
+Public API:
+- ``PRViolation``               — typed result for a single ordering violation
+- ``detect_out_of_order_prs()`` — main detection coroutine; called by poller
+                                   and the /api/intelligence/pr-violations route
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+from pydantic import BaseModel
+
+from agentception.readers.github import get_active_label, get_issue, get_open_prs_with_body
+
+logger = logging.getLogger(__name__)
+
+# Matches "Closes #NNN", "Close #NNN", "closes #NNN" in PR bodies.
+_CLOSES_PATTERN: re.Pattern[str] = re.compile(r"[Cc]loses?\s+#(\d+)")
+
+
+class PRViolation(BaseModel):
+    """A PR whose linked issue belongs to a pipeline phase that is no longer active.
+
+    ``expected_label`` is the currently active agentception/* label.
+    ``actual_label``   is the label carried by the issue the PR closes.
+    ``linked_issue``   is the issue number parsed from 'Closes #N' in the PR body.
+    """
+
+    pr_number: int
+    pr_title: str
+    expected_label: str
+    actual_label: str
+    linked_issue: int | None
+
+
+def _parse_closes(body: str) -> int | None:
+    """Return the first issue number from a 'Closes #NNN' reference, or None.
+
+    Only the first reference is returned — a PR closing multiple issues is
+    rare in this codebase, and the first reference is always the primary one.
+    """
+    match = _CLOSES_PATTERN.search(body)
+    return int(match.group(1)) if match else None
+
+
+async def _get_issue_ac_label(issue_number: int) -> str | None:
+    """Return the first ``agentception/*`` label of an issue, or None.
+
+    Returns None when the issue cannot be fetched (e.g. deleted or private)
+    or when it carries no agentception/* label.
+    """
+    try:
+        issue = await get_issue(issue_number)
+    except RuntimeError:
+        logger.warning("⚠️  Could not fetch issue #%d for label check", issue_number)
+        return None
+
+    labels = issue.get("labels", [])
+    if isinstance(labels, list):
+        for label in labels:
+            if isinstance(label, str) and label.startswith("agentception/"):
+                return label
+    return None
+
+
+async def detect_out_of_order_prs() -> list[PRViolation]:
+    """Detect open PRs whose linked issue belongs to a non-active pipeline phase.
+
+    Algorithm per PR:
+    1. Parse ``Closes #NNN`` from the PR body.
+    2. Fetch that issue's ``agentception/*`` label from GitHub.
+    3. Compare against the currently active label (lowest-numbered open phase).
+    4. Mismatch → append a ``PRViolation``.
+
+    PRs with no ``Closes #N`` reference or whose linked issue carries no
+    ``agentception/*`` label are silently skipped — they cannot be classified.
+
+    Returns an empty list when there is no active label or no violations.
+    """
+    active_label = await get_active_label()
+    if not active_label:
+        logger.debug("🔍 No active label — skipping out-of-order PR check")
+        return []
+
+    open_prs = await get_open_prs_with_body()
+    violations: list[PRViolation] = []
+
+    for pr in open_prs:
+        pr_number = pr.get("number")
+        if not isinstance(pr_number, int):
+            continue
+
+        pr_title = pr.get("title", "")
+        if not isinstance(pr_title, str):
+            pr_title = str(pr_title)
+
+        body = pr.get("body", "")
+        if not isinstance(body, str):
+            body = ""
+
+        linked_issue = _parse_closes(body)
+        if linked_issue is None:
+            logger.debug("🔍 PR #%d has no 'Closes #N' — skipping", pr_number)
+            continue
+
+        actual_label = await _get_issue_ac_label(linked_issue)
+        if actual_label is None:
+            continue
+
+        if actual_label != active_label:
+            logger.warning(
+                "⚠️  PR #%d links issue #%d with label %r (active=%r)",
+                pr_number,
+                linked_issue,
+                actual_label,
+                active_label,
+            )
+            violations.append(
+                PRViolation(
+                    pr_number=pr_number,
+                    pr_title=pr_title,
+                    expected_label=active_label,
+                    actual_label=actual_label,
+                    linked_issue=linked_issue,
+                )
+            )
+
+    return violations

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -21,6 +21,7 @@ import time
 from pathlib import Path
 
 from agentception.config import settings
+from agentception.intelligence.guards import detect_out_of_order_prs
 from agentception.models import AgentNode, AgentStatus, PipelineState, TaskFile
 from agentception.readers.github import (
     get_active_label,
@@ -201,6 +202,20 @@ async def detect_alerts(
         if last_commit > 0.0 and (now - last_commit) > _STUCK_THRESHOLD_SECONDS:
             label = f"issue #{tf.issue_number}" if tf.issue_number else path.name
             alerts.append(f"Possible stuck agent on {label}")
+
+    # ── Alert 4: structured out-of-order PR violations (linked-issue check) ─
+    # Complements Alert 2: while Alert 2 checks the PR's own labels, this
+    # check inspects the issue the PR closes — more precise for the common
+    # case where the PR body contains a 'Closes #N' reference.
+    try:
+        violations = await detect_out_of_order_prs()
+        for v in violations:
+            alerts.append(
+                f"Out-of-order PR #{v.pr_number} — "
+                f"expected {v.expected_label}, got {v.actual_label}"
+            )
+    except Exception as exc:
+        logger.warning("⚠️  detect_out_of_order_prs failed: %s", exc)
 
     return alerts
 

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -178,6 +178,29 @@ async def get_open_prs() -> list[dict[str, object]]:
     return [item for item in result if isinstance(item, dict)]
 
 
+async def get_open_prs_with_body() -> list[dict[str, object]]:
+    """List open PRs targeting ``dev`` including the body text.
+
+    Like ``get_open_prs()`` but also fetches the PR body so callers can parse
+    ``Closes #NNN`` references to identify linked issues.  Used by the
+    out-of-order PR guard (``agentception.intelligence.guards``).
+    """
+    repo = settings.gh_repo
+    args = [
+        "pr", "list",
+        "--repo", repo,
+        "--base", "dev",
+        "--state", "open",
+        "--json", "number,title,headRefName,labels,body",
+    ]
+    result = await gh_json(args, ".", "get_open_prs_with_body")
+    if not isinstance(result, list):
+        raise RuntimeError(
+            f"get_open_prs_with_body: expected list from gh, got {type(result).__name__}"
+        )
+    return [item for item in result if isinstance(item, dict)]
+
+
 async def get_wip_issues() -> list[dict[str, object]]:
     """Return issues currently labelled ``agent:wip``.
 

--- a/agentception/routes/api.py
+++ b/agentception/routes/api.py
@@ -14,9 +14,10 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException
 
 from agentception.config import settings
+from agentception.intelligence.guards import PRViolation, detect_out_of_order_prs
 from agentception.models import AgentNode, PipelineConfig, PipelineState, SpawnRequest, SpawnResult
 from agentception.poller import get_state
-from agentception.readers.github import add_wip_label, get_issue
+from agentception.readers.github import add_wip_label, close_pr, get_issue
 from agentception.readers.pipeline_config import read_pipeline_config, write_pipeline_config
 from agentception.readers.transcripts import read_transcript_messages
 from agentception.routes.ui import _find_agent
@@ -211,6 +212,45 @@ def _build_agent_task(
         f"REQUIRED_OUTPUT=pr_url\n"
         f"ON_BLOCK=stop\n"
     )
+
+
+@router.get("/intelligence/pr-violations", tags=["intelligence"])
+async def pr_violations_api() -> list[PRViolation]:
+    """Return open PRs that violate active pipeline phase ordering.
+
+    Checks each open PR's ``Closes #N`` reference against the currently active
+    ``agentception/*`` label.  A PR is a violation when the issue it closes
+    belongs to an earlier (or later) phase than the one currently being worked.
+
+    Returns an empty list when there are no violations or no active label.
+    """
+    return await detect_out_of_order_prs()
+
+
+@router.post("/intelligence/pr-violations/{pr_number}/close", tags=["intelligence"])
+async def close_violating_pr(pr_number: int) -> dict[str, int]:
+    """Close a PR identified as an out-of-order violation.
+
+    Posts an automated comment explaining the closure before closing the PR so
+    the git history and GitHub timeline both retain the reason.
+
+    Raises
+    ------
+    HTTP 500
+        When the ``gh pr close`` subprocess call fails (e.g. PR already closed).
+    """
+    try:
+        await close_pr(
+            pr_number,
+            "Closed by AgentCeption: out-of-order PR violation.",
+        )
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to close PR #{pr_number}: {exc}",
+        ) from exc
+    logger.info("✅ Closed violating PR #%d", pr_number)
+    return {"closed": pr_number}
 
 
 @router.post("/control/spawn")

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -71,13 +71,44 @@
     </div>
   </div>
 
-  {# ── Alert banners ─────────────────────────────────────────────────────── #}
+  {# ── Generic alert banners ─────────────────────────────────────────────── #}
   <template x-for="alert in state.alerts" :key="alert">
     <div class="alert-banner" role="alert">
       <span>⚠️</span>
       <span x-text="alert"></span>
     </div>
   </template>
+
+  {#
+    PR violation banners — one per out-of-order PR, with a one-click Close PR
+    action.  Data is fetched from GET /api/intelligence/pr-violations on load
+    and after each Close action so the list stays current without a full
+    page reload.  Alpine.js manages the fetch lifecycle.
+  #}
+  <div
+    x-data="prViolations()"
+    x-init="load()"
+  >
+    <template x-for="v in violations" :key="v.pr_number">
+      <div class="alert-banner alert-banner--violation" role="alert">
+        <span>🚫</span>
+        <span>
+          Out-of-order PR
+          <strong x-text="'#' + v.pr_number"></strong>
+          <em x-text="v.pr_title"></em>
+          — expected <code x-text="v.expected_label"></code>,
+          got <code x-text="v.actual_label"></code>
+        </span>
+        <button
+          class="btn btn-danger btn-sm"
+          @click="closeViolation(v.pr_number)"
+          :disabled="closing === v.pr_number"
+          x-text="closing === v.pr_number ? 'Closing…' : 'Close PR'"
+          aria-label="Close out-of-order PR"
+        ></button>
+      </div>
+    </template>
+  </div>
 
   {# ── Two-column overview layout ────────────────────────────────────────── #}
   <div class="overview-columns">
@@ -309,6 +340,49 @@ function pipelineDashboard(initial) {
       if (secs < 60) return secs + 's ago';
       if (secs < 3600) return Math.floor(secs / 60) + 'm ago';
       return Math.floor(secs / 3600) + 'h ago';
+    },
+  };
+}
+
+/**
+ * Alpine.js component for PR violation banners.
+ *
+ * Fetches GET /api/intelligence/pr-violations on mount and after each
+ * successful Close action so the list stays current without a page reload.
+ * Closing a PR posts to POST /api/intelligence/pr-violations/{n}/close and
+ * removes the entry from the local list on success.
+ */
+function prViolations() {
+  return {
+    violations: [],
+    closing: null,
+
+    async load() {
+      try {
+        const res = await fetch('/api/intelligence/pr-violations');
+        if (res.ok) {
+          this.violations = await res.json();
+        }
+      } catch (_) {
+        // Network error — keep empty list; next poll will retry.
+      }
+    },
+
+    async closeViolation(prNumber) {
+      this.closing = prNumber;
+      try {
+        const res = await fetch(
+          `/api/intelligence/pr-violations/${prNumber}/close`,
+          { method: 'POST' },
+        );
+        if (res.ok) {
+          this.violations = this.violations.filter(v => v.pr_number !== prNumber);
+        }
+      } catch (_) {
+        // Network error — leave the card visible so the user can retry.
+      } finally {
+        this.closing = null;
+      }
     },
   };
 }

--- a/agentception/tests/test_agentception_guards.py
+++ b/agentception/tests/test_agentception_guards.py
@@ -1,0 +1,196 @@
+"""Tests for agentception/intelligence/guards.py (AC-403).
+
+Coverage:
+- detect_out_of_order_prs() returns empty list when all PRs are in order
+- detect_out_of_order_prs() returns PRViolation when phase label mismatches
+- detect_out_of_order_prs() skips PRs with no 'Closes #N' reference
+- close_pr() is called via the /api/intelligence/pr-violations/{n}/close route
+
+Run targeted:
+    pytest agentception/tests/test_agentception_guards.py -v
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentception.intelligence.guards import PRViolation, detect_out_of_order_prs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pr(
+    number: int,
+    title: str = "feat: something",
+    body: str = "",
+    labels: list[dict[str, str]] | None = None,
+) -> dict[str, object]:
+    """Build a minimal PR dict matching the shape returned by get_open_prs_with_body."""
+    return {
+        "number": number,
+        "title": title,
+        "headRefName": f"feat/issue-{number}",
+        "labels": labels or [],
+        "body": body,
+    }
+
+
+def _make_issue(number: int, label: str) -> dict[str, object]:
+    """Build a minimal issue dict matching the shape returned by get_issue."""
+    return {
+        "number": number,
+        "state": "OPEN",
+        "title": f"Issue #{number}",
+        "labels": [label],
+    }
+
+
+# ---------------------------------------------------------------------------
+# test_detect_no_violations_when_all_in_order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_detect_no_violations_when_all_in_order() -> None:
+    """All PRs link to issues in the active phase — no violations returned."""
+    active = "agentception/4-intelligence"
+    prs = [
+        _make_pr(100, body="Closes #200"),
+        _make_pr(101, body="Closes #201"),
+    ]
+    issue_200 = _make_issue(200, active)
+    issue_201 = _make_issue(201, active)
+
+    def _fake_get_issue(number: int) -> dict[str, object]:
+        return {200: issue_200, 201: issue_201}[number]
+
+    with (
+        patch(
+            "agentception.intelligence.guards.get_active_label",
+            new_callable=AsyncMock,
+            return_value=active,
+        ),
+        patch(
+            "agentception.intelligence.guards.get_open_prs_with_body",
+            new_callable=AsyncMock,
+            return_value=prs,
+        ),
+        patch(
+            "agentception.intelligence.guards.get_issue",
+            side_effect=_fake_get_issue,
+        ),
+    ):
+        violations = await detect_out_of_order_prs()
+
+    assert violations == [], f"Expected no violations, got: {violations}"
+
+
+# ---------------------------------------------------------------------------
+# test_detect_violation_wrong_phase_label
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_detect_violation_wrong_phase_label() -> None:
+    """A PR linking to an issue from a past phase produces a PRViolation."""
+    active = "agentception/4-intelligence"
+    old_label = "agentception/0-scaffold"
+    prs = [
+        _make_pr(77, title="feat: old work", body="Closes #608"),
+    ]
+    issue_608 = _make_issue(608, old_label)
+
+    with (
+        patch(
+            "agentception.intelligence.guards.get_active_label",
+            new_callable=AsyncMock,
+            return_value=active,
+        ),
+        patch(
+            "agentception.intelligence.guards.get_open_prs_with_body",
+            new_callable=AsyncMock,
+            return_value=prs,
+        ),
+        patch(
+            "agentception.intelligence.guards.get_issue",
+            new_callable=AsyncMock,
+            return_value=issue_608,
+        ),
+    ):
+        violations = await detect_out_of_order_prs()
+
+    assert len(violations) == 1
+    v = violations[0]
+    assert isinstance(v, PRViolation)
+    assert v.pr_number == 77
+    assert v.pr_title == "feat: old work"
+    assert v.expected_label == active
+    assert v.actual_label == old_label
+    assert v.linked_issue == 608
+
+
+# ---------------------------------------------------------------------------
+# test_detect_no_linked_issue_skips
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_detect_no_linked_issue_skips() -> None:
+    """PRs without a 'Closes #N' reference are silently skipped."""
+    active = "agentception/4-intelligence"
+    prs = [
+        _make_pr(50, body="This PR has no closes reference."),
+        _make_pr(51, body=""),  # empty body
+    ]
+
+    with (
+        patch(
+            "agentception.intelligence.guards.get_active_label",
+            new_callable=AsyncMock,
+            return_value=active,
+        ),
+        patch(
+            "agentception.intelligence.guards.get_open_prs_with_body",
+            new_callable=AsyncMock,
+            return_value=prs,
+        ),
+        patch(
+            "agentception.intelligence.guards.get_issue",
+            new_callable=AsyncMock,
+        ) as mock_get_issue,
+    ):
+        violations = await detect_out_of_order_prs()
+
+    # get_issue should never be called since no PR has a Closes reference.
+    mock_get_issue.assert_not_called()
+    assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# test_close_violating_pr_calls_gh
+# ---------------------------------------------------------------------------
+
+
+def test_close_violating_pr_calls_gh() -> None:
+    """The close endpoint calls close_pr() with the correct PR number and message."""
+    from fastapi.testclient import TestClient
+
+    from agentception.app import app
+
+    with TestClient(app) as client:
+        with patch(
+            "agentception.routes.api.close_pr",
+            new_callable=AsyncMock,
+        ) as mock_close:
+            response = client.post("/api/intelligence/pr-violations/42/close")
+
+    assert response.status_code == 200
+    assert response.json() == {"closed": 42}
+    mock_close.assert_awaited_once_with(
+        42,
+        "Closed by AgentCeption: out-of-order PR violation.",
+    )

--- a/agentception/tests/test_agentception_poller.py
+++ b/agentception/tests/test_agentception_poller.py
@@ -71,6 +71,7 @@ async def test_tick_returns_pipeline_state() -> None:
     with (
         patch("agentception.poller.list_active_worktrees", new_callable=AsyncMock, return_value=[]),
         patch("agentception.poller.build_github_board", new_callable=AsyncMock, return_value=board),
+        patch("agentception.poller.detect_out_of_order_prs", new_callable=AsyncMock, return_value=[]),
     ):
         before = time.time()
         state = await tick()
@@ -93,6 +94,7 @@ async def test_tick_updates_global_state() -> None:
     with (
         patch("agentception.poller.list_active_worktrees", new_callable=AsyncMock, return_value=[]),
         patch("agentception.poller.build_github_board", new_callable=AsyncMock, return_value=board),
+        patch("agentception.poller.detect_out_of_order_prs", new_callable=AsyncMock, return_value=[]),
     ):
         state = await tick()
 
@@ -188,7 +190,12 @@ async def test_stale_claim_alert_detected() -> None:
         wip_issues=[{"number": 42, "title": "Test issue", "labels": [{"name": "agent:wip"}]}],
     )
     # No worktrees — issue 42 has no live worktree.
-    alerts = await detect_alerts([], board)
+    with patch(
+        "agentception.poller.detect_out_of_order_prs",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        alerts = await detect_alerts([], board)
 
     assert any("Stale claim on #42" in a for a in alerts), f"Expected stale-claim alert, got: {alerts}"
 
@@ -203,7 +210,12 @@ async def test_no_stale_claim_when_worktree_exists() -> None:
         wip_issues=[{"number": 99, "title": "In progress", "labels": [{"name": "agent:wip"}]}],
     )
     worktrees = [_make_worktree(issue_number=99, branch="feat/issue-99")]
-    alerts = await detect_alerts(worktrees, board)
+    with patch(
+        "agentception.poller.detect_out_of_order_prs",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        alerts = await detect_alerts(worktrees, board)
 
     assert not any("Stale claim on #99" in a for a in alerts)
 
@@ -223,7 +235,12 @@ async def test_out_of_order_pr_alert() -> None:
         ],
         wip_issues=[],
     )
-    alerts = await detect_alerts([], board)
+    with patch(
+        "agentception.poller.detect_out_of_order_prs",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        alerts = await detect_alerts([], board)
 
     assert any("Out-of-order PR #77" in a for a in alerts), f"Expected out-of-order alert, got: {alerts}"
 
@@ -244,10 +261,17 @@ async def test_stuck_agent_alert_detected(tmp_path: Path) -> None:
     ]
     board = _empty_board()
 
-    with patch(
-        "agentception.poller.worktree_last_commit_time",
-        new_callable=AsyncMock,
-        return_value=old_timestamp,
+    with (
+        patch(
+            "agentception.poller.worktree_last_commit_time",
+            new_callable=AsyncMock,
+            return_value=old_timestamp,
+        ),
+        patch(
+            "agentception.poller.detect_out_of_order_prs",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
     ):
         alerts = await detect_alerts(worktrees, board)
 


### PR DESCRIPTION
## Summary
Closes #630 — automated detection of open PRs whose linked issue belongs to a pipeline phase that no longer matches the currently active label, with a one-click Close PR action from the dashboard.

## Root Cause / Motivation
Without automated detection, out-of-order PRs (like PR #608) could only be caught manually during code review. This guard runs on every poll cycle and surfaces violations immediately in the dashboard.

## Solution

### New module: `agentception/intelligence/guards.py`
- `PRViolation` Pydantic model with `pr_number`, `pr_title`, `expected_label`, `actual_label`, `linked_issue`
- `detect_out_of_order_prs()` async function: for each open PR, parses `Closes #NNN` from the body, fetches that issue's `agentception/*` label, compares against the active label, and returns violations

### Integration: `agentception/poller.py`
- `detect_out_of_order_prs()` called inside `detect_alerts()` (Alert 4)
- Violations appear as alert strings in `PipelineState.alerts` on every poll

### New API endpoints: `agentception/routes/api.py`
- `GET /api/intelligence/pr-violations` → `list[PRViolation]`
- `POST /api/intelligence/pr-violations/{pr_number}/close` → `{"closed": pr_number}` (calls `close_pr()` with audit comment)

### UI: `agentception/templates/overview.html`
- New `prViolations` Alpine.js component fetches violations on mount and after each close action
- Each violation shows PR number, title, label mismatch, and a "Close PR" button with loading state

### New GitHub reader: `agentception/readers/github.py`
- `get_open_prs_with_body()` — fetches PRs with body text for `Closes #N` parsing (separate cache key from `get_open_prs()`)

### Tests: `agentception/tests/test_agentception_guards.py`
- `test_detect_no_violations_when_all_in_order`
- `test_detect_violation_wrong_phase_label`
- `test_detect_no_linked_issue_skips`
- `test_close_violating_pr_calls_gh`
- Existing poller tests updated to mock `detect_out_of_order_prs` (prevents real GitHub calls in `detect_alerts` tests)

## Verification
- [x] mypy clean (36 source files, 0 errors)
- [x] 4 new guard tests pass
- [x] 14 existing poller tests pass (no regressions)
- [x] 26 github + scaffold tests pass

---

<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Architecture** | `the_guardian:fastapi:python` |
| **Skills** | FastAPI · Python / FastAPI |
| **Role** | `python-developer` |
| **Session** | `eng-20260302T042748Z-26d2` |
| **Batch (VP)** | `eng-20260302T042552Z-0019` |
| **Wave (CTO)** | `wave-2-20260301` |
| **VP** | `Engineering VP · eng-20260302T042552Z-0019` |

</details>