### PR TITLE
fix: switch pipeline config from htmx to agentception

### DIFF
--- a/.cursor/parallel-issue-to-pr.md
+++ b/.cursor/parallel-issue-to-pr.md
@@ -402,7 +402,7 @@ WTNAME=$(basename "$(pwd)")
 
 # Detect codebase from issue label in .agent-task
 ISSUE_LABEL=$(grep "^ISSUE_LABEL=" .agent-task 2>/dev/null | cut -d= -f2 || echo "")
-IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^htmx/" || true)
+IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^agentception/" || true)
 
 # mypy — route by codebase (agentception and maestro are independent; never cross-run)
 if [ "$IS_AC" -gt 0 ]; then
@@ -679,7 +679,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   # what was already broken. This baseline is your contract with the next agent.
   # Detect codebase from .agent-task label — set once, used throughout this run.
   ISSUE_LABEL=$(grep "^ISSUE_LABEL=" .agent-task 2>/dev/null | cut -d= -f2 || echo "")
-  IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^htmx/" || true)
+  IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^agentception/" || true)
 
   echo "=== PRE-EXISTING MYPY BASELINE (dev, before any changes) ==="
   # Route by codebase — agentception and maestro are independent; never cross-run.
@@ -1374,20 +1374,20 @@ Every piece of code you write or touch must satisfy:
 Run in order — types before tests:
 
 ```
-docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/"
+docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
 ```
 
-Then run **only the test files for modules you changed** — never `tests/` as a directory:
+Then run **only the test files for modules you changed** — never `agentception/tests/` as a directory:
 
 ```
 # Module-name convention:
-# agentception/app.py                → tests/test_agentception_scaffold.py
-# agentception/readers/worktrees.py  → tests/test_agentception_worktrees.py
-# agentception/readers/github.py     → tests/test_agentception_github.py
-# agentception/poller.py             → tests/test_agentception_poller.py
-# agentception/routes/ui.py          → tests/test_agentception_ui_overview.py
+# agentception/app.py                → agentception/tests/test_agentception_scaffold.py
+# agentception/readers/worktrees.py  → agentception/tests/test_agentception_worktrees.py
+# agentception/readers/github.py     → agentception/tests/test_agentception_github.py
+# agentception/poller.py             → agentception/tests/test_agentception_poller.py
+# agentception/routes/ui.py          → agentception/tests/test_agentception_ui_overview.py
 
-docker compose exec maestro pytest tests/test_<your_module>.py -v
+docker compose exec agentception pytest agentception/tests/test_<your_module>.py -v
 ```
 
 The full suite is CI's job. Running it in every agent session doesn't scale.

--- a/.cursor/parallel-pr-review.md
+++ b/.cursor/parallel-pr-review.md
@@ -296,9 +296,9 @@ the container. After checking out the PR branch, your worktree's code is
 REPO=$(git worktree list | head -1 | awk '{print $1}')
 WTNAME=$(basename "$(pwd)")
 
-# Detect codebase from PR labels (htmx/* vs maestro/storpheus)
+# Detect codebase from PR labels (agentception/* vs maestro/storpheus)
 IS_AC=$(gh pr view $N --repo $GH_REPO --json labels \
-  --jq '.labels[].name' | grep -c "^htmx/" || true)
+  --jq '.labels[].name' | grep -c "^agentception/" || true)
 
 # mypy — route by codebase (NEVER run both; they are independent codebases)
 # Both codebases use the same pattern: PYTHONPATH=/worktrees/$WTNAME pointing at the
@@ -1175,12 +1175,14 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
   if [ "$SPAWN_MODE" = "chain" ]; then
     # ── CHAIN MODE: merge happened → spawn next engineer for next unclaimed issue ──
 
-    # Mirror the CTO's label-ordering logic: find the lowest-numbered htmx/* label
+    # Mirror the CTO's label-ordering logic: find the lowest-numbered agentception/* label
     # that still has open issues. NEVER pick from a later label while an earlier one
     # still has work. This prevents later-phase issues from being claimed prematurely.
     ACTIVE_LABEL=""
-       for label in htmx/0-foundation htmx/1-independent htmx/2-main-ui \
-                        htmx/3-analysis htmx/4-canvas htmx/5-cleanup; do
+       for label in agentception/0-scaffold agentception/1-controls \
+                        agentception/2-telemetry agentception/3-roles \
+                        agentception/4-intelligence agentception/5-scaling \
+                        agentception/6-generalization; do
       COUNT=$(gh issue list --state open --repo "$GH_REPO" \
                 --label "$label" --json number --jq 'length')
       if [ "$COUNT" -gt 0 ]; then
@@ -1205,7 +1207,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     NEXT_ISSUE=""
     if [ -z "$ACTIVE_LABEL" ]; then
-      echo "ℹ️  No open htmx/ or batch issues remain — chain complete."
+      echo "ℹ️  No open agentception/ or batch issues remain — chain complete."
     else
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       NEXT_ISSUE=$(gh issue list \
@@ -1247,7 +1249,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
       # Resolve the primary label so the engineer can route mypy/tests correctly.
       NEXT_ISSUE_LABEL=$(gh issue view "$NEXT_ISSUE" --repo "$GH_REPO" \
-        --json labels --jq '[.labels[].name | select(startswith("htmx/"))] | first // ""')
+        --json labels --jq '[.labels[].name | select(startswith("agentception/"))] | first // ""')
 
       cat > "$NEXT_WORKTREE/.agent-task" <<TASK
 WORKFLOW=issue-to-pr
@@ -1566,9 +1568,9 @@ GH_REPO=${GH_REPO:-cgcardona/maestro}
 WTNAME=$(basename "$(pwd)")
 # Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
 IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "htmx/" || true)
+  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "agentception/" || true)
 if [ "$IS_AC" -gt 0 ]; then
-  docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
+  docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
 else
   REPO=$(git worktree list | head -1 | awk '{print $1}')
   cd "$REPO" && docker compose exec maestro sh -c \

--- a/.cursor/roles/cto.md
+++ b/.cursor/roles/cto.md
@@ -88,8 +88,10 @@ LOOP:
        # Labels are processed in strict order — NEVER skip ahead.
        # Find the lowest-numbered label that still has open issues.
        ACTIVE_LABEL=""
-       for label in htmx/0-foundation htmx/1-independent htmx/2-main-ui \
-                        htmx/3-analysis htmx/4-canvas htmx/5-cleanup; do
+       for label in agentception/0-scaffold agentception/1-controls \
+                        agentception/2-telemetry agentception/3-roles \
+                        agentception/4-intelligence agentception/5-scaling \
+                        agentception/6-generalization; do
          COUNT=$(gh issue list --state open --repo cgcardona/maestro \
                    --label "$label" --json number --jq 'length')
          if [ "$COUNT" -gt 0 ]; then
@@ -125,7 +127,7 @@ LOOP:
      this to more than 1 Eng VP regardless of queue depth.
 
      ⚠️  ACTIVE_LABEL GATE: The single Eng VP ONLY works on ACTIVE_LABEL issues.
-     It MUST NOT claim issues from any other htmx/* label.
+     It MUST NOT claim issues from any other agentception/* label.
 
   4. Dispatch all allocated VPs simultaneously in ONE message
      (one Task call per VP, all in the same response):
@@ -155,10 +157,10 @@ runtime.
 **Engineering VP Task prompt — construct as follows:**
 
   Part 1 — prefix:
-    "CTO_WAVE=<wave-N-timestamp>. ACTIVE_LABEL=<htmx/X-label>.
+    "CTO_WAVE=<wave-N-timestamp>. ACTIVE_LABEL=<agentception/X-label>.
      Seed your pool and wait for it to drain.
-     You MUST only query and claim issues labeled exactly '<htmx/X-label>'
-     — no other htmx/* labels."
+     You MUST only query and claim issues labeled exactly '<agentception/X-label>'
+     — no other agentception/* labels."
 
   Part 2 — VP role + full downstream kickoff chain:
     Paste the entire ## Embedded Eng VP Role section below verbatim.
@@ -182,11 +184,11 @@ CTO and VPs do not track dependencies. The canonical prompts handle it.
 
 ## Label scoping rules (critical)
 
-- **Issues:** only htmx/-tagged issues are in scope. Filter every query:
-  `--jq '[.[] | select(.labels | map(.name) | any(startswith("htmx/")))]'`
-- **PRs:** ALL open PRs against `dev` are in scope — PRs never carry `htmx/*` labels.
-  Never add a htmx/ label to a PR. Never filter PRs by label.
-- The QA VP must NOT require htmx/ labels on PRs — it reviews every open PR, full stop.
+- **Issues:** only agentception/-tagged issues are in scope. Filter every query:
+  `--jq '[.[] | select(.labels | map(.name) | any(startswith("agentception/")))]'`
+- **PRs:** ALL open PRs against `dev` are in scope — PRs never carry `agentception/*` labels.
+  Never add a agentception/ label to a PR. Never filter PRs by label.
+- The QA VP must NOT require agentception/ labels on PRs — it reviews every open PR, full stop.
 
 ## What you never do
 
@@ -277,8 +279,8 @@ SEED:
        done
 
   3. Query open unclaimed issues — ACTIVE_LABEL only (passed by CTO in your dispatch prompt):
-       # ACTIVE_LABEL is the single htmx/* label the CTO assigned to you.
-       # NEVER query all htmx/* labels — you are scoped to exactly one label per VP run.
+       # ACTIVE_LABEL is the single agentception/* label the CTO assigned to you.
+       # NEVER query all agentception/* labels — you are scoped to exactly one label per VP run.
        # This prevents you from accidentally claiming issues from a later phase.
        ACTIVE_LABEL="<from CTO dispatch prompt>"
        gh issue list --state open --repo cgcardona/maestro --label "$ACTIVE_LABEL" \
@@ -462,7 +464,7 @@ Worktrees live at: `$HOME/.cursor/worktrees/maestro/issue-{N}/`
 ```
 TASK=issue-to-pr
 ISSUE_NUMBER=<N>
-ISSUE_LABEL=<primary htmx/* label from: gh issue view <N> --json labels --jq '[.labels[].name | select(startswith("htmx/"))] | first'>
+ISSUE_LABEL=<primary agentception/* label from: gh issue view <N> --json labels --jq '[.labels[].name | select(startswith("agentception/"))] | first'>
 BRANCH=feat/issue-<N>
 WORKTREE=$HOME/.cursor/worktrees/maestro/issue-<N>
 ROLE=python-developer
@@ -476,7 +478,7 @@ WAVE=<CTO_WAVE>
 COGNITIVE_ARCH=<COGNITIVE_ARCH from step 5c above, e.g. "lovelace:htmx:jinja2:alpine">
 ```
 
-`ISSUE_LABEL` is the primary scoping label (e.g. `htmx/0-scaffold`). Leaf agents use it to route mypy and tests to the correct codebase container — never cross-run muse_hub checks on maestro or vice versa.
+`ISSUE_LABEL` is the primary scoping label (e.g. `agentception/0-scaffold`). Leaf agents use it to route mypy and tests to the correct codebase container — never cross-run agentception checks on maestro or vice versa.
 
 `COGNITIVE_ARCH` is the selected cognitive architecture for this specific issue. Format: `figure:skill1:skill2` (up to 3 skills). Leaf agents pass it to `python3 /app/scripts/gen_prompts/resolve_arch.py "$COGNITIVE_ARCH"` to assemble their context block. See `scripts/gen_prompts/TICKET_TAXONOMY.md` for the full taxonomy and rationale.
 
@@ -902,7 +904,7 @@ WTNAME=$(basename "$(pwd)")
 
 # Detect codebase from issue label in .agent-task
 ISSUE_LABEL=$(grep "^ISSUE_LABEL=" .agent-task 2>/dev/null | cut -d= -f2 || echo "")
-IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^htmx/" || true)
+IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^agentception/" || true)
 
 # mypy — route by codebase (agentception and maestro are independent; never cross-run)
 if [ "$IS_AC" -gt 0 ]; then
@@ -1179,7 +1181,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   # what was already broken. This baseline is your contract with the next agent.
   # Detect codebase from .agent-task label — set once, used throughout this run.
   ISSUE_LABEL=$(grep "^ISSUE_LABEL=" .agent-task 2>/dev/null | cut -d= -f2 || echo "")
-  IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^htmx/" || true)
+  IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^agentception/" || true)
 
   echo "=== PRE-EXISTING MYPY BASELINE (dev, before any changes) ==="
   # Route by codebase — agentception and maestro are independent; never cross-run.
@@ -1874,20 +1876,20 @@ Every piece of code you write or touch must satisfy:
 Run in order — types before tests:
 
 ```
-docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/"
+docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
 ```
 
-Then run **only the test files for modules you changed** — never `tests/` as a directory:
+Then run **only the test files for modules you changed** — never `agentception/tests/` as a directory:
 
 ```
 # Module-name convention:
-# agentception/app.py                → tests/test_agentception_scaffold.py
-# agentception/readers/worktrees.py  → tests/test_agentception_worktrees.py
-# agentception/readers/github.py     → tests/test_agentception_github.py
-# agentception/poller.py             → tests/test_agentception_poller.py
-# agentception/routes/ui.py          → tests/test_agentception_ui_overview.py
+# agentception/app.py                → agentception/tests/test_agentception_scaffold.py
+# agentception/readers/worktrees.py  → agentception/tests/test_agentception_worktrees.py
+# agentception/readers/github.py     → agentception/tests/test_agentception_github.py
+# agentception/poller.py             → agentception/tests/test_agentception_poller.py
+# agentception/routes/ui.py          → agentception/tests/test_agentception_ui_overview.py
 
-docker compose exec maestro pytest tests/test_<your_module>.py -v
+docker compose exec agentception pytest agentception/tests/test_<your_module>.py -v
 ```
 
 The full suite is CI's job. Running it in every agent session doesn't scale.
@@ -2384,9 +2386,9 @@ the container. After checking out the PR branch, your worktree's code is
 REPO=$(git worktree list | head -1 | awk '{print $1}')
 WTNAME=$(basename "$(pwd)")
 
-# Detect codebase from PR labels (htmx/* vs maestro/storpheus)
+# Detect codebase from PR labels (agentception/* vs maestro/storpheus)
 IS_AC=$(gh pr view $N --repo $GH_REPO --json labels \
-  --jq '.labels[].name' | grep -c "^htmx/" || true)
+  --jq '.labels[].name' | grep -c "^agentception/" || true)
 
 # mypy — route by codebase (NEVER run both; they are independent codebases)
 # Both codebases use the same pattern: PYTHONPATH=/worktrees/$WTNAME pointing at the
@@ -3263,12 +3265,14 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
   if [ "$SPAWN_MODE" = "chain" ]; then
     # ── CHAIN MODE: merge happened → spawn next engineer for next unclaimed issue ──
 
-    # Mirror the CTO's label-ordering logic: find the lowest-numbered htmx/* label
+    # Mirror the CTO's label-ordering logic: find the lowest-numbered agentception/* label
     # that still has open issues. NEVER pick from a later label while an earlier one
     # still has work. This prevents later-phase issues from being claimed prematurely.
     ACTIVE_LABEL=""
-       for label in htmx/0-foundation htmx/1-independent htmx/2-main-ui \
-                        htmx/3-analysis htmx/4-canvas htmx/5-cleanup; do
+       for label in agentception/0-scaffold agentception/1-controls \
+                        agentception/2-telemetry agentception/3-roles \
+                        agentception/4-intelligence agentception/5-scaling \
+                        agentception/6-generalization; do
       COUNT=$(gh issue list --state open --repo "$GH_REPO" \
                 --label "$label" --json number --jq 'length')
       if [ "$COUNT" -gt 0 ]; then
@@ -3293,7 +3297,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     NEXT_ISSUE=""
     if [ -z "$ACTIVE_LABEL" ]; then
-      echo "ℹ️  No open htmx/ or batch issues remain — chain complete."
+      echo "ℹ️  No open agentception/ or batch issues remain — chain complete."
     else
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       NEXT_ISSUE=$(gh issue list \
@@ -3335,7 +3339,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
       # Resolve the primary label so the engineer can route mypy/tests correctly.
       NEXT_ISSUE_LABEL=$(gh issue view "$NEXT_ISSUE" --repo "$GH_REPO" \
-        --json labels --jq '[.labels[].name | select(startswith("htmx/"))] | first // ""')
+        --json labels --jq '[.labels[].name | select(startswith("agentception/"))] | first // ""')
 
       cat > "$NEXT_WORKTREE/.agent-task" <<TASK
 WORKFLOW=issue-to-pr
@@ -3654,9 +3658,9 @@ GH_REPO=${GH_REPO:-cgcardona/maestro}
 WTNAME=$(basename "$(pwd)")
 # Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
 IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "htmx/" || true)
+  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "agentception/" || true)
 if [ "$IS_AC" -gt 0 ]; then
-  docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
+  docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
 else
   REPO=$(git worktree list | head -1 | awk '{print $1}')
   cd "$REPO" && docker compose exec maestro sh -c \
@@ -4208,9 +4212,9 @@ the container. After checking out the PR branch, your worktree's code is
 REPO=$(git worktree list | head -1 | awk '{print $1}')
 WTNAME=$(basename "$(pwd)")
 
-# Detect codebase from PR labels (htmx/* vs maestro/storpheus)
+# Detect codebase from PR labels (agentception/* vs maestro/storpheus)
 IS_AC=$(gh pr view $N --repo $GH_REPO --json labels \
-  --jq '.labels[].name' | grep -c "^htmx/" || true)
+  --jq '.labels[].name' | grep -c "^agentception/" || true)
 
 # mypy — route by codebase (NEVER run both; they are independent codebases)
 # Both codebases use the same pattern: PYTHONPATH=/worktrees/$WTNAME pointing at the
@@ -5087,12 +5091,14 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
   if [ "$SPAWN_MODE" = "chain" ]; then
     # ── CHAIN MODE: merge happened → spawn next engineer for next unclaimed issue ──
 
-    # Mirror the CTO's label-ordering logic: find the lowest-numbered htmx/* label
+    # Mirror the CTO's label-ordering logic: find the lowest-numbered agentception/* label
     # that still has open issues. NEVER pick from a later label while an earlier one
     # still has work. This prevents later-phase issues from being claimed prematurely.
     ACTIVE_LABEL=""
-       for label in htmx/0-foundation htmx/1-independent htmx/2-main-ui \
-                        htmx/3-analysis htmx/4-canvas htmx/5-cleanup; do
+       for label in agentception/0-scaffold agentception/1-controls \
+                        agentception/2-telemetry agentception/3-roles \
+                        agentception/4-intelligence agentception/5-scaling \
+                        agentception/6-generalization; do
       COUNT=$(gh issue list --state open --repo "$GH_REPO" \
                 --label "$label" --json number --jq 'length')
       if [ "$COUNT" -gt 0 ]; then
@@ -5117,7 +5123,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     NEXT_ISSUE=""
     if [ -z "$ACTIVE_LABEL" ]; then
-      echo "ℹ️  No open htmx/ or batch issues remain — chain complete."
+      echo "ℹ️  No open agentception/ or batch issues remain — chain complete."
     else
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       NEXT_ISSUE=$(gh issue list \
@@ -5159,7 +5165,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
       # Resolve the primary label so the engineer can route mypy/tests correctly.
       NEXT_ISSUE_LABEL=$(gh issue view "$NEXT_ISSUE" --repo "$GH_REPO" \
-        --json labels --jq '[.labels[].name | select(startswith("htmx/"))] | first // ""')
+        --json labels --jq '[.labels[].name | select(startswith("agentception/"))] | first // ""')
 
       cat > "$NEXT_WORKTREE/.agent-task" <<TASK
 WORKFLOW=issue-to-pr
@@ -5478,9 +5484,9 @@ GH_REPO=${GH_REPO:-cgcardona/maestro}
 WTNAME=$(basename "$(pwd)")
 # Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
 IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "htmx/" || true)
+  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "agentception/" || true)
 if [ "$IS_AC" -gt 0 ]; then
-  docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
+  docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
 else
   REPO=$(git worktree list | head -1 | awk '{print $1}')
   cd "$REPO" && docker compose exec maestro sh -c \
@@ -5920,7 +5926,7 @@ WTNAME=$(basename "$(pwd)")
 
 # Detect codebase from issue label in .agent-task
 ISSUE_LABEL=$(grep "^ISSUE_LABEL=" .agent-task 2>/dev/null | cut -d= -f2 || echo "")
-IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^htmx/" || true)
+IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^agentception/" || true)
 
 # mypy — route by codebase (agentception and maestro are independent; never cross-run)
 if [ "$IS_AC" -gt 0 ]; then
@@ -6197,7 +6203,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   # what was already broken. This baseline is your contract with the next agent.
   # Detect codebase from .agent-task label — set once, used throughout this run.
   ISSUE_LABEL=$(grep "^ISSUE_LABEL=" .agent-task 2>/dev/null | cut -d= -f2 || echo "")
-  IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^htmx/" || true)
+  IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^agentception/" || true)
 
   echo "=== PRE-EXISTING MYPY BASELINE (dev, before any changes) ==="
   # Route by codebase — agentception and maestro are independent; never cross-run.
@@ -6892,20 +6898,20 @@ Every piece of code you write or touch must satisfy:
 Run in order — types before tests:
 
 ```
-docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/"
+docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
 ```
 
-Then run **only the test files for modules you changed** — never `tests/` as a directory:
+Then run **only the test files for modules you changed** — never `agentception/tests/` as a directory:
 
 ```
 # Module-name convention:
-# agentception/app.py                → tests/test_agentception_scaffold.py
-# agentception/readers/worktrees.py  → tests/test_agentception_worktrees.py
-# agentception/readers/github.py     → tests/test_agentception_github.py
-# agentception/poller.py             → tests/test_agentception_poller.py
-# agentception/routes/ui.py          → tests/test_agentception_ui_overview.py
+# agentception/app.py                → agentception/tests/test_agentception_scaffold.py
+# agentception/readers/worktrees.py  → agentception/tests/test_agentception_worktrees.py
+# agentception/readers/github.py     → agentception/tests/test_agentception_github.py
+# agentception/poller.py             → agentception/tests/test_agentception_poller.py
+# agentception/routes/ui.py          → agentception/tests/test_agentception_ui_overview.py
 
-docker compose exec maestro pytest tests/test_<your_module>.py -v
+docker compose exec agentception pytest agentception/tests/test_<your_module>.py -v
 ```
 
 The full suite is CI's job. Running it in every agent session doesn't scale.

--- a/.cursor/roles/engineering-manager.md
+++ b/.cursor/roles/engineering-manager.md
@@ -15,40 +15,7 @@ entire chain to drain.
 
 ```
 SEED:
-  0. A/B mode — resolve ROLE_FILE before seeding any agents:
-       # When ab_mode.enabled is true in pipeline-config.json the VP alternates
-       # between variant_a_file (even BATCH_ID second) and variant_b_file (odd).
-       # Must run BEFORE generating BATCH_ID so the resolved file is available
-       # for the .agent-task written in step 5d.
-       ROLE_FILE=".cursor/roles/python-developer.md"
-       AB_MODE=$(python3 -c "
-import json, sys
-try:
-    c = json.load(open('/Users/gabriel/dev/tellurstori/maestro/.cursor/pipeline-config.json'))
-    print(c.get('ab_mode', {}).get('enabled', False))
-except Exception:
-    print(False)
-")
-       if [ "$AB_MODE" = "True" ]; then
-         SECONDS_PART=$(echo "$BATCH_ID" | grep -oE 'T[0-9]{6}Z' | grep -oE '[0-9]{6}' | cut -c5-6)
-         if [ $((SECONDS_PART % 2)) -eq 0 ]; then
-           ROLE_FILE=$(python3 -c "
-import json
-c = json.load(open('/Users/gabriel/dev/tellurstori/maestro/.cursor/pipeline-config.json'))
-print(c['ab_mode']['variant_a_file'])
-")
-           echo "🔀 A/B mode: even second → variant A → $ROLE_FILE"
-         else
-           ROLE_FILE=$(python3 -c "
-import json
-c = json.load(open('/Users/gabriel/dev/tellurstori/maestro/.cursor/pipeline-config.json'))
-print(c['ab_mode']['variant_b_file'])
-")
-           echo "🔀 A/B mode: odd second → variant B → $ROLE_FILE"
-         fi
-       fi
-
-  0.5 Pipeline-pause sentinel — check BEFORE seeding any agents:
+  0. Pipeline-pause sentinel — check BEFORE seeding any agents:
        # The AgentCeption dashboard writes .cursor/.pipeline-pause to request a pause.
        # When the file exists, wait 30 s and restart the SEED block without spawning.
        [ -f /Users/gabriel/dev/tellurstori/maestro/.cursor/.pipeline-pause ] && \
@@ -101,8 +68,8 @@ print(c['ab_mode']['variant_b_file'])
        done
 
   3. Query open unclaimed issues — ACTIVE_LABEL only (passed by CTO in your dispatch prompt):
-       # ACTIVE_LABEL is the single htmx/* label the CTO assigned to you.
-       # NEVER query all htmx/* labels — you are scoped to exactly one label per VP run.
+       # ACTIVE_LABEL is the single agentception/* label the CTO assigned to you.
+       # NEVER query all agentception/* labels — you are scoped to exactly one label per VP run.
        # This prevents you from accidentally claiming issues from a later phase.
        ACTIVE_LABEL="<from CTO dispatch prompt>"
        gh issue list --state open --repo cgcardona/maestro --label "$ACTIVE_LABEL" \
@@ -286,7 +253,7 @@ Worktrees live at: `$HOME/.cursor/worktrees/maestro/issue-{N}/`
 ```
 TASK=issue-to-pr
 ISSUE_NUMBER=<N>
-ISSUE_LABEL=<primary htmx/* label from: gh issue view <N> --json labels --jq '[.labels[].name | select(startswith("htmx/"))] | first'>
+ISSUE_LABEL=<primary agentception/* label from: gh issue view <N> --json labels --jq '[.labels[].name | select(startswith("agentception/"))] | first'>
 BRANCH=feat/issue-<N>
 WORKTREE=$HOME/.cursor/worktrees/maestro/issue-<N>
 ROLE=python-developer
@@ -300,7 +267,7 @@ WAVE=<CTO_WAVE>
 COGNITIVE_ARCH=<COGNITIVE_ARCH from step 5c above, e.g. "lovelace:htmx:jinja2:alpine">
 ```
 
-`ISSUE_LABEL` is the primary scoping label (e.g. `htmx/0-scaffold`). Leaf agents use it to route mypy and tests to the correct codebase container — never cross-run muse_hub checks on maestro or vice versa.
+`ISSUE_LABEL` is the primary scoping label (e.g. `agentception/0-scaffold`). Leaf agents use it to route mypy and tests to the correct codebase container — never cross-run agentception checks on maestro or vice versa.
 
 `COGNITIVE_ARCH` is the selected cognitive architecture for this specific issue. Format: `figure:skill1:skill2` (up to 3 skills). Leaf agents pass it to `python3 /app/scripts/gen_prompts/resolve_arch.py "$COGNITIVE_ARCH"` to assemble their context block. See `scripts/gen_prompts/TICKET_TAXONOMY.md` for the full taxonomy and rationale.
 
@@ -726,7 +693,7 @@ WTNAME=$(basename "$(pwd)")
 
 # Detect codebase from issue label in .agent-task
 ISSUE_LABEL=$(grep "^ISSUE_LABEL=" .agent-task 2>/dev/null | cut -d= -f2 || echo "")
-IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^htmx/" || true)
+IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^agentception/" || true)
 
 # mypy — route by codebase (agentception and maestro are independent; never cross-run)
 if [ "$IS_AC" -gt 0 ]; then
@@ -1003,7 +970,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   # what was already broken. This baseline is your contract with the next agent.
   # Detect codebase from .agent-task label — set once, used throughout this run.
   ISSUE_LABEL=$(grep "^ISSUE_LABEL=" .agent-task 2>/dev/null | cut -d= -f2 || echo "")
-  IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^htmx/" || true)
+  IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^agentception/" || true)
 
   echo "=== PRE-EXISTING MYPY BASELINE (dev, before any changes) ==="
   # Route by codebase — agentception and maestro are independent; never cross-run.
@@ -1698,20 +1665,20 @@ Every piece of code you write or touch must satisfy:
 Run in order — types before tests:
 
 ```
-docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/"
+docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
 ```
 
-Then run **only the test files for modules you changed** — never `tests/` as a directory:
+Then run **only the test files for modules you changed** — never `agentception/tests/` as a directory:
 
 ```
 # Module-name convention:
-# agentception/app.py                → tests/test_agentception_scaffold.py
-# agentception/readers/worktrees.py  → tests/test_agentception_worktrees.py
-# agentception/readers/github.py     → tests/test_agentception_github.py
-# agentception/poller.py             → tests/test_agentception_poller.py
-# agentception/routes/ui.py          → tests/test_agentception_ui_overview.py
+# agentception/app.py                → agentception/tests/test_agentception_scaffold.py
+# agentception/readers/worktrees.py  → agentception/tests/test_agentception_worktrees.py
+# agentception/readers/github.py     → agentception/tests/test_agentception_github.py
+# agentception/poller.py             → agentception/tests/test_agentception_poller.py
+# agentception/routes/ui.py          → agentception/tests/test_agentception_ui_overview.py
 
-docker compose exec maestro pytest tests/test_<your_module>.py -v
+docker compose exec agentception pytest agentception/tests/test_<your_module>.py -v
 ```
 
 The full suite is CI's job. Running it in every agent session doesn't scale.
@@ -2208,9 +2175,9 @@ the container. After checking out the PR branch, your worktree's code is
 REPO=$(git worktree list | head -1 | awk '{print $1}')
 WTNAME=$(basename "$(pwd)")
 
-# Detect codebase from PR labels (htmx/* vs maestro/storpheus)
+# Detect codebase from PR labels (agentception/* vs maestro/storpheus)
 IS_AC=$(gh pr view $N --repo $GH_REPO --json labels \
-  --jq '.labels[].name' | grep -c "^htmx/" || true)
+  --jq '.labels[].name' | grep -c "^agentception/" || true)
 
 # mypy — route by codebase (NEVER run both; they are independent codebases)
 # Both codebases use the same pattern: PYTHONPATH=/worktrees/$WTNAME pointing at the
@@ -3087,12 +3054,14 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
   if [ "$SPAWN_MODE" = "chain" ]; then
     # ── CHAIN MODE: merge happened → spawn next engineer for next unclaimed issue ──
 
-    # Mirror the CTO's label-ordering logic: find the lowest-numbered htmx/* label
+    # Mirror the CTO's label-ordering logic: find the lowest-numbered agentception/* label
     # that still has open issues. NEVER pick from a later label while an earlier one
     # still has work. This prevents later-phase issues from being claimed prematurely.
     ACTIVE_LABEL=""
-       for label in htmx/0-foundation htmx/1-independent htmx/2-main-ui \
-                        htmx/3-analysis htmx/4-canvas htmx/5-cleanup; do
+       for label in agentception/0-scaffold agentception/1-controls \
+                        agentception/2-telemetry agentception/3-roles \
+                        agentception/4-intelligence agentception/5-scaling \
+                        agentception/6-generalization; do
       COUNT=$(gh issue list --state open --repo "$GH_REPO" \
                 --label "$label" --json number --jq 'length')
       if [ "$COUNT" -gt 0 ]; then
@@ -3117,7 +3086,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     NEXT_ISSUE=""
     if [ -z "$ACTIVE_LABEL" ]; then
-      echo "ℹ️  No open htmx/ or batch issues remain — chain complete."
+      echo "ℹ️  No open agentception/ or batch issues remain — chain complete."
     else
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       NEXT_ISSUE=$(gh issue list \
@@ -3159,7 +3128,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
       # Resolve the primary label so the engineer can route mypy/tests correctly.
       NEXT_ISSUE_LABEL=$(gh issue view "$NEXT_ISSUE" --repo "$GH_REPO" \
-        --json labels --jq '[.labels[].name | select(startswith("htmx/"))] | first // ""')
+        --json labels --jq '[.labels[].name | select(startswith("agentception/"))] | first // ""')
 
       cat > "$NEXT_WORKTREE/.agent-task" <<TASK
 WORKFLOW=issue-to-pr
@@ -3478,9 +3447,9 @@ GH_REPO=${GH_REPO:-cgcardona/maestro}
 WTNAME=$(basename "$(pwd)")
 # Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
 IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "htmx/" || true)
+  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "agentception/" || true)
 if [ "$IS_AC" -gt 0 ]; then
-  docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
+  docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
 else
   REPO=$(git worktree list | head -1 | awk '{print $1}')
   cd "$REPO" && docker compose exec maestro sh -c \

--- a/.cursor/roles/pr-reviewer.md
+++ b/.cursor/roles/pr-reviewer.md
@@ -52,9 +52,9 @@ GH_REPO=${GH_REPO:-cgcardona/maestro}
 WTNAME=$(basename "$(pwd)")
 # Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
 IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "htmx/" || true)
+  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "agentception/" || true)
 if [ "$IS_AC" -gt 0 ]; then
-  docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
+  docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
 else
   REPO=$(git worktree list | head -1 | awk '{print $1}')
   cd "$REPO" && docker compose exec maestro sh -c \

--- a/.cursor/roles/python-developer.md
+++ b/.cursor/roles/python-developer.md
@@ -46,20 +46,20 @@ Every piece of code you write or touch must satisfy:
 Run in order — types before tests:
 
 ```
-docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/"
+docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
 ```
 
-Then run **only the test files for modules you changed** — never `tests/` as a directory:
+Then run **only the test files for modules you changed** — never `agentception/tests/` as a directory:
 
 ```
 # Module-name convention:
-# agentception/app.py                → tests/test_agentception_scaffold.py
-# agentception/readers/worktrees.py  → tests/test_agentception_worktrees.py
-# agentception/readers/github.py     → tests/test_agentception_github.py
-# agentception/poller.py             → tests/test_agentception_poller.py
-# agentception/routes/ui.py          → tests/test_agentception_ui_overview.py
+# agentception/app.py                → agentception/tests/test_agentception_scaffold.py
+# agentception/readers/worktrees.py  → agentception/tests/test_agentception_worktrees.py
+# agentception/readers/github.py     → agentception/tests/test_agentception_github.py
+# agentception/poller.py             → agentception/tests/test_agentception_poller.py
+# agentception/routes/ui.py          → agentception/tests/test_agentception_ui_overview.py
 
-docker compose exec maestro pytest tests/test_<your_module>.py -v
+docker compose exec agentception pytest agentception/tests/test_<your_module>.py -v
 ```
 
 The full suite is CI's job. Running it in every agent session doesn't scale.

--- a/.cursor/roles/qa-manager.md
+++ b/.cursor/roles/qa-manager.md
@@ -513,9 +513,9 @@ the container. After checking out the PR branch, your worktree's code is
 REPO=$(git worktree list | head -1 | awk '{print $1}')
 WTNAME=$(basename "$(pwd)")
 
-# Detect codebase from PR labels (htmx/* vs maestro/storpheus)
+# Detect codebase from PR labels (agentception/* vs maestro/storpheus)
 IS_AC=$(gh pr view $N --repo $GH_REPO --json labels \
-  --jq '.labels[].name' | grep -c "^htmx/" || true)
+  --jq '.labels[].name' | grep -c "^agentception/" || true)
 
 # mypy — route by codebase (NEVER run both; they are independent codebases)
 # Both codebases use the same pattern: PYTHONPATH=/worktrees/$WTNAME pointing at the
@@ -1392,12 +1392,14 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
   if [ "$SPAWN_MODE" = "chain" ]; then
     # ── CHAIN MODE: merge happened → spawn next engineer for next unclaimed issue ──
 
-    # Mirror the CTO's label-ordering logic: find the lowest-numbered htmx/* label
+    # Mirror the CTO's label-ordering logic: find the lowest-numbered agentception/* label
     # that still has open issues. NEVER pick from a later label while an earlier one
     # still has work. This prevents later-phase issues from being claimed prematurely.
     ACTIVE_LABEL=""
-       for label in htmx/0-foundation htmx/1-independent htmx/2-main-ui \
-                        htmx/3-analysis htmx/4-canvas htmx/5-cleanup; do
+       for label in agentception/0-scaffold agentception/1-controls \
+                        agentception/2-telemetry agentception/3-roles \
+                        agentception/4-intelligence agentception/5-scaling \
+                        agentception/6-generalization; do
       COUNT=$(gh issue list --state open --repo "$GH_REPO" \
                 --label "$label" --json number --jq 'length')
       if [ "$COUNT" -gt 0 ]; then
@@ -1422,7 +1424,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     NEXT_ISSUE=""
     if [ -z "$ACTIVE_LABEL" ]; then
-      echo "ℹ️  No open htmx/ or batch issues remain — chain complete."
+      echo "ℹ️  No open agentception/ or batch issues remain — chain complete."
     else
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       NEXT_ISSUE=$(gh issue list \
@@ -1464,7 +1466,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
       # Resolve the primary label so the engineer can route mypy/tests correctly.
       NEXT_ISSUE_LABEL=$(gh issue view "$NEXT_ISSUE" --repo "$GH_REPO" \
-        --json labels --jq '[.labels[].name | select(startswith("htmx/"))] | first // ""')
+        --json labels --jq '[.labels[].name | select(startswith("agentception/"))] | first // ""')
 
       cat > "$NEXT_WORKTREE/.agent-task" <<TASK
 WORKFLOW=issue-to-pr
@@ -1783,9 +1785,9 @@ GH_REPO=${GH_REPO:-cgcardona/maestro}
 WTNAME=$(basename "$(pwd)")
 # Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
 IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "htmx/" || true)
+  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "agentception/" || true)
 if [ "$IS_AC" -gt 0 ]; then
-  docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
+  docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
 else
   REPO=$(git worktree list | head -1 | awk '{print $1}')
   cd "$REPO" && docker compose exec maestro sh -c \
@@ -2225,7 +2227,7 @@ WTNAME=$(basename "$(pwd)")
 
 # Detect codebase from issue label in .agent-task
 ISSUE_LABEL=$(grep "^ISSUE_LABEL=" .agent-task 2>/dev/null | cut -d= -f2 || echo "")
-IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^htmx/" || true)
+IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^agentception/" || true)
 
 # mypy — route by codebase (agentception and maestro are independent; never cross-run)
 if [ "$IS_AC" -gt 0 ]; then
@@ -2502,7 +2504,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   # what was already broken. This baseline is your contract with the next agent.
   # Detect codebase from .agent-task label — set once, used throughout this run.
   ISSUE_LABEL=$(grep "^ISSUE_LABEL=" .agent-task 2>/dev/null | cut -d= -f2 || echo "")
-  IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^htmx/" || true)
+  IS_AC=$(echo "$ISSUE_LABEL" | grep -c "^agentception/" || true)
 
   echo "=== PRE-EXISTING MYPY BASELINE (dev, before any changes) ==="
   # Route by codebase — agentception and maestro are independent; never cross-run.
@@ -3197,20 +3199,20 @@ Every piece of code you write or touch must satisfy:
 Run in order — types before tests:
 
 ```
-docker compose exec maestro sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/maestro/ /worktrees/$WTNAME/tests/"
+docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
 ```
 
-Then run **only the test files for modules you changed** — never `tests/` as a directory:
+Then run **only the test files for modules you changed** — never `agentception/tests/` as a directory:
 
 ```
 # Module-name convention:
-# agentception/app.py                → tests/test_agentception_scaffold.py
-# agentception/readers/worktrees.py  → tests/test_agentception_worktrees.py
-# agentception/readers/github.py     → tests/test_agentception_github.py
-# agentception/poller.py             → tests/test_agentception_poller.py
-# agentception/routes/ui.py          → tests/test_agentception_ui_overview.py
+# agentception/app.py                → agentception/tests/test_agentception_scaffold.py
+# agentception/readers/worktrees.py  → agentception/tests/test_agentception_worktrees.py
+# agentception/readers/github.py     → agentception/tests/test_agentception_github.py
+# agentception/poller.py             → agentception/tests/test_agentception_poller.py
+# agentception/routes/ui.py          → agentception/tests/test_agentception_ui_overview.py
 
-docker compose exec maestro pytest tests/test_<your_module>.py -v
+docker compose exec agentception pytest agentception/tests/test_<your_module>.py -v
 ```
 
 The full suite is CI's job. Running it in every agent session doesn't scale.

--- a/scripts/gen_prompts/config.yaml
+++ b/scripts/gen_prompts/config.yaml
@@ -23,17 +23,18 @@ pipeline:
   # Strict phase order — CTO and chain-spawn iterate this list top to bottom.
   # To switch projects, replace the entire phases list and update `codebases.active`.
   phases:
-    - "htmx/0-foundation"
-    - "htmx/1-independent"
-    - "htmx/2-main-ui"
-    - "htmx/3-analysis"
-    - "htmx/4-canvas"
-    - "htmx/5-cleanup"
+    - "agentception/0-scaffold"
+    - "agentception/1-controls"
+    - "agentception/2-telemetry"
+    - "agentception/3-roles"
+    - "agentception/4-intelligence"
+    - "agentception/5-scaling"
+    - "agentception/6-generalization"
 
 codebases:
   # Which codebase agents are currently working on.
   # Determines which mypy/test commands are used in IS_AC routing.
-  active: "muse_hub"
+  active: "agentception"
 
   muse_hub:
     container: "maestro"
@@ -79,33 +80,36 @@ labels:
   # Top-level label that scopes all work for the current active codebase.
   # Update this block when switching projects.
   project:
-    name: "htmx-migration"
-    color: "1c7ed6"
-    description: "HTMX + SSR migration — replaces JS shell pattern"
+    name: "agentception"
+    color: "8250df"
+    description: "AgentCeption — autonomous multi-agent pipeline"
 
   # ── Phase labels ────────────────────────────────────────────────────────────
   # Must stay in sync with pipeline.phases above (same names, same order).
   # The CTO and chain-spawn logic iterate phases strictly top-to-bottom.
   # Adding a new phase: add it to pipeline.phases AND here, then re-run generate.py.
   phases:
-    - name: "htmx/0-foundation"
+    - name: "agentception/0-scaffold"
       color: "6741d9"
-      description: "HTMX migration Phase 0 · Foundation infrastructure (sequential)"
-    - name: "htmx/1-independent"
+      description: "AgentCeption Phase 0 · Foundation scaffold"
+    - name: "agentception/1-controls"
       color: "1098ad"
-      description: "HTMX migration Phase 1 · Independent ui_*.py file pages (parallelizable)"
-    - name: "htmx/2-main-ui"
+      description: "AgentCeption Phase 1 · Pipeline controls (kill, pause, spawn)"
+    - name: "agentception/2-telemetry"
       color: "0d6efd"
-      description: "HTMX migration Phase 2 · ui.py main page batches"
-    - name: "htmx/3-analysis"
+      description: "AgentCeption Phase 2 · Telemetry and observability"
+    - name: "agentception/3-roles"
       color: "198754"
-      description: "HTMX migration Phase 3 · Analysis dimension pages"
-    - name: "htmx/4-canvas"
+      description: "AgentCeption Phase 3 · Role file management and editing"
+    - name: "agentception/4-intelligence"
       color: "f59f00"
-      description: "HTMX migration Phase 4 · Canvas / Audio partial SSR (keep JS core)"
-    - name: "htmx/5-cleanup"
+      description: "AgentCeption Phase 4 · Pipeline intelligence and DAG"
+    - name: "agentception/5-scaling"
       color: "d63939"
-      description: "HTMX migration Phase 5 · Cleanup — trim JS, final audit"
+      description: "AgentCeption Phase 5 · Scaling advisor and A/B testing"
+    - name: "agentception/6-generalization"
+      color: "0ca678"
+      description: "AgentCeption Phase 6 · Multi-repo generalization and export"
 
   # ── Utility / triage labels ────────────────────────────────────────────────
   # Standard labels used across issues and PRs. Kept here for completeness

--- a/scripts/gen_prompts/sync_labels.sh
+++ b/scripts/gen_prompts/sync_labels.sh
@@ -24,15 +24,16 @@ echo '── Claim label ──────────────────�
 sync_label 'agent:wip' '0075ca' 'Claimed by a pipeline agent — do not assign manually'
 
 echo '── Project label ────────────────────────────────────────────'
-sync_label 'htmx-migration' '1c7ed6' 'HTMX + SSR migration — replaces JS shell pattern'
+sync_label 'agentception' '8250df' 'AgentCeption — autonomous multi-agent pipeline'
 
 echo '── Phase labels ─────────────────────────────────────────────'
-sync_label 'htmx/0-foundation' '6741d9' 'HTMX migration Phase 0 · Foundation infrastructure (sequential)'
-sync_label 'htmx/1-independent' '1098ad' 'HTMX migration Phase 1 · Independent ui_*.py file pages (parallelizable)'
-sync_label 'htmx/2-main-ui' '0d6efd' 'HTMX migration Phase 2 · ui.py main page batches'
-sync_label 'htmx/3-analysis' '198754' 'HTMX migration Phase 3 · Analysis dimension pages'
-sync_label 'htmx/4-canvas' 'f59f00' 'HTMX migration Phase 4 · Canvas / Audio partial SSR (keep JS core)'
-sync_label 'htmx/5-cleanup' 'd63939' 'HTMX migration Phase 5 · Cleanup — trim JS, final audit'
+sync_label 'agentception/0-scaffold' '6741d9' 'AgentCeption Phase 0 · Foundation scaffold'
+sync_label 'agentception/1-controls' '1098ad' 'AgentCeption Phase 1 · Pipeline controls (kill, pause, spawn)'
+sync_label 'agentception/2-telemetry' '0d6efd' 'AgentCeption Phase 2 · Telemetry and observability'
+sync_label 'agentception/3-roles' '198754' 'AgentCeption Phase 3 · Role file management and editing'
+sync_label 'agentception/4-intelligence' 'f59f00' 'AgentCeption Phase 4 · Pipeline intelligence and DAG'
+sync_label 'agentception/5-scaling' 'd63939' 'AgentCeption Phase 5 · Scaling advisor and A/B testing'
+sync_label 'agentception/6-generalization' '0ca678' 'AgentCeption Phase 6 · Multi-repo generalization and export'
 
 echo '── Utility labels ───────────────────────────────────────────'
 sync_label 'bug' 'd73a4a' 'Something isn'\''t working'


### PR DESCRIPTION
config.yaml had `active: muse_hub` and `htmx/*` phases — CTO was querying the wrong labels and finding zero issues every wave. Flipped to `agentception` with all 7 phases. Regenerated all prompt files.