### PR TITLE
fix(ui): replace ambiguous RUNNING badge with labelled poller status + clean toggle

### DIFF
--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -170,6 +170,81 @@ main {
   margin-left: auto;
 }
 
+/* ── Poller control (far-right of summary bar) ─────────────────────────────── */
+
+.poller-control {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-left: auto;
+  padding-left: 1.5rem;
+  border-left: 1px solid var(--border);
+}
+
+.poller-status {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.poller-status__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.poller-status--live .poller-status__dot        { background: #22c55e; box-shadow: 0 0 6px #22c55e88; animation: pulse-dot 2s ease-in-out infinite; }
+.poller-status--reconnecting .poller-status__dot { background: #f59e0b; }
+.poller-status--paused .poller-status__dot       { background: var(--text-muted); }
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.45; }
+}
+
+.poller-status__label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.poller-status--live .poller-status__label        { color: #22c55e; }
+.poller-status--reconnecting .poller-status__label { color: #f59e0b; }
+.poller-status--paused .poller-status__label       { color: var(--text-muted); }
+
+.poller-toggle-btn {
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.3rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.poller-toggle-btn--pause {
+  color: var(--text-secondary);
+  border-color: var(--border);
+}
+.poller-toggle-btn--pause:hover {
+  background: rgba(255,255,255,0.06);
+  border-color: var(--text-secondary);
+  color: var(--text-primary);
+}
+
+.poller-toggle-btn--resume {
+  color: #22c55e;
+  border-color: #22c55e55;
+}
+.poller-toggle-btn--resume:hover {
+  background: rgba(34,197,94,0.1);
+  border-color: #22c55e;
+}
+
 .summary-label {
   font-size: 0.6875rem;
   text-transform: uppercase;

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -35,39 +35,29 @@
       <span class="summary-label">Last polled</span>
       <span class="summary-value" x-text="relativeTime(state.polled_at)"></span>
     </div>
-    <div class="summary-item summary-item--status">
-      <span
-        class="summary-label"
-        :class="connected ? 'text-success' : 'text-danger'"
-        x-text="connected ? '● Live' : '○ Reconnecting…'"
-      ></span>
-    </div>
-
     {#
-      Pause/resume toggle — issues a POST via HTMX and swaps only this element
-      so the rest of the dashboard stays live.  The paused flag is polled from
-      /api/control/status on page load and updated optimistically on click.
+      Poller status + pause/resume — grouped at the far right of the summary bar.
+      Shows a labelled live/reconnecting dot and a clearly-labelled toggle button
+      so it's obvious this controls the AgentCeption background poller, not a wave.
     #}
     <div
-      class="summary-item summary-item--control"
+      class="poller-control"
       id="pipeline-control"
       x-data="pipelineControl()"
       x-init="fetchStatus()"
     >
-      <span
-        class="pipeline-status-badge"
-        :class="paused ? 'pipeline-status-badge--paused' : 'pipeline-status-badge--running'"
-        x-text="paused ? 'PAUSED' : 'RUNNING'"
-        role="status"
-        :aria-label="paused ? 'Pipeline paused' : 'Pipeline running'"
-      ></span>
+      <div class="poller-status" :class="paused ? 'poller-status--paused' : (connected ? 'poller-status--live' : 'poller-status--reconnecting')">
+        <span class="poller-status__dot"></span>
+        <span class="poller-status__label" x-text="paused ? 'Poller paused' : (connected ? 'Poller live' : 'Reconnecting…')"></span>
+      </div>
       <button
-        class="control-btn"
-        :class="paused ? 'control-btn--resume' : 'control-btn--pause'"
-        x-text="paused ? 'Resume' : 'Pause'"
+        class="poller-toggle-btn"
+        :class="paused ? 'poller-toggle-btn--resume' : 'poller-toggle-btn--pause'"
         @click="toggle()"
-        :aria-label="paused ? 'Resume pipeline' : 'Pause pipeline'"
-      ></button>
+        :title="paused ? 'Resume AgentCeption poller' : 'Pause AgentCeption poller'"
+      >
+        <span x-text="paused ? '▶ Resume' : '⏸ Pause'"></span>
+      </button>
     </div>
   </div>
 


### PR DESCRIPTION
RUNNING/PAUSE was unstyled and gave no context about what was running. Replaced with a clearly-labelled poller-control group.