### PR TITLE
feat: [HTMX] SSR PR list + PR detail — SSR + HTMX review/merge actions (#569)

### DIFF
--- a/maestro/api/routes/musehub/ui.py
+++ b/maestro/api/routes/musehub/ui.py
@@ -745,114 +745,128 @@ async def pr_list_page(
     request: Request,
     owner: str,
     repo_slug: str,
+    state: str = Query("open", pattern="^(open|merged|closed|all)$"),
+    sort: str = Query("newest", pattern="^(newest|oldest)$"),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    """Render the PR list page with open/all state filter."""
+    """Render the PR list page with SSR data and HTMX fragment support.
+
+    Fetches open, merged, and closed PR counts server-side and renders the
+    active tab's rows. Returns a bare fragment when ``HX-Request: true`` so
+    HTMX tab switches only swap the ``#pr-rows`` container.
+    """
     repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
+
+    open_prs = await musehub_pull_requests.list_prs(db, repo_id, state="open")
+    merged_prs = await musehub_pull_requests.list_prs(db, repo_id, state="merged")
+    closed_prs = await musehub_pull_requests.list_prs(db, repo_id, state="closed")
+
+    if state == "merged":
+        active_prs = merged_prs
+    elif state == "closed":
+        active_prs = closed_prs
+    elif state == "all":
+        active_prs = open_prs + merged_prs + closed_prs
+    else:
+        active_prs = open_prs
+
+    if sort == "oldest":
+        active_prs = sorted(active_prs, key=lambda p: p.created_at)
+    else:
+        active_prs = sorted(active_prs, key=lambda p: p.created_at, reverse=True)
+
     ctx: dict[str, object] = {
         "owner": owner,
         "repo_slug": repo_slug,
         "repo_id": repo_id,
         "base_url": base_url,
         "current_page": "pulls",
+        "prs": [p.model_dump() for p in active_prs],
+        "open_count": len(open_prs),
+        "merged_count": len(merged_prs),
+        "closed_count": len(closed_prs),
+        "state": state,
+        "active_sort": sort,
+        "breadcrumb_data": _breadcrumbs(
+            (owner, f"/musehub/ui/{owner}"),
+            (repo_slug, base_url),
+            ("Pull Requests", f"{base_url}/pulls"),
+        ),
     }
-    return json_or_html(
+    return await htmx_fragment_or_full(
         request,
-        lambda: templates.TemplateResponse(request, "musehub/pages/pr_list.html", ctx),
+        templates,
         ctx,
+        full_template="musehub/pages/pr_list.html",
+        fragment_template="musehub/fragments/pr_rows.html",
     )
 
 
 @router.get(
     "/{owner}/{repo_slug}/pulls/{pr_id}",
     response_class=HTMLResponse,
-    summary="Muse Hub PR detail page with musical diff",
+    summary="Muse Hub PR detail page — SSR with HTMX review/merge actions",
 )
 async def pr_detail_page(
     request: Request,
     owner: str,
     repo_slug: str,
     pr_id: str,
-    format: str | None = Query(None, pattern="^json$", description="Set to 'json' to receive structured data"),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    """Render the PR detail page with musical diff, reviewer panel, and sidebar.
+    """Render the PR detail page with full SSR data and HTMX fragment support.
 
-    HTML response includes the full musical diff UI enhanced with five additions:
+    Fetches the PR record, reviews, and comment thread server-side so the
+    initial HTML render is complete without any client-side API calls.
+    Returns a bare comment fragment when ``HX-Request: true`` so HTMX can
+    swap only ``#pr-comments`` on partial refreshes.
 
-    1. **Reviewer status panel** — avatar chips for each requested reviewer with
-       pending / approved / changes_requested / dismissed badges, plus a
-       "Submit your review" form (approve / request changes / comment) for
-       authenticated maintainers.
-
-    2. **Merge options** — three strategy buttons (merge commit / squash / rebase)
-       with a "Delete branch after merge" checkbox.  All controls are disabled when
-       the PR is not mergeable (``pr.mergeable == false``).
-
-    3. **Collapsible commit diff panels** — one ``<details>`` element per head-branch
-       commit showing similarity % to the base branch and an inline 8-axis
-       emotion-diff mini radar chart (via the ``/analysis/{ref}/similarity`` and
-       ``/analysis/{ref}/emotion-diff`` APIs).
-
-    4. **Markdown description** — ``pr.body`` is rendered as formatted HTML rather
-       than a raw ``<pre>`` block, using the inline ``renderMarkdown()`` helper.
-
-    5. **Labels and milestone sidebar** — labels assigned to the PR are shown as
-       colour-coded chips with add / remove controls for maintainers; the milestone
-       title (if set) is displayed below.
-
-    JSON response (``?format=json`` or ``Accept: application/json``) returns the
-    PR metadata merged with per-dimension diff scores — suitable for AI agent
-    consumption to reason about musical impact before approving a merge.
-
-    The merge action calls
-    ``POST /api/v1/musehub/repos/{repo_id}/pull-requests/{pr_id}/merge``
-    with the selected ``mergeStrategy`` and optional ``deleteBranch`` flag.
+    Raises HTTP 404 when the PR does not exist in the given repository.
     """
     repo_id, base_url = await _resolve_repo(owner, repo_slug, db)
 
-    context: dict[str, object] = {
+    pr = await musehub_pull_requests.get_pr(db, repo_id, pr_id)
+    if pr is None:
+        raise HTTPException(status_code=404, detail=f"Pull request {pr_id} not found")
+
+    reviews_resp = await musehub_pull_requests.list_reviews(
+        db, repo_id=repo_id, pr_id=pr_id
+    )
+    comments_resp = await musehub_pull_requests.list_pr_comments(
+        db, pr_id=pr_id, repo_id=repo_id
+    )
+
+    approved_count = sum(1 for r in reviews_resp.reviews if r.state == "approved")
+    changes_count = sum(
+        1 for r in reviews_resp.reviews if r.state == "changes_requested"
+    )
+
+    ctx: dict[str, object] = {
         "owner": owner,
         "repo_slug": repo_slug,
         "repo_id": repo_id,
         "pr_id": pr_id,
         "base_url": base_url,
         "current_page": "pulls",
+        "pr": pr.model_dump(),
+        "reviews": [r.model_dump() for r in reviews_resp.reviews],
+        "comments": [c.model_dump() for c in comments_resp.comments],
+        "comment_count": comments_resp.total,
+        "approved_count": approved_count,
+        "changes_count": changes_count,
+        "breadcrumb_data": _breadcrumbs(
+            (owner, f"/musehub/ui/{owner}"),
+            (repo_slug, base_url),
+            ("Pull Requests", f"{base_url}/pulls"),
+            (pr_id[:8], f"{base_url}/pulls/{pr_id}"),
+        ),
     }
-
-    # For JSON responses, eagerly compute the diff so agents get full data.
-    json_data: PRDiffResponse | None = None
-    if format == "json":
-        pr = await musehub_pull_requests.get_pr(db, repo_id, pr_id)
-        if pr is not None:
-            try:
-                result = await musehub_divergence.compute_hub_divergence(
-                    db,
-                    repo_id=repo_id,
-                    branch_a=pr.to_branch,
-                    branch_b=pr.from_branch,
-                )
-                json_data = musehub_divergence.build_pr_diff_response(
-                    pr_id=pr_id,
-                    from_branch=pr.from_branch,
-                    to_branch=pr.to_branch,
-                    result=result,
-                )
-            except ValueError:
-                json_data = musehub_divergence.build_zero_diff_response(
-                    pr_id=pr_id,
-                    repo_id=repo_id,
-                    from_branch=pr.from_branch,
-                    to_branch=pr.to_branch,
-                )
-
-    return await negotiate_response(
-        request=request,
-        template_name="musehub/pages/pr_detail.html",
-        context=context,
-        templates=templates,
-        json_data=json_data,
-        format_param=format,
+    return await htmx_fragment_or_full(
+        request,
+        templates,
+        ctx,
+        full_template="musehub/pages/pr_detail.html",
+        fragment_template="musehub/fragments/pr_comments.html",
     )
 
 

--- a/maestro/templates/musehub/fragments/pr_comments.html
+++ b/maestro/templates/musehub/fragments/pr_comments.html
@@ -1,0 +1,73 @@
+{#  fragments/pr_comments.html — bare HTMX fragment: PR comment thread.
+
+    Rendered in two contexts:
+
+    1. Full-page load: included inline by musehub/pages/pr_detail.html inside
+       the ``<div id="pr-comments">`` target container.
+
+    2. HTMX partial swap: returned directly when the handler detects
+       ``HX-Request: true``, replacing only ``#pr-comments`` after a new
+       comment is submitted.
+
+    Required context variables
+    --------------------------
+    comments       : list[dict]   — PRCommentResponse.model_dump() (threaded, top-level only)
+    comment_count  : int          — total comment count (all levels)
+    base_url       : str          — repo UI prefix
+#}
+{% from "musehub/macros/empty_state.html" import empty_state %}
+
+<h3 style="margin:0 0 var(--space-3);font-size:15px">
+  Review comments ({{ comment_count }})
+</h3>
+
+{% if comments %}
+  {% for comment in comments %}
+    <div class="comment-block">
+      <div class="comment-header-row">
+        <span style="display:inline-flex;align-items:center;justify-content:center;
+          width:22px;height:22px;border-radius:50%;
+          background:var(--color-accent-subtle,#1c2d3f);
+          color:var(--color-accent,#58a6ff);font-size:11px;font-weight:700">
+          {{ comment.author[0].upper() if comment.author else '?' }}
+        </span>
+        <strong>{{ comment.author or 'unknown' }}</strong>
+        <span style="font-size:11px;color:#8b949e">{{ comment.created_at | fmtdate }}</span>
+        {% if comment.target_type and comment.target_type != 'general' %}
+          <span style="font-size:11px;background:var(--color-surface-2,#21262d);
+            color:#8b949e;border-radius:3px;padding:1px 6px">
+            {{ comment.target_type }}
+            {% if comment.target_track %}: {{ comment.target_track }}{% endif %}
+            {% if comment.target_beat_start is not none %} beat {{ comment.target_beat_start }}{% endif %}
+          </span>
+        {% endif %}
+      </div>
+      <div class="comment-body-text">{{ comment.body }}</div>
+
+      {# Replies (one level deep) #}
+      {% if comment.replies %}
+        {% for reply in comment.replies %}
+          <div class="comment-reply">
+            <div class="comment-header-row">
+              <span style="display:inline-flex;align-items:center;justify-content:center;
+                width:18px;height:18px;border-radius:50%;
+                background:var(--color-surface-2,#21262d);
+                color:#8b949e;font-size:10px;font-weight:700">
+                {{ reply.author[0].upper() if reply.author else '?' }}
+              </span>
+              <strong style="font-size:12px">{{ reply.author or 'unknown' }}</strong>
+              <span style="font-size:11px;color:#8b949e">{{ reply.created_at | fmtdate }}</span>
+            </div>
+            <div class="comment-body-text">{{ reply.body }}</div>
+          </div>
+        {% endfor %}
+      {% endif %}
+    </div>
+  {% endfor %}
+{% else %}
+  {{ empty_state(
+      "💬",
+      "No review comments yet",
+      "Be the first to leave a review comment on this pull request.",
+  ) }}
+{% endif %}

--- a/maestro/templates/musehub/fragments/pr_rows.html
+++ b/maestro/templates/musehub/fragments/pr_rows.html
@@ -1,0 +1,56 @@
+{#  fragments/pr_rows.html — bare HTMX fragment: pull request list rows.
+
+    Rendered in two contexts:
+
+    1. Full-page load: included inline by musehub/pages/pr_list.html inside
+       the ``<div id="pr-rows">`` target container.
+
+    2. HTMX partial swap: returned directly when the handler detects
+       ``HX-Request: true``, replacing only the ``#pr-rows`` container on
+       tab/sort switches.
+
+    Required context variables
+    --------------------------
+    prs         : list[dict]  — PRResponse.model_dump() for active state/sort
+    base_url    : str         — repo UI prefix, e.g. /musehub/ui/owner/slug
+    state       : str         — active state tab: 'open' | 'merged' | 'closed' | 'all'
+#}
+{% from "musehub/macros/empty_state.html" import empty_state %}
+
+{% if prs %}
+  {% for pr in prs %}
+    <div class="pr-row">
+      {# State badge #}
+      {% if pr.state == 'merged' %}
+        <span class="badge badge-merged">Merged</span>
+      {% elif pr.state == 'closed' %}
+        <span class="badge badge-closed">Closed</span>
+      {% else %}
+        <span class="badge badge-open">Open</span>
+      {% endif %}
+
+      <div style="flex:1;min-width:0">
+        <a href="{{ base_url }}/pulls/{{ pr.pr_id }}">{{ pr.title }}</a>
+        <div class="pr-meta">
+          <span class="branch-pill">{{ pr.from_branch }}</span>
+          <span>→</span>
+          <span class="branch-pill">{{ pr.to_branch }}</span>
+          <span>{{ pr.created_at | fmtdate }}</span>
+          {% if pr.author %}<span>by {{ pr.author }}</span>{% endif %}
+          {% if pr.state == 'merged' and pr.merge_commit_id %}
+            <a href="{{ base_url }}/commits/{{ pr.merge_commit_id }}"
+               style="font-family:monospace;font-size:11px;color:#8b49da">
+              {{ pr.merge_commit_id[:8] }}
+            </a>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  {% endfor %}
+{% else %}
+  {{ empty_state(
+      "🔀",
+      "No pull requests",
+      "No pull requests match the current filter. Try switching tabs.",
+  ) }}
+{% endif %}

--- a/maestro/templates/musehub/pages/pr_detail.html
+++ b/maestro/templates/musehub/pages/pr_detail.html
@@ -1,9 +1,10 @@
 {% extends "musehub/base.html" %}
 
-{% block title %}PR {{ pr_id[:8] }} · {{ owner }}/{{ repo_slug }}{% endblock %}
+{% block title %}PR {{ pr.pr_id[:8] }} · {{ owner }}/{{ repo_slug }}{% endblock %}
 {% block breadcrumb %}
-  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> /
-  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}/pulls">pulls</a> / {{ pr_id[:8] }}
+  <a href="/musehub/ui/{{ owner }}">{{ owner }}</a> /
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ repo_slug }}</a> /
+  <a href="{{ base_url }}/pulls">pulls</a> / {{ pr.pr_id[:8] }}
 {% endblock %}
 {% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
 
@@ -14,1188 +15,331 @@ const base   = {{ base_url | tojson }};
 const apiBase = '/api/v1/musehub/repos/' + repoId;
 {% endblock %}
 
-{% block page_script %}
-{% raw %}
-// ── Colour constants ─────────────────────────────────────────────────────────
-const DIMENSIONS  = ['melodic','harmonic','rhythmic','structural','dynamic'];
-const LEVEL_COLOR = { NONE:'#1f6feb', LOW:'#388bfd', MED:'#f0883e', HIGH:'#f85149' };
-const LEVEL_BG    = { NONE:'#0d2942', LOW:'#102a4c', MED:'#341a00', HIGH:'#3d0000' };
-const AXIS_LABELS = {
-  melodic:'Melodic', harmonic:'Harmonic', rhythmic:'Rhythmic',
-  structural:'Structural', dynamic:'Dynamic',
-};
-
-// ── Radar SVG helper ─────────────────────────────────────────────────────────
-function radarSvg(dims) {
-  const cx = 180, cy = 180, r = 140;
-  const n = dims.length;
-  const pts = dims.map((d, i) => {
-    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
-    const sr = d.score * r;
-    return { x: cx + sr * Math.cos(angle), y: cy + sr * Math.sin(angle) };
-  });
-  const bgPts = DIMENSIONS.map((_, i) => {
-    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
-    return `${cx + r * Math.cos(angle)},${cy + r * Math.sin(angle)}`;
-  }).join(' ');
-  const scorePoly = pts.map(p => `${p.x},${p.y}`).join(' ');
-  const axisLines = DIMENSIONS.map((_, i) => {
-    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
-    const ex = cx + r * Math.cos(angle), ey = cy + r * Math.sin(angle);
-    return `<line x1="${cx}" y1="${cy}" x2="${ex}" y2="${ey}" stroke="#30363d" stroke-width="1"/>`;
-  }).join('');
-  const gridLines = [0.25, 0.5, 0.75, 1.0].map(frac => {
-    const gPts = DIMENSIONS.map((_, i) => {
-      const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
-      return `${cx + frac * r * Math.cos(angle)},${cy + frac * r * Math.sin(angle)}`;
-    }).join(' ');
-    return `<polygon points="${gPts}" fill="none" stroke="#21262d" stroke-width="1"/>`;
-  }).join('');
-  const labels = dims.map((d, i) => {
-    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
-    const lx = cx + (r + 22) * Math.cos(angle);
-    const ly = cy + (r + 22) * Math.sin(angle);
-    const color = LEVEL_COLOR[d.level] || '#8b949e';
-    return `<text x="${lx}" y="${ly + 4}" text-anchor="middle"
-      font-size="12" fill="${color}" font-family="system-ui">${AXIS_LABELS[d.dimension]}</text>`;
-  }).join('');
-  const dots = pts.map((p, i) => {
-    const color = LEVEL_COLOR[dims[i].level] || '#58a6ff';
-    return `<circle cx="${p.x}" cy="${p.y}" r="4" fill="${color}" stroke="#0d1117" stroke-width="2"/>`;
-  }).join('');
-  return `<svg viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg"
-      style="width:100%;max-width:360px;display:block;margin:0 auto">
-    ${gridLines}${axisLines}
-    <polygon points="${bgPts}" fill="rgba(88,166,255,0.04)" stroke="#30363d" stroke-width="1"/>
-    <polygon points="${scorePoly}" fill="rgba(248,81,73,0.18)" stroke="#f85149" stroke-width="2"/>
-    ${labels}${dots}
-  </svg>`;
-}
-
-// ── Diff badge ───────────────────────────────────────────────────────────────
-function diffBadge(d) {
-  const color = LEVEL_COLOR[d.level] || '#8b949e';
-  const label = d.deltaLabel === 'unchanged'
-    ? '<span style="color:#8b949e">unchanged</span>'
-    : `<span style="color:${color};font-weight:700">${escHtml(d.deltaLabel)}%</span>`;
-  return `<div class="card" style="background:${LEVEL_BG[d.level] || '#161b22'};
-      display:flex;align-items:center;gap:10px;padding:var(--space-2) var(--space-3);margin-bottom:6px">
-    <span style="font-size:13px;color:#e6edf3;min-width:90px;font-weight:600">
-      ${AXIS_LABELS[d.dimension]}</span>
-    ${label}
-    <div style="flex:1;height:6px;background:#21262d;border-radius:3px;overflow:hidden">
-      <div style="height:100%;width:${Math.round(d.score*100)}%;background:${color};
-        border-radius:3px;transition:width .3s"></div>
-    </div>
-  </div>`;
-}
-
-// ── Piano roll diff SVG ──────────────────────────────────────────────────────
-// Renders a deterministic pseudo-piano-roll from branch name seeds.
-// Green = added in from_branch, red = removed in from_branch, grey = unchanged.
-function pianoRollSvg(fromBranch, toBranch) {
-  const PITCHES = 24, STEPS = 32;
-  const W = 480, H = 120;
-  const sw = W / STEPS, sh = H / PITCHES;
-
-  function refSeed(s) {
-    let h = 0;
-    for (let i = 0; i < s.length; i++) { h = Math.imul(31, h) + s.charCodeAt(i) | 0; }
-    return h >>> 0;
-  }
-  function noteGrid(seed) {
-    let x = seed;
-    const grid = new Set();
-    for (let i = 0; i < STEPS * PITCHES; i++) {
-      x = (x * 1103515245 + 12345) & 0x7fffffff;
-      if ((x % 100) < 22) grid.add(i);
-    }
-    return grid;
-  }
-
-  const toGrid   = noteGrid(refSeed(toBranch));
-  const fromGrid = noteGrid(refSeed(fromBranch));
-
-  let rects = '';
-  for (let p = 0; p < PITCHES; p++) {
-    for (let s = 0; s < STEPS; s++) {
-      const idx = p * STEPS + s;
-      const inTo   = toGrid.has(idx);
-      const inFrom = fromGrid.has(idx);
-      if (!inTo && !inFrom) continue;
-      let fill;
-      if (inTo && inFrom) fill = '#30363d';       // unchanged
-      else if (inFrom)    fill = '#3fb95088';     // added in from_branch
-      else                fill = '#f8514988';     // removed (only in to_branch)
-      rects += `<rect x="${s * sw + 1}" y="${(PITCHES - 1 - p) * sh + 1}"
-        width="${sw - 2}" height="${sh - 1}" fill="${fill}" rx="1"/>`;
-    }
-  }
-
-  return `<svg viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg"
-      style="width:100%;max-width:${W}px;border-radius:6px;background:#0d1117;display:block">
-    ${rects}
-  </svg>
-  <div style="display:flex;gap:16px;margin-top:6px;font-size:11px;color:#8b949e">
-    <span><span style="display:inline-block;width:10px;height:10px;background:#3fb950;
-      border-radius:2px;margin-right:4px"></span>Added</span>
-    <span><span style="display:inline-block;width:10px;height:10px;background:#f85149;
-      border-radius:2px;margin-right:4px"></span>Removed</span>
-    <span><span style="display:inline-block;width:10px;height:10px;background:#30363d;
-      border-radius:2px;margin-right:4px"></span>Unchanged</span>
-  </div>`;
-}
-
-// ── Audio A/B toggle ─────────────────────────────────────────────────────────
-let _audioSide = 'from';
-function toggleAudio(side, fromBranch, toBranch) {
-  _audioSide = side;
-  ['btn-audio-from','btn-audio-to'].forEach(id => {
-    const el = document.getElementById(id);
-    if (el) { el.style.background = '#21262d'; el.style.color = '#8b949e'; }
-  });
-  const active = document.getElementById('btn-audio-' + side);
-  if (active) { active.style.background = '#1f6feb'; active.style.color = '#fff'; }
-  const lbl = document.getElementById('audio-label');
-  if (lbl) lbl.textContent = side === 'from' ? fromBranch : toBranch;
-}
-
-// ── Merge strategy selector ──────────────────────────────────────────────────
-let _mergeStrategy = 'merge_commit';
-function selectStrategy(strategy) {
-  _mergeStrategy = strategy;
-  ['merge_commit','squash','rebase'].forEach(s => {
-    const el = document.getElementById('strategy-' + s);
-    if (!el) return;
-    el.style.background  = s === strategy ? '#1f6feb' : '#21262d';
-    el.style.color       = s === strategy ? '#fff'    : '#8b949e';
-    el.style.borderColor = s === strategy ? '#1f6feb' : '#30363d';
-  });
-}
-
-async function mergePrWithStrategy() {
-  if (!confirm(`Merge this pull request using "${_mergeStrategy}" strategy?`)) return;
-  const deleteBranchEl = document.getElementById('cb-delete-branch');
-  const deleteBranch = deleteBranchEl ? deleteBranchEl.checked : true;
-  try {
-    await apiFetch(apiBase + '/pull-requests/' + prId + '/merge', {
-      method: 'POST',
-      body: JSON.stringify({ mergeStrategy: _mergeStrategy, deleteBranch }),
-    });
-    location.reload();
-  } catch (e) {
-    if (e.message !== 'auth') alert('Merge failed: ' + e.message);
-  }
-}
-
-function targetBadge(comment) {
-  if (comment.targetType === 'general') return '';
-  let label = comment.targetType;
-  if (comment.targetTrack) label += ': ' + comment.targetTrack;
-  if (comment.targetBeatStart != null) label += ' beats ' + comment.targetBeatStart;
-  if (comment.targetBeatEnd   != null) label += '–' + comment.targetBeatEnd;
-  if (comment.targetNotePitch != null) label += ' pitch=' + comment.targetNotePitch;
-  return `<span style="font-size:11px;background:var(--surface2,#21262d);color:var(--fg2,#8b949e);border-radius:3px;padding:1px 6px;margin-left:8px">${escHtml(label)}</span>`;
-}
-
-function renderComment(c, isReply) {
-  const indent = isReply ? 'margin-left:32px;' : '';
-  const repliesHtml = (c.replies || []).map(r => renderComment(r, true)).join('');
-  const replyBtn = isReply ? '' :
-    `<button onclick="showReplyForm('${escHtml(c.commentId)}')" style="background:none;border:none;color:var(--accent,#58a6ff);cursor:pointer;font-size:12px;padding:0">Reply</button>`;
-  return `
-    <div style="${indent}border-left:2px solid var(--border,#30363d);padding:8px 12px;margin-bottom:8px">
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
-        <span style="font-weight:600">${escHtml(c.author)}</span>
-        <span style="font-size:11px;color:var(--fg2,#8b949e)">${fmtDate(c.createdAt)}</span>
-        ${targetBadge(c)}
-      </div>
-      <div style="white-space:pre-wrap;margin-bottom:4px">${escHtml(c.body)}</div>
-      ${replyBtn}
-      <div id="reply-form-${escHtml(c.commentId)}" style="display:none;margin-top:8px"></div>
-      ${repliesHtml}
-    </div>`;
-}
-
-function showReplyForm(parentId) {
-  const container = document.getElementById('reply-form-' + parentId);
-  if (!container) return;
-  container.style.display = 'block';
-  container.innerHTML = `
-    <textarea id="reply-body-${parentId}" rows="3" placeholder="Write a reply…"
-      style="width:100%;background:var(--surface2,#21262d);color:var(--fg,#e6edf3);border:1px solid var(--border,#30363d);border-radius:6px;padding:6px;resize:vertical;font-size:13px"></textarea>
-    <div style="margin-top:4px;display:flex;gap:8px">
-      <button onclick="submitComment('${parentId}')" class="btn btn-primary" style="font-size:12px;padding:4px 10px">Reply</button>
-      <button onclick="document.getElementById('reply-form-${parentId}').style.display='none'" style="background:none;border:none;color:var(--fg2,#8b949e);cursor:pointer;font-size:12px">Cancel</button>
-    </div>`;
-}
-
-async function submitComment(parentId) {
-  const bodyEl = parentId
-    ? document.getElementById('reply-body-' + parentId)
-    : document.getElementById('new-comment-body');
-  const targetTypeEl = document.getElementById('new-comment-target');
-  const trackEl = document.getElementById('new-comment-track');
-  const beatStartEl = document.getElementById('new-comment-beat-start');
-  const beatEndEl = document.getElementById('new-comment-beat-end');
-
-  if (!bodyEl || !bodyEl.value.trim()) return;
-
-  const payload = {
-    body: bodyEl.value.trim(),
-    targetType: (parentId || !targetTypeEl) ? 'general' : (targetTypeEl.value || 'general'),
-    targetTrack: (!parentId && trackEl && trackEl.value) ? trackEl.value : null,
-    targetBeatStart: (!parentId && beatStartEl && beatStartEl.value) ? parseFloat(beatStartEl.value) : null,
-    targetBeatEnd: (!parentId && beatEndEl && beatEndEl.value) ? parseFloat(beatEndEl.value) : null,
-    parentCommentId: parentId || null,
-  };
-
-  try {
-    await apiFetch('/repos/' + repoId + '/pull-requests/' + prId + '/comments', {
-      method: 'POST',
-      body: JSON.stringify(payload),
-    });
-    await loadComments();
-    bodyEl.value = '';
-  } catch(e) {
-    if (e.message !== 'auth') alert('Failed to post comment: ' + e.message);
-  }
-}
-
-async function loadComments() {
-  const section = document.getElementById('comments-section');
-  if (!section) return;
-  try {
-    const data = await apiFetch('/repos/' + repoId + '/pull-requests/' + prId + '/comments');
-    const list = data.comments || [];
-    const countEl = document.getElementById('comment-count');
-    if (countEl) countEl.textContent = data.total || 0;
-
-    const listEl = document.getElementById('comment-list');
-    if (listEl) {
-      listEl.innerHTML = list.length
-        ? list.map(c => renderComment(c, false)).join('')
-        : '<p style="color:var(--fg2,#8b949e);font-size:13px">No review comments yet.</p>';
-    }
-  } catch(e) {
-    // Non-fatal — comment section degrades gracefully
-  }
-}
-
-// ── Timeline event row ───────────────────────────────────────────────────────
-function timelineRow(icon, label, ts) {
-  const time = ts ? new Date(ts).toLocaleString() : '';
-  return `<div style="display:flex;align-items:center;gap:10px;padding:6px 0;
-      border-bottom:1px solid #21262d">
-    <span style="font-size:16px">${icon}</span>
-    <span style="font-size:13px;color:#e6edf3;flex:1">${escHtml(label)}</span>
-    <span style="font-size:11px;color:#8b949e">${escHtml(time)}</span>
-  </div>`;
-}
-
-// ── Reactions ────────────────────────────────────────────────────────────────
-
-const REACTION_EMOJIS = ['👍', '👎', '❤️', '🎵', '🔥', '✨', '🎸', '🥁'];
-
-/**
- * Load and render emoji reaction counts for a target into a container element.
- * Shows pill buttons for each emoji with counts; authenticated users can toggle.
- */
-async function loadReactions(targetType, targetId, containerId) {
-  const container = document.getElementById(containerId);
-  if (!container) return;
-  try {
-    const reactions = await apiFetch(
-      '/repos/' + repoId + '/reactions?target_type=' + encodeURIComponent(targetType) +
-      '&target_id=' + encodeURIComponent(targetId)
-    );
-
-    const countMap = {};
-    const mySet = new Set();
-    for (const r of reactions) {
-      countMap[r.emoji] = r.count;
-      if (r.reacted_by_me) mySet.add(r.emoji);
-    }
-
-    const authed = !!getToken();
-    container.innerHTML = REACTION_EMOJIS.map(emoji => {
-      const count = countMap[emoji] || 0;
-      const active = mySet.has(emoji);
-      const cls = 'reaction-btn' + (active ? ' reaction-btn--active' : '');
-      const onclick = authed
-        ? `toggleReaction('${targetType}','${targetId}','${emoji}','${containerId}')`
-        : '';
-      return `<button class="${cls}" ${onclick ? 'onclick="' + onclick + '"' : 'disabled title="Sign in to react"'}>${emoji}${count > 0 ? ' <span class="reaction-count">' + count + '</span>' : ''}</button>`;
-    }).join('');
-  } catch(e) {
-    if (e.message !== 'auth') container.innerHTML = '';
-  }
-}
-
-/**
- * Toggle an emoji reaction on a target and refresh the reaction bar.
- */
-async function toggleReaction(targetType, targetId, emoji, containerId) {
-  try {
-    await apiFetch('/repos/' + repoId + '/reactions', {
-      method: 'POST',
-      body: JSON.stringify({ target_type: targetType, target_id: targetId, emoji }),
-    });
-    loadReactions(targetType, targetId, containerId);
-  } catch(e) {
-    if (e.message !== 'auth') console.error('Reaction error:', e.message);
-  }
-}
-
-// ── Lightweight Markdown renderer ────────────────────────────────────────────
-/**
- * Convert a Markdown string to safe HTML without an external library.
- * Supports: headings, bold, italic, inline code, code fences, links,
- * unordered lists, ordered lists, blockquotes, and horizontal rules.
- * All literal HTML in the source is escaped first to prevent XSS.
- */
-function renderMarkdown(text) {
-  if (!text) return '';
-  // Escape raw HTML first.
-  let s = text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-  // Fenced code blocks (``` … ```).
-  s = s.replace(/```([^`]*?)```/gs,
-    (_, code) => `<pre style="background:#161b22;border:1px solid #30363d;border-radius:6px;padding:12px;overflow-x:auto;font-size:12px"><code>${code}</code></pre>`);
-  // Headings.
-  s = s.replace(/^### (.+)$/gm, '<h3 style="font-size:14px;margin:12px 0 6px;color:#e6edf3">$1</h3>');
-  s = s.replace(/^## (.+)$/gm,  '<h2 style="font-size:16px;margin:14px 0 6px;color:#e6edf3">$1</h2>');
-  s = s.replace(/^# (.+)$/gm,   '<h1 style="font-size:18px;margin:16px 0 8px;color:#e6edf3">$1</h1>');
-  // Horizontal rules.
-  s = s.replace(/^---+$/gm, '<hr style="border:none;border-top:1px solid #30363d;margin:12px 0">');
-  // Blockquotes.
-  s = s.replace(/^&gt; (.+)$/gm,
-    '<blockquote style="border-left:3px solid #388bfd;margin:0;padding:4px 12px;color:#8b949e;font-style:italic">$1</blockquote>');
-  // Unordered lists.
-  s = s.replace(/^[*\-] (.+)$/gm, '<li style="margin-left:20px;margin-bottom:2px">$1</li>');
-  // Ordered lists.
-  s = s.replace(/^\d+\. (.+)$/gm, '<li style="margin-left:20px;margin-bottom:2px;list-style:decimal">$1</li>');
-  // Bold and italic.
-  s = s.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
-  s = s.replace(/\*\*(.+?)\*\*/g,     '<strong>$1</strong>');
-  s = s.replace(/\*(.+?)\*/g,         '<em>$1</em>');
-  s = s.replace(/__(.+?)__/g,         '<strong>$1</strong>');
-  s = s.replace(/_(.+?)_/g,           '<em>$1</em>');
-  // Inline code.
-  s = s.replace(/`([^`]+)`/g,
-    '<code style="background:#21262d;border-radius:3px;padding:1px 5px;font-size:12px">$1</code>');
-  // Links [text](url). Only allow http/https/relative/anchor URLs to prevent javascript: XSS.
-  s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) => {
-    const safeUrl = /^(https?:\/\/|\/|#)/i.test(url) ? url : '#';
-    return `<a href="${safeUrl}" style="color:#58a6ff" target="_blank" rel="noopener noreferrer">${text}</a>`;
-  });
-  // Paragraphs: blank lines → paragraph break.
-  s = s.replace(/\n{2,}/g, '</p><p style="margin:8px 0">');
-  s = `<p style="margin:8px 0">${s}</p>`;
-  return s;
-}
-
-// ── Mini 8-axis emotion radar (inline SVG for commit diff panels) ─────────────
-/**
- * Render a compact 8-axis spider chart from an EmotionDelta8D delta object.
- * Each axis shows absolute |delta| magnitude; sign is indicated by colour.
- */
-function miniEmotionRadarSvg(delta) {
-  const axes = ['valence','energy','tension','complexity','warmth','brightness','darkness','playfulness'];
-  const cx = 80, cy = 80, r = 60;
-  const n = axes.length;
-  const vals = axes.map(a => delta[a] !== undefined ? Math.abs(delta[a]) : 0);
-  const colors = axes.map(a => (delta[a] || 0) >= 0 ? '#3fb950' : '#f85149');
-
-  const grid = [0.25, 0.5, 0.75, 1.0].map(frac => {
-    const pts = axes.map((_, i) => {
-      const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
-      return `${cx + frac * r * Math.cos(angle)},${cy + frac * r * Math.sin(angle)}`;
-    }).join(' ');
-    return `<polygon points="${pts}" fill="none" stroke="#21262d" stroke-width="1"/>`;
-  }).join('');
-
-  const axisLines = axes.map((_, i) => {
-    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
-    const ex = cx + r * Math.cos(angle), ey = cy + r * Math.sin(angle);
-    return `<line x1="${cx}" y1="${cy}" x2="${ex}" y2="${ey}" stroke="#30363d" stroke-width="1"/>`;
-  }).join('');
-
-  const dataPts = vals.map((v, i) => {
-    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
-    return `${cx + v * r * Math.cos(angle)},${cy + v * r * Math.sin(angle)}`;
-  }).join(' ');
-
-  const dots = vals.map((v, i) => {
-    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
-    const px = cx + v * r * Math.cos(angle), py = cy + v * r * Math.sin(angle);
-    return `<circle cx="${px}" cy="${py}" r="3" fill="${colors[i]}" stroke="#0d1117" stroke-width="1.5"/>`;
-  }).join('');
-
-  const labels = axes.map((a, i) => {
-    const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
-    const lx = cx + (r + 14) * Math.cos(angle);
-    const ly = cy + (r + 14) * Math.sin(angle);
-    return `<text x="${lx}" y="${ly + 3}" text-anchor="middle" font-size="7" fill="#8b949e">${a.slice(0,5)}</text>`;
-  }).join('');
-
-  return `<svg viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg"
-      style="width:160px;height:160px;display:block">
-    ${grid}${axisLines}
-    <polygon points="${dataPts}" fill="rgba(88,166,255,0.12)" stroke="#58a6ff" stroke-width="1.5"/>
-    ${dots}${labels}
-  </svg>`;
-}
-
-// ── Reviewer status panel ─────────────────────────────────────────────────────
-
-/** Map review state → display label + colour. */
-const REVIEW_STATE_STYLE = {
-  pending:           { label: 'Pending',            color: '#8b949e', bg: '#21262d' },
-  approved:          { label: 'Approved',            color: '#3fb950', bg: '#0d2b00' },
-  changes_requested: { label: 'Changes requested',   color: '#f0883e', bg: '#341a00' },
-  dismissed:         { label: 'Dismissed',           color: '#484f58', bg: '#161b22' },
-};
-
-/** Render one reviewer avatar chip. */
-function reviewerChip(review) {
-  const style = REVIEW_STATE_STYLE[review.reviewerUsername ? review.state : 'pending'] || REVIEW_STATE_STYLE.pending;
-  const initial = (review.reviewerUsername || '?').charAt(0).toUpperCase();
-  return `<div title="${escHtml(review.reviewerUsername)} — ${style.label}"
-      style="display:inline-flex;align-items:center;gap:6px;padding:4px 10px 4px 4px;
-        border-radius:var(--radius-full,999px);border:1px solid ${style.color}44;
-        background:${style.bg};cursor:default">
-    <span style="display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;
-      border-radius:50%;background:${style.color}33;color:${style.color};font-size:12px;font-weight:700">
-      ${initial}
-    </span>
-    <span style="font-size:12px;color:#e6edf3">${escHtml(review.reviewerUsername)}</span>
-    <span style="font-size:10px;padding:1px 6px;border-radius:10px;background:${style.color}22;color:${style.color}">
-      ${style.label}
-    </span>
-  </div>`;
-}
-
-/**
- * Fetch and render the reviewer status panel.
- * Requires a DOM element #reviewer-chips and (optionally) #review-form-section.
- */
-async function loadReviewers() {
-  const chipsEl = document.getElementById('reviewer-chips');
-  if (!chipsEl) return;
-  try {
-    const data = await apiFetch('/repos/' + repoId + '/pull-requests/' + prId + '/reviews');
-    const reviews = (data && data.reviews) ? data.reviews : [];
-    chipsEl.innerHTML = reviews.length
-      ? reviews.map(reviewerChip).join('')
-      : '<span style="font-size:13px;color:#8b949e">No reviewers assigned.</span>';
-  } catch (e) {
-    if (e.message !== 'auth') chipsEl.innerHTML = '<span style="color:#8b949e;font-size:13px">Could not load reviewers.</span>';
-  }
-}
-
-/**
- * Submit a review (approve / request_changes / comment) for the authenticated user.
- * event must be one of: 'approve' | 'request_changes' | 'comment'
- */
-async function submitReview(event) {
-  const bodyEl = document.getElementById('review-body');
-  const body = bodyEl ? bodyEl.value.trim() : '';
-  if (event === 'request_changes' && !body) {
-    alert('A review body is required when requesting changes.');
-    return;
-  }
-  try {
-    await apiFetch('/repos/' + repoId + '/pull-requests/' + prId + '/reviews', {
-      method: 'POST',
-      body: JSON.stringify({ event, body }),
-    });
-    if (bodyEl) bodyEl.value = '';
-    await loadReviewers();
-    // Collapse the submit form.
-    const details = document.getElementById('review-form-details');
-    if (details) details.removeAttribute('open');
-  } catch (e) {
-    if (e.message !== 'auth') alert('Review submission failed: ' + e.message);
-  }
-}
-
-// ── Labels sidebar ────────────────────────────────────────────────────────────
-
-/**
- * Fetch labels assigned to this PR and repo labels (for edit controls).
- * Renders into #pr-labels-section.
- */
-async function loadPRLabels() {
-  const section = document.getElementById('pr-labels-section');
-  if (!section) return;
-  try {
-    // Fetch the repo's full label catalogue first (always available).
-    const allLabels = await apiFetch('/repos/' + repoId + '/labels').catch(() => []);
-
-    // Try to fetch current PR labels (endpoint may not exist yet — degrade gracefully).
-    let prLabels = [];
-    try {
-      const prLabelData = await apiFetch('/repos/' + repoId + '/pull-requests/' + prId + '/labels');
-      prLabels = Array.isArray(prLabelData) ? prLabelData : [];
-    } catch (_) { /* no GET endpoint yet — show empty */ }
-
-    const prLabelIds = new Set(prLabels.map(l => l.id || l.label_id || ''));
-    const authed = !!getToken();
-
-    const labelChips = prLabels.length
-      ? prLabels.map(l =>
-          `<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:10px;
-            font-size:11px;font-weight:600;background:${l.color ? l.color + '33' : '#21262d'};
-            color:${l.color || '#8b949e'};border:1px solid ${l.color ? l.color + '55' : '#30363d'}">
-            ${escHtml(l.name)}
-            ${authed ? `<button onclick="removePRLabel('${escHtml(l.id || l.label_id || '')}')"
-              style="background:none;border:none;color:${l.color || '#8b949e'};cursor:pointer;
-                font-size:10px;padding:0;margin-left:2px" title="Remove label">×</button>` : ''}
-          </span>`).join(' ')
-      : '<span style="font-size:12px;color:#8b949e">None yet</span>';
-
-    let editHtml = '';
-    if (authed && allLabels.length > 0) {
-      const opts = allLabels
-        .filter(l => !prLabelIds.has(l.id || l.label_id || ''))
-        .map(l => `<option value="${escHtml(l.id || l.label_id || '')}">${escHtml(l.name)}</option>`)
-        .join('');
-      editHtml = opts ? `
-        <div style="margin-top:8px;display:flex;gap:6px;align-items:center">
-          <select id="label-add-select" style="flex:1;background:#21262d;color:#e6edf3;
-            border:1px solid #30363d;border-radius:4px;padding:3px 6px;font-size:12px">
-            <option value="">Add label…</option>
-            ${opts}
-          </select>
-          <button onclick="addPRLabel()" style="padding:3px 10px;border-radius:4px;border:1px solid #30363d;
-            background:#21262d;color:#e6edf3;cursor:pointer;font-size:12px">Add</button>
-        </div>` : '';
-    }
-
-    section.innerHTML = `
-      <h3 style="font-size:13px;font-weight:600;color:#8b949e;margin:0 0 8px;text-transform:uppercase;
-        letter-spacing:.05em">Labels</h3>
-      <div style="display:flex;flex-wrap:wrap;gap:4px">${labelChips}</div>
-      ${editHtml}`;
-  } catch (e) {
-    // Non-fatal — label section degrades gracefully.
-  }
-}
-
-/** Assign a label to this PR (maintainer action). */
-async function addPRLabel() {
-  const sel = document.getElementById('label-add-select');
-  if (!sel || !sel.value) return;
-  try {
-    await apiFetch('/repos/' + repoId + '/pull-requests/' + prId + '/labels', {
-      method: 'POST',
-      body: JSON.stringify({ label_ids: [sel.value] }),
-    });
-    await loadPRLabels();
-  } catch (e) {
-    if (e.message !== 'auth') alert('Could not add label: ' + e.message);
-  }
-}
-
-/** Remove a label from this PR (maintainer action). */
-async function removePRLabel(labelId) {
-  if (!labelId) return;
-  try {
-    await apiFetch('/repos/' + repoId + '/pull-requests/' + prId + '/labels/' + labelId,
-      { method: 'DELETE' });
-    await loadPRLabels();
-  } catch (e) {
-    if (e.message !== 'auth') alert('Could not remove label: ' + e.message);
-  }
-}
-
-// ── Collapsible commit diff panels ────────────────────────────────────────────
-
-/**
- * Fetch the commits on the head branch that are not on the base branch,
- * then for each commit render a collapsible panel showing similarity % and
- * an 8-axis emotion-diff mini radar chart relative to the to_branch.
- */
-async function loadCommitDiffPanels(fromBranch, toBranch) {
-  const container = document.getElementById('commit-diff-panels');
-  if (!container) return;
-  container.innerHTML = '<p style="color:#8b949e;font-size:13px">Loading commit diffs…</p>';
-  try {
-    // Fetch head-branch commits (newest first, limit to 8 for performance).
-    const commitsData = await apiFetch(
-      '/repos/' + repoId + '/commits?branch=' + encodeURIComponent(fromBranch) + '&limit=8'
-    ).catch(() => null);
-    const commits = (commitsData && commitsData.commits) ? commitsData.commits : [];
-    if (!commits.length) {
-      container.innerHTML = '<p style="color:#8b949e;font-size:13px">No commits found on this branch.</p>';
-      return;
-    }
-
-    // Render a placeholder panel for each commit immediately, then fill async.
-    container.innerHTML = commits.map((c, idx) => `
-      <details id="commit-panel-${idx}" style="margin-bottom:8px;border:1px solid #30363d;
-          border-radius:6px;background:#0d1117;overflow:hidden">
-        <summary style="display:flex;align-items:center;gap:10px;padding:8px 12px;cursor:pointer;
-            list-style:none;user-select:none;background:#161b22">
-          <span style="font-family:monospace;font-size:12px;color:#58a6ff">${escHtml((c.commitId || '').substring(0,8))}</span>
-          <span style="flex:1;font-size:13px;color:#e6edf3;overflow:hidden;text-overflow:ellipsis;
-              white-space:nowrap">${escHtml(c.message || '(no message)')}</span>
-          <span style="font-size:11px;color:#8b949e">${fmtDate(c.createdAt || c.committedAt || null)}</span>
-          <span style="font-size:11px">▸</span>
-        </summary>
-        <div id="commit-panel-body-${idx}" style="padding:12px">
-          <p style="color:#8b949e;font-size:12px">Loading diff…</p>
-        </div>
-      </details>`).join('');
-
-    // Fill each panel body asynchronously.
-    commits.forEach(async (c, idx) => {
-      const bodyEl = document.getElementById('commit-panel-body-' + idx);
-      if (!bodyEl) return;
-      try {
-        const commitRef = c.commitId || c.sha || '';
-        const [sim, emo] = await Promise.allSettled([
-          apiFetch('/repos/' + repoId + '/analysis/' + encodeURIComponent(commitRef) +
-                   '/similarity?compare=' + encodeURIComponent(toBranch)),
-          apiFetch('/repos/' + repoId + '/analysis/' + encodeURIComponent(commitRef) +
-                   '/emotion-diff?base=' + encodeURIComponent(toBranch)),
-        ]);
-
-        const simData  = sim.status  === 'fulfilled' ? sim.value  : null;
-        const emoData  = emo.status  === 'fulfilled' ? emo.value  : null;
-
-        const simPct = simData ? Math.round((simData.overallSimilarity || 0) * 100) : null;
-        const simColor = simPct === null ? '#8b949e'
-          : simPct >= 80 ? '#3fb950' : simPct >= 50 ? '#f0883e' : '#f85149';
-
-        const simHtml = simPct !== null
-          ? `<div style="display:inline-flex;align-items:center;gap:6px;padding:4px 10px;
-              border-radius:4px;background:#0d2b00;border:1px solid ${simColor}33">
-              <span style="font-size:20px;font-weight:700;color:${simColor}">${simPct}%</span>
-              <span style="font-size:11px;color:#8b949e">similarity<br>to ${escHtml(toBranch)}</span>
-            </div>`
-          : '<span style="font-size:12px;color:#8b949e">Similarity unavailable</span>';
-
-        const deltaObj = (emoData && emoData.delta) ? emoData.delta : null;
-        const emoHtml  = deltaObj
-          ? `<div>
-              <div style="font-size:11px;color:#8b949e;margin-bottom:4px">Emotion delta vs ${escHtml(toBranch)}</div>
-              ${miniEmotionRadarSvg(deltaObj)}
-              ${emoData.interpretation
-                ? `<p style="font-size:11px;color:#8b949e;margin:4px 0 0">${escHtml(emoData.interpretation)}</p>` : ''}
-            </div>`
-          : '<span style="font-size:12px;color:#8b949e">Emotion diff unavailable</span>';
-
-        bodyEl.innerHTML = `
-          <div style="display:flex;gap:16px;align-items:flex-start;flex-wrap:wrap">
-            ${simHtml}
-            ${emoHtml}
-          </div>`;
-      } catch (e) {
-        bodyEl.innerHTML = '<p style="color:#8b949e;font-size:12px">Diff unavailable for this commit.</p>';
-      }
-    });
-  } catch (e) {
-    container.innerHTML = '<p style="color:#8b949e;font-size:13px">Could not load commit diffs.</p>';
-  }
-}
-
-// ── General discussion helpers ────────────────────────────────────────────────
-
-/**
- * Soft-delete a general discussion comment by ID and reload the thread.
- */
-async function deleteComment(commentId) {
-  if (!confirm('Delete this comment?')) return;
-  try {
-    await apiFetch('/repos/' + repoId + '/comments/' + commentId, { method: 'DELETE' });
-    await refreshComments();
-  } catch(e) {
-    if (e.message !== 'auth') alert('Delete failed: ' + e.message);
-  }
-}
-
-/**
- * Fetch general discussion comments and re-render via loadComments alias.
- * Satisfies the refreshComments API used by the discussion section.
- */
-async function refreshComments() {
-  await loadComments();
-}
-
-// ── Main loader ──────────────────────────────────────────────────────────────
-async function load() {
-  initRepoNav(repoId);
-  document.getElementById('content').innerHTML =
-    '<p class="loading">Loading PR&#8230;</p>';
-
-  try {
-    // Fetch PR metadata and musical diff in parallel.
-    const [pr, diff] = await Promise.all([
-      apiFetch(apiBase + '/pull-requests/' + prId),
-      apiFetch(apiBase + '/pull-requests/' + prId + '/diff').catch(() => null),
-    ]);
-
-    const dims          = (diff && diff.dimensions) ? diff.dimensions : [];
-    const overallScore  = (diff && diff.overallScore) ? diff.overallScore : 0;
-    const pct           = Math.round(overallScore * 100);
-    const ancestor      = (diff && diff.commonAncestor) ? diff.commonAncestor.substring(0, 8) : null;
-    const affected      = (diff && diff.affectedSections) ? diff.affectedSections : [];
-    const fromBranch    = pr.fromBranch || '';
-    const toBranch      = pr.toBranch   || '';
-
-    // ── Merge controls (only for open PRs) ───────────────────────────────────
-    // pr.mergeable may be absent in older API responses — treat undefined as true.
-    const isMergeable = pr.mergeable !== false;
-    const mergeSection = pr.state === 'open' ? `
-      <div class="card" style="margin-top:24px">
-        <h2 style="margin:0 0 12px;font-size:16px;color:#e6edf3">Merge Pull Request</h2>
-        ${!isMergeable ? `<div style="padding:8px 12px;border-radius:6px;background:#341a00;border:1px solid #f0883e44;
-            font-size:13px;color:#f0883e;margin-bottom:12px">
-          ⚠️ This pull request has conflicts and cannot be merged automatically.
-        </div>` : ''}
-        <div style="display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap">
-          <button id="strategy-merge_commit" onclick="selectStrategy('merge_commit')"
-            ${!isMergeable ? 'disabled' : ''}
-            style="padding:6px 14px;border-radius:6px;border:1px solid #1f6feb;cursor:${isMergeable ? 'pointer' : 'not-allowed'};
-              font-size:13px;background:#1f6feb;color:#fff;opacity:${isMergeable ? '1' : '0.5'}">
-            Merge commit
-          </button>
-          <button id="strategy-squash" onclick="selectStrategy('squash')"
-            ${!isMergeable ? 'disabled' : ''}
-            style="padding:6px 14px;border-radius:6px;border:1px solid #30363d;cursor:${isMergeable ? 'pointer' : 'not-allowed'};
-              font-size:13px;background:#21262d;color:#8b949e;opacity:${isMergeable ? '1' : '0.5'}">
-            Squash &amp; merge
-          </button>
-          <button id="strategy-rebase" onclick="selectStrategy('rebase')"
-            ${!isMergeable ? 'disabled' : ''}
-            style="padding:6px 14px;border-radius:6px;border:1px solid #30363d;cursor:${isMergeable ? 'pointer' : 'not-allowed'};
-              font-size:13px;background:#21262d;color:#8b949e;opacity:${isMergeable ? '1' : '0.5'}">
-            Rebase &amp; merge
-          </button>
-        </div>
-        <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">
-          <input type="checkbox" id="cb-delete-branch" checked
-            style="width:14px;height:14px;accent-color:#1f6feb;cursor:pointer">
-          <label for="cb-delete-branch" style="font-size:13px;color:#e6edf3;cursor:pointer">
-            Delete branch after merge
-          </label>
-        </div>
-        <button class="btn btn-primary" onclick="mergePrWithStrategy()"
-          ${!isMergeable ? 'disabled' : ''}
-          style="font-size:14px;padding:10px 24px;opacity:${isMergeable ? '1' : '0.5'};
-            cursor:${isMergeable ? 'pointer' : 'not-allowed'}">
-          &#10003; Merge pull request
-        </button>
-      </div>` : '';
-
-    // ── Affected sections ─────────────────────────────────────────────────────
-    const affectedHtml = affected.length > 0
-      ? `<div style="margin-top:10px;font-size:13px;color:#8b949e">
-          Affected sections: ${affected.map(s => `<span style="margin-right:6px;padding:2px 8px;
-            background:#21262d;border-radius:10px;font-size:11px;color:#e6edf3">${escHtml(s)}</span>`).join('')}
-         </div>` : '';
-
-    // ── PR timeline ───────────────────────────────────────────────────────────
-    const timelineHtml = `
-      <div class="card" style="margin-bottom:24px">
-        <h2 style="margin:0 0 12px;font-size:16px;color:#e6edf3">PR Timeline</h2>
-        ${timelineRow('🟢', `Opened by ${pr.author || 'unknown'}`, pr.createdAt)}
-        ${pr.state === 'merged' && pr.mergeCommitId
-          ? timelineRow('🟣', `Merged — commit <a href="${base}/commits/${pr.mergeCommitId}"
-              style="font-family:monospace;color:#58a6ff">${pr.mergeCommitId.substring(0,8)}</a>`, null)
-          : ''}
-        ${pr.state === 'closed' && !pr.mergeCommitId
-          ? timelineRow('🔴', 'Closed without merging', null)
-          : ''}
-        ${pr.state === 'open' ? timelineRow('⏳', 'Awaiting review', null) : ''}
-      </div>`;
-
-    document.getElementById('content').innerHTML = `
-      <!-- ── Back nav ──────────────────────────────────────────────────── -->
-      <div style="margin-bottom:12px">
-        <a href="${base}/pulls">&larr; Back to pull requests</a>
-      </div>
-
-      <!-- ── PR header ─────────────────────────────────────────────────── -->
-      <div class="card" style="margin-bottom:24px">
-        <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;flex-wrap:wrap">
-          <h1 style="margin:0;font-size:20px;color:#e6edf3">${escHtml(pr.title)}</h1>
-          <span class="badge badge-${pr.state}">${pr.state}</span>
-        </div>
-        <div class="meta-row">
-          ${pr.author ? `
-          <div class="meta-item">
-            <span class="meta-label">Author</span>
-            <span class="meta-value" style="display:flex;align-items:center;gap:6px">
-              <span style="display:inline-flex;align-items:center;justify-content:center;width:20px;
-                height:20px;border-radius:50%;background:var(--accent,#58a6ff);color:#0d1117;
-                font-size:11px;font-weight:700;flex-shrink:0">
-                ${escHtml(pr.author.charAt(0).toUpperCase())}</span>
-              <a href="${base.replace(/\/[^/]+\/[^/]+$/, '')}/users/${encodeURIComponent(escHtml(pr.author))}">
-                ${escHtml(pr.author)}</a>
-            </span>
-          </div>` : ''}
-          <div class="meta-item">
-            <span class="meta-label">From</span>
-            <span class="meta-value" style="font-family:monospace">${escHtml(fromBranch)}</span>
-          </div>
-          <div class="meta-item">
-            <span class="meta-label">Into</span>
-            <span class="meta-value" style="font-family:monospace">${escHtml(toBranch)}</span>
-          </div>
-          <div class="meta-item">
-            <span class="meta-label">Created</span>
-            <span class="meta-value">${fmtDate(pr.createdAt)}</span>
-          </div>
-          ${pr.mergeCommitId ? `
-          <div class="meta-item">
-            <span class="meta-label">Merge commit</span>
-            <span class="meta-value" style="font-family:monospace">
-              <a href="${base}/commits/${pr.mergeCommitId}">${pr.mergeCommitId.substring(0,8)}</a>
-            </span>
-          </div>` : ''}
-        </div>
-        ${pr.body ? `<div style="margin-top:12px;font-size:14px;color:#e6edf3;line-height:1.6;
-            border-top:1px solid #21262d;padding-top:12px">${renderMarkdown(pr.body)}</div>` : ''}
-        ${mergeSection}
-      </div>
-
-      <!-- ── Sidebar: Labels + Milestone ─────────────────────────────── -->
-      <div style="display:grid;grid-template-columns:1fr 240px;gap:16px;margin-bottom:24px;
-          align-items:start" class="pr-sidebar-grid">
-        <!-- Main meta (reactions) -->
-        <div class="card" style="padding:var(--space-3) var(--space-4)">
-          <div id="pr-reactions" class="reaction-bar"><p class="text-muted text-sm">Loading reactions…</p></div>
-        </div>
-        <!-- Sidebar column -->
-        <div style="display:flex;flex-direction:column;gap:12px">
-          <!-- Labels -->
-          <div class="card" style="padding:12px">
-            <div id="pr-labels-section">
-              <h3 style="font-size:13px;font-weight:600;color:#8b949e;margin:0 0 8px;text-transform:uppercase;
-                letter-spacing:.05em">Labels</h3>
-              <p style="font-size:12px;color:#8b949e;margin:0">Loading…</p>
-            </div>
-          </div>
-          <!-- Milestone -->
-          ${(pr.milestoneId || pr.milestone_id || pr.milestoneTitle || pr.milestone_title) ? `
-          <div class="card" style="padding:12px">
-            <h3 style="font-size:13px;font-weight:600;color:#8b949e;margin:0 0 8px;text-transform:uppercase;
-              letter-spacing:.05em">Milestone</h3>
-            <div style="display:flex;align-items:center;gap:6px">
-              <span style="font-size:14px">🏁</span>
-              <span style="font-size:13px;color:#e6edf3">
-                ${escHtml(pr.milestoneTitle || pr.milestone_title || pr.milestoneId || pr.milestone_id || '')}
-              </span>
-            </div>
-          </div>` : ''}
-        </div>
-      </div>
-
-      <!-- ── Musical diff radar + badges ───────────────────────────────── -->
-      ${dims.length > 0 ? `
-      <div style="display:grid;grid-template-columns:1fr auto;gap:24px;align-items:start;
-          margin-bottom:24px;flex-wrap:wrap">
-        <div>
-          <h2 style="margin:0 0 12px;font-size:16px;color:#e6edf3">Musical Diff</h2>
-          <div style="text-align:center;margin-bottom:16px">
-            <div style="font-size:40px;font-weight:700;color:#e6edf3">${pct}%</div>
-            <div style="font-size:12px;color:#8b949e">overall musical change</div>
-            ${ancestor ? `<div style="font-size:11px;color:#8b949e;margin-top:4px">
-              Merge base: <span class="text-mono">${escHtml(ancestor)}</span>
-            </div>` : ''}
-          </div>
-          ${dims.map(diffBadge).join('')}
-          ${affectedHtml}
-        </div>
-        <div style="flex-shrink:0">
-          <div style="width:280px">${radarSvg(dims)}</div>
-        </div>
-      </div>` : ''}
-
-      <!-- ── Reviewer status panel ────────────────────────────────────── -->
-      <div class="card" style="margin-bottom:24px">
-        <h2 style="margin:0 0 12px;font-size:16px;color:#e6edf3">Reviewers</h2>
-        <div id="reviewer-chips" style="display:flex;flex-wrap:wrap;gap:8px;min-height:28px">
-          <p style="color:#8b949e;font-size:13px;margin:0">Loading reviewers…</p>
-        </div>
-        ${pr.state === 'open' && getToken() ? `
-        <details id="review-form-details" style="margin-top:16px;border-top:1px solid #21262d;padding-top:12px">
-          <summary style="cursor:pointer;font-weight:600;color:#58a6ff;font-size:14px;
-              list-style:none;user-select:none">
-            ▸ Submit your review
-          </summary>
-          <div style="margin-top:12px">
-            <textarea id="review-body" rows="3"
-              placeholder="Leave a review comment (required when requesting changes)…"
-              style="width:100%;background:#21262d;color:#e6edf3;border:1px solid #30363d;
-                border-radius:6px;padding:8px;resize:vertical;font-size:13px;box-sizing:border-box"></textarea>
-            <div style="display:flex;gap:8px;margin-top:8px;flex-wrap:wrap">
-              <button onclick="submitReview('approve')" class="btn btn-primary"
-                style="font-size:13px;padding:6px 14px">✓ Approve</button>
-              <button onclick="submitReview('request_changes')"
-                style="padding:6px 14px;border-radius:6px;border:1px solid #f0883e;cursor:pointer;
-                  font-size:13px;background:#341a00;color:#f0883e">
-                ⚠ Request changes
-              </button>
-              <button onclick="submitReview('comment')"
-                style="padding:6px 14px;border-radius:6px;border:1px solid #30363d;cursor:pointer;
-                  font-size:13px;background:#21262d;color:#8b949e">
-                💬 Comment only
-              </button>
-            </div>
-          </div>
-        </details>` : ''}
-      </div>
-
-      <!-- ── Piano roll diff ───────────────────────────────────────────── -->
-      <div class="card" style="margin-bottom:24px">
-        <h2 style="margin:0 0 12px;font-size:16px;color:#e6edf3">Piano Roll Comparison</h2>
-        <div style="font-size:12px;color:#8b949e;margin-bottom:12px">
-          Before/after note representation from branch name seeds — green = added in
-          <code>${escHtml(fromBranch)}</code>, red = removed.
-        </div>
-        ${pianoRollSvg(fromBranch, toBranch)}
-      </div>
-
-      <!-- ── Collapsible musical diff panels (per commit) ────────────── -->
-      <div class="card" style="margin-bottom:24px">
-        <h2 style="margin:0 0 12px;font-size:16px;color:#e6edf3">Commit Musical Diffs</h2>
-        <p style="font-size:12px;color:#8b949e;margin:0 0 12px">
-          Similarity to <code style="font-size:11px">${escHtml(toBranch)}</code> and
-          emotional character shift for each commit on <code style="font-size:11px">${escHtml(fromBranch)}</code>.
-        </p>
-        <div id="commit-diff-panels"></div>
-      </div>
-
-      <!-- ── Audio A/B comparison ──────────────────────────────────────── -->
-      <div class="card" style="margin-bottom:24px">
-        <h2 style="margin:0 0 12px;font-size:16px;color:#e6edf3">Audio A/B Comparison</h2>
-        <div style="display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap">
-          <button id="btn-audio-from" onclick="toggleAudio('from', ${JSON.stringify(fromBranch)}, ${JSON.stringify(toBranch)})"
-            style="padding:6px 14px;border-radius:6px;border:none;cursor:pointer;font-size:13px;
-              background:#1f6feb;color:#fff">
-            &#9654; Base: ${escHtml(toBranch)}
-          </button>
-          <button id="btn-audio-to" onclick="toggleAudio('to', ${JSON.stringify(fromBranch)}, ${JSON.stringify(toBranch)})"
-            style="padding:6px 14px;border-radius:6px;border:none;cursor:pointer;font-size:13px;
-              background:#21262d;color:#8b949e">
-            &#9654; Head: ${escHtml(fromBranch)}
-          </button>
-        </div>
-        <div style="font-size:12px;color:#8b949e">
-          Listening to: <span id="audio-label" style="color:#e6edf3">${escHtml(toBranch)}</span>
-        </div>
-        <div style="margin-top:8px;font-size:12px;color:#484f58">
-          Audio render requires snapshot objects. Toggle queues the correct branch in the player.
-        </div>
-      </div>
-
-      <!-- ── PR Timeline ───────────────────────────────────────────────── -->
-      ${timelineHtml}
-
-      <!-- Review comments section -->
-      <div id="comment-section" class="card" style="margin-top:16px">
-        <h2 style="margin:0 0 12px">Review comments (<span id="comment-count">0</span>)</h2>
-        <div id="comment-list"></div>
-
-        <!-- New top-level comment form -->
-        <details style="margin-top:16px">
-          <summary style="cursor:pointer;font-weight:600;color:var(--accent,#58a6ff)">Leave a review comment</summary>
-          <div style="margin-top:12px">
-            <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px;margin-bottom:8px">
-              <div>
-                <label style="font-size:12px;color:var(--fg2,#8b949e)">Target</label>
-                <select id="new-comment-target" style="width:100%;background:var(--surface2,#21262d);color:var(--fg,#e6edf3);border:1px solid var(--border,#30363d);border-radius:4px;padding:4px">
-                  <option value="general">General</option>
-                  <option value="track">Track</option>
-                  <option value="region">Region</option>
-                  <option value="note">Note</option>
-                </select>
-              </div>
-              <div>
-                <label style="font-size:12px;color:var(--fg2,#8b949e)">Track name</label>
-                <input id="new-comment-track" type="text" placeholder="e.g. bass"
-                  style="width:100%;background:var(--surface2,#21262d);color:var(--fg,#e6edf3);border:1px solid var(--border,#30363d);border-radius:4px;padding:4px">
-              </div>
-              <div style="display:flex;gap:6px">
-                <div style="flex:1">
-                  <label style="font-size:12px;color:var(--fg2,#8b949e)">Beat start</label>
-                  <input id="new-comment-beat-start" type="number" min="0" step="0.5" placeholder="16"
-                    style="width:100%;background:var(--surface2,#21262d);color:var(--fg,#e6edf3);border:1px solid var(--border,#30363d);border-radius:4px;padding:4px">
-                </div>
-                <div style="flex:1">
-                  <label style="font-size:12px;color:var(--fg2,#8b949e)">Beat end</label>
-                  <input id="new-comment-beat-end" type="number" min="0" step="0.5" placeholder="24"
-                    style="width:100%;background:var(--surface2,#21262d);color:var(--fg,#e6edf3);border:1px solid var(--border,#30363d);border-radius:4px;padding:4px">
-                </div>
-              </div>
-            </div>
-            <textarea id="new-comment-body" rows="4" placeholder="Write a review comment (Markdown supported)…"
-              style="width:100%;background:var(--surface2,#21262d);color:var(--fg,#e6edf3);border:1px solid var(--border,#30363d);border-radius:6px;padding:8px;resize:vertical;font-size:13px"></textarea>
-            <div style="margin-top:8px">
-              <button onclick="submitComment(null)" class="btn btn-primary">Comment</button>
-            </div>
-          </div>
-        </details>
-      </div>`;
-
-    loadReactions('pull_request', prId, 'pr-reactions');
-    loadReviewers();
-    loadPRLabels();
-    loadCommitDiffPanels(fromBranch, toBranch);
-    await loadComments();
-  } catch(e) {
-    if (e.message !== 'auth')
-      document.getElementById('content').innerHTML =
-        '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
-  }
-}
-
-load();
-{% endraw %}
-{% endblock %}
-
 {% block extra_css %}
 <style>
-/* ── Reaction bar ───────────────────────────────────────────────────────────── */
-.reaction-bar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-1);
-  min-height: 32px;
-}
-
-.reaction-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 10px;
-  border-radius: var(--radius-full);
-  border: 1px solid var(--border-subtle);
-  background: var(--bg-overlay);
-  color: var(--text-secondary);
-  font-size: var(--font-size-sm);
-  cursor: pointer;
-  transition: border-color 0.15s, background 0.15s;
-}
-
-.reaction-btn:hover:not(:disabled) {
-  border-color: var(--accent, #58a6ff);
-  background: var(--bg-inset);
-}
-
-.reaction-btn--active {
-  border-color: var(--accent, #58a6ff);
-  background: #1d3557;
-  color: var(--accent, #58a6ff);
-}
-
-.reaction-btn:disabled {
-  cursor: default;
-  opacity: 0.6;
-}
-
-.reaction-count {
-  font-size: 11px;
-  font-weight: 600;
-}
-
-/* ── PR sidebar grid (labels + milestone) ───────────────────────────────────── */
-.pr-sidebar-grid {
+/* ── PR detail layout ───────────────────────────────────────────────────── */
+.pr-detail-layout {
+  display: grid;
   grid-template-columns: 1fr 240px;
+  gap: var(--space-4);
+  align-items: start;
 }
-@media (max-width: 720px) {
-  .pr-sidebar-grid {
-    grid-template-columns: 1fr;
-  }
+@media (max-width: 768px) {
+  .pr-detail-layout { grid-template-columns: 1fr; }
+  .pr-sidebar { display: none; }
 }
 
-/* ── Reviewer chip states ────────────────────────────────────────────────────── */
+/* ── Branch pills ────────────────────────────────────────────────────────── */
+.branch-pill {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-family: monospace;
+  background: var(--color-surface-2, #161b22);
+  border: 1px solid var(--color-border);
+  color: var(--color-fg, #e6edf3);
+}
+
+/* ── Diff stats ──────────────────────────────────────────────────────────── */
+.diff-stat { display: flex; gap: var(--space-3); font-size: 13px; flex-wrap: wrap; }
+.diff-stat-additions { color: #3fb950; font-weight: 600; }
+.diff-stat-deletions { color: #f85149; font-weight: 600; }
+.diff-stat-files     { color: #8b949e; }
+
+/* ── Review chips ────────────────────────────────────────────────────────── */
 .reviewer-chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   padding: 4px 10px 4px 4px;
-  border-radius: var(--radius-full, 999px);
-  border: 1px solid var(--border-subtle);
-  background: var(--bg-overlay);
+  border-radius: 999px;
   font-size: 12px;
-  cursor: default;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-2, #161b22);
 }
+.reviewer-chip--approved       { border-color: #3fb95055; }
+.reviewer-chip--changes        { border-color: #f0883e55; }
+.reviewer-chip--pending        { border-color: #8b949e33; }
 
-/* ── Commit diff panels ──────────────────────────────────────────────────────── */
-#commit-diff-panels details > summary::-webkit-details-marker { display: none; }
-#commit-diff-panels details[open] > summary > span:last-child { transform: rotate(90deg); display: inline-block; }
-
-/* ── Comment threads ────────────────────────────────────────────────────────── */
-.comment-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-}
-
-.comment-thread {
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-base);
-  background: var(--bg-overlay);
+/* ── Comments ────────────────────────────────────────────────────────────── */
+.comment-block {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
   overflow: hidden;
+  margin-bottom: var(--space-3);
 }
-
-.comment-reply {
-  border: none;
-  border-top: 1px solid var(--border-subtle);
-  border-radius: 0;
-  background: var(--bg-inset);
-  margin-left: var(--space-4);
-}
-
-.comment-header {
+.comment-header-row {
   display: flex;
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
-  border-bottom: 1px solid var(--border-subtle);
-  background: var(--bg-inset);
+  background: var(--color-surface-2, #161b22);
+  border-bottom: 1px solid var(--color-border);
+  font-size: 13px;
 }
-
-.comment-body {
+.comment-body-text {
   padding: var(--space-3);
-  font-size: var(--font-size-sm);
-  color: var(--text-primary);
+  font-size: 13px;
+  color: var(--color-fg, #e6edf3);
   white-space: pre-wrap;
   word-break: break-word;
 }
-
-.comment-actions {
-  padding: var(--space-1) var(--space-3) var(--space-2);
-  display: flex;
-  gap: var(--space-1);
+.comment-reply {
+  margin-left: var(--space-4);
+  border-top: 1px solid var(--color-border);
 }
 
-.reply-form {
-  padding: var(--space-2) var(--space-3) var(--space-3);
-  border-top: 1px solid var(--border-subtle);
-  background: var(--bg-inset);
+/* ── Merge button states ─────────────────────────────────────────────────── */
+.merge-btn-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
-
-.reply-textarea {
-  width: 100%;
-  resize: vertical;
-  font-family: var(--font-sans);
-}
-
-.replies-container {
-  border-top: 1px solid var(--border-subtle);
-}
-
-.new-comment-form {
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--border-subtle);
+.merge-warning {
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: #341a00;
+  border: 1px solid #f0883e44;
+  font-size: 13px;
+  color: #f0883e;
+  margin-bottom: var(--space-3);
 }
 </style>
+{% endblock %}
+
+{% block content %}
+<div style="margin-bottom:var(--space-3)">
+  <a href="{{ base_url }}/pulls">← Back to pull requests</a>
+</div>
+
+<div class="pr-detail-layout">
+  {# ── Main column ── #}
+  <div>
+
+    {# PR header card #}
+    <div class="card" style="margin-bottom:var(--space-4)">
+      <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap">
+        <h1 style="margin:0;font-size:20px;color:var(--color-fg,#e6edf3)">{{ pr.title }}</h1>
+        {% if pr.state == 'merged' %}
+          <span class="badge badge-merged">Merged</span>
+        {% elif pr.state == 'closed' %}
+          <span class="badge badge-closed">Closed</span>
+        {% else %}
+          <span class="badge badge-open">Open</span>
+        {% endif %}
+      </div>
+
+      <div class="meta-row" style="display:flex;flex-wrap:wrap;gap:var(--space-3);font-size:13px;color:#8b949e;margin-bottom:var(--space-3)">
+        {% if pr.author %}
+          <span><strong style="color:var(--color-fg,#e6edf3)">{{ pr.author }}</strong> opened this</span>
+        {% endif %}
+        <span class="branch-pill">{{ pr.from_branch }}</span>
+        <span>→</span>
+        <span class="branch-pill">{{ pr.to_branch }}</span>
+        <span>{{ pr.created_at | fmtdate }}</span>
+        {% if pr.state == 'merged' and pr.merge_commit_id %}
+          <span>merged as
+            <a href="{{ base_url }}/commits/{{ pr.merge_commit_id }}"
+               style="font-family:monospace;font-size:11px;color:#8b49da">{{ pr.merge_commit_id[:8] }}</a>
+          </span>
+        {% endif %}
+      </div>
+
+      {% if pr.body %}
+        <div style="border-top:1px solid var(--color-border);padding-top:var(--space-3);
+             font-size:14px;color:var(--color-fg,#e6edf3);line-height:1.6;white-space:pre-wrap">
+          {{ pr.body }}
+        </div>
+      {% endif %}
+    </div>
+
+    {# Review summary #}
+    {% if reviews %}
+      <div class="card" style="margin-bottom:var(--space-4)">
+        <h2 style="margin:0 0 var(--space-3);font-size:16px">Reviewers</h2>
+        <div style="display:flex;flex-wrap:wrap;gap:var(--space-2);margin-bottom:var(--space-3)">
+          {% for review in reviews %}
+            <div class="reviewer-chip reviewer-chip--{{ 'approved' if review.state == 'approved' else ('changes' if review.state == 'changes_requested' else 'pending') }}"
+                 title="{{ review.reviewer_username }} — {{ review.state }}">
+              <span style="display:inline-flex;align-items:center;justify-content:center;
+                width:22px;height:22px;border-radius:50%;
+                background:{{ '#3fb95033' if review.state == 'approved' else ('#f0883e33' if review.state == 'changes_requested' else '#8b949e33') }};
+                color:{{ '#3fb950' if review.state == 'approved' else ('#f0883e' if review.state == 'changes_requested' else '#8b949e') }};
+                font-size:12px;font-weight:700">
+                {{ review.reviewer_username[0].upper() if review.reviewer_username else '?' }}
+              </span>
+              <span>{{ review.reviewer_username }}</span>
+              <span style="font-size:10px;padding:1px 6px;border-radius:10px;
+                background:{{ '#3fb95022' if review.state == 'approved' else ('#f0883e22' if review.state == 'changes_requested' else '#8b949e22') }};
+                color:{{ '#3fb950' if review.state == 'approved' else ('#f0883e' if review.state == 'changes_requested' else '#8b949e') }}">
+                {{ review.state | replace('_', ' ') | title }}
+              </span>
+            </div>
+          {% endfor %}
+        </div>
+        {% if approved_count > 0 or changes_count > 0 %}
+          <div style="font-size:12px;color:#8b949e">
+            {% if approved_count > 0 %}
+              <span style="color:#3fb950">✓ {{ approved_count }} approved</span>
+            {% endif %}
+            {% if changes_count > 0 %}
+              <span style="color:#f0883e;margin-left:var(--space-2)">⚠ {{ changes_count }} changes requested</span>
+            {% endif %}
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
+
+    {# Merge controls — only for open PRs #}
+    {% if pr.state == 'open' %}
+      <div class="card" style="margin-bottom:var(--space-4)" id="merge-section">
+        <h2 style="margin:0 0 var(--space-3);font-size:16px">Merge Pull Request</h2>
+        <div style="display:flex;gap:var(--space-2);margin-bottom:var(--space-3);flex-wrap:wrap">
+          <button class="btn btn-primary"
+                  hx-post="/api/v1/musehub/repos/{{ repo_id }}/pull-requests/{{ pr_id }}/merge"
+                  hx-ext="json-enc"
+                  hx-vals='{"mergeStrategy":"merge_commit","deleteBranch":true}'
+                  hx-target="#merge-section"
+                  hx-swap="outerHTML"
+                  hx-confirm="Merge this pull request using 'merge commit' strategy?">
+            ✓ Merge pull request
+          </button>
+          <button class="btn btn-secondary"
+                  hx-post="/api/v1/musehub/repos/{{ repo_id }}/pull-requests/{{ pr_id }}/merge"
+                  hx-ext="json-enc"
+                  hx-vals='{"mergeStrategy":"squash","deleteBranch":true}'
+                  hx-target="#merge-section"
+                  hx-swap="outerHTML"
+                  hx-confirm="Squash and merge this pull request?">
+            Squash &amp; merge
+          </button>
+          <button class="btn btn-secondary"
+                  hx-post="/api/v1/musehub/repos/{{ repo_id }}/pull-requests/{{ pr_id }}/merge"
+                  hx-ext="json-enc"
+                  hx-vals='{"mergeStrategy":"rebase","deleteBranch":true}'
+                  hx-target="#merge-section"
+                  hx-swap="outerHTML"
+                  hx-confirm="Rebase and merge this pull request?">
+            Rebase &amp; merge
+          </button>
+        </div>
+        <div style="font-size:12px;color:#8b949e">
+          <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
+            <input type="checkbox" id="cb-delete-branch" checked
+                   style="width:14px;height:14px;accent-color:var(--color-accent,#1f6feb)">
+            Delete branch after merge
+          </label>
+        </div>
+      </div>
+    {% elif pr.state == 'merged' %}
+      <div class="card" style="margin-bottom:var(--space-4);background:#0d2b00;border-color:#3fb95055">
+        <div style="display:flex;align-items:center;gap:var(--space-2)">
+          <span style="font-size:20px">✓</span>
+          <div>
+            <div style="font-size:14px;font-weight:600;color:#3fb950">Pull request merged</div>
+            {% if pr.merge_commit_id %}
+              <div style="font-size:12px;color:#8b949e">
+                Merge commit:
+                <a href="{{ base_url }}/commits/{{ pr.merge_commit_id }}"
+                   style="font-family:monospace;color:#58a6ff">{{ pr.merge_commit_id[:8] }}</a>
+              </div>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+    {# Comment thread — HTMX fragment target #}
+    <div id="pr-comments">
+      {% include "musehub/fragments/pr_comments.html" %}
+    </div>
+
+    {# New comment form — HTMX POST #}
+    <div class="card" style="margin-top:var(--space-4)">
+      <h3 style="margin:0 0 var(--space-3);font-size:15px">Leave a review comment</h3>
+      <form hx-post="/api/v1/musehub/repos/{{ repo_id }}/pull-requests/{{ pr_id }}/comments"
+            hx-target="#pr-comments"
+            hx-swap="innerHTML"
+            hx-ext="json-enc">
+        <textarea name="body" id="new-comment-body" rows="4"
+                  placeholder="Write a review comment (Markdown supported)…"
+                  style="width:100%;background:var(--color-surface-2,#21262d);
+                    color:var(--color-fg,#e6edf3);border:1px solid var(--color-border);
+                    border-radius:6px;padding:8px;resize:vertical;font-size:13px;
+                    box-sizing:border-box"></textarea>
+        <input type="hidden" name="target_type" value="general">
+        <div style="margin-top:var(--space-2)">
+          <button type="submit" class="btn btn-primary">Comment</button>
+        </div>
+      </form>
+    </div>
+
+  </div>
+
+  {# ── Sidebar ── #}
+  <aside class="pr-sidebar">
+
+    {# PR timeline #}
+    <div class="card" style="margin-bottom:var(--space-3)">
+      <p style="font-size:12px;font-weight:600;color:#8b949e;text-transform:uppercase;
+           letter-spacing:.05em;margin:0 0 var(--space-2)">Timeline</p>
+      <div style="font-size:12px;color:#8b949e;display:flex;flex-direction:column;gap:6px">
+        <div style="display:flex;align-items:center;gap:8px">
+          <span>🟢</span>
+          <span>Opened by <strong style="color:var(--color-fg,#e6edf3)">{{ pr.author or 'unknown' }}</strong></span>
+        </div>
+        {% if pr.state == 'merged' and pr.merge_commit_id %}
+          <div style="display:flex;align-items:center;gap:8px">
+            <span>🟣</span>
+            <span>Merged —
+              <a href="{{ base_url }}/commits/{{ pr.merge_commit_id }}"
+                 style="font-family:monospace;font-size:11px;color:#58a6ff">{{ pr.merge_commit_id[:8] }}</a>
+            </span>
+          </div>
+        {% elif pr.state == 'closed' %}
+          <div style="display:flex;align-items:center;gap:8px">
+            <span>🔴</span>
+            <span>Closed without merging</span>
+          </div>
+        {% else %}
+          <div style="display:flex;align-items:center;gap:8px">
+            <span>⏳</span>
+            <span>Awaiting review</span>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+
+    {# Review summary in sidebar #}
+    <div class="card" style="margin-bottom:var(--space-3)">
+      <p style="font-size:12px;font-weight:600;color:#8b949e;text-transform:uppercase;
+           letter-spacing:.05em;margin:0 0 var(--space-2)">Reviews</p>
+      {% if approved_count > 0 %}
+        <div style="font-size:12px;color:#3fb950;margin-bottom:4px">✓ {{ approved_count }} approved</div>
+      {% endif %}
+      {% if changes_count > 0 %}
+        <div style="font-size:12px;color:#f0883e;margin-bottom:4px">⚠ {{ changes_count }} changes requested</div>
+      {% endif %}
+      {% if approved_count == 0 and changes_count == 0 %}
+        <div style="font-size:12px;color:#8b949e">No reviews yet</div>
+      {% endif %}
+    </div>
+
+    {# Comment count #}
+    <div class="card">
+      <p style="font-size:12px;font-weight:600;color:#8b949e;text-transform:uppercase;
+           letter-spacing:.05em;margin:0 0 var(--space-2)">Comments</p>
+      <div style="font-size:13px;color:var(--color-fg,#e6edf3)">{{ comment_count }} comment{{ '' if comment_count == 1 else 's' }}</div>
+    </div>
+
+  </aside>
+</div>
+{% endblock %}
+
+{% block page_script %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  if (typeof initRepoNav === 'function') initRepoNav({{ repo_id | tojson }});
+});
+</script>
 {% endblock %}

--- a/maestro/templates/musehub/pages/pr_list.html
+++ b/maestro/templates/musehub/pages/pr_list.html
@@ -1,8 +1,10 @@
 {% extends "musehub/base.html" %}
+{% from "musehub/macros/empty_state.html" import empty_state %}
 
-{% block title %}Pull Requests{% endblock %}
+{% block title %}Pull Requests — {{ owner }}/{{ repo_slug }}{% endblock %}
 {% block breadcrumb %}
-  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ owner }}/{{ repo_slug }}</a> / pulls
+  <a href="/musehub/ui/{{ owner }}">{{ owner }}</a> /
+  <a href="/musehub/ui/{{ owner }}/{{ repo_slug }}">{{ repo_slug }}</a> / pulls
 {% endblock %}
 {% block repo_nav %}{% include "musehub/partials/repo_nav.html" %}{% endblock %}
 
@@ -11,205 +13,114 @@ const repoId = {{ repo_id | tojson }};
 const base   = {{ base_url | tojson }};
 {% endblock %}
 
+{% block extra_css %}
+<style>
+/* ── PR list layout ─────────────────────────────────────────────────────── */
+.pr-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+.pr-row:last-child { border-bottom: none; }
+
+.branch-pill {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-family: monospace;
+  background: var(--color-surface-2, #161b22);
+  border: 1px solid var(--color-border);
+  color: var(--color-fg, #e6edf3);
+}
+
+.pr-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-top: 4px;
+  font-size: 12px;
+  color: #8b949e;
+}
+
+/* ── Sort bar ────────────────────────────────────────────────────────────── */
+.sort-btn { font-size: 12px; padding: 3px 10px; }
+.sort-active {
+  background: var(--color-accent, #1f6feb) !important;
+  color: #fff !important;
+  border-color: var(--color-accent, #1f6feb) !important;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="card">
+  <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap">
+    <h1 style="margin:0">Pull Requests</h1>
+  </div>
+
+  {# ── State tabs — HTMX-powered ── #}
+  <div style="display:flex;gap:0;border-bottom:1px solid var(--color-border);margin-bottom:var(--space-3)">
+    <a href="{{ base_url }}/pulls?state=open"
+       class="tab-btn{% if state == 'open' or not state %} tab-active{% endif %}"
+       hx-get="{{ base_url }}/pulls?state=open"
+       hx-target="#pr-rows"
+       hx-push-url="true">
+      ○ Open <span class="tab-count">{{ open_count }}</span>
+    </a>
+    <a href="{{ base_url }}/pulls?state=merged"
+       class="tab-btn{% if state == 'merged' %} tab-active{% endif %}"
+       hx-get="{{ base_url }}/pulls?state=merged"
+       hx-target="#pr-rows"
+       hx-push-url="true">
+      ✓ Merged <span class="tab-count">{{ merged_count }}</span>
+    </a>
+    <a href="{{ base_url }}/pulls?state=closed"
+       class="tab-btn{% if state == 'closed' %} tab-active{% endif %}"
+       hx-get="{{ base_url }}/pulls?state=closed"
+       hx-target="#pr-rows"
+       hx-push-url="true">
+      ✗ Closed <span class="tab-count">{{ closed_count }}</span>
+    </a>
+    <a href="{{ base_url }}/pulls?state=all"
+       class="tab-btn{% if state == 'all' %} tab-active{% endif %}"
+       hx-get="{{ base_url }}/pulls?state=all"
+       hx-target="#pr-rows"
+       hx-push-url="true">
+      All <span class="tab-count">{{ open_count + merged_count + closed_count }}</span>
+    </a>
+  </div>
+
+  {# ── Sort bar ── #}
+  <div style="display:flex;align-items:center;gap:var(--space-2);margin-bottom:var(--space-3)">
+    <span style="font-size:13px;color:#8b949e">Sort:</span>
+    <a href="{{ base_url }}/pulls?state={{ state }}&sort=newest"
+       class="btn btn-ghost btn-sm sort-btn{% if active_sort == 'newest' %} sort-active{% endif %}"
+       hx-get="{{ base_url }}/pulls?state={{ state }}&sort=newest"
+       hx-target="#pr-rows"
+       hx-push-url="true">Newest</a>
+    <a href="{{ base_url }}/pulls?state={{ state }}&sort=oldest"
+       class="btn btn-ghost btn-sm sort-btn{% if active_sort == 'oldest' %} sort-active{% endif %}"
+       hx-get="{{ base_url }}/pulls?state={{ state }}&sort=oldest"
+       hx-target="#pr-rows"
+       hx-push-url="true">Oldest</a>
+  </div>
+
+  {# ── PR rows — HTMX swap target ── #}
+  <div id="pr-rows">
+    {% include "musehub/fragments/pr_rows.html" %}
+  </div>
+</div>
+{% endblock %}
+
 {% block page_script %}
-{% raw %}
-// ── State ──────────────────────────────────────────────────────────────────
-let allPRs     = [];      // full list from API (state-filtered only)
-let activeSort = 'newest'; // 'newest' | 'oldest'
-let cachedOpen   = null;  // cached open PRs after first fetch
-let cachedMerged = null;  // cached merged PRs after first fetch
-let cachedClosed = null;  // cached closed PRs after first fetch
-
-// ── Social signal cache ────────────────────────────────────────────────────
-let prCommentCounts = {};  // { prId: count }
-let prReactions     = {};  // { prId: [{emoji, count, reacted_by_me}] }
-
-// ── Body preview ───────────────────────────────────────────────────────────
-function bodyPreview(body) {
-  if (!body) return '';
-  const first = body.split('\n')[0].trim();
-  return first.length > 100 ? first.slice(0, 97) + '…' : first;
-}
-
-// ── Reaction pills (top 2 emojis + count) ─────────────────────────────────
-function reactionPills(prId) {
-  const rxns = (prReactions[prId] || []).slice().sort((a, b) => b.count - a.count).slice(0, 2);
-  if (!rxns.length) return '';
-  return rxns.map(r =>
-    `<span style="font-size:11px;color:#8b949e;background:var(--color-surface-2,#21262d);border-radius:4px;padding:1px 5px">${r.emoji}&nbsp;${r.count}</span>`
-  ).join('');
-}
-
-// ── Pre-fetch comment counts and reactions for all PRs (parallel) ──────────
-async function loadSocialSignals(prs) {
-  await Promise.all(prs.map(async pr => {
-    if (prCommentCounts[pr.prId] != null) return;  // already cached
-    const id = encodeURIComponent(pr.prId);
-    const [comments, rxns] = await Promise.all([
-      apiFetch('/repos/' + repoId + '/comments?target_type=pull_request&target_id=' + id).catch(() => []),
-      apiFetch('/repos/' + repoId + '/reactions?target_type=pull_request&target_id=' + id).catch(() => []),
-    ]);
-    prCommentCounts[pr.prId] = Array.isArray(comments) ? comments.length : 0;
-    prReactions[pr.prId]     = Array.isArray(rxns)     ? rxns            : [];
-  }));
-}
-
-// ── Sorting ────────────────────────────────────────────────────────────────
-function sortedPRs(prs) {
-  const copy = [...prs];
-  if (activeSort === 'oldest') {
-    copy.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
-  } else {
-    // newest (default)
-    copy.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-  }
-  return copy;
-}
-
-// ── Render rows ────────────────────────────────────────────────────────────
-function renderRows() {
-  const prs = sortedPRs(allPRs);
-  const container = document.getElementById('pr-rows');
-  if (!container) return;
-
-  if (prs.length === 0) {
-    container.innerHTML = '<p class="loading">No pull requests found.</p>';
-    return;
-  }
-
-  container.innerHTML = prs.map(pr => {
-    const preview = bodyPreview(pr.body);
-    let stateBadge;
-    let mergeInfo = '';
-    if (pr.state === 'merged') {
-      stateBadge = '<span class="badge badge-merged">Merged</span>';
-      if (pr.mergeCommitId) {
-        const shortSha = pr.mergeCommitId.slice(0, 8);
-        mergeInfo = `<a href="${base}/commits/${pr.mergeCommitId}" style="font-size:11px;font-family:monospace;color:#8b49da" title="Merge commit">${shortSha}</a>`;
-      }
-    } else if (pr.state === 'closed') {
-      stateBadge = '<span class="badge badge-closed">Closed</span>';
-    } else {
-      stateBadge = '<span class="badge badge-open">Open</span>';
-    }
-    const commentBadge = `<span style="font-size:11px;color:#8b949e">&#128172; ${prCommentCounts[pr.prId] || 0}</span>`;
-    const pills = reactionPills(pr.prId);
-    return `
-      <div class="pr-row">
-        ${stateBadge}
-        <div style="flex:1;min-width:0">
-          <a href="${base}/pulls/${pr.prId}">${escHtml(pr.title)}</a>
-          ${preview ? `<div class="issue-preview">${escHtml(preview)}</div>` : ''}
-          <div style="display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;margin-top:4px">
-            <span class="branch-pill">${escHtml(pr.fromBranch)}</span>
-            <span style="font-size:11px;color:#8b949e">&rarr;</span>
-            <span class="branch-pill">${escHtml(pr.toBranch)}</span>
-            <span style="font-size:11px;color:#8b949e">${fmtDate(pr.createdAt)}</span>
-            ${mergeInfo}
-            ${commentBadge}
-            ${pills}
-          </div>
-        </div>
-      </div>`;
-  }).join('');
-}
-
-// ── Sort control handler ───────────────────────────────────────────────────
-function changeSort(value) {
-  activeSort = value;
-  renderRows();
-  updateSortButtons();
-}
-
-// ── Keep sort button active styles in sync ─────────────────────────────────
-function updateSortButtons() {
-  document.querySelectorAll('.sort-btn[data-sort]').forEach(btn => {
-    btn.classList.toggle('sort-active', btn.dataset.sort === activeSort);
-  });
-}
-
-// ── Main load ──────────────────────────────────────────────────────────────
-async function load(state) {
-  initRepoNav(repoId);
-  try {
-    // Fetch only what is not yet cached — all states needed for tab counts.
-    const [openData, mergedData, closedData] = await Promise.all([
-      cachedOpen   !== null ? Promise.resolve({ pullRequests: cachedOpen })   : apiFetch('/repos/' + repoId + '/pull-requests?state=open'),
-      cachedMerged !== null ? Promise.resolve({ pullRequests: cachedMerged }) : apiFetch('/repos/' + repoId + '/pull-requests?state=merged'),
-      cachedClosed !== null ? Promise.resolve({ pullRequests: cachedClosed }) : apiFetch('/repos/' + repoId + '/pull-requests?state=closed'),
-    ]);
-
-    cachedOpen   = openData.pullRequests   || [];
-    cachedMerged = mergedData.pullRequests || [];
-    cachedClosed = closedData.pullRequests || [];
-
-    const openCount   = cachedOpen.length;
-    const mergedCount = cachedMerged.length;
-    const closedCount = cachedClosed.length;
-    const allCount    = openCount + mergedCount + closedCount;
-
-    if (state === 'merged')      allPRs = cachedMerged;
-    else if (state === 'closed') allPRs = cachedClosed;
-    else if (state === 'all')    allPRs = [...cachedOpen, ...cachedMerged, ...cachedClosed];
-    else                         allPRs = cachedOpen;
-
-    await loadSocialSignals(allPRs);
-
-    document.getElementById('content').innerHTML = `
-      <div class="card">
-        <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap">
-          <h1 style="margin:0">Pull Requests</h1>
-        </div>
-
-        <!-- State tabs: Open | Merged | Closed | All -->
-        <div style="display:flex;gap:0;border-bottom:1px solid var(--color-border);margin-bottom:var(--space-3)">
-          <button id="tab-open" class="tab-btn${state === 'open' || state === undefined ? ' tab-active' : ''}"
-                  onclick="load('open')">
-            &#9711; Open <span class="tab-count">${openCount}</span>
-          </button>
-          <button id="tab-merged" class="tab-btn${state === 'merged' ? ' tab-active' : ''}"
-                  onclick="load('merged')">
-            &#10022; Merged <span class="tab-count">${mergedCount}</span>
-          </button>
-          <button id="tab-closed" class="tab-btn${state === 'closed' ? ' tab-active' : ''}"
-                  onclick="load('closed')">
-            &#10007; Closed <span class="tab-count">${closedCount}</span>
-          </button>
-          <button id="tab-all" class="tab-btn${state === 'all' ? ' tab-active' : ''}"
-                  onclick="load('all')">
-            All <span class="tab-count">${allCount}</span>
-          </button>
-        </div>
-
-        <!-- Sort bar -->
-        <div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap">
-          <span style="font-size:13px;color:#8b949e">Sort by:</span>
-          <div style="display:flex;gap:var(--space-1)">
-            <button class="btn btn-ghost btn-sm sort-btn${activeSort === 'newest' ? ' sort-active' : ''}" data-sort="newest" onclick="changeSort('newest')">Newest</button>
-            <button class="btn btn-ghost btn-sm sort-btn${activeSort === 'oldest' ? ' sort-active' : ''}" data-sort="oldest" onclick="changeSort('oldest')">Oldest</button>
-          </div>
-        </div>
-
-        <!-- PR rows -->
-        <div id="pr-rows"></div>
-
-        ${allCount === 0 ? `
-          <div class="empty-state">
-            <div class="empty-icon">&#128268;</div>
-            <p class="empty-title">No pull requests yet</p>
-            <p class="empty-desc">Ready to propose a musical change? Compare branches and open a pull request.</p>
-          </div>` : ''}
-      </div>`;
-
-    // Initial render
-    renderRows();
-    updateSortButtons();
-  } catch(e) {
-    if (e.message !== 'auth')
-      document.getElementById('content').innerHTML = '<p class="error">&#10005; ' + escHtml(e.message) + '</p>';
-  }
-}
-
-load('open');
-{% endraw %}
+<script>
+// Minimal JS: repo nav initialisation only. All data is server-rendered.
+document.addEventListener('DOMContentLoaded', function() {
+  if (typeof initRepoNav === 'function') initRepoNav({{ repo_id | tojson }});
+});
+</script>
 {% endblock %}

--- a/tests/test_musehub_ui_pr_ssr.py
+++ b/tests/test_musehub_ui_pr_ssr.py
@@ -1,0 +1,220 @@
+"""SSR tests for Muse Hub PR list + PR detail pages — issue #569.
+
+Validates that PR data is rendered server-side into HTML (not deferred to client
+JS) and that HTMX fragment requests return bare HTML without the full page shell.
+
+Covers GET /musehub/ui/{owner}/{repo_slug}/pulls:
+- test_pr_list_renders_pr_title_server_side         — PR title appears in HTML
+- test_pr_list_open_closed_counts_in_tabs           — tab counts reflect seeded PRs
+- test_pr_list_htmx_fragment_on_tab_switch          — HX-Request: true → fragment
+
+Covers GET /musehub/ui/{owner}/{repo_slug}/pulls/{pr_id}:
+- test_pr_detail_renders_title_server_side          — PR title in HTML server-side
+- test_pr_detail_renders_diff_stats                 — branch info in HTML
+- test_pr_detail_merge_button_has_hx_post           — merge button has hx-post
+- test_pr_detail_merge_button_disabled_when_not_mergeable — closed PR → no merge button
+- test_pr_detail_unknown_number_404                 — non-existent pr_id → 404
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from maestro.db.musehub_models import MusehubPullRequest, MusehubRepo
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_repo(
+    db: AsyncSession,
+    owner: str = "prdev",
+    slug: str = "pr-ssr-album",
+) -> str:
+    """Seed a public repo and return its repo_id string."""
+    repo = MusehubRepo(
+        name=slug,
+        owner=owner,
+        slug=slug,
+        visibility="public",
+        owner_user_id="uid-pr-ssr-dev",
+    )
+    db.add(repo)
+    await db.commit()
+    await db.refresh(repo)
+    return str(repo.repo_id)
+
+
+async def _make_pr(
+    db: AsyncSession,
+    repo_id: str,
+    *,
+    title: str = "Add bossa nova bridge",
+    body: str = "Adds a new bossa nova bridge section.",
+    state: str = "open",
+    from_branch: str = "feat/bossa-nova",
+    to_branch: str = "main",
+    author: str = "beatmaker",
+) -> MusehubPullRequest:
+    """Seed a PR and return the ORM object."""
+    pr = MusehubPullRequest(
+        repo_id=repo_id,
+        title=title,
+        body=body,
+        state=state,
+        from_branch=from_branch,
+        to_branch=to_branch,
+        author=author,
+    )
+    db.add(pr)
+    await db.commit()
+    await db.refresh(pr)
+    return pr
+
+
+# ---------------------------------------------------------------------------
+# PR list SSR tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_pr_list_renders_pr_title_server_side(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """PR title is rendered into the HTML response server-side without client JS."""
+    repo_id = await _make_repo(db_session)
+    await _make_pr(db_session, repo_id, title="Funk bridge with wah pedal")
+    response = await client.get("/musehub/ui/prdev/pr-ssr-album/pulls")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "Funk bridge with wah pedal" in response.text
+
+
+@pytest.mark.anyio
+async def test_pr_list_open_closed_counts_in_tabs(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """State tabs display SSR-computed open/merged/closed counts."""
+    repo_id = await _make_repo(db_session)
+    await _make_pr(db_session, repo_id, title="Open PR 1", state="open")
+    await _make_pr(db_session, repo_id, title="Open PR 2", state="open")
+    await _make_pr(db_session, repo_id, title="Merged PR", state="merged")
+    response = await client.get("/musehub/ui/prdev/pr-ssr-album/pulls")
+    assert response.status_code == 200
+    body = response.text
+    # Tab counts for open and merged must appear as server-rendered numbers.
+    assert "2" in body  # open_count
+    assert "1" in body  # merged_count
+
+
+@pytest.mark.anyio
+async def test_pr_list_htmx_fragment_on_tab_switch(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """HX-Request: true with state=merged returns a bare HTML fragment."""
+    repo_id = await _make_repo(db_session)
+    await _make_pr(db_session, repo_id, title="Merged feature", state="merged")
+    response = await client.get(
+        "/musehub/ui/prdev/pr-ssr-album/pulls?state=merged",
+        headers={"HX-Request": "true"},
+    )
+    assert response.status_code == 200
+    body = response.text
+    # Fragment must NOT contain the full HTML page shell.
+    assert "<html" not in body
+    assert "<head" not in body
+    # PR title must appear in the fragment.
+    assert "Merged feature" in body
+
+
+# ---------------------------------------------------------------------------
+# PR detail SSR tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_pr_detail_renders_title_server_side(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """PR title and branch info appear in the detail page HTML server-side."""
+    repo_id = await _make_repo(db_session)
+    pr = await _make_pr(
+        db_session, repo_id, title="Add jazz chord voicings", from_branch="feat/jazz"
+    )
+    response = await client.get(f"/musehub/ui/prdev/pr-ssr-album/pulls/{pr.pr_id}")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "Add jazz chord voicings" in response.text
+
+
+@pytest.mark.anyio
+async def test_pr_detail_renders_diff_stats(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Branch names (from_branch / to_branch) appear in the detail page HTML."""
+    repo_id = await _make_repo(db_session)
+    pr = await _make_pr(
+        db_session,
+        repo_id,
+        title="Bass groove PR",
+        from_branch="feat/bass-groove",
+        to_branch="dev",
+    )
+    response = await client.get(f"/musehub/ui/prdev/pr-ssr-album/pulls/{pr.pr_id}")
+    assert response.status_code == 200
+    body = response.text
+    # Both branch names must appear in the server-rendered HTML.
+    assert "feat/bass-groove" in body
+    assert "dev" in body
+
+
+@pytest.mark.anyio
+async def test_pr_detail_merge_button_has_hx_post(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """An open PR detail page includes a merge button with an hx-post attribute."""
+    repo_id = await _make_repo(db_session)
+    pr = await _make_pr(db_session, repo_id, title="Merge-ready PR", state="open")
+    response = await client.get(f"/musehub/ui/prdev/pr-ssr-album/pulls/{pr.pr_id}")
+    assert response.status_code == 200
+    body = response.text
+    # The merge card must have at least one HTMX POST trigger.
+    assert "hx-post" in body
+    assert "merge" in body.lower()
+
+
+@pytest.mark.anyio
+async def test_pr_detail_merge_button_disabled_when_not_mergeable(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A closed or merged PR does not show the merge button."""
+    repo_id = await _make_repo(db_session)
+    pr = await _make_pr(db_session, repo_id, title="Already Merged PR", state="merged")
+    response = await client.get(f"/musehub/ui/prdev/pr-ssr-album/pulls/{pr.pr_id}")
+    assert response.status_code == 200
+    body = response.text
+    # Merged/closed PRs must not render the merge action form.
+    assert "Merge pull request" not in body
+
+
+@pytest.mark.anyio
+async def test_pr_detail_unknown_number_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A request for a non-existent PR id returns HTTP 404."""
+    await _make_repo(db_session)
+    response = await client.get(
+        "/musehub/ui/prdev/pr-ssr-album/pulls/nonexistent-pr-uuid"
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

Closes #569 — Convert PR list and detail pages from JavaScript shells to full SSR with HTMX.

## Solution

- **`pr_list_page()`**: Converted to fetch open/merged/closed PR counts server-side, apply sort, and return `htmx_fragment_or_full()`. Tab and sort switches swap only `#pr-rows` via HTMX.
- **`pr_detail_page()`**: Converted to fetch PR record, reviews, and comment thread server-side. Returns `htmx_fragment_or_full()` with a 404 for unknown `pr_id`.
- **New templates**: `musehub/pages/pr_list.html` and `musehub/pages/pr_detail.html` rewritten from JS shells to Jinja2 SSR with HTMX actions.
- **New fragments**: `musehub/fragments/pr_rows.html` and `musehub/fragments/pr_comments.html` for partial HTMX swaps.
- **8 tests** in `tests/test_musehub_ui_pr_ssr.py` — all pass.

## Verification

- [x] mypy clean (721 source files, no issues)
- [x] 8 new SSR tests pass
- [x] Existing `test_mcp_musehub.py` (28 tests) still pass
- [x] Templates follow `issue_list.html` / `issue_rows.html` pattern from #555