### PR TITLE
chore: integrate mypy fully across all three services

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -28,7 +28,8 @@ When uncertain: (1) preserve existing patterns, (2) prefer smaller changes over 
 - **Dev bind mounts are active.** `docker-compose.override.yml` bind-mounts `maestro/`, `tests/`, `scripts/`, `storpheus/`, and `pyproject.toml` into the containers. Host file edits are **instantly visible** inside the container — no rebuild needed for code changes. Only rebuild (`docker compose build <service> && docker compose up -d`) when you change `requirements.txt`, `Dockerfile`, or `entrypoint.sh`.
 - **Two containers:** `maestro` (`maestro/`, `tests/`) and `storpheus` (`storpheus/`). Both have mypy and pytest.
 - **Verification order: mypy → tests → docs.** Always run mypy first. Fix type errors before running tests so you only need one test pass.
-- **Mypy (both):** `docker compose exec maestro mypy maestro/ tests/` AND `docker compose exec storpheus mypy .`. Both pass before committing.
+- **Mypy (all three services):** `docker compose exec maestro mypy maestro/ tests/` AND `docker compose exec agentception mypy agentception/` AND `docker compose exec storpheus mypy .`. All three pass before committing.
+- **Typing ratchet:** `python tools/typing_audit.py --dirs maestro/ tests/ --max-any 28` (maestro) and `--dirs agentception/ --max-any 10` (agentception). Never raise a ceiling without justification.
 - **Tests:** Run individual files yourself; user runs full suite. Regression test for every bug fix: `test_<what_broke>_<fixed_behavior>`.
 - **Show full output:** Never truncate, pipe through `head`/`tail`, or hide shell output.
 - **After tests pass:** Update affected docs, then commit — don't wait to be asked.
@@ -36,8 +37,9 @@ When uncertain: (1) preserve existing patterns, (2) prefer smaller changes over 
 ## Code standards
 
 - **Every Python file** starts with `from __future__ import annotations`. No exceptions.
-- Black formatting. Type hints everywhere. `list[...]`/`dict[...]` style. No `# type: ignore` without reason.
-- **Mypy before tests:** Run `docker compose exec <service> mypy <file>` on every Python file you create or modify. Fix all type errors before running tests — this avoids needing to re-run the test suite after type fixes.
+- Black formatting. Type hints everywhere — 100% coverage, no untyped functions or parameters. `list[...]`/`dict[...]` style. No `# type: ignore` without a reason comment explaining why.
+- **Mypy before tests — always.** Run `docker compose exec <service> mypy <path>` on every Python file you create or modify. Fix all type errors before running tests — this avoids needing to re-run the test suite after type fixes. All three services (`maestro`, `agentception`, `storpheus`) are gated by mypy in CI.
+- **`Any` is a last resort.** Prefer `object`, `TypedDict`, or a Pydantic `BaseModel`. Every `Any` counts against the ratchet; never suppress the ratchet.
 - Async for all I/O. `logging.getLogger(__name__)` — never `print()`. `STORI_*` env vars via `app.config.settings`.
 - Sparse logs with emoji prefixes (❌ error, ⚠️ warning, ✅ success). No noise.
 - Docstrings on public modules/classes/functions. "Why" over "what." Update docs in the same commit as code changes.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,8 @@
 # Runs only on PRs and direct pushes targeting main (i.e. dev → main).
 # Feature branch → dev PRs are intentionally excluded to avoid CI noise
 # during the parallel-agent development cycle.
-# Two jobs: maestro (app/ + tests/) and storpheus (storpheus/).
+# Three service jobs: maestro, storpheus, agentception.
+# All run mypy BEFORE tests — type errors block the test run.
 name: Test & Coverage
 
 on:
@@ -29,7 +30,7 @@ jobs:
 
 
   maestro:
-    name: Maestro (app/ + tests/)
+    name: Maestro (maestro/ + tests/)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,9 +51,9 @@ jobs:
           python -m mypy -p maestro
           python -m mypy -p tests
 
-      - name: Typing ratchet (Any regression guard)
+      - name: Typing ratchet — maestro (Any regression guard)
         run: |
-          python tools/typing_audit.py --max-any 28
+          python tools/typing_audit.py --dirs maestro/ tests/ --max-any 28
 
       - name: Run tests with coverage
         env:
@@ -85,3 +86,47 @@ jobs:
       - name: Run tests
         run: |
           pytest storpheus/test_*.py -v --tb=short
+
+  agentception:
+    name: AgentCeption (agentception/)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install system dependencies
+        # asyncpg needs libpq for its C extension on Linux.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libpq-dev
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r agentception/requirements.txt
+          pip install coverage
+
+      - name: Type check (mypy)
+        # Run from repo root with explicit config so we use agentception/pyproject.toml,
+        # not the root pyproject.toml (which has maestro-specific overrides).
+        run: |
+          python -m mypy agentception/ --config-file agentception/pyproject.toml
+
+      - name: Typing ratchet — agentception (Any regression guard)
+        # Threshold matches the current legitimate Any usage in db/queries.py.
+        # Raise the ceiling only when genuinely unavoidable; never suppress blindly.
+        run: |
+          python tools/typing_audit.py --dirs agentception/ --max-any 10
+
+      - name: Run tests with coverage
+        env:
+          GH_REPO: "test-org/test-repo"
+          GH_TOKEN: "test-token-for-ci"
+          AC_DATABASE_URL: ""
+        run: |
+          coverage run -m pytest agentception/tests/ -v --tb=short
+          coverage report --fail-under=80 --show-missing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,82 @@
+# Pre-commit hooks for Maestro monorepo.
+#
+# Hooks run against staged files before each commit.  The mypy hooks delegate
+# to running containers via `docker compose exec` so Python never runs on the
+# host (matching our Docker-first policy).
+#
+# Setup (one-time):
+#   pip install pre-commit
+#   pre-commit install
+#
+# Run manually against all files:
+#   pre-commit run --all-files
+#
+# NOTE: mypy hooks require the service containers to be running:
+#   docker compose up -d maestro agentception storpheus
+#
+# Each hook is scoped to its service's file tree so unchanged services are
+# skipped entirely — a change in agentception/ never triggers maestro mypy.
+
+repos:
+  # ── Standard file hygiene ────────────────────────────────────────────────
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: "\\.(md|txt)$"
+      - id: end-of-file-fixer
+        exclude: "\\.(md)$"
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: detect-private-key
+
+  # ── Mypy — Maestro service ───────────────────────────────────────────────
+  - repo: local
+    hooks:
+      - id: mypy-maestro
+        name: "mypy · maestro/ + tests/"
+        language: system
+        entry: docker compose exec -T maestro mypy maestro/ tests/
+        pass_filenames: false
+        files: ^(maestro|tests)/
+        types: [python]
+
+  # ── Mypy — AgentCeption service ──────────────────────────────────────────
+  - repo: local
+    hooks:
+      - id: mypy-agentception
+        name: "mypy · agentception/"
+        language: system
+        entry: docker compose exec -T agentception mypy agentception/
+        pass_filenames: false
+        files: ^agentception/
+        types: [python]
+
+  # ── Mypy — Storpheus service ─────────────────────────────────────────────
+  - repo: local
+    hooks:
+      - id: mypy-storpheus
+        name: "mypy · storpheus/"
+        language: system
+        entry: docker compose exec -T storpheus mypy .
+        pass_filenames: false
+        files: ^storpheus/
+        types: [python]
+
+  # ── future __annotations__ guard ────────────────────────────────────────
+  # Every Python file in all services must start with
+  # `from __future__ import annotations` per the workspace rules.
+  - repo: local
+    hooks:
+      - id: future-annotations
+        name: "from __future__ import annotations required"
+        language: pygrep
+        entry: "^from __future__ import annotations"
+        args: ["--negate"]
+        files: ^(maestro|tests|storpheus|agentception)/.*\\.py$
+        # Exclude generated files that we don't control (alembic templates).
+        exclude: "(alembic/script\\.py\\.mako|alembic/versions/)"
+        types: [python]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,11 +117,30 @@ The backend serves the frontend via SSE streaming and tool calls. The SSE event 
 ## Code Generation Rules
 
 - **Every Python file** must start with `from __future__ import annotations` as the first import. No exceptions.
-- **Mypy before tests:** Run mypy on every Python file you create or modify. Fix all type errors before running tests — this avoids needing to re-run the test suite after type fixes.
+- **Type everything, 100%.** No untyped function parameters, no untyped return values, no bare `object` where a precise type is known. Use `list[X]`, `dict[K, V]`, `tuple[A, B]`, `X | None` — never the `Optional[X]` form.
+- **Mypy before tests — always, without exception.** Run mypy on every Python file you create or modify before running the test suite. Fix all type errors first. If you run tests and then discover type errors, you must re-run tests after fixing them. One pass is cheaper.
+- **`Any` is a last resort, not a default.** Use `dict[str, object]` for truly heterogeneous data. Use `TypedDict` or a `BaseModel` subclass for structured data. `Any` is only acceptable in the DB query layer (`db/queries.py`) where the shape varies per caller, and must stay within the typing ratchet ceiling (`--max-any 10` for agentception, `--max-any 28` for maestro).
+- **No `# type: ignore` without a reason comment.** Every suppression must explain why: `# type: ignore[attr-defined]  # SQLAlchemy dynamic attr`.
 - **Editing existing files:** Only modify necessary sections. Preserve formatting, structure, and surrounding code.
 - **Creating new files:** Write complete, self-contained modules. Include imports, type hints, and docstrings.
 - **Before finishing any task:** Confirm types pass (mypy), tests pass, imports resolve, no orphaned code.
 - **No rebuild needed for code changes.** Dev bind mounts (`docker-compose.override.yml`) ensure host file edits are live inside the container immediately. Only rebuild (`docker compose build <service> && docker compose up -d`) when `requirements.txt`, `Dockerfile`, or `entrypoint.sh` change.
+
+### Mypy enforcement chain
+
+| Layer | Command | Threshold |
+|-------|---------|-----------|
+| Local (Maestro) | `docker compose exec maestro mypy maestro/ tests/` | strict, 0 errors |
+| Local (AgentCeption) | `docker compose exec agentception mypy agentception/` | strict, 0 errors |
+| Local (Storpheus) | `docker compose exec storpheus mypy .` | strict, 0 errors |
+| Pre-commit hook | Runs the above automatically on `git commit` | blocks commit |
+| CI — Maestro | `python -m mypy -p maestro && python -m mypy -p tests` | blocks PR merge |
+| CI — AgentCeption | `python -m mypy agentception/ --config-file agentception/pyproject.toml` | blocks PR merge |
+| CI — Storpheus | `python -m mypy storpheus/` | blocks PR merge |
+| Typing ratchet — Maestro | `python tools/typing_audit.py --dirs maestro/ tests/ --max-any 28` | blocks PR merge |
+| Typing ratchet — AgentCeption | `python tools/typing_audit.py --dirs agentception/ --max-any 10` | blocks PR merge |
+
+All three services run `mypy` with `strict = true`. The ratchets prevent `Any` count from growing even if individual occurrences are "valid".
 
 ### Jinja2 + Alpine.js / HTMX: always single-quote attributes containing `tojson`
 

--- a/agentception/pyproject.toml
+++ b/agentception/pyproject.toml
@@ -44,7 +44,20 @@ include = ["agentception*"]
 [tool.mypy]
 python_version = "3.11"
 strict = true
+explicit_package_bases = true
+warn_unreachable = true
+show_error_codes = true
+
+# Third-party stubs are not always available; suppress missing-import noise
+# for libraries that ship without inline types.
+[[tool.mypy.overrides]]
+module = ["sqlalchemy.*", "alembic.*", "asyncpg.*", "aiosqlite.*"]
 ignore_missing_imports = true
+
+# pytest decorators are untyped by design; relaxing this keeps test files clean.
+[[tool.mypy.overrides]]
+module = ["agentception.tests.*"]
+disallow_untyped_decorators = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tools/typing_audit.py
+++ b/tools/typing_audit.py
@@ -4,9 +4,10 @@
 Outputs JSON (machine-readable) + a human summary to stdout.
 
 Usage:
-    python tools/typing_audit.py                        # audit app/ + tests/ + storpheus/
+    python tools/typing_audit.py                        # maestro/ + tests/ + storpheus/ + agentception/
     python tools/typing_audit.py --json artifacts/typing_audit.json
-    python tools/typing_audit.py --dirs app/ storpheus/
+    python tools/typing_audit.py --dirs maestro/ storpheus/
+    python tools/typing_audit.py --dirs agentception/ --max-any 10
 """
 
 from __future__ import annotations
@@ -222,7 +223,7 @@ def main() -> None:
     parser.add_argument(
         "--dirs",
         nargs="+",
-        default=["app/", "tests/", "storpheus/"],
+        default=["maestro/", "tests/", "storpheus/", "agentception/"],
         help="Directories to scan",
     )
     parser.add_argument("--json", type=str, help="Write JSON report to file")


### PR DESCRIPTION
## Summary

- **CI gate for AgentCeption** — the `test.yml` workflow had no job for `agentception/`. PRs that broke its types passed CI silently. Now all three services (maestro, storpheus, agentception) run mypy before tests and block on failure.
- **Typing ratchet for AgentCeption** — adds `python tools/typing_audit.py --dirs agentception/ --max-any 10`. The ceiling reflects the current legitimate `Any` usage (DB query layer return types). Raising it requires justification.
- **AgentCeption pyproject.toml tightened** — adds `explicit_package_bases`, `warn_unreachable`, `show_error_codes`, SQLAlchemy/asyncpg stub overrides, and a test-module decorator override to match Maestro's strictness level.
- **typing_audit.py default dirs fixed** — was scanning `app/` (which doesn't exist); now scans `maestro/ tests/ storpheus/ agentception/`.
- **Pre-commit config** — new `.pre-commit-config.yaml` with per-service mypy hooks via `docker compose exec`, file hygiene hooks, and a `from __future__ import annotations` guard on all Python files.
- **AGENTS.md + .cursorrules** — full enforcement chain documented as a reference table; `Any` policy and ratchet ceiling documented.

## Enforcement chain after this PR

```
git commit  →  pre-commit hook  →  docker compose exec <service> mypy
git push    →  CI job           →  python -m mypy <service>/ (strict)
            →  typing ratchet   →  --max-any 10 (agentception) / 28 (maestro)
            →  tests            →  pytest (only runs if mypy passed)
```

## Test plan
- [x] `docker compose exec agentception mypy agentception/` — 63 files, 0 errors
- [x] `docker compose exec maestro mypy maestro/ tests/` — 740 files, 0 errors