### PR TITLE
feat(agentception): wire pipeline-config phases into GUI + Start Wave button

### DIFF
--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -257,14 +257,30 @@ async def get_wip_issues() -> list[dict[str, object]]:
 
 
 async def get_active_label() -> str | None:
-    """Find the lowest-numbered ``agentception/*`` label that has open issues.
+    """Return the first label in ``pipeline-config.json`` active_labels_order that has open issues.
 
-    Labels follow the pattern ``agentception/<N>-<slug>``.  The «active»
-    label is the one with the smallest ``<N>`` — i.e. the phase currently
-    being worked on.
+    The pipeline config is the single source of truth for label ordering — it
+    is not hardcoded to any prefix.  This means the function works for any
+    label scheme (``agentception/*``, ``ac-ui/*``, ``htmx/*``, etc.) as long
+    as ``pipeline-config.json`` lists them in the desired phase order.
 
-    Returns ``None`` when no open issues carry an ``agentception/*`` label.
+    Returns the first label (lowest index in active_labels_order) for which at
+    least one open GitHub issue carries that label.  Returns ``None`` when the
+    config is unreadable or no configured label has open issues.
     """
+    from agentception.readers.pipeline_config import read_pipeline_config  # local import to avoid circular
+
+    try:
+        config = await read_pipeline_config()
+        labels_order: list[str] = config.active_labels_order
+    except Exception as exc:
+        logger.warning("⚠️  Could not read pipeline config for active label: %s", exc)
+        labels_order = []
+
+    if not labels_order:
+        return None
+
+    # Fetch all labels present on any open issue (one gh call, cached).
     repo = settings.gh_repo
     args = [
         "issue", "list",
@@ -276,22 +292,14 @@ async def get_active_label() -> str | None:
     if not isinstance(result, list):
         raise RuntimeError(f"get_active_label: expected list from gh, got {type(result).__name__}")
 
-    agentception_labels: set[str] = {
-        name for name in result if isinstance(name, str) and name.startswith("agentception/")
-    }
-    if not agentception_labels:
-        return None
+    open_labels: set[str] = {name for name in result if isinstance(name, str)}
 
-    def _sort_key(name: str) -> int:
-        """Extract the numeric prefix after the slash for ordering."""
-        suffix = name.split("/", 1)[-1]          # e.g. "0-scaffold"
-        prefix = suffix.split("-", 1)[0]          # e.g. "0"
-        try:
-            return int(prefix)
-        except ValueError:
-            return 999
+    # Return the first configured label that actually has open issues.
+    for label in labels_order:
+        if label in open_labels:
+            return label
 
-    return min(agentception_labels, key=_sort_key)
+    return None
 
 
 async def get_issue(number: int) -> dict[str, object]:

--- a/agentception/readers/pipeline_config.py
+++ b/agentception/readers/pipeline_config.py
@@ -25,13 +25,12 @@ _DEFAULTS: dict[str, int | list[str]] = {
     "max_qa_vps": 1,
     "pool_size_per_vp": 4,
     "active_labels_order": [
-        "agentception/0-scaffold",
-        "agentception/1-controls",
-        "agentception/2-telemetry",
-        "agentception/3-roles",
-        "agentception/4-intelligence",
-        "agentception/5-scaling",
-        "agentception/6-generalization",
+        "ac-ui/0-critical-bugs",
+        "ac-ui/1-design-tokens",
+        "ac-ui/2-data-model",
+        "ac-ui/3-core-pages",
+        "ac-ui/4-controls-intelligence",
+        "ac-ui/5-polish",
     ],
 }
 

--- a/agentception/routes/api.py
+++ b/agentception/routes/api.py
@@ -12,14 +12,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
 
 from agentception.config import settings
 from agentception.intelligence.analyzer import IssueAnalysis, analyze_issue
 from agentception.intelligence.dag import DependencyDAG, build_dag
 from agentception.intelligence.guards import PRViolation, detect_out_of_order_prs
-from agentception.models import AgentNode, PipelineConfig, PipelineState, SpawnRequest, SpawnResult, SwitchProjectRequest
+from agentception.models import AgentNode, PipelineConfig, PipelineState, SpawnRequest, SpawnResult, SwitchProjectRequest  # noqa: E501
 from agentception.poller import get_state
-from agentception.readers.github import add_wip_label, close_pr, get_issue
+from agentception.readers.github import add_wip_label, close_pr, get_active_label, get_issue, get_open_issues
 from agentception.readers.pipeline_config import read_pipeline_config, switch_project, write_pipeline_config
 from agentception.readers.transcripts import read_transcript_messages
 from agentception.routes.ui import _find_agent
@@ -418,6 +419,112 @@ async def spawn_agent(body: SpawnRequest) -> SpawnResult:
         branch=branch,
         agent_task=agent_task_content,
     )
+
+
+def _issue_is_claimed_api(iss: dict[str, object]) -> bool:
+    """Return True when an issue carries the ``agent:wip`` label."""
+    raw = iss.get("labels")
+    if not isinstance(raw, list):
+        return False
+    for lbl in raw:
+        if isinstance(lbl, str) and lbl == "agent:wip":
+            return True
+        if isinstance(lbl, dict) and lbl.get("name") == "agent:wip":
+            return True
+    return False
+
+
+class WaveSpawnResult(BaseModel):
+    """Result of a batch spawn-wave operation."""
+
+    active_label: str
+    spawned: list[SpawnResult]
+    skipped: list[dict[str, object]]  # issues skipped because already claimed / worktree exists
+
+
+@router.post("/control/spawn-wave", tags=["control"])
+async def spawn_wave(role: str = "python-developer") -> WaveSpawnResult:
+    """Spawn agents for all unclaimed issues in the currently active phase.
+
+    Reads the active phase label from ``pipeline-config.json``, fetches all
+    open unclaimed issues carrying that label, and calls the single-spawn
+    logic for each one.  Issues that are already claimed or already have a
+    worktree are silently skipped (not an error).
+
+    This is the "Start Wave" action available in the Overview dashboard.  The
+    caller is still responsible for launching a Cursor Task pointed at each
+    returned worktree path — this endpoint only creates the worktrees and
+    ``.agent-task`` files.
+
+    Parameters
+    ----------
+    role:
+        Role file slug to assign to every spawned agent.  Defaults to
+        ``python-developer``.  Must be a member of ``VALID_ROLES``.
+
+    Raises
+    ------
+    HTTP 404
+        When no active phase label is found in ``pipeline-config.json`` or
+        no open issues carry that label.
+    HTTP 422
+        When ``role`` is not a recognised role slug.
+    """
+    from agentception.models import VALID_ROLES
+    if role not in VALID_ROLES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown role {role!r}. Valid roles: {sorted(VALID_ROLES)}",
+        )
+
+    active_label = await get_active_label()
+    if not active_label:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "No active phase label found. Check that pipeline-config.json "
+                "active_labels_order contains labels with open issues."
+            ),
+        )
+
+    phase_issues = await get_open_issues(label=active_label)
+    unclaimed = [iss for iss in phase_issues if not _issue_is_claimed_api(iss)]
+
+    if not unclaimed:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"No unclaimed open issues found for label '{active_label}'. "
+                "All issues may already be claimed or there are no open issues."
+            ),
+        )
+
+    spawned: list[SpawnResult] = []
+    skipped: list[dict[str, object]] = []
+
+    for iss in unclaimed:
+        issue_num = iss.get("number")
+        if not isinstance(issue_num, int):
+            continue
+        try:
+            result = await spawn_agent(SpawnRequest(issue_number=issue_num, role=role))
+            spawned.append(result)
+            logger.info("✅ Wave spawn: issue #%d → %s", issue_num, result.worktree)
+        except HTTPException as exc:
+            # 409 = already claimed or worktree exists → skip, not an error.
+            if exc.status_code == 409:
+                skipped.append({"issue_number": issue_num, "reason": exc.detail})
+                logger.info("⏭️  Wave spawn skipped issue #%d: %s", issue_num, exc.detail)
+            else:
+                # Any other error (404 issue gone, 500 git failure) — skip and log.
+                skipped.append({"issue_number": issue_num, "reason": exc.detail})
+                logger.warning("⚠️  Wave spawn failed for issue #%d: %s", issue_num, exc.detail)
+
+    logger.info(
+        "✅ spawn-wave complete: label=%s spawned=%d skipped=%d",
+        active_label, len(spawned), len(skipped),
+    )
+    return WaveSpawnResult(active_label=active_label, spawned=spawned, skipped=skipped)
 
 
 @router.post("/analyze/issue/{number}", tags=["intelligence"])

--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -21,7 +21,7 @@ from agentception.intelligence.analyzer import IssueAnalysis, analyze_issue
 from agentception.intelligence.dag import DependencyDAG, build_dag
 from agentception.models import AgentNode, PipelineConfig, PipelineState, RoleMeta, VALID_ROLES
 from agentception.poller import get_state
-from agentception.readers.github import get_open_issues
+from agentception.readers.github import get_active_label, get_open_issues
 from agentception.readers.pipeline_config import read_pipeline_config
 from agentception.readers.transcripts import read_transcript_messages
 from agentception.routes.roles import list_roles
@@ -34,6 +34,12 @@ _TEMPLATES = Jinja2Templates(directory=str(_HERE.parent / "templates"))
 # Register path filters used by agent.html kill-endpoint modal.
 _TEMPLATES.env.filters["basename"] = os.path.basename
 _TEMPLATES.env.filters["dirname"] = os.path.dirname
+
+# Inject global template variables so every template can reference them without
+# the route handler having to pass them explicitly.
+from agentception.config import settings as _settings
+_TEMPLATES.env.globals["gh_repo"] = _settings.gh_repo
+_TEMPLATES.env.globals["gh_base_url"] = f"https://github.com/{_settings.gh_repo}"
 
 
 def _format_ts(ts: float) -> str:
@@ -98,20 +104,41 @@ async def overview(request: Request) -> HTMLResponse:
 
     Renders on every request with the latest polled state. The page connects
     to ``GET /events`` via SSE to receive live updates without reloading.
-    Open unclaimed issues are fetched from GitHub and displayed in the board
-    sidebar with an "Analyze" button each.
+
+    Board sidebar shows only issues carrying the active phase label (from
+    ``pipeline-config.json`` active_labels_order), filtered to unclaimed ones.
+    This keeps the board focused on the current phase rather than showing all
+    open issues across every label.
     """
     state = get_state() or PipelineState.empty()
     board_issues: list[dict[str, object]] = []
+    active_phase_label: str | None = None
+    total_phase_issues: int = 0
+
     try:
-        all_open = await get_open_issues()
-        board_issues = [iss for iss in all_open if not _issue_is_claimed(iss)]
+        active_phase_label = await get_active_label()
+        if active_phase_label:
+            # Fetch only issues in the current active phase.
+            phase_issues = await get_open_issues(label=active_phase_label)
+            total_phase_issues = len(phase_issues)
+            board_issues = [iss for iss in phase_issues if not _issue_is_claimed(iss)]
+        else:
+            # Fallback: show all unclaimed open issues when no phase is configured.
+            all_open = await get_open_issues()
+            board_issues = [iss for iss in all_open if not _issue_is_claimed(iss)]
     except Exception as exc:  # pragma: no cover — network failure path
         logger.warning("⚠️ Could not fetch open issues for board sidebar: %s", exc)
+
     return _TEMPLATES.TemplateResponse(
         request,
         "overview.html",
-        {"state": state, "board_issues": board_issues},
+        {
+            "state": state,
+            "board_issues": board_issues,
+            "active_phase_label": active_phase_label,
+            "total_phase_issues": total_phase_issues,
+            "unclaimed_count": len(board_issues),
+        },
     )
 
 
@@ -174,7 +201,7 @@ async def agents_list(request: Request) -> HTMLResponse:
 
 
 @router.get("/controls", response_class=HTMLResponse)
-async def controls_hub(request: Request) -> HTMLResponse:
+async def controls_hub(request: Request) -> Response:
     """Controls hub — redirects to the spawn form (the primary control action)."""
     from starlette.responses import RedirectResponse
     return RedirectResponse(url="/control/spawn", status_code=302)

--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -999,3 +999,77 @@ main {
   font-weight: 500;
   color: var(--text-primary);
 }
+
+/* ── Wave Control Panel ──────────────────────────────────────────────────── */
+
+.wave-control-card {
+  border-left: 3px solid var(--accent);
+}
+
+.wave-control-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.wave-phase-label {
+  margin-bottom: 0.25rem;
+}
+
+.wave-phase-stats {
+  font-size: 0.8125rem;
+}
+
+.label-chip--active {
+  background: rgba(99, 102, 241, 0.15);
+  border-color: var(--accent);
+  color: var(--accent-hover);
+}
+
+.label-chip--none {
+  background: rgba(148, 163, 184, 0.15);
+  border-color: var(--border);
+  color: var(--text-muted);
+}
+
+.btn-wave-start {
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.wave-result {
+  border-top: 1px solid var(--border);
+  padding-top: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.wave-worktree-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.375rem;
+  font-size: 0.8125rem;
+}
+
+.wave-issue-num {
+  font-weight: 600;
+  color: var(--accent);
+  min-width: 2.5rem;
+}
+
+.wave-worktree-path {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  word-break: break-all;
+}
+
+.text-success {
+  color: var(--success, #22c55e);
+}
+
+/* Ensure active label in summary bar uses real data */
+.summary-value--phase {
+  font-weight: 700;
+  color: var(--accent);
+}

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -297,21 +297,86 @@
     <aside class="github-board" aria-label="GitHub board">
       <h2 class="section-title">GitHub Board</h2>
 
-      <div class="card">
-        <div class="board-label-row">
-          <span
-            class="label-chip"
-            x-text="state.active_label ?? 'No active label'"
-          ></span>
+      {# ── Wave Control panel ──────────────────────────────────────────── #}
+      <div
+        class="card wave-control-card"
+        x-data="waveControl()"
+        x-init="init()"
+      >
+        <div class="wave-control-header">
+          <div>
+            <div class="wave-phase-label">
+              {% if active_phase_label %}
+                <span class="label-chip label-chip--active">{{ active_phase_label }}</span>
+              {% else %}
+                <span class="label-chip label-chip--none">No active phase</span>
+              {% endif %}
+            </div>
+            <div class="wave-phase-stats">
+              {% if active_phase_label %}
+                <span class="text-muted">
+                  {{ unclaimed_count }} unclaimed
+                  <span class="board-stats-sep">·</span>
+                  {{ total_phase_issues - unclaimed_count }} claimed
+                  <span class="board-stats-sep">·</span>
+                  {{ total_phase_issues }} total
+                </span>
+              {% else %}
+                <span class="text-muted">Set active_labels_order in pipeline-config.json</span>
+              {% endif %}
+            </div>
+          </div>
+
+          {# Start Wave button — only shown when there are unclaimed issues #}
+          {% if active_phase_label and unclaimed_count > 0 %}
+          <button
+            class="btn btn-primary btn-wave-start"
+            @click="startWave()"
+            :disabled="launching"
+            x-text="launching ? 'Launching…' : 'Start Wave'"
+            title="Spawn agents for all {{ unclaimed_count }} unclaimed issues in {{ active_phase_label }}"
+            aria-label="Start pipeline wave"
+          ></button>
+          {% elif active_phase_label %}
+          <span class="badge badge--green">All claimed ✓</span>
+          {% endif %}
         </div>
+
+        {# Wave launch result #}
+        <template x-if="waveResult">
+          <div class="wave-result mt-1">
+            <p class="text-success">
+              ✅ <strong x-text="waveResult.spawned.length"></strong> worktree(s) created.
+              Launch a Cursor Task for each path below.
+            </p>
+            <template x-for="s in waveResult.spawned" :key="s.spawned">
+              <div class="wave-worktree-row">
+                <span class="wave-issue-num">#<span x-text="s.spawned"></span></span>
+                <code class="wave-worktree-path" x-text="s.worktree"></code>
+              </div>
+            </template>
+            <template x-if="waveResult.skipped.length > 0">
+              <p class="text-muted mt-1">
+                ⏭ <span x-text="waveResult.skipped.length"></span> skipped (already claimed or worktree exists).
+              </p>
+            </template>
+          </div>
+        </template>
+
+        <template x-if="waveError">
+          <div class="alert-banner mt-1" role="alert">
+            <span>❌</span>
+            <span x-text="waveError"></span>
+          </div>
+        </template>
 
         <div class="board-stats mt-1">
           <span class="text-muted">
-            <span x-text="state.issues_open"></span> open issue<span x-show="state.issues_open !== 1">s</span>
+            <span x-text="state.issues_open"></span> open issues (all labels)
           </span>
           <span class="board-stats-sep">·</span>
           <span class="text-muted">
-            <span x-text="state.prs_open"></span> open PR<span x-show="state.prs_open !== 1">s</span>
+            <span x-text="state.prs_open"></span> open PRs
           </span>
         </div>
       </div>
@@ -376,7 +441,7 @@
           <div class="issue-card-header">
             <a
               class="issue-card-number"
-              href="https://github.com/cgcardona/maestro/issues/{{ issue.number }}"
+              href="{{ gh_base_url }}/issues/{{ issue.number }}"
               target="_blank"
               rel="noopener noreferrer"
             >#{{ issue.number }}</a>
@@ -404,6 +469,46 @@
 </div>{# Alpine root #}
 
 <script>
+/**
+ * Alpine.js component for the Wave Control panel.
+ *
+ * Calls POST /api/control/spawn-wave to create worktrees for all unclaimed
+ * issues in the active phase.  Shows worktree paths on success so the user
+ * knows where to point Cursor Tasks.
+ */
+function waveControl() {
+  return {
+    launching: false,
+    waveResult: null,
+    waveError: null,
+
+    init() {
+      // No auto-fetch needed — all data comes from server-side template vars.
+    },
+
+    async startWave() {
+      this.launching = true;
+      this.waveResult = null;
+      this.waveError = null;
+
+      try {
+        const resp = await fetch('/api/control/spawn-wave', { method: 'POST' });
+        const data = await resp.json();
+
+        if (!resp.ok) {
+          this.waveError = data.detail ?? `HTTP ${resp.status}`;
+        } else {
+          this.waveResult = data;
+        }
+      } catch (err) {
+        this.waveError = `Network error: ${err.message}`;
+      } finally {
+        this.launching = false;
+      }
+    },
+  };
+}
+
 /**
  * Alpine.js component for the pipeline overview dashboard.
  *

--- a/agentception/tests/test_agentception_github.py
+++ b/agentception/tests/test_agentception_github.py
@@ -192,30 +192,55 @@ async def test_get_wip_issues_passes_label() -> None:
 # ---------------------------------------------------------------------------
 
 @pytest.mark.anyio
-async def test_get_active_label_returns_lowest() -> None:
-    """get_active_label() must return the agentception/* label with the lowest numeric prefix."""
-    label_names = [
-        "agentception/2-something",
-        "agentception/0-scaffold",
-        "agentception/1-readers",
-        "enhancement",
-    ]
+async def test_get_active_label_returns_first_match_from_config() -> None:
+    """get_active_label() returns the first label in pipeline-config active_labels_order
+    that has an open issue — not the lexicographically lowest label."""
+    from agentception.models import PipelineConfig
+    from agentception.readers import pipeline_config as _pc
 
-    with patch(
-        "agentception.readers.github.asyncio.create_subprocess_exec",
-        return_value=_make_process(json.dumps(label_names).encode()),
+    mock_config = PipelineConfig(
+        max_eng_vps=1,
+        max_qa_vps=1,
+        pool_size_per_vp=4,
+        active_labels_order=["ac-ui/0-critical-bugs", "ac-ui/1-design-tokens", "ac-ui/2-data-model"],
+    )
+    # Issues only have ac-ui/1 and ac-ui/2 labels (phase 0 is all done)
+    label_names = ["ac-ui/1-design-tokens", "ac-ui/2-data-model", "enhancement"]
+
+    with (
+        patch.object(_pc, "read_pipeline_config", return_value=mock_config),
+        patch(
+            "agentception.readers.github.asyncio.create_subprocess_exec",
+            return_value=_make_process(json.dumps(label_names).encode()),
+        ),
     ):
         result = await get_active_label()
 
-    assert result == "agentception/0-scaffold"
+    # ac-ui/0 has no open issues, so ac-ui/1 is the first match
+    assert result == "ac-ui/1-design-tokens"
 
 
 @pytest.mark.anyio
-async def test_get_active_label_returns_none_when_no_agentception_labels() -> None:
-    """get_active_label() must return None when no agentception/* labels are present."""
-    with patch(
-        "agentception.readers.github.asyncio.create_subprocess_exec",
-        return_value=_make_process(json.dumps(["enhancement", "batch-01"]).encode()),
+async def test_get_active_label_returns_none_when_no_configured_labels_have_issues() -> None:
+    """get_active_label() returns None when no label in active_labels_order has open issues."""
+    from agentception.models import PipelineConfig
+    from agentception.readers import pipeline_config as _pc
+
+    mock_config = PipelineConfig(
+        max_eng_vps=1,
+        max_qa_vps=1,
+        pool_size_per_vp=4,
+        active_labels_order=["ac-ui/0-critical-bugs", "ac-ui/1-design-tokens"],
+    )
+    # No ac-ui/* issues open
+    label_names_no_match = ["enhancement", "batch-01", "bug"]
+
+    with (
+        patch.object(_pc, "read_pipeline_config", return_value=mock_config),
+        patch(
+            "agentception.readers.github.asyncio.create_subprocess_exec",
+            return_value=_make_process(json.dumps(label_names_no_match).encode()),
+        ),
     ):
         result = await get_active_label()
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -58,5 +58,8 @@ services:
     volumes:
       # Live code — host edits are instantly visible; no rebuild needed
       - ./agentception:/app/agentception
+      # .cursor/ — mounted so pipeline-config.json and role files are readable
+      # by get_active_label(), read_pipeline_config(), and the spawn endpoint.
+      - ./.cursor:/app/.cursor:ro
       # agentception tests live under agentception/tests/ (isolated from maestro conftest)
       - ${HOME}/.cursor/worktrees/maestro:/worktrees


### PR DESCRIPTION
## Summary

- **`get_active_label()` now reads `pipeline-config.json`** instead of hardcoding `agentception/` prefix — the GUI correctly identifies `ac-ui/0-critical-bugs` as the active phase immediately.
- **Overview board filters by active phase** — sidebar shows only the current phase's issues (5 unclaimed in `ac-ui/0-critical-bugs`), not all 100+ open issues.
- **`POST /api/control/spawn-wave`** — new endpoint that spawns agents for all unclaimed issues in the active phase in one call; returns worktree paths for each.
- **Wave Control panel** on the Overview page with a "Start Wave" button that calls `spawn-wave` and shows resulting worktree paths inline.
- **`gh_repo` / `gh_base_url` template globals** — no template hardcodes the repo slug anymore.
- **`.cursor/` mounted into agentception container** (read-only) so `pipeline-config.json` is live.

## Test plan
- [ ] `http://localhost:7777/` shows `Active label: ac-ui/0-critical-bugs` in the summary bar
- [ ] Board sidebar shows only the 5 `ac-ui/0-critical-bugs` issues
- [ ] "Start Wave" button spawns worktrees for all unclaimed issues and shows paths
- [ ] `POST /api/control/spawn-wave` returns `{"active_label": "ac-ui/0-critical-bugs", "spawned": [...], "skipped": [...]}`
- [ ] All 32 GitHub reader + spawn tests pass