### PR TITLE
feat: [HTMX] Infrastructure: fragment response helpers + HX-Request detection

### DIFF
--- a/maestro/api/routes/musehub/htmx_helpers.py
+++ b/maestro/api/routes/musehub/htmx_helpers.py
@@ -1,30 +1,102 @@
-"""HTMX request detection helpers for MuseHub route handlers.
+"""HTMX request detection and fragment response helpers for MuseHub route handlers.
 
-These thin wrappers read HTMX-specific request headers so route handlers can
-return either a full-page response (normal browser navigation) or an HTML
-fragment (HTMX partial update) without duplicating header-inspection logic.
+These thin utilities read HTMX-specific request headers so handlers can
+return either a full-page response or a partial fragment without duplicating
+header-inspection logic across every route.
 
-Usage in a route handler::
+Usage pattern for migrated route handlers::
 
-    from maestro.api.routes.musehub.htmx_helpers import is_htmx
+    return await htmx_fragment_or_full(
+        request, templates, ctx,
+        full_template="musehub/pages/issue_list.html",
+        fragment_template="musehub/fragments/issue_rows.html",
+    )
 
-    @router.get("/musehub/ui/...")
-    async def my_view(request: Request) -> HTMLResponse:
-        if is_htmx(request):
-            return fragment_response(...)
-        return full_page_response(...)
+Priority order when a request arrives:
+1. HTMX partial request (HX-Request: true) + fragment_template → return fragment
+2. No HTMX header, or no fragment_template provided → return full page
 """
 
 from __future__ import annotations
 
+import json
+
 from fastapi import Request
+from fastapi.templating import Jinja2Templates
+from starlette.responses import Response
 
 
 def is_htmx(request: Request) -> bool:
-    """Return True when the request was initiated by HTMX (HX-Request: true header present)."""
+    """Return True when the request was initiated by HTMX (HX-Request header present)."""
     return request.headers.get("HX-Request") == "true"
 
 
 def is_htmx_boosted(request: Request) -> bool:
-    """Return True when the request came from an hx-boost link (HX-Boosted: true header present)."""
+    """Return True when the request came from an hx-boost link (HX-Boosted header present)."""
     return request.headers.get("HX-Boosted") == "true"
+
+
+async def htmx_fragment_or_full(
+    request: Request,
+    templates: Jinja2Templates,
+    ctx: dict[str, object],
+    full_template: str,
+    fragment_template: str | None = None,
+) -> Response:
+    """Return a fragment for HTMX requests, full page for direct navigation.
+
+    When HTMX sends ``HX-Request: true`` and a ``fragment_template`` is provided,
+    the response contains only the fragment — no ``<html>``, ``<head>``, or nav.
+    Direct browser navigation (bookmark, refresh, first load) always receives
+    the complete page that extends ``base.html``.
+
+    Args:
+        request: The incoming FastAPI request.
+        templates: The ``Jinja2Templates`` instance from the route module.
+        ctx: Template context dict shared by both full and fragment templates.
+        full_template: Jinja2 path to the full-page template (extends base.html).
+        fragment_template: Jinja2 path to the bare fragment template (no extends).
+            When ``None``, always returns the full page regardless of request type.
+
+    Returns:
+        ``TemplateResponse`` using either ``fragment_template`` or ``full_template``.
+    """
+    if is_htmx(request) and fragment_template is not None:
+        return templates.TemplateResponse(request, fragment_template, ctx)
+    return templates.TemplateResponse(request, full_template, ctx)
+
+
+def htmx_trigger(response: Response, event: str, detail: dict[str, object] | None = None) -> None:
+    """Set ``HX-Trigger`` header to fire a client-side event after the swap.
+
+    Use for toast notifications, badge refreshes, and other side effects that
+    should happen after HTMX swaps the response into the DOM::
+
+        htmx_trigger(response, "toast", {"message": "Issue closed", "type": "success"})
+
+    Args:
+        response: The Starlette/FastAPI response object to mutate.
+        event: The client-side event name HTMX will dispatch.
+        detail: Optional payload attached to the event. When ``None``, the
+            event fires with ``True`` as its value (a simple signal).
+    """
+    payload: dict[str, object] = {event: detail} if detail is not None else {event: True}
+    response.headers["HX-Trigger"] = json.dumps(payload)
+
+
+def htmx_redirect(url: str) -> Response:
+    """Return an ``HX-Redirect`` response that redirects HTMX without a full page reload.
+
+    The browser URL bar updates and HTMX fetches the target page, but the
+    navigation happens client-side rather than issuing a 302 that the browser
+    follows before HTMX can intercept.
+
+    Args:
+        url: The target URL the client should navigate to.
+
+    Returns:
+        A 200 response with the ``HX-Redirect`` header set; HTMX performs the redirect.
+    """
+    r = Response(status_code=200)
+    r.headers["HX-Redirect"] = url
+    return r

--- a/maestro/api/routes/musehub/negotiate.py
+++ b/maestro/api/routes/musehub/negotiate.py
@@ -1,17 +1,23 @@
 """Content negotiation helper for MuseHub dual-format endpoints.
 
-Every MuseHub URL can serve two audiences from the same path:
+Every MuseHub URL can serve three audiences from the same path:
 - HTML to browsers (default, ``Accept: text/html``)
 - JSON to agents/scripts (``Accept: application/json`` or ``?format=json``)
+- HTMX fragment to HTMX requests (``HX-Request: true``)
 
 This module provides ``negotiate_response()`` — a single function that route
 handlers call after preparing both a Pydantic data model and a Jinja2 template
-context. The function inspects the ``Accept`` header and an optional
-``?format`` query parameter, then dispatches to the correct serialiser.
+context.  The function inspects headers and an optional ``?format`` query
+parameter, then dispatches to the correct serialiser.
+
+Priority order (first match wins):
+1. ``HX-Request: true`` + ``fragment_template`` provided → return bare fragment
+2. ``?format=json`` or ``Accept: application/json`` → return JSON
+3. Default → return full HTML page
 
 Design rationale:
-- One URL, two audiences — agents get structured JSON, humans get rich HTML.
-- No separate ``/api/v1/...`` endpoint needed; one handler serves both.
+- One URL, three audiences — HTMX gets fragments, agents get JSON, humans get HTML.
+- No separate ``/api/v1/...`` endpoint needed; one handler serves all.
 - ``?format=json`` as a fallback for clients that cannot set ``Accept`` headers
   (e.g. browser ``<a>`` links, ``curl`` without ``-H``).
 - JSON keys use camelCase via Pydantic ``by_alias=True``, matching the existing
@@ -27,6 +33,8 @@ from fastapi.responses import JSONResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 from starlette.responses import Response
+
+from maestro.api.routes.musehub.htmx_helpers import is_htmx
 
 logger = logging.getLogger(__name__)
 
@@ -53,29 +61,45 @@ async def negotiate_response(
     templates: Jinja2Templates,
     json_data: BaseModel | None = None,
     format_param: str | None = None,
+    fragment_template: str | None = None,
 ) -> Response:
-    """Return an HTML or JSON response based on the caller's preference.
+    """Return an HTML, fragment, or JSON response based on the caller's preference.
 
     Route handlers should call this instead of constructing responses directly.
     The handler prepares:
-    - ``context`` — Jinja2 template variables for the HTML path.
-    - ``json_data`` — Pydantic model for the JSON path (camelCase serialised).
+    - ``context``           — Jinja2 template variables for both HTML paths.
+    - ``json_data``         — Pydantic model for the JSON path (camelCase serialised).
+    - ``fragment_template`` — Bare fragment template for HTMX partial updates.
+
+    Priority order (first match wins):
+    1. HTMX request (``HX-Request: true``) + ``fragment_template`` provided
+       → returns bare fragment (no ``<html>``, ``<head>``, or nav).
+    2. JSON requested (``?format=json`` or ``Accept: application/json``)
+       → returns ``JSONResponse`` with camelCase keys.
+    3. Default → returns full ``TemplateResponse`` using ``template_name``.
 
     When ``json_data`` is ``None`` and JSON is requested, ``context`` is
-    serialised as-is. This is a fallback for pages that have no structured
+    serialised as-is.  This is a fallback for pages that have no structured
     backend data; prefer providing a Pydantic model whenever possible.
 
     Args:
         request: The incoming FastAPI request (needed for template rendering).
-        template_name: Jinja2 template path relative to the templates dir.
+        template_name: Jinja2 template path for the full-page HTML response.
         context: Template context dict (also used as fallback JSON payload).
         templates: The ``Jinja2Templates`` instance from the route module.
         json_data: Optional Pydantic model to serialise for the JSON path.
         format_param: Value of the ``?format`` query parameter, or ``None``.
+        fragment_template: Optional Jinja2 path to a bare fragment template
+            (no ``{% extends %}``). When provided, HTMX requests receive this
+            fragment instead of the full page.
 
     Returns:
-        ``JSONResponse`` with camelCase keys, or ``TemplateResponse`` for HTML.
+        ``TemplateResponse`` (fragment or full page), or ``JSONResponse``.
     """
+    if is_htmx(request) and fragment_template is not None:
+        logger.debug("✅ negotiate_response: HTMX fragment path — %s", fragment_template)
+        return templates.TemplateResponse(request, fragment_template, context)
+
     if _wants_json(request, format_param):
         if json_data is not None:
             payload: dict[str, Any] = json_data.model_dump(by_alias=True, mode="json")

--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -77,6 +77,7 @@ from sqlalchemy import func, select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import Response as StarletteResponse
 
+from maestro.api.routes.musehub.htmx_helpers import htmx_fragment_or_full, htmx_trigger, is_htmx
 from maestro.api.routes.musehub.json_alternate import json_or_html
 from maestro.api.routes.musehub.negotiate import negotiate_response
 from maestro.api.routes.musehub.ui_jsonld import jsonld_release, jsonld_repo, render_jsonld_script

--- a/tests/test_musehub_htmx_helpers.py
+++ b/tests/test_musehub_htmx_helpers.py
@@ -1,0 +1,182 @@
+"""Tests for maestro.api.routes.musehub.htmx_helpers.
+
+Covers HX-Request detection, HX-Boosted detection, fragment/full routing,
+HX-Trigger header emission, and HX-Redirect response generation.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.datastructures import Headers
+from starlette.responses import Response
+from starlette.testclient import TestClient
+
+from maestro.api.routes.musehub.htmx_helpers import (
+    htmx_fragment_or_full,
+    htmx_redirect,
+    htmx_trigger,
+    is_htmx,
+    is_htmx_boosted,
+)
+
+
+def _make_request(headers: dict[str, str] | None = None) -> MagicMock:
+    """Return a mock FastAPI Request with the given headers."""
+    req = MagicMock()
+    req.headers = Headers(headers=headers or {})
+    return req
+
+
+def _make_templates(rendered_name: list[str]) -> MagicMock:
+    """Return a mock Jinja2Templates that records the template name used."""
+
+    templates = MagicMock()
+
+    def fake_response(request: object, name: str, ctx: object) -> Response:
+        rendered_name.append(name)
+        return Response(content=f"<rendered:{name}>", media_type="text/html")
+
+    templates.TemplateResponse = fake_response
+    return templates
+
+
+# ---------------------------------------------------------------------------
+# is_htmx
+# ---------------------------------------------------------------------------
+
+
+def test_is_htmx_returns_true_with_header() -> None:
+    req = _make_request({"HX-Request": "true"})
+    assert is_htmx(req) is True
+
+
+def test_is_htmx_returns_false_without_header() -> None:
+    req = _make_request()
+    assert is_htmx(req) is False
+
+
+def test_is_htmx_returns_false_wrong_value() -> None:
+    req = _make_request({"HX-Request": "false"})
+    assert is_htmx(req) is False
+
+
+def test_is_htmx_returns_false_on_capitalised_value() -> None:
+    """Header value comparison is case-sensitive; 'True' ≠ 'true'."""
+    req = _make_request({"HX-Request": "True"})
+    assert is_htmx(req) is False
+
+
+# ---------------------------------------------------------------------------
+# is_htmx_boosted
+# ---------------------------------------------------------------------------
+
+
+def test_is_htmx_boosted_with_header() -> None:
+    req = _make_request({"HX-Boosted": "true"})
+    assert is_htmx_boosted(req) is True
+
+
+def test_is_htmx_boosted_without_header() -> None:
+    req = _make_request()
+    assert is_htmx_boosted(req) is False
+
+
+# ---------------------------------------------------------------------------
+# htmx_fragment_or_full
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_htmx_fragment_or_full_returns_fragment_on_htmx_request() -> None:
+    rendered: list[str] = []
+    req = _make_request({"HX-Request": "true"})
+    templates = _make_templates(rendered)
+    ctx: dict[str, object] = {}
+
+    await htmx_fragment_or_full(
+        req, templates, ctx,
+        full_template="pages/full.html",
+        fragment_template="fragments/part.html",
+    )
+
+    assert rendered == ["fragments/part.html"]
+
+
+@pytest.mark.anyio
+async def test_htmx_fragment_or_full_returns_full_on_direct_request() -> None:
+    rendered: list[str] = []
+    req = _make_request()  # no HX-Request header
+    templates = _make_templates(rendered)
+    ctx: dict[str, object] = {}
+
+    await htmx_fragment_or_full(
+        req, templates, ctx,
+        full_template="pages/full.html",
+        fragment_template="fragments/part.html",
+    )
+
+    assert rendered == ["pages/full.html"]
+
+
+@pytest.mark.anyio
+async def test_htmx_fragment_or_full_returns_full_when_no_fragment_template() -> None:
+    """Even an HTMX request must get the full page when no fragment_template is given."""
+    rendered: list[str] = []
+    req = _make_request({"HX-Request": "true"})
+    templates = _make_templates(rendered)
+    ctx: dict[str, object] = {}
+
+    await htmx_fragment_or_full(
+        req, templates, ctx,
+        full_template="pages/full.html",
+        fragment_template=None,
+    )
+
+    assert rendered == ["pages/full.html"]
+
+
+# ---------------------------------------------------------------------------
+# htmx_trigger
+# ---------------------------------------------------------------------------
+
+
+def test_htmx_trigger_sets_header_with_detail() -> None:
+    response = Response(content="ok")
+    htmx_trigger(response, "toast", {"message": "Issue closed", "type": "success"})
+
+    raw = response.headers["HX-Trigger"]
+    parsed = json.loads(raw)
+    assert parsed == {"toast": {"message": "Issue closed", "type": "success"}}
+
+
+def test_htmx_trigger_sets_header_without_detail() -> None:
+    response = Response(content="ok")
+    htmx_trigger(response, "refresh")
+
+    raw = response.headers["HX-Trigger"]
+    parsed = json.loads(raw)
+    assert parsed == {"refresh": True}
+
+
+def test_htmx_trigger_sets_header_with_none_detail() -> None:
+    response = Response(content="ok")
+    htmx_trigger(response, "ping", None)
+
+    raw = response.headers["HX-Trigger"]
+    parsed = json.loads(raw)
+    assert parsed == {"ping": True}
+
+
+# ---------------------------------------------------------------------------
+# htmx_redirect
+# ---------------------------------------------------------------------------
+
+
+def test_htmx_redirect_sets_hx_redirect_header() -> None:
+    response = htmx_redirect("/musehub/ui/owner/repo")
+
+    assert response.status_code == 200
+    assert response.headers["HX-Redirect"] == "/musehub/ui/owner/repo"


### PR DESCRIPTION
## Summary

Closes #554 — Fragment response helper (`htmx_fragment_or_full`) + HX-Request detection for HTMX SSR migration.

## Motivation

Every migrated route handler needs to return full HTML for browser nav and fragments for HTMX partial updates. This infrastructure centralizes that logic so page migration agents can call a single helper without understanding its internals.

## Changes

- **`maestro/api/routes/musehub/htmx_helpers.py`** — Extended with `htmx_fragment_or_full()`, `htmx_trigger()`, `htmx_redirect()`. Existing `is_htmx()` and `is_htmx_boosted()` preserved.
- **`maestro/api/routes/musehub/negotiate.py`** — Added `fragment_template` parameter + HTMX priority (check 1 of 3) before JSON negotiation.
- **`maestro/api/routes/musehub/ui.py`** — Import of helpers added so they are available for subsequent page migrations.
- **`maestro/templates/musehub/fragments/`** — New directory with `.gitkeep`; subsequent issues add fragment templates here.
- **`tests/test_musehub_htmx_helpers.py`** — 13 tests covering all helpers and both code paths (HX-Request present and absent).

## Verification

- [x] mypy clean (709 source files, 0 errors)
- [x] 13 tests pass, 0 warnings
- [x] Docs updated (module docstrings on all new functions)

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Architecture** | `turing:htmx:jinja2` |
| **Session** | `eng-20260302T062414Z-3774` |
| **Batch** | `eng-20260302T060305Z-555b` |
| **Wave (CTO)** | `wave-1-20260302T060010Z` |

</details>