### PR TITLE
feat(agentception): self-contained Postgres DB layer with 7 ac_* tables

### DIFF
--- a/agentception/alembic.ini
+++ b/agentception/alembic.ini
@@ -1,0 +1,47 @@
+# Alembic configuration for AgentCeption (self-contained — no maestro imports).
+# Run from the repo root:
+#   AC_DATABASE_URL=postgresql+asyncpg://... alembic -c agentception/alembic.ini upgrade head
+
+[alembic]
+script_location = agentception/alembic
+file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
+timezone = UTC
+truncate_slug_length = 40
+output_encoding = utf-8
+# Database URL is injected in env.py from AC_DATABASE_URL. Never stored here.
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/agentception/alembic/env.py
+++ b/agentception/alembic/env.py
@@ -1,0 +1,87 @@
+"""Alembic environment for AgentCeption — fully self-contained, no maestro imports."""
+from __future__ import annotations
+
+import asyncio
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
+
+from agentception.db.base import Base
+from agentception.db import models  # noqa: F401 — registers all ac_* tables on Base.metadata
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+# Resolve the database URL from the environment.
+# AC_DATABASE_URL is the canonical name; fall back to DATABASE_URL if unset
+# so the agentception container can share the maestro Postgres credentials
+# without duplicating the secret.
+_db_url: str = os.environ.get("AC_DATABASE_URL") or os.environ.get("DATABASE_URL") or ""
+if not _db_url:
+    raise RuntimeError(
+        "Set AC_DATABASE_URL (or DATABASE_URL) before running AgentCeption migrations."
+    )
+
+# Alembic's sync engine needs a sync driver — strip async dialect markers.
+_sync_url: str = _db_url.replace("+asyncpg", "").replace("+aiosqlite", "")
+config.set_main_option("sqlalchemy.url", _sync_url)
+
+
+def run_migrations_offline() -> None:
+    """Emit SQL to stdout without a live DB connection."""
+    context.configure(
+        url=_sync_url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+        compare_server_default=True,
+        version_table="alembic_version_ac",
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def _do_run_migrations(connection: Connection) -> None:
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
+        compare_server_default=True,
+        # Separate version table so AgentCeption migrations don't collide with
+        # Maestro's alembic_version entries in the shared Postgres instance.
+        version_table="alembic_version_ac",
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def _run_async_migrations() -> None:
+    cfg = config.get_section(config.config_ini_section, {})
+    cfg["sqlalchemy.url"] = _db_url  # async driver for the live connection
+
+    connectable = async_engine_from_config(
+        cfg, prefix="sqlalchemy.", poolclass=pool.NullPool
+    )
+    async with connectable.connect() as connection:
+        await connection.run_sync(_do_run_migrations)
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    asyncio.run(_run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/agentception/alembic/script.py.mako
+++ b/agentception/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/agentception/alembic/versions/0001_ac_initial_schema.py
+++ b/agentception/alembic/versions/0001_ac_initial_schema.py
@@ -1,0 +1,152 @@
+"""ac initial schema
+
+THIS IS THE ONLY MIGRATION for AgentCeption during the monorepo phase.
+New ac_* tables are added here directly (upgrade/downgrade pair).
+When AgentCeption is extracted to its own repo, this becomes its migration 0001.
+
+Revision ID: ac0001
+Revises:
+Create Date: 2026-03-02
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "ac0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── ac_waves ─────────────────────────────────────────────────────────────
+    op.create_table(
+        "ac_waves",
+        sa.Column("id", sa.String(128), primary_key=True),
+        sa.Column("phase_label", sa.String(256), nullable=False),
+        sa.Column("role", sa.String(128), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("spawn_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("skip_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+    # ── ac_agent_runs ─────────────────────────────────────────────────────────
+    op.create_table(
+        "ac_agent_runs",
+        sa.Column("id", sa.String(512), primary_key=True),
+        sa.Column("wave_id", sa.String(128), sa.ForeignKey("ac_waves.id"), nullable=True),
+        sa.Column("issue_number", sa.Integer(), nullable=True),
+        sa.Column("pr_number", sa.Integer(), nullable=True),
+        sa.Column("branch", sa.String(256), nullable=True),
+        sa.Column("worktree_path", sa.String(512), nullable=True),
+        sa.Column("role", sa.String(128), nullable=False),
+        sa.Column("status", sa.String(64), nullable=False),
+        sa.Column("attempt_number", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("spawn_mode", sa.String(64), nullable=True),
+        sa.Column("batch_id", sa.String(128), nullable=True),
+        sa.Column("spawned_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_activity_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_ac_agent_runs_wave_id", "ac_agent_runs", ["wave_id"])
+    op.create_index("ix_ac_agent_runs_issue_number", "ac_agent_runs", ["issue_number"])
+    op.create_index("ix_ac_agent_runs_pr_number", "ac_agent_runs", ["pr_number"])
+    op.create_index("ix_ac_agent_runs_batch_id", "ac_agent_runs", ["batch_id"])
+
+    # ── ac_issues ─────────────────────────────────────────────────────────────
+    op.create_table(
+        "ac_issues",
+        sa.Column("github_number", sa.Integer(), primary_key=True),
+        sa.Column("repo", sa.String(256), primary_key=True),
+        sa.Column("title", sa.String(512), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("state", sa.String(32), nullable=False),
+        sa.Column("phase_label", sa.String(256), nullable=True),
+        sa.Column("labels_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("content_hash", sa.String(64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("first_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_ac_issues_state", "ac_issues", ["state"])
+    op.create_index("ix_ac_issues_phase_label", "ac_issues", ["phase_label"])
+
+    # ── ac_pull_requests ──────────────────────────────────────────────────────
+    op.create_table(
+        "ac_pull_requests",
+        sa.Column("github_number", sa.Integer(), primary_key=True),
+        sa.Column("repo", sa.String(256), primary_key=True),
+        sa.Column("title", sa.String(512), nullable=False),
+        sa.Column("state", sa.String(32), nullable=False),
+        sa.Column("head_ref", sa.String(256), nullable=True),
+        sa.Column("closes_issue_number", sa.Integer(), nullable=True),
+        sa.Column("labels_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("content_hash", sa.String(64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("merged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("first_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_ac_pull_requests_state", "ac_pull_requests", ["state"])
+
+    # ── ac_agent_messages ─────────────────────────────────────────────────────
+    op.create_table(
+        "ac_agent_messages",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "agent_run_id",
+            sa.String(512),
+            sa.ForeignKey("ac_agent_runs.id"),
+            nullable=False,
+        ),
+        sa.Column("role", sa.String(64), nullable=False),
+        sa.Column("content", sa.Text(), nullable=True),
+        sa.Column("tool_name", sa.String(256), nullable=True),
+        sa.Column("sequence_index", sa.Integer(), nullable=False),
+        sa.Column("recorded_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "ix_ac_agent_messages_run_seq",
+        "ac_agent_messages",
+        ["agent_run_id", "sequence_index"],
+    )
+
+    # ── ac_role_versions ──────────────────────────────────────────────────────
+    op.create_table(
+        "ac_role_versions",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("role_name", sa.String(128), nullable=False),
+        sa.Column("content_hash", sa.String(64), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("first_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("role_name", "content_hash", name="uq_ac_role_versions"),
+    )
+    op.create_index("ix_ac_role_versions_role_name", "ac_role_versions", ["role_name"])
+
+    # ── ac_pipeline_snapshots ─────────────────────────────────────────────────
+    op.create_table(
+        "ac_pipeline_snapshots",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("polled_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("active_label", sa.String(256), nullable=True),
+        sa.Column("issues_open", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("prs_open", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("agents_active", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("alerts_json", sa.Text(), nullable=False, server_default="[]"),
+    )
+    op.create_index(
+        "ix_ac_pipeline_snapshots_polled_at", "ac_pipeline_snapshots", ["polled_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("ac_pipeline_snapshots")
+    op.drop_table("ac_role_versions")
+    op.drop_table("ac_agent_messages")
+    op.drop_table("ac_pull_requests")
+    op.drop_table("ac_issues")
+    op.drop_table("ac_agent_runs")
+    op.drop_table("ac_waves")

--- a/agentception/app.py
+++ b/agentception/app.py
@@ -25,6 +25,7 @@ from fastapi.staticfiles import StaticFiles
 from sse_starlette.sse import EventSourceResponse
 from starlette.requests import Request
 
+from agentception.db.engine import close_db, init_db
 from agentception.poller import polling_loop, subscribe, unsubscribe
 from agentception.routes.api import router as api_router
 from agentception.routes.control import router as control_router
@@ -41,7 +42,8 @@ _HERE = Path(__file__).parent
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    """Start the background poller on startup; cancel it on shutdown."""
+    """Start DB, background poller on startup; tear both down on shutdown."""
+    await init_db()
     poller = asyncio.create_task(polling_loop(), name="agentception-poller")
     logger.info("✅ AgentCeption poller started")
     try:
@@ -52,6 +54,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             await poller
         except asyncio.CancelledError:
             pass
+        await close_db()
 
 
 app = FastAPI(

--- a/agentception/config.py
+++ b/agentception/config.py
@@ -36,6 +36,13 @@ class AgentCeptionSettings(BaseSettings):
     gh_repo: str = "cgcardona/maestro"
     poll_interval_seconds: int = 5
     github_cache_seconds: int = 10
+    database_url: str | None = None
+    """Async database URL for AgentCeption's own ac_* tables.
+
+    Set via ``AC_DATABASE_URL`` env var (docker-compose injects this).
+    Falls back to a local SQLite file when absent so the service starts
+    without Postgres in pure-filesystem dev mode.
+    """
 
     @model_validator(mode="after")
     def _apply_active_project(self) -> AgentCeptionSettings:

--- a/agentception/db/__init__.py
+++ b/agentception/db/__init__.py
@@ -1,0 +1,6 @@
+"""AgentCeption database package.
+
+Self-contained: own Base, engine, session factory, and Alembic migration tree.
+Designed for clean extraction to a standalone service — no imports from maestro.db.
+"""
+from __future__ import annotations

--- a/agentception/db/base.py
+++ b/agentception/db/base.py
@@ -1,0 +1,12 @@
+"""Declarative base for all AgentCeption ORM models.
+
+Intentionally isolated from ``maestro.db.database.Base`` so that this package
+can be extracted to its own service without touching the Maestro codebase.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base class for all AgentCeption (ac_*) SQLAlchemy models."""

--- a/agentception/db/engine.py
+++ b/agentception/db/engine.py
@@ -1,0 +1,100 @@
+"""Async SQLAlchemy engine, session factory, and lifecycle helpers for AgentCeption.
+
+Intentionally mirrors the pattern in ``maestro/db/database.py`` so both services
+look consistent while remaining fully independent — no cross-imports.
+
+Schema is owned by Alembic (``agentception/alembic/``).  This module only
+creates the engine and session factory; it never calls ``CREATE TABLE``.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+logger = logging.getLogger(__name__)
+
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+def _get_url() -> str:
+    """Read AC_DATABASE_URL from settings; fall back to SQLite for local dev."""
+    from agentception.config import settings  # local import — avoids circular at module load
+
+    url = getattr(settings, "database_url", None)
+    if not url:
+        url = "sqlite+aiosqlite:///./agentception.db"
+        logger.warning("⚠️  AC_DATABASE_URL not set — using SQLite: %s", url)
+    return url
+
+
+async def init_db() -> None:
+    """Initialise the async engine and session factory.
+
+    Called once in the FastAPI lifespan before the app starts serving requests.
+    Alembic must have already run ``upgrade head`` before this is called.
+    """
+    global _engine, _session_factory
+
+    url = _get_url()
+    display_url = url.split("@")[-1] if "@" in url else url
+    logger.info("✅ AgentCeption DB initialising: %s", display_url)
+
+    connect_args: dict[str, object] = {}
+    if url.startswith("sqlite"):
+        connect_args["check_same_thread"] = False
+
+    _engine = create_async_engine(url, echo=False, connect_args=connect_args)
+    _session_factory = async_sessionmaker(
+        bind=_engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    # Import models to register them on Base.metadata even though DDL is
+    # Alembic-owned.  This ensures relationship resolution works at runtime.
+    from agentception.db import models  # noqa: F401
+
+    logger.info("✅ AgentCeption DB ready")
+
+
+async def close_db() -> None:
+    """Dispose of the engine and clear module-level singletons."""
+    global _engine, _session_factory
+    if _engine:
+        await _engine.dispose()
+        _engine = None
+        _session_factory = None
+        logger.info("✅ AgentCeption DB connection closed")
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """FastAPI dependency — yields a committed-on-success / rolled-back-on-error session."""
+    if _session_factory is None:
+        raise RuntimeError("AgentCeption DB not initialised. Call init_db() first.")
+    async with _session_factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+def get_session() -> AsyncSession:
+    """Return a raw session for background tasks (non-FastAPI contexts).
+
+    Usage::
+
+        async with get_session() as session:
+            session.add(row)
+            await session.commit()
+    """
+    if _session_factory is None:
+        raise RuntimeError("AgentCeption DB not initialised. Call init_db() first.")
+    return _session_factory()

--- a/agentception/db/models.py
+++ b/agentception/db/models.py
@@ -1,0 +1,303 @@
+"""AgentCeption ORM models — all tables use the ``ac_`` prefix.
+
+Entity hierarchy
+----------------
+ACWave
+    One row per "Start Wave" click (or any batch spawn).  Groups ACAgentRuns.
+
+ACAgentRun
+    One row per agent working one issue in one wave.  Tracks the full lifecycle
+    from spawn to completion.  FK to ACWave (nullable for manually-spawned runs).
+
+ACIssue
+    Mirror of a GitHub issue, refreshed on every tick via hash-diff so we only
+    write when fields change.  Preserves history across state transitions.
+
+ACPullRequest
+    Mirror of a GitHub PR, same hash-diff strategy as ACIssue.
+
+ACAgentMessage
+    One row per message in an agent's Cursor transcript.  Written async so it
+    never blocks the tick loop.  Enables full-text search and heuristics.
+
+ACRoleVersion
+    Content-addressed snapshot of a role prompt file.  New row only when the
+    SHA-256 hash of the file content changes — tracks prompt evolution over time.
+
+ACPipelineSnapshot
+    Time-series: one row per poller tick.  Lightweight (no text blobs).
+    Enables trend charts, SLA analysis, and anomaly detection.
+"""
+from __future__ import annotations
+
+import datetime
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from agentception.db.base import Base
+
+
+# ---------------------------------------------------------------------------
+# ACWave — one per batch spawn
+# ---------------------------------------------------------------------------
+
+
+class ACWave(Base):
+    """A batch spawn operation — one "Start Wave" click = one ACWave."""
+
+    __tablename__ = "ac_waves"
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    """BATCH_ID from the .agent-task file (e.g. ``eng-20260302T084507Z-16da``)."""
+
+    phase_label: Mapped[str] = mapped_column(String(256), nullable=False)
+    """Active phase label at spawn time (e.g. ``ac-ui/0-critical-bugs``)."""
+
+    role: Mapped[str] = mapped_column(String(128), nullable=False)
+    """Agent role used for this wave (e.g. ``python-developer``)."""
+
+    started_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    completed_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    spawn_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    """Number of agents successfully spawned."""
+
+    skip_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    """Number of issues skipped (already claimed or worktree existed)."""
+
+    agent_runs: Mapped[list[ACAgentRun]] = relationship(
+        "ACAgentRun", back_populates="wave", cascade="all, delete-orphan"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ACAgentRun — one per agent / issue
+# ---------------------------------------------------------------------------
+
+
+class ACAgentRun(Base):
+    """Lifecycle of one agent working one issue."""
+
+    __tablename__ = "ac_agent_runs"
+
+    id: Mapped[str] = mapped_column(String(512), primary_key=True)
+    """Worktree path (unique per run) or generated UUID for manual spawns."""
+
+    wave_id: Mapped[str | None] = mapped_column(
+        String(128), ForeignKey("ac_waves.id"), nullable=True, index=True
+    )
+    issue_number: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    pr_number: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    branch: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    worktree_path: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    role: Mapped[str] = mapped_column(String(128), nullable=False)
+    status: Mapped[str] = mapped_column(String(64), nullable=False)
+    """IMPLEMENTING | REVIEWING | DONE | STALE | UNKNOWN"""
+
+    attempt_number: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    spawn_mode: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    """chain | wave | manual"""
+
+    batch_id: Mapped[str | None] = mapped_column(String(128), nullable=True, index=True)
+
+    spawned_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    last_activity_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    wave: Mapped[ACWave | None] = relationship("ACWave", back_populates="agent_runs")
+    messages: Mapped[list[ACAgentMessage]] = relationship(
+        "ACAgentMessage", back_populates="agent_run", cascade="all, delete-orphan"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ACIssue — GitHub issue mirror (hash-diff sync)
+# ---------------------------------------------------------------------------
+
+
+class ACIssue(Base):
+    """Mirror of a GitHub issue, refreshed on every poller tick via hash-diff.
+
+    Only written when ``content_hash`` changes, so the row always reflects the
+    latest GitHub state without hammering the DB on every tick.
+    """
+
+    __tablename__ = "ac_issues"
+
+    github_number: Mapped[int] = mapped_column(Integer, primary_key=True)
+    repo: Mapped[str] = mapped_column(String(256), nullable=False, primary_key=True)
+    title: Mapped[str] = mapped_column(String(512), nullable=False)
+    body: Mapped[str | None] = mapped_column(Text, nullable=True)
+    state: Mapped[str] = mapped_column(String(32), nullable=False)
+    """open | closed"""
+
+    phase_label: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    """Active phase label at the time of last sync."""
+
+    labels_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    """JSON-serialised list of label name strings."""
+
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    """SHA-256 of (title + state + labels_json) — write guard for hash-diff."""
+
+    created_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    closed_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    first_seen_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    last_synced_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    __table_args__ = (
+        Index("ix_ac_issues_state", "state"),
+        Index("ix_ac_issues_phase_label", "phase_label"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# ACPullRequest — GitHub PR mirror (hash-diff sync)
+# ---------------------------------------------------------------------------
+
+
+class ACPullRequest(Base):
+    """Mirror of a GitHub pull request, refreshed on every tick via hash-diff."""
+
+    __tablename__ = "ac_pull_requests"
+
+    github_number: Mapped[int] = mapped_column(Integer, primary_key=True)
+    repo: Mapped[str] = mapped_column(String(256), nullable=False, primary_key=True)
+    title: Mapped[str] = mapped_column(String(512), nullable=False)
+    state: Mapped[str] = mapped_column(String(32), nullable=False)
+    """open | closed | merged"""
+
+    head_ref: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    closes_issue_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    labels_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    created_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    merged_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    first_seen_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    last_synced_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    __table_args__ = (Index("ix_ac_pull_requests_state", "state"),)
+
+
+# ---------------------------------------------------------------------------
+# ACAgentMessage — full transcript (written async)
+# ---------------------------------------------------------------------------
+
+
+class ACAgentMessage(Base):
+    """One message from a Cursor agent transcript.
+
+    Written asynchronously so reading + persisting transcripts never blocks
+    the 5-second tick loop.  Enables full-text search and ML feature extraction.
+    """
+
+    __tablename__ = "ac_agent_messages"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    agent_run_id: Mapped[str] = mapped_column(
+        String(512), ForeignKey("ac_agent_runs.id"), nullable=False, index=True
+    )
+    role: Mapped[str] = mapped_column(String(64), nullable=False)
+    """user | assistant | tool_call | tool_result | thinking"""
+
+    content: Mapped[str | None] = mapped_column(Text, nullable=True)
+    tool_name: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    sequence_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    recorded_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    agent_run: Mapped[ACAgentRun] = relationship("ACAgentRun", back_populates="messages")
+
+    __table_args__ = (
+        Index("ix_ac_agent_messages_run_seq", "agent_run_id", "sequence_index"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# ACRoleVersion — content-addressed role prompt snapshots
+# ---------------------------------------------------------------------------
+
+
+class ACRoleVersion(Base):
+    """Content-addressed snapshot of a role prompt file.
+
+    A new row is inserted only when the SHA-256 hash of the file content
+    changes, making this a full audit trail of every prompt change over time.
+    """
+
+    __tablename__ = "ac_role_versions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    role_name: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    first_seen_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    __table_args__ = (
+        UniqueConstraint("role_name", "content_hash", name="uq_ac_role_versions"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# ACPipelineSnapshot — time-series tick state
+# ---------------------------------------------------------------------------
+
+
+class ACPipelineSnapshot(Base):
+    """One row per poller tick — lightweight time-series of pipeline health.
+
+    No text blobs; stores only scalar counts and the active label.
+    Use for trend charts, SLA analysis, and anomaly detection.
+    """
+
+    __tablename__ = "ac_pipeline_snapshots"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    polled_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+    active_label: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    issues_open: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    prs_open: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    agents_active: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    alerts_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    """JSON array of alert strings from the tick."""

--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -1,0 +1,352 @@
+"""DB persistence layer called by the AgentCeption poller after each tick.
+
+Strategy per entity type
+------------------------
+ACPipelineSnapshot  — one row per tick, always (lightweight scalars only).
+ACIssue / ACPullRequest — upsert on hash-diff: only write when content changes.
+ACAgentRun          — upsert on every tick so status transitions are recorded.
+ACAgentMessage      — fire-and-forget async task, never blocks the tick loop.
+ACRoleVersion       — insert-if-not-exists on role file content hash.
+
+All writes are wrapped in a single ``try/except`` so a DB outage never takes
+down the poller — the dashboard degrades gracefully to filesystem-only mode.
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime
+import hashlib
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from agentception.db.engine import get_session
+from agentception.db.models import (
+    ACAgentMessage,
+    ACAgentRun,
+    ACIssue,
+    ACPipelineSnapshot,
+    ACPullRequest,
+    ACRoleVersion,
+)
+
+if TYPE_CHECKING:
+    from agentception.models import AgentNode, PipelineState
+
+logger = logging.getLogger(__name__)
+
+_UTC = datetime.timezone.utc
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(_UTC)
+
+
+def _hash(*parts: str) -> str:
+    """SHA-256 of the concatenation of all parts — used as the change sentinel."""
+    return hashlib.sha256("".join(parts).encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Public entry point — called by poller.tick()
+# ---------------------------------------------------------------------------
+
+
+async def persist_tick(
+    state: PipelineState,
+    open_issues: list[dict[str, object]],
+    open_prs: list[dict[str, object]],
+    gh_repo: str,
+) -> None:
+    """Persist everything derived from one polling tick.
+
+    Swallows all exceptions so a DB outage never crashes the poller.
+    """
+    try:
+        async with get_session() as session:
+            await _upsert_snapshot(session, state)
+            await _upsert_issues(session, open_issues, state.active_label, gh_repo)
+            await _upsert_prs(session, open_prs, gh_repo)
+            await _upsert_agent_runs(session, state.agents)
+            await session.commit()
+    except Exception as exc:
+        logger.warning("⚠️  DB persist_tick failed (non-fatal): %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot
+# ---------------------------------------------------------------------------
+
+
+async def _upsert_snapshot(session: object, state: PipelineState) -> None:  # type: ignore[type-arg]
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    assert isinstance(session, AsyncSession)
+    snap = ACPipelineSnapshot(
+        polled_at=datetime.datetime.fromtimestamp(state.polled_at, tz=_UTC),
+        active_label=state.active_label,
+        issues_open=state.issues_open,
+        prs_open=state.prs_open,
+        agents_active=len(state.agents),
+        alerts_json=json.dumps(state.alerts),
+    )
+    session.add(snap)
+
+
+# ---------------------------------------------------------------------------
+# Issues (hash-diff upsert)
+# ---------------------------------------------------------------------------
+
+
+async def _upsert_issues(
+    session: object,
+    issues: list[dict[str, object]],
+    active_label: str | None,
+    repo: str,
+) -> None:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    assert isinstance(session, AsyncSession)
+    now = _now()
+
+    for raw in issues:
+        num = raw.get("number")
+        if not isinstance(num, int):
+            continue
+        title = str(raw.get("title", ""))
+        state_str = str(raw.get("state", "open"))
+        labels_raw = raw.get("labels", [])
+        label_names: list[str] = []
+        if isinstance(labels_raw, list):
+            for lbl in labels_raw:
+                if isinstance(lbl, str):
+                    label_names.append(lbl)
+                elif isinstance(lbl, dict):
+                    n = lbl.get("name")
+                    if isinstance(n, str):
+                        label_names.append(n)
+        labels_json = json.dumps(sorted(label_names))
+        content_hash = _hash(title, state_str, labels_json)
+
+        result = await session.execute(
+            select(ACIssue).where(ACIssue.github_number == num, ACIssue.repo == repo)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing is None:
+            session.add(
+                ACIssue(
+                    github_number=num,
+                    repo=repo,
+                    title=title,
+                    body=str(raw.get("body", "")) or None,
+                    state=state_str,
+                    phase_label=active_label,
+                    labels_json=labels_json,
+                    content_hash=content_hash,
+                    first_seen_at=now,
+                    last_synced_at=now,
+                )
+            )
+        elif existing.content_hash != content_hash:
+            existing.title = title
+            existing.state = state_str
+            existing.phase_label = active_label
+            existing.labels_json = labels_json
+            existing.content_hash = content_hash
+            existing.last_synced_at = now
+
+
+# ---------------------------------------------------------------------------
+# PRs (hash-diff upsert)
+# ---------------------------------------------------------------------------
+
+
+async def _upsert_prs(
+    session: object,
+    prs: list[dict[str, object]],
+    repo: str,
+) -> None:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    assert isinstance(session, AsyncSession)
+    now = _now()
+
+    for raw in prs:
+        num = raw.get("number")
+        if not isinstance(num, int):
+            continue
+        title = str(raw.get("title", ""))
+        state_str = str(raw.get("state", "open"))
+        head_ref = raw.get("headRefName")
+        labels_raw = raw.get("labels", [])
+        label_names: list[str] = []
+        if isinstance(labels_raw, list):
+            label_names = [
+                lbl.get("name", "") if isinstance(lbl, dict) else str(lbl)
+                for lbl in labels_raw
+                if isinstance(lbl, (str, dict))
+            ]
+        labels_json = json.dumps(sorted(label_names))
+        content_hash = _hash(title, state_str, labels_json, str(head_ref))
+
+        result = await session.execute(
+            select(ACPullRequest).where(
+                ACPullRequest.github_number == num, ACPullRequest.repo == repo
+            )
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing is None:
+            session.add(
+                ACPullRequest(
+                    github_number=num,
+                    repo=repo,
+                    title=title,
+                    state=state_str,
+                    head_ref=str(head_ref) if isinstance(head_ref, str) else None,
+                    labels_json=labels_json,
+                    content_hash=content_hash,
+                    first_seen_at=now,
+                    last_synced_at=now,
+                )
+            )
+        elif existing.content_hash != content_hash:
+            existing.title = title
+            existing.state = state_str
+            existing.head_ref = str(head_ref) if isinstance(head_ref, str) else None
+            existing.labels_json = labels_json
+            existing.content_hash = content_hash
+            existing.last_synced_at = now
+
+
+# ---------------------------------------------------------------------------
+# Agent runs (status upsert)
+# ---------------------------------------------------------------------------
+
+
+async def _upsert_agent_runs(
+    session: object,
+    agents: list[AgentNode],
+) -> None:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    assert isinstance(session, AsyncSession)
+    now = _now()
+
+    for agent in agents:
+        run_id = agent.id
+        result = await session.execute(
+            select(ACAgentRun).where(ACAgentRun.id == run_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing is None:
+            session.add(
+                ACAgentRun(
+                    id=run_id,
+                    wave_id=None,
+                    issue_number=agent.issue_number,
+                    pr_number=agent.pr_number,
+                    branch=agent.branch,
+                    worktree_path=agent.worktree_path,
+                    role=agent.role,
+                    status=agent.status.value,
+                    batch_id=agent.batch_id,
+                    spawned_at=now,
+                    last_activity_at=now,
+                )
+            )
+        else:
+            existing.status = agent.status.value
+            existing.pr_number = agent.pr_number
+            existing.last_activity_at = now
+
+
+# ---------------------------------------------------------------------------
+# Role version snapshot (content-addressed insert-if-new)
+# ---------------------------------------------------------------------------
+
+
+async def persist_role_version(role_name: str, content: str) -> None:
+    """Snapshot a role file if its content has changed since last seen.
+
+    Called at startup and whenever a role file is read.  Safe to call
+    concurrently — the unique constraint on (role_name, content_hash) acts
+    as the idempotency guard.
+    """
+    content_hash = _hash(content)
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACRoleVersion).where(
+                    ACRoleVersion.role_name == role_name,
+                    ACRoleVersion.content_hash == content_hash,
+                )
+            )
+            if result.scalar_one_or_none() is None:
+                session.add(
+                    ACRoleVersion(
+                        role_name=role_name,
+                        content_hash=content_hash,
+                        content=content,
+                        first_seen_at=_now(),
+                    )
+                )
+                await session.commit()
+                logger.info("📸 Role version snapshot: %s (%s…)", role_name, content_hash[:8])
+    except Exception as exc:
+        logger.warning("⚠️  persist_role_version failed (non-fatal): %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Agent messages (async fire-and-forget)
+# ---------------------------------------------------------------------------
+
+
+async def persist_agent_messages_async(
+    agent_run_id: str,
+    messages: list[dict[str, object]],
+) -> None:
+    """Persist transcript messages without blocking the caller.
+
+    Launched as a background asyncio Task so the tick loop is never delayed
+    by transcript I/O.  Errors are swallowed — message loss is preferable to
+    a crashed poller.
+    """
+    asyncio.create_task(_write_messages(agent_run_id, messages))
+
+
+async def _write_messages(
+    agent_run_id: str,
+    messages: list[dict[str, object]],
+) -> None:
+    try:
+        async with get_session() as session:
+            # Determine the next sequence index to avoid duplicates.
+            result = await session.execute(
+                select(ACAgentMessage.sequence_index)
+                .where(ACAgentMessage.agent_run_id == agent_run_id)
+                .order_by(ACAgentMessage.sequence_index.desc())
+                .limit(1)
+            )
+            last_seq = result.scalar_one_or_none()
+            start_idx = (last_seq + 1) if last_seq is not None else 0
+            now = _now()
+
+            for i, msg in enumerate(list(messages)[start_idx:], start=start_idx):
+                session.add(
+                    ACAgentMessage(
+                        agent_run_id=agent_run_id,
+                        role=str(msg.get("role", "unknown")),
+                        content=str(msg.get("content", "")) or None,
+                        tool_name=str(msg.get("tool_name", "")) or None,
+                        sequence_index=i,
+                        recorded_at=now,
+                    )
+                )
+            await session.commit()
+    except Exception as exc:
+        logger.warning("⚠️  _write_messages failed (non-fatal): %s", exc)

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -273,7 +273,7 @@ async def broadcast(state: PipelineState) -> None:
 
 
 async def tick() -> PipelineState:
-    """Execute a single polling cycle: collect → merge → detect → broadcast.
+    """Execute a single polling cycle: collect → merge → detect → persist → broadcast.
 
     This is the unit of work for the background loop.  It is also the
     function to call directly in tests to exercise the full data pipeline
@@ -300,6 +300,20 @@ async def tick() -> PipelineState:
     )
 
     _state = state
+
+    # Persist tick data to Postgres (non-blocking — swallows DB errors so
+    # a database outage cannot crash the poller or stall the SSE stream).
+    try:
+        from agentception.db.persist import persist_tick
+        await persist_tick(
+            state=state,
+            open_issues=github.open_issues,
+            open_prs=github.open_prs,
+            gh_repo=settings.gh_repo,
+        )
+    except Exception as exc:
+        logger.warning("⚠️  DB persist skipped (non-fatal): %s", exc)
+
     await broadcast(state)
     return state
 

--- a/agentception/requirements.txt
+++ b/agentception/requirements.txt
@@ -7,6 +7,12 @@ pydantic-settings>=2.3.0
 sse-starlette>=2.1.0
 httpx>=0.27.0
 python-multipart>=0.0.9
+# Database
+sqlalchemy>=2.0.0
+asyncpg>=0.29.0
+aiosqlite>=0.20.0
+alembic>=1.13.0
+# Testing
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
 pytest-anyio>=0.0.0

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -61,6 +61,10 @@ services:
       # below so spawned worktrees land on the host at the expected path.
       AC_REPO_DIR: /repo
       AC_WORKTREES_DIR: /worktrees
+      # AgentCeption's own ac_* tables live in the shared Postgres instance.
+      # Same DB as Maestro during the monorepo phase; ac_* prefix avoids collisions.
+      # When AgentCeption is extracted, point this at its own DB.
+      AC_DATABASE_URL: "postgresql+asyncpg://maestro:${DB_PASSWORD}@postgres:5432/maestro"
     volumes:
       # Live code — host edits are instantly visible; no rebuild needed
       - ./agentception:/app/agentception


### PR DESCRIPTION
Adds a fully isolated DB layer to AgentCeption — own Base, own async engine, own Alembic migration tree (agentception/alembic.ini). Extraction to standalone repo = folder move. 7 ac_* tables, live snapshots every 5s, 310 tests passing.