### PR TITLE
fix(ui): use single quotes on x-data to prevent JSON double-quote collision

### DIFF
--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -9,7 +9,7 @@
   received from GET /events (SSE) and applied reactively without page reload.
 #}
 <div
-  x-data="pipelineDashboard({{ state.model_dump() | tojson }})"
+  x-data='pipelineDashboard({{ state.model_dump() | tojson }})'
   x-init="connect()"
 >
 


### PR DESCRIPTION
The double-quoted JSON inside a double-quoted HTML attribute caused the browser to terminate the attribute at the first JSON key. Alpine never saw the component definition, producing the full console storm of ReferenceErrors for `state`, `connect`, `relativeTime`, `connected`.