### PR TITLE
feat: [AC-401] dependency DAG builder — parse all issue bodies for Depends on #NNN

### DIFF
--- a/agentception/intelligence/dag.py
+++ b/agentception/intelligence/dag.py
@@ -1,0 +1,138 @@
+"""Dependency DAG builder for the AgentCeption intelligence layer.
+
+Parses every open issue body for ``Depends on #NNN`` patterns and assembles
+a directed acyclic graph (DAG) of issue dependencies.  The DAG is the
+foundation for the dashboard visualisation (AC-402) and feeds the scheduling
+intelligence that prevents an agent from starting work before its dependencies
+are merged.
+
+Typical usage::
+
+    from agentception.intelligence.dag import build_dag
+
+    dag = await build_dag()
+    for (src, dst) in dag.edges:
+        print(f"#{src} depends on #{dst}")
+"""
+from __future__ import annotations
+
+import logging
+
+from pydantic import BaseModel
+
+from agentception.intelligence.analyzer import parse_deps_from_body
+from agentception.readers.github import get_open_issues
+
+logger = logging.getLogger(__name__)
+
+# Re-export so callers can import parse_deps_from_body from this module
+# without knowing it lives in analyzer.py.
+__all__ = ["IssueNode", "DependencyDAG", "build_dag", "parse_deps_from_body"]
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+class IssueNode(BaseModel):
+    """A single issue node in the dependency DAG.
+
+    Fields mirror the data available from the GitHub API.  ``deps`` lists the
+    issue numbers that *this* issue depends on — i.e. work that must be
+    completed before this issue can be started.
+    """
+
+    number: int
+    title: str
+    state: str          # "open" | "closed"
+    labels: list[str]
+    has_wip: bool
+    deps: list[int]     # issue numbers this one depends on
+
+
+class DependencyDAG(BaseModel):
+    """Directed acyclic graph of open issue dependencies.
+
+    ``edges`` encodes ``(from, to)`` pairs where *from* depends on *to*.
+    Both ``from`` and ``to`` are GitHub issue numbers.  The ``nodes`` list
+    contains one :class:`IssueNode` per open issue regardless of whether it
+    participates in any edge.
+    """
+
+    nodes: list[IssueNode]
+    edges: list[tuple[int, int]]   # (from, to) — from depends on to
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def build_dag() -> DependencyDAG:
+    """Fetch all open issues, parse their dependencies, and return the DAG.
+
+    Calls :func:`~agentception.readers.github.get_open_issues` once to
+    retrieve every open issue with its body text, then applies
+    :func:`parse_deps_from_body` to extract ``Depends on #N`` declarations.
+    Closed issues are not included as nodes; edges that reference closed
+    issues are still recorded (the referenced issue will simply not appear
+    in ``nodes``).
+
+    Returns
+    -------
+    DependencyDAG
+        ``nodes`` — one per open issue; ``edges`` — one per dependency pair.
+
+    Raises
+    ------
+    RuntimeError
+        When the GitHub CLI subprocess exits with a non-zero status.
+    """
+    raw_issues = await get_open_issues()
+    logger.debug("✅ build_dag: fetched %d open issues", len(raw_issues))
+
+    nodes: list[IssueNode] = []
+    edges: list[tuple[int, int]] = []
+
+    for issue in raw_issues:
+        number = int(issue["number"]) if isinstance(issue["number"], (int, str)) else 0
+        title = str(issue.get("title", ""))
+        state = str(issue.get("state", "open"))
+        body = str(issue.get("body", "") or "")
+
+        # Normalise labels: gh returns a list of label objects {"name": "...", ...}
+        raw_labels = issue.get("labels", [])
+        label_names: list[str] = []
+        if isinstance(raw_labels, list):
+            for lbl in raw_labels:
+                if isinstance(lbl, dict):
+                    name = lbl.get("name")
+                    if isinstance(name, str):
+                        label_names.append(name)
+                elif isinstance(lbl, str):
+                    label_names.append(lbl)
+
+        has_wip = "agent:wip" in label_names
+        deps = parse_deps_from_body(body)
+
+        nodes.append(
+            IssueNode(
+                number=number,
+                title=title,
+                state=state,
+                labels=label_names,
+                has_wip=has_wip,
+                deps=deps,
+            )
+        )
+
+        for dep_number in deps:
+            edges.append((number, dep_number))
+
+    logger.info(
+        "✅ build_dag: %d nodes, %d edges",
+        len(nodes),
+        len(edges),
+    )
+    return DependencyDAG(nodes=nodes, edges=edges)

--- a/agentception/routes/intelligence.py
+++ b/agentception/routes/intelligence.py
@@ -17,11 +17,37 @@ import logging
 
 from fastapi import APIRouter, HTTPException
 
+from agentception.intelligence.dag import DependencyDAG, build_dag
 from agentception.readers.github import clear_wip_label
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/intelligence", tags=["intelligence"])
+
+
+@router.get("/dag")
+async def dag_api() -> DependencyDAG:
+    """Return the full dependency DAG for all open issues.
+
+    Fetches every open issue via the GitHub CLI, parses ``Depends on #N``
+    declarations from each body, and returns a directed graph of dependencies.
+
+    The response is consumed by the AC-402 DAG visualisation and by the
+    intelligence layer's scheduling logic to prevent early assignment.
+
+    Raises
+    ------
+    HTTP 500
+        When the GitHub CLI subprocess fails (e.g. auth error, rate-limit).
+    """
+    try:
+        return await build_dag()
+    except RuntimeError as exc:
+        logger.error("❌ Failed to build dependency DAG: %s", exc)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to build dependency DAG: {exc}",
+        ) from exc
 
 
 @router.post("/stale-claims/{issue_number}/clear")

--- a/agentception/tests/test_agentception_dag.py
+++ b/agentception/tests/test_agentception_dag.py
@@ -1,0 +1,283 @@
+"""Tests for the AgentCeption dependency DAG builder.
+
+Covers parse_deps_from_body (all known variants) and build_dag (with
+mocked GitHub data) to keep tests hermetic — no live API calls.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentception.intelligence.dag import (
+    DependencyDAG,
+    IssueNode,
+    build_dag,
+    parse_deps_from_body,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_deps_from_body
+# ---------------------------------------------------------------------------
+
+
+def test_parse_deps_simple() -> None:
+    """'Depends on: #552' → [552]."""
+    body = "## Overview\n\nDepends on: #552\n\nSome description."
+    assert parse_deps_from_body(body) == [552]
+
+
+def test_parse_deps_bold_markdown() -> None:
+    """'**Depends on:** #553' → [553]."""
+    body = "**Depends on:** #553\n\nRest of the body."
+    assert parse_deps_from_body(body) == [553]
+
+
+def test_parse_deps_multiple() -> None:
+    """Multiple 'Depends on' lines each contribute their own issue number."""
+    body = (
+        "**Depends on:** #552\n"
+        "Some other text.\n"
+        "Blocked by #600\n"
+        "More text.\n"
+    )
+    result = parse_deps_from_body(body)
+    assert 552 in result
+    assert 600 in result
+    assert result == sorted(result), "result should be sorted"
+
+
+def test_parse_deps_multiple_on_one_line() -> None:
+    """'Depends on #552, #553' → [552, 553]."""
+    body = "Depends on #552, #553 to be available first."
+    result = parse_deps_from_body(body)
+    assert result == [552, 553]
+
+
+def test_parse_deps_requires_keyword() -> None:
+    """'Requires #614' is also recognised."""
+    body = "Requires #614 to land first."
+    assert parse_deps_from_body(body) == [614]
+
+
+def test_parse_deps_no_deps() -> None:
+    """Body with no dependency declarations → []."""
+    body = "## Overview\n\nJust a standalone task.\n\n## Acceptance Criteria\n- [ ] Done"
+    assert parse_deps_from_body(body) == []
+
+
+def test_parse_deps_range_only_first() -> None:
+    """'Depends on: #552–#585' — range notation: only numbers with # prefix are captured.
+
+    This is a known limitation (documented): the function extracts every
+    '#NNN' token on the dependency line, so '#552' is found but '#585'
+    is only captured if it is also prefixed with '#'.  A range using an
+    en-dash without a second '#' prefix is treated as prose and only the
+    first number is extracted.
+    """
+    body = "Depends on: #552–585"
+    result = parse_deps_from_body(body)
+    assert 552 in result
+    # 585 is NOT prefixed with '#' in en-dash range notation — only 552 found.
+    assert 585 not in result
+
+
+def test_parse_deps_deduplicates() -> None:
+    """Same issue number mentioned twice in the body appears only once."""
+    body = "Depends on #552\nAlso depends on #552"
+    result = parse_deps_from_body(body)
+    assert result.count(552) == 1
+
+
+# ---------------------------------------------------------------------------
+# build_dag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_dag_no_issues() -> None:
+    """When there are no open issues, the DAG should be empty."""
+    with patch(
+        "agentception.intelligence.dag.get_open_issues",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        dag = await build_dag()
+
+    assert isinstance(dag, DependencyDAG)
+    assert dag.nodes == []
+    assert dag.edges == []
+
+
+@pytest.mark.anyio
+async def test_build_dag_single_issue_no_deps() -> None:
+    """A single issue with no dependency declarations produces one node and no edges."""
+    fake_issue = {
+        "number": 10,
+        "title": "Standalone issue",
+        "state": "open",
+        "labels": [{"name": "enhancement"}],
+        "body": "Just a task with no dependencies.",
+    }
+    with patch(
+        "agentception.intelligence.dag.get_open_issues",
+        new_callable=AsyncMock,
+        return_value=[fake_issue],
+    ):
+        dag = await build_dag()
+
+    assert len(dag.nodes) == 1
+    assert dag.nodes[0].number == 10
+    assert dag.nodes[0].deps == []
+    assert dag.edges == []
+
+
+@pytest.mark.anyio
+async def test_build_dag_chain() -> None:
+    """A → B → C chain produces correct nodes and edges.
+
+    Issue A depends on B, which depends on C.
+    Expected edges: (A, B) and (B, C).
+    """
+    issues = [
+        {
+            "number": 30,
+            "title": "Issue A",
+            "state": "open",
+            "labels": [],
+            "body": "Depends on #20",
+        },
+        {
+            "number": 20,
+            "title": "Issue B",
+            "state": "open",
+            "labels": [],
+            "body": "Depends on #10",
+        },
+        {
+            "number": 10,
+            "title": "Issue C",
+            "state": "open",
+            "labels": [],
+            "body": "No dependencies.",
+        },
+    ]
+    with patch(
+        "agentception.intelligence.dag.get_open_issues",
+        new_callable=AsyncMock,
+        return_value=issues,
+    ):
+        dag = await build_dag()
+
+    assert len(dag.nodes) == 3
+    assert (30, 20) in dag.edges
+    assert (20, 10) in dag.edges
+    assert len(dag.edges) == 2
+
+    node_map = {n.number: n for n in dag.nodes}
+    assert node_map[30].deps == [20]
+    assert node_map[20].deps == [10]
+    assert node_map[10].deps == []
+
+
+@pytest.mark.anyio
+async def test_build_dag_has_wip_flag() -> None:
+    """Issues with the 'agent:wip' label should have has_wip=True."""
+    issue = {
+        "number": 55,
+        "title": "WIP issue",
+        "state": "open",
+        "labels": [{"name": "agent:wip"}, {"name": "enhancement"}],
+        "body": "",
+    }
+    with patch(
+        "agentception.intelligence.dag.get_open_issues",
+        new_callable=AsyncMock,
+        return_value=[issue],
+    ):
+        dag = await build_dag()
+
+    assert dag.nodes[0].has_wip is True
+    assert "agent:wip" in dag.nodes[0].labels
+    assert "enhancement" in dag.nodes[0].labels
+
+
+@pytest.mark.anyio
+async def test_build_dag_label_extraction() -> None:
+    """Labels are extracted correctly from both dict and string formats."""
+    issue_dict_labels = {
+        "number": 1,
+        "title": "Dict labels",
+        "state": "open",
+        "labels": [{"name": "agentception/4-intelligence"}, {"name": "enhancement"}],
+        "body": "",
+    }
+    with patch(
+        "agentception.intelligence.dag.get_open_issues",
+        new_callable=AsyncMock,
+        return_value=[issue_dict_labels],
+    ):
+        dag = await build_dag()
+
+    node = dag.nodes[0]
+    assert "agentception/4-intelligence" in node.labels
+    assert "enhancement" in node.labels
+
+
+@pytest.mark.anyio
+async def test_build_dag_multiple_deps() -> None:
+    """An issue with multiple dependencies produces multiple edges."""
+    issue = {
+        "number": 100,
+        "title": "Multi-dep issue",
+        "state": "open",
+        "labels": [],
+        "body": "Depends on #50, #60, #70",
+    }
+    with patch(
+        "agentception.intelligence.dag.get_open_issues",
+        new_callable=AsyncMock,
+        return_value=[issue],
+    ):
+        dag = await build_dag()
+
+    assert len(dag.edges) == 3
+    assert (100, 50) in dag.edges
+    assert (100, 60) in dag.edges
+    assert (100, 70) in dag.edges
+    assert dag.nodes[0].deps == [50, 60, 70]
+
+
+# ---------------------------------------------------------------------------
+# IssueNode / DependencyDAG models
+# ---------------------------------------------------------------------------
+
+
+def test_issue_node_model() -> None:
+    """IssueNode can be constructed and serialised correctly."""
+    node = IssueNode(
+        number=42,
+        title="Test issue",
+        state="open",
+        labels=["enhancement", "agentception"],
+        has_wip=False,
+        deps=[10, 20],
+    )
+    assert node.number == 42
+    assert node.has_wip is False
+    assert node.deps == [10, 20]
+    data = node.model_dump()
+    assert data["labels"] == ["enhancement", "agentception"]
+
+
+def test_dependency_dag_model() -> None:
+    """DependencyDAG serialises nodes and edges without loss."""
+    node = IssueNode(
+        number=1, title="A", state="open", labels=[], has_wip=False, deps=[2]
+    )
+    dag = DependencyDAG(nodes=[node], edges=[(1, 2)])
+    assert dag.edges[0] == (1, 2)
+    assert dag.nodes[0].number == 1
+    dumped = dag.model_dump()
+    assert dumped["edges"] == [(1, 2)]


### PR DESCRIPTION
## Summary
Closes #628 — Implements the dependency graph builder for the AgentCeption intelligence layer.

## Root Cause / Motivation
The DAG visualisation (AC-402) and scheduling intelligence needed a backend module to parse open issue bodies for `Depends on #NNN` patterns and assemble a directed acyclic graph. Without it, the intelligence layer had no way to detect or enforce dependency ordering between issues.

## Solution

### New: `agentception/intelligence/dag.py`
- `IssueNode` — Pydantic model with `number`, `title`, `state`, `labels`, `has_wip`, `deps`
- `DependencyDAG` — Pydantic model with `nodes: list[IssueNode]` and `edges: list[tuple[int, int]]` where `(from, to)` means "from depends on to"
- `parse_deps_from_body(body)` — re-exports from `analyzer.py` (already well-tested, avoids duplication)
- `build_dag()` — async function that fetches all open issues, parses deps from each body, and assembles the DAG

### Modified: `agentception/routes/intelligence.py`
- Added `GET /api/intelligence/dag` endpoint returning `DependencyDAG`

### New: `agentception/tests/test_agentception_dag.py`
16 tests covering:
- `parse_deps_from_body`: simple, bold markdown, multiple on one line, `Requires` keyword, no deps, en-dash range (known limitation), deduplication
- `build_dag`: empty result, single issue no deps, A→B→C chain, has_wip flag, label extraction, multiple deps

## Verification
- [x] mypy clean (41 source files, no issues)
- [x] 16 new tests pass
- [x] Existing guards and scaffold tests pass (17/17)
- [x] Docs: module docstring explains why + contract; all public functions have docstrings

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Architecture** | `turing:fastapi:python` |
| **Session** | `eng-20260302T050321Z-461e` |
| **Batch** | `eng-20260302T050154Z-52ca` |
| **Wave (CTO)** | `wave-4-20260301` |

</details>