### PR TITLE
fix(css): close missing } on .agent-task-pre

### DIFF
--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -772,6 +772,7 @@ main {
   white-space: pre;
   overflow-x: auto;
   margin: 0;
+}
 
 /* ── Kill button (inline ✕ in agent rows) ─────────────────────────────────── */
 


### PR DESCRIPTION
One-line fix: the unclosed block was silently discarding all CSS rules declared after it — kill button, modal backdrop, telemetry chart, and badge colour classes all broken. Closes #729.