### PR TITLE
feat: A/B results dashboard — compare role versions by PR outcomes

### DIFF
--- a/agentception/intelligence/ab_results.py
+++ b/agentception/intelligence/ab_results.py
@@ -1,0 +1,215 @@
+"""A/B results dashboard computation for AgentCeption (AC-505).
+
+Aggregates pipeline wave data and correlates each wave with an A/B role
+variant (A = even-second BATCH_ID, B = odd-second BATCH_ID).  For each
+variant, computes outcome metrics: PRs opened, PRs merged, average reviewer
+grade, and merge rate.  This enables the Engineering VP to compare two role
+prompt variants against hard outcome signals rather than impressions.
+
+The grade is extracted from merged-PR body text and PR review comments using
+a regex that matches patterns like "Grade: `A`" or "Grade: A".  When no grade
+can be parsed, ``avg_grade`` is ``None``.
+
+Typical call site (route handler)::
+
+    from agentception.intelligence.ab_results import compute_ab_results
+
+    variant_a, variant_b = await compute_ab_results()
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Literal
+
+from pydantic import BaseModel
+
+from agentception.intelligence.ab_mode import _is_even_batch
+from agentception.intelligence.role_versions import read_role_versions
+from agentception.readers.github import get_merged_prs, get_pr_comments
+from agentception.telemetry import aggregate_waves
+
+logger = logging.getLogger(__name__)
+
+# Matches patterns like "Grade: `A`", "Grade: A", "Grade B" in reviewer comments.
+_GRADE_RE = re.compile(r"\bGrade[:\s]+[`*]?([A-F])[`*]?", re.IGNORECASE)
+
+# Numeric mapping used to average letter grades.
+_GRADE_TO_NUM: dict[str, int] = {"A": 4, "B": 3, "C": 2, "D": 1, "F": 0}
+_NUM_TO_GRADE: dict[int, str] = {v: k for k, v in _GRADE_TO_NUM.items()}
+
+
+class ABVariantResult(BaseModel):
+    """Outcome metrics for one A/B role variant across all applicable batches.
+
+    ``variant`` is ``"A"`` (even-second BATCH_ID) or ``"B"`` (odd-second).
+    ``role_sha`` is the git SHA of the role file version active during these
+    batches, sourced from ``role-versions.json``; empty string when unknown.
+    ``avg_grade`` is the mean letter grade across all reviewer-graded PRs in
+    this variant; ``None`` when no graded PRs are found.
+    ``merge_rate`` is ``prs_merged / prs_opened``; ``0.0`` when ``prs_opened``
+    is zero to avoid division-by-zero.
+    """
+
+    variant: Literal["A", "B"]
+    role_sha: str
+    batch_ids: list[str]
+    prs_opened: int
+    prs_merged: int
+    avg_grade: str | None
+    merge_rate: float
+
+
+def _extract_grade(text: str) -> str | None:
+    """Return the first letter grade A–F found in ``text``, or ``None``.
+
+    Recognises patterns produced by the QA reviewer agent:
+    ``Grade: `A```, ``Grade: A``, ``Grade A``, case-insensitively.
+    """
+    match = _GRADE_RE.search(text)
+    return match.group(1).upper() if match else None
+
+
+def _average_grade(grades: list[str]) -> str | None:
+    """Convert letter grades to a numeric average and back.
+
+    Returns ``None`` for an empty input list.  Uses a 4-point scale:
+    A=4, B=3, C=2, D=1, F=0.  The averaged value is rounded to the nearest
+    integer before converting back to a letter so ``["A", "B"]`` → ``"B"``
+    (average 3.5, rounds to 4 → ``"A"`` with Python ``round`` banker's
+    rounding; kept as-is — both outcomes are valid approximations).
+    """
+    if not grades:
+        return None
+    nums = [_GRADE_TO_NUM.get(g.upper(), 0) for g in grades]
+    return _NUM_TO_GRADE.get(round(sum(nums) / len(nums)), "F")
+
+
+async def _fetch_grade_for_pr(pr: dict[str, object]) -> str | None:
+    """Try to extract a reviewer grade for the given PR.
+
+    First checks the PR body, then falls back to fetching PR comments.
+    Returns ``None`` when no grade pattern is found in either place.
+    """
+    body = str(pr.get("body") or "")
+    grade = _extract_grade(body)
+    if grade:
+        return grade
+
+    pr_number = pr.get("number")
+    if not isinstance(pr_number, int):
+        return None
+
+    try:
+        comments = await get_pr_comments(pr_number)
+        for comment in comments:
+            grade = _extract_grade(comment)
+            if grade:
+                return grade
+    except Exception as exc:
+        logger.debug("⚠️  Could not fetch comments for PR #%s: %s", pr_number, exc)
+
+    return None
+
+
+async def compute_ab_results() -> tuple[ABVariantResult, ABVariantResult]:
+    """Return ``(variant_a, variant_b)`` outcome metrics.
+
+    Aggregates all recorded waves, assigns each to variant A or B based on
+    the parity of the BATCH_ID timestamp's seconds component, then correlates
+    with merged-PR data from GitHub to compute per-variant outcome metrics.
+
+    Waves whose BATCH_ID cannot be parsed are silently skipped — they cannot
+    be attributed to either variant and should not pollute the comparison.
+
+    GitHub calls (merged PRs, PR comments) are attempted on a best-effort
+    basis: failures are logged at WARNING level and result in zero merged PRs /
+    no grades rather than a hard error so the dashboard always loads.
+    """
+    # ── Role SHA attribution ───────────────────────────────────────────────
+    versions_data = await read_role_versions()
+    ab_cfg = versions_data.get("ab_mode")
+    variant_a_sha = ""
+    variant_b_sha = ""
+    if isinstance(ab_cfg, dict):
+        raw_a = ab_cfg.get("variant_a_sha")
+        raw_b = ab_cfg.get("variant_b_sha")
+        variant_a_sha = str(raw_a) if raw_a else ""
+        variant_b_sha = str(raw_b) if raw_b else ""
+
+    # ── Wave aggregation ───────────────────────────────────────────────────
+    waves = await aggregate_waves()
+
+    a_batch_ids: list[str] = []
+    b_batch_ids: list[str] = []
+    a_prs_opened = 0
+    b_prs_opened = 0
+    a_issues: set[int] = set()
+    b_issues: set[int] = set()
+
+    for wave in waves:
+        is_even = _is_even_batch(wave.batch_id)
+        if is_even is None:
+            # Unparseable batch_id — cannot assign variant; skip.
+            logger.debug("⚠️  Skipping wave with unparseable batch_id: %r", wave.batch_id)
+            continue
+        if is_even:
+            a_batch_ids.append(wave.batch_id)
+            a_prs_opened += wave.prs_opened
+            a_issues.update(wave.issues_worked)
+        else:
+            b_batch_ids.append(wave.batch_id)
+            b_prs_opened += wave.prs_opened
+            b_issues.update(wave.issues_worked)
+
+    # ── Merged-PR correlation ──────────────────────────────────────────────
+    # Match merged PRs to variants via the issue number embedded in the branch
+    # name (``feat/issue-NNN``).  Grade is extracted from PR body + comments.
+    a_merged = 0
+    b_merged = 0
+    a_grades: list[str] = []
+    b_grades: list[str] = []
+
+    try:
+        merged_prs = await get_merged_prs()
+        for pr in merged_prs:
+            branch = str(pr.get("headRefName") or "")
+            issue_match = re.search(r"issue-(\d+)", branch)
+            if not issue_match:
+                continue
+            issue_num = int(issue_match.group(1))
+
+            if issue_num in a_issues:
+                a_merged += 1
+                grade = await _fetch_grade_for_pr(pr)
+                if grade:
+                    a_grades.append(grade)
+            elif issue_num in b_issues:
+                b_merged += 1
+                grade = await _fetch_grade_for_pr(pr)
+                if grade:
+                    b_grades.append(grade)
+    except Exception as exc:
+        logger.warning("⚠️  Could not fetch merged PRs for A/B results: %s", exc)
+
+    # ── Assemble results ───────────────────────────────────────────────────
+    return (
+        ABVariantResult(
+            variant="A",
+            role_sha=variant_a_sha,
+            batch_ids=a_batch_ids,
+            prs_opened=a_prs_opened,
+            prs_merged=a_merged,
+            avg_grade=_average_grade(a_grades),
+            merge_rate=a_merged / a_prs_opened if a_prs_opened > 0 else 0.0,
+        ),
+        ABVariantResult(
+            variant="B",
+            role_sha=variant_b_sha,
+            batch_ids=b_batch_ids,
+            prs_opened=b_prs_opened,
+            prs_merged=b_merged,
+            avg_grade=_average_grade(b_grades),
+            merge_rate=b_merged / b_prs_opened if b_prs_opened > 0 else 0.0,
+        ),
+    )

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -201,6 +201,52 @@ async def get_open_prs_with_body() -> list[dict[str, object]]:
     return [item for item in result if isinstance(item, dict)]
 
 
+async def get_merged_prs() -> list[dict[str, object]]:
+    """List merged pull requests targeting the ``dev`` branch.
+
+    Returns each PR as a dict with at minimum: ``number``, ``headRefName``,
+    ``body``, and ``mergedAt``.  Used by the A/B results dashboard to
+    correlate PR outcomes (merge status, reviewer grade) with agent batches.
+    """
+    repo = settings.gh_repo
+    args = [
+        "pr", "list",
+        "--repo", repo,
+        "--base", "dev",
+        "--state", "merged",
+        "--json", "number,headRefName,body,mergedAt",
+    ]
+    result = await gh_json(args, ".", "get_merged_prs")
+    if not isinstance(result, list):
+        raise RuntimeError(f"get_merged_prs: expected list from gh, got {type(result).__name__}")
+    return [item for item in result if isinstance(item, dict)]
+
+
+async def get_pr_comments(pr_number: int) -> list[str]:
+    """Return the body text of all comments posted on a pull request.
+
+    Fetches issue-timeline comments (which includes entries created via
+    ``gh pr comment``) using the GitHub REST API.  Returns an empty list
+    when the PR has no comments or when the API call fails so callers can
+    treat a missing grade as ``None`` without special-casing.
+
+    Parameters
+    ----------
+    pr_number:
+        GitHub pull request number.
+    """
+    repo = settings.gh_repo
+    cache_key = f"get_pr_comments:{pr_number}"
+    result = await gh_json(
+        ["api", f"repos/{repo}/issues/{pr_number}/comments"],
+        "[.[].body]",
+        cache_key,
+    )
+    if not isinstance(result, list):
+        return []
+    return [str(c) for c in result if isinstance(c, str)]
+
+
 async def get_wip_issues() -> list[dict[str, object]]:
     """Return issues currently labelled ``agent:wip``.
 

--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -16,6 +16,7 @@ from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
 from starlette.responses import Response
 
+from agentception.intelligence.ab_results import ABVariantResult, compute_ab_results
 from agentception.intelligence.analyzer import IssueAnalysis, analyze_issue
 from agentception.intelligence.dag import DependencyDAG, build_dag
 from agentception.models import AgentNode, PipelineConfig, PipelineState, RoleMeta, VALID_ROLES
@@ -286,6 +287,48 @@ async def dag_page(request: Request) -> HTMLResponse:
         request,
         "dag.html",
         {"dag": dag.model_dump()},
+    )
+
+
+@router.get("/ab-testing", response_class=HTMLResponse)
+async def ab_testing_page(request: Request) -> HTMLResponse:
+    """A/B role variant comparison dashboard — side-by-side outcome metrics.
+
+    Renders the A/B results page (AC-505): two comparison cards showing
+    PRs opened, merge rate, average reviewer grade, and batch count for each
+    role variant.  A winner badge is shown when one variant's merge rate or
+    average grade clearly outperforms the other.
+
+    Data comes from :func:`~agentception.intelligence.ab_results.compute_ab_results`.
+    On any computation error the page renders with zero-value results and an
+    error banner rather than returning HTTP 500 so the UI stays accessible.
+    """
+    error: str | None = None
+    variant_a: ABVariantResult | None = None
+    variant_b: ABVariantResult | None = None
+    try:
+        variant_a, variant_b = await compute_ab_results()
+    except Exception as exc:  # pragma: no cover — infrastructure error path
+        error = f"Could not compute A/B results: {exc}"
+        logger.warning("⚠️  A/B results computation failed: %s", exc)
+
+    # Determine winner based on merge rate; fall back to no winner on a tie.
+    winner: str | None = None
+    if variant_a is not None and variant_b is not None:
+        if variant_a.merge_rate > variant_b.merge_rate:
+            winner = "A"
+        elif variant_b.merge_rate > variant_a.merge_rate:
+            winner = "B"
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "ab_testing.html",
+        {
+            "variant_a": variant_a,
+            "variant_b": variant_b,
+            "winner": winner,
+            "error": error,
+        },
     )
 
 

--- a/agentception/templates/ab_testing.html
+++ b/agentception/templates/ab_testing.html
@@ -1,0 +1,225 @@
+{% extends "base.html" %}
+
+{% block title %}AgentCeption — A/B Testing{% endblock %}
+
+{% block content %}
+{#
+  A/B role variant comparison dashboard (AC-505).
+  Two side-by-side cards compare Variant A (even-second BATCH_ID) against
+  Variant B (odd-second BATCH_ID) across: PRs opened, merge rate, average
+  reviewer grade, and batch count.  A winner badge appears when one variant's
+  merge rate clearly outperforms the other.  Below the cards is a raw data
+  table listing each batch, its assigned variant, PRs opened, and grade.
+#}
+
+<h1 class="section-title">A/B Role Variant Comparison</h1>
+<p class="text-muted mt-1" style="margin-bottom: 1.5rem;">
+  Comparing agent outcomes across two role prompt variants.
+  <strong>Variant A</strong> = even-second BATCH_ID &nbsp;·&nbsp;
+  <strong>Variant B</strong> = odd-second BATCH_ID.
+</p>
+
+{# ── Error banner ─────────────────────────────────────────────────────────── #}
+{% if error %}
+<div class="card mt-2" style="border-left: 3px solid var(--color-error, #dc2626);">
+  <p class="text-muted">⚠️ {{ error }}</p>
+</div>
+{% endif %}
+
+{# ── Comparison cards ─────────────────────────────────────────────────────── #}
+{% if variant_a and variant_b %}
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 1rem;">
+
+  {# Variant A card #}
+  <div class="card" style="position: relative;">
+    {% if winner == "A" %}
+    <span class="badge badge--green" style="position: absolute; top: 0.75rem; right: 0.75rem;">
+      🏆 Winner
+    </span>
+    {% endif %}
+    <h2 class="section-title" style="margin-bottom: 0.75rem;">
+      Variant A
+      {% if winner == "A" %}<span style="color: var(--color-success, #16a34a);">✓</span>{% endif %}
+    </h2>
+    {% if variant_a.role_sha %}
+    <p class="text-muted" style="font-family: monospace; font-size: 0.8rem; margin-bottom: 0.75rem;">
+      SHA: {{ variant_a.role_sha[:12] }}
+    </p>
+    {% endif %}
+
+    <table class="telemetry-table" style="width: 100%;">
+      <tbody>
+        <tr>
+          <td class="text-muted">Batches</td>
+          <td><strong>{{ variant_a.batch_ids | length }}</strong></td>
+        </tr>
+        <tr>
+          <td class="text-muted">PRs opened</td>
+          <td><strong>{{ variant_a.prs_opened }}</strong></td>
+        </tr>
+        <tr>
+          <td class="text-muted">PRs merged</td>
+          <td><strong>{{ variant_a.prs_merged }}</strong></td>
+        </tr>
+        <tr>
+          <td class="text-muted">Merge rate</td>
+          <td>
+            <strong>
+              {% if variant_a.merge_rate > 0 %}
+              {{ "%.0f%%" | format(variant_a.merge_rate * 100) }}
+              {% else %}
+              —
+              {% endif %}
+            </strong>
+          </td>
+        </tr>
+        <tr>
+          <td class="text-muted">Avg grade</td>
+          <td>
+            <strong>
+              {% if variant_a.avg_grade %}
+              <span class="badge
+                {%- if variant_a.avg_grade == 'A' %} badge--green
+                {%- elif variant_a.avg_grade == 'B' %} badge--blue
+                {%- elif variant_a.avg_grade in ('D', 'F') %} badge--red
+                {%- else %} badge--grey
+                {%- endif %}">
+                {{ variant_a.avg_grade }}
+              </span>
+              {% else %}
+              <span class="text-muted">—</span>
+              {% endif %}
+            </strong>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  {# Variant B card #}
+  <div class="card" style="position: relative;">
+    {% if winner == "B" %}
+    <span class="badge badge--green" style="position: absolute; top: 0.75rem; right: 0.75rem;">
+      🏆 Winner
+    </span>
+    {% endif %}
+    <h2 class="section-title" style="margin-bottom: 0.75rem;">
+      Variant B
+      {% if winner == "B" %}<span style="color: var(--color-success, #16a34a);">✓</span>{% endif %}
+    </h2>
+    {% if variant_b.role_sha %}
+    <p class="text-muted" style="font-family: monospace; font-size: 0.8rem; margin-bottom: 0.75rem;">
+      SHA: {{ variant_b.role_sha[:12] }}
+    </p>
+    {% endif %}
+
+    <table class="telemetry-table" style="width: 100%;">
+      <tbody>
+        <tr>
+          <td class="text-muted">Batches</td>
+          <td><strong>{{ variant_b.batch_ids | length }}</strong></td>
+        </tr>
+        <tr>
+          <td class="text-muted">PRs opened</td>
+          <td><strong>{{ variant_b.prs_opened }}</strong></td>
+        </tr>
+        <tr>
+          <td class="text-muted">PRs merged</td>
+          <td><strong>{{ variant_b.prs_merged }}</strong></td>
+        </tr>
+        <tr>
+          <td class="text-muted">Merge rate</td>
+          <td>
+            <strong>
+              {% if variant_b.merge_rate > 0 %}
+              {{ "%.0f%%" | format(variant_b.merge_rate * 100) }}
+              {% else %}
+              —
+              {% endif %}
+            </strong>
+          </td>
+        </tr>
+        <tr>
+          <td class="text-muted">Avg grade</td>
+          <td>
+            <strong>
+              {% if variant_b.avg_grade %}
+              <span class="badge
+                {%- if variant_b.avg_grade == 'A' %} badge--green
+                {%- elif variant_b.avg_grade == 'B' %} badge--blue
+                {%- elif variant_b.avg_grade in ('D', 'F') %} badge--red
+                {%- else %} badge--grey
+                {%- endif %}">
+                {{ variant_b.avg_grade }}
+              </span>
+              {% else %}
+              <span class="text-muted">—</span>
+              {% endif %}
+            </strong>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+{# ── No-winner note ───────────────────────────────────────────────────────── #}
+{% if not winner %}
+<p class="text-muted mt-2" style="text-align: center; font-style: italic;">
+  No clear winner yet — variants are tied or insufficient data.
+</p>
+{% endif %}
+
+{# ── Raw data: batch breakdown ────────────────────────────────────────────── #}
+{% if variant_a.batch_ids or variant_b.batch_ids %}
+<section class="mt-2">
+  <h2 class="section-title">Batch Breakdown</h2>
+  <div class="card" style="padding: 0; overflow: hidden;">
+    <table class="telemetry-table" style="width: 100%; margin: 0;">
+      <thead>
+        <tr>
+          <th>Batch ID</th>
+          <th>Variant</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for batch_id in variant_a.batch_ids %}
+        <tr>
+          <td style="font-family: monospace; font-size: 0.85rem;">{{ batch_id }}</td>
+          <td>
+            <span class="badge badge--blue">A</span>
+          </td>
+        </tr>
+        {% endfor %}
+        {% for batch_id in variant_b.batch_ids %}
+        <tr>
+          <td style="font-family: monospace; font-size: 0.85rem;">{{ batch_id }}</td>
+          <td>
+            <span class="badge badge--grey">B</span>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% else %}
+<div class="card mt-2">
+  <p class="text-muted empty-state">
+    No A/B batch data yet. Batches appear once agents run with A/B mode enabled.
+  </p>
+</div>
+{% endif %}
+
+{% else %}
+{# Fallback: results unavailable (e.g. error before compute_ab_results returned) #}
+{% if not error %}
+<div class="card mt-2">
+  <p class="text-muted empty-state">
+    A/B results are unavailable. Enable A/B mode in the pipeline config and run at least one wave.
+  </p>
+</div>
+{% endif %}
+{% endif %}
+
+{% endblock %}

--- a/agentception/templates/base.html
+++ b/agentception/templates/base.html
@@ -51,6 +51,10 @@
        class="{% if request.url.path.startswith('/dag') %}active{% endif %}">
       DAG
     </a>
+    <a href="/ab-testing"
+       class="{% if request.url.path.startswith('/ab-testing') %}active{% endif %}">
+      A/B
+    </a>
   </nav>
 
   <main role="main">

--- a/agentception/tests/test_agentception_ab_results.py
+++ b/agentception/tests/test_agentception_ab_results.py
@@ -1,0 +1,266 @@
+"""Tests for A/B results dashboard computation and route (AC-505).
+
+Covers the three acceptance criteria from issue #638:
+- test_compute_ab_results_empty: empty waves produce zero-value results for both variants.
+- test_compute_ab_results_assigns_correct_variant: even-second batch → variant A,
+  odd-second batch → variant B.
+- test_ab_page_returns_200: GET /ab-testing returns HTTP 200.
+
+Run targeted:
+    docker compose exec agentception pytest agentception/tests/test_agentception_ab_results.py -v
+"""
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+from agentception.intelligence.ab_results import (
+    ABVariantResult,
+    _average_grade,
+    _extract_grade,
+    compute_ab_results,
+)
+from agentception.models import AgentNode, AgentStatus
+from agentception.telemetry import WaveSummary
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    """Synchronous test client wrapping the AgentCeption FastAPI app."""
+    with TestClient(app) as c:
+        yield c
+
+
+def _make_wave(batch_id: str, issues: list[int], prs_opened: int = 1) -> WaveSummary:
+    """Build a minimal WaveSummary for testing purposes."""
+    import time
+
+    now = time.time()
+    return WaveSummary(
+        batch_id=batch_id,
+        started_at=now - 600,
+        ended_at=now - 60,
+        issues_worked=issues,
+        prs_opened=prs_opened,
+        prs_merged=0,
+        estimated_tokens=0,
+        estimated_cost_usd=0.0,
+        agents=[
+            AgentNode(
+                id=f"agent-{issues[0]}",
+                role="python-developer",
+                status=AgentStatus.DONE,
+                issue_number=issues[0],
+                batch_id=batch_id,
+            )
+        ] if issues else [],
+    )
+
+
+# ── _extract_grade ────────────────────────────────────────────────────────────
+
+
+def test_extract_grade_backtick_format() -> None:
+    """_extract_grade must parse the reviewer's standard comment format."""
+    assert _extract_grade("✅ **Review complete — Grade: `A`**") == "A"
+
+
+def test_extract_grade_plain_format() -> None:
+    """_extract_grade must handle plain 'Grade: X' without backticks."""
+    assert _extract_grade("Grade: B — solid implementation.") == "B"
+
+
+def test_extract_grade_returns_none_when_absent() -> None:
+    """_extract_grade returns None when no grade pattern is present."""
+    assert _extract_grade("No grade information in this text.") is None
+
+
+# ── _average_grade ────────────────────────────────────────────────────────────
+
+
+def test_average_grade_empty_returns_none() -> None:
+    """_average_grade returns None for an empty list."""
+    assert _average_grade([]) is None
+
+
+def test_average_grade_single_grade() -> None:
+    """_average_grade returns the single grade unchanged."""
+    assert _average_grade(["A"]) == "A"
+
+
+def test_average_grade_mixed() -> None:
+    """_average_grade averages correctly: A + C = B (numeric mean 3)."""
+    result = _average_grade(["A", "C"])
+    assert result == "B"
+
+
+# ── compute_ab_results: empty ─────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_compute_ab_results_empty() -> None:
+    """compute_ab_results returns zero-value results for both variants when there are no waves."""
+    empty_versions: dict[str, object] = {"versions": {}, "ab_mode": {}}
+    empty_waves: list[WaveSummary] = []
+    empty_prs: list[dict[str, object]] = []
+
+    with (
+        patch(
+            "agentception.intelligence.ab_results.read_role_versions",
+            new=AsyncMock(return_value=empty_versions),
+        ),
+        patch(
+            "agentception.intelligence.ab_results.aggregate_waves",
+            new=AsyncMock(return_value=empty_waves),
+        ),
+        patch(
+            "agentception.intelligence.ab_results.get_merged_prs",
+            new=AsyncMock(return_value=empty_prs),
+        ),
+    ):
+        variant_a, variant_b = await compute_ab_results()
+
+    assert variant_a.variant == "A"
+    assert variant_a.prs_opened == 0
+    assert variant_a.prs_merged == 0
+    assert variant_a.avg_grade is None
+    assert variant_a.merge_rate == 0.0
+    assert variant_a.batch_ids == []
+
+    assert variant_b.variant == "B"
+    assert variant_b.prs_opened == 0
+    assert variant_b.prs_merged == 0
+    assert variant_b.avg_grade is None
+    assert variant_b.merge_rate == 0.0
+    assert variant_b.batch_ids == []
+
+
+# ── compute_ab_results: variant assignment ────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_compute_ab_results_assigns_correct_variant() -> None:
+    """Even-second BATCH_ID maps to variant A; odd-second maps to variant B.
+
+    Given one wave with an even-second batch (→ A, issue 100) and one with an
+    odd-second batch (→ B, issue 200), compute_ab_results must place their
+    stats in the correct variant buckets.  A merged PR for issue 100 (branch
+    feat/issue-100) is attributed to variant A; one for issue 200 goes to B.
+    """
+    # Even second (00) → variant A.
+    wave_a = _make_wave("eng-20260302T120000Z-aaaa", [100], prs_opened=1)
+    # Odd second (01) → variant B.
+    wave_b = _make_wave("eng-20260302T120001Z-bbbb", [200], prs_opened=2)
+
+    merged_prs: list[dict[str, object]] = [
+        {
+            "number": 50,
+            "headRefName": "feat/issue-100",
+            "body": "✅ Review complete — Grade: `A`\n\nCloses #100",
+            "mergedAt": "2026-03-02T12:01:00Z",
+        },
+        {
+            "number": 51,
+            "headRefName": "feat/issue-200",
+            "body": "Closes #200",  # no grade in body
+            "mergedAt": "2026-03-02T12:02:00Z",
+        },
+    ]
+
+    # PR 51 has no grade in body; simulate a comment with a grade.
+    async def fake_get_pr_comments(pr_number: int) -> list[str]:
+        if pr_number == 51:
+            return ["✅ Review complete — Grade: `B`\nMerged at: 2026-03-02T12:02:30Z"]
+        return []
+
+    empty_versions: dict[str, object] = {
+        "versions": {},
+        "ab_mode": {"variant_a_sha": "abc123", "variant_b_sha": "def456"},
+    }
+
+    with (
+        patch(
+            "agentception.intelligence.ab_results.read_role_versions",
+            new=AsyncMock(return_value=empty_versions),
+        ),
+        patch(
+            "agentception.intelligence.ab_results.aggregate_waves",
+            new=AsyncMock(return_value=[wave_a, wave_b]),
+        ),
+        patch(
+            "agentception.intelligence.ab_results.get_merged_prs",
+            new=AsyncMock(return_value=merged_prs),
+        ),
+        patch(
+            "agentception.intelligence.ab_results.get_pr_comments",
+            side_effect=fake_get_pr_comments,
+        ),
+    ):
+        variant_a, variant_b = await compute_ab_results()
+
+    # Variant A — even-second batch, issue 100.
+    assert variant_a.variant == "A"
+    assert "eng-20260302T120000Z-aaaa" in variant_a.batch_ids
+    assert variant_a.prs_opened == 1
+    assert variant_a.prs_merged == 1
+    assert variant_a.avg_grade == "A"
+    assert variant_a.merge_rate == 1.0
+    assert variant_a.role_sha == "abc123"
+
+    # Variant B — odd-second batch, issue 200.
+    assert variant_b.variant == "B"
+    assert "eng-20260302T120001Z-bbbb" in variant_b.batch_ids
+    assert variant_b.prs_opened == 2
+    assert variant_b.prs_merged == 1
+    assert variant_b.avg_grade == "B"
+    assert variant_b.merge_rate == 0.5
+    assert variant_b.role_sha == "def456"
+
+
+# ── GET /ab-testing → 200 ────────────────────────────────────────────────────
+
+
+def test_ab_page_returns_200(client: TestClient) -> None:
+    """GET /ab-testing must return HTTP 200 with variant comparison cards."""
+    mock_a = ABVariantResult(
+        variant="A",
+        role_sha="abc123def456",
+        batch_ids=["eng-20260302T120000Z-aaaa"],
+        prs_opened=3,
+        prs_merged=3,
+        avg_grade="A",
+        merge_rate=1.0,
+    )
+    mock_b = ABVariantResult(
+        variant="B",
+        role_sha="def456abc123",
+        batch_ids=["eng-20260302T120001Z-bbbb"],
+        prs_opened=2,
+        prs_merged=1,
+        avg_grade="B",
+        merge_rate=0.5,
+    )
+
+    with patch(
+        "agentception.routes.ui.compute_ab_results",
+        new=AsyncMock(return_value=(mock_a, mock_b)),
+    ):
+        response = client.get("/ab-testing")
+
+    assert response.status_code == 200
+    html = response.text
+    # Both variant cards must be present.
+    assert "Variant A" in html
+    assert "Variant B" in html
+    # Winner badge must appear for A (higher merge rate).
+    assert "Winner" in html
+    # Batch IDs must appear in the breakdown table.
+    assert "eng-20260302T120000Z-aaaa" in html
+    assert "eng-20260302T120001Z-bbbb" in html


### PR DESCRIPTION
## Summary
Closes #638 — Add GET /ab-testing page showing comparison table of A/B role variants.

## Root Cause / Motivation
AgentCeption needed visibility into which role variants produce better PR outcomes. Without an A/B results view, it is impossible to evaluate whether variant experimentation improves merge rates or reviewer grades.

## Solution
- Added `agentception/intelligence/ab_results.py` with `ABVariantResult` Pydantic model and `compute_ab_results()` async function that groups waves by BATCH_ID timestamp parity (even second → A, odd second → B), correlates with merged PR data from GitHub, and extracts reviewer grades from PR body + comments
- Added `get_merged_prs()` and `get_pr_comments()` reader functions to `agentception/readers/github.py`
- Added `GET /ab-testing` route to `agentception/routes/ui.py`
- Added `agentception/templates/ab_testing.html` with side-by-side comparison cards, winner badge, per-metric rows, and raw batch breakdown table
- Added A/B nav link to `agentception/templates/base.html`
- Added 9 tests in `agentception/tests/test_agentception_ab_results.py`: `test_compute_ab_results_empty`, `test_compute_ab_results_assigns_correct_variant`, `test_ab_page_returns_200`, plus helpers for `_extract_grade` and `_average_grade`
- Registered `ABVariantResult` in `docs/reference/type-contracts.md`

## Verification
- [x] mypy clean (50 source files, 0 issues)
- [x] 9 tests pass
- [x] Docs updated

---
<details><summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Architecture** | `hopper:jinja2` |
| **Role** | `python-developer` |
| **Session** | `eng-20260302T062738Z-72a6` |
| **Batch** | `eng-20260302T062429Z-2167` |
| **Wave** | `wave-1-20260302T061859Z` |

</details>