### PR TITLE
fix(agentception): board shows 'All claimed ✓' falsely when DB not yet synced

### DIFF
--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -373,7 +373,12 @@
             </div>
           </div>
 
-          {# Start Wave — reactive: shown when there are unclaimed issues #}
+          {#
+            Three mutually exclusive CTA states — evaluated in priority order:
+            1. Unclaimed issues exist → "Start Wave" button
+            2. Board has issues, all claimed → "All claimed ✓" badge
+            3. Board is empty (DB not yet synced) → "Syncing…" hint
+          #}
           <template x-if="state.active_label && unclaimedCount() > 0">
             <button
               class="btn btn-primary btn-wave-start"
@@ -384,8 +389,11 @@
               aria-label="Start pipeline wave"
             ></button>
           </template>
-          <template x-if="state.active_label && unclaimedCount() === 0">
+          <template x-if="state.active_label && state.board_issues && state.board_issues.length > 0 && unclaimedCount() === 0">
             <span class="badge badge--green">All claimed ✓</span>
+          </template>
+          <template x-if="state.active_label && (!state.board_issues || state.board_issues.length === 0)">
+            <span class="text-muted board-syncing">Syncing…</span>
           </template>
         </div>
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,24 +3,22 @@
 # Auto-merged by `docker compose up` (no -f flag needed).
 # Production: `docker compose -f docker-compose.yml up` skips this file.
 #
-# ┌─────────────────────────────────────────────────────────────────────┐
-# │  REBUILD GUIDE — when do you need `docker compose build <service>`? │
-# ├─────────────────────────────────────────────────────────────────────┤
-# │  REBUILD REQUIRED          │  NO REBUILD — live via bind-mount      │
-# ├────────────────────────────┼────────────────────────────────────────┤
-# │  requirements.txt changed  │  maestro/**/*.py                       │
-# │  Dockerfile changed        │  tests/**/*.py                         │
-# │  New top-level dir added   │  scripts/**                            │
-# │  (not yet in volumes below)│  alembic/**                            │
-# │                            │  /worktrees/<id>/**  (worktrees)       │
-# │                            │  tourdeforce/**                  │
-# │                            │  tools/**                              │
-# │                            │  pyproject.toml                        │
-# │                            │  storpheus/**/*.py                     │
-# └────────────────────────────┴────────────────────────────────────────┘
+# ┌──────────────────────────────────────────────────────────────────────────┐
+# │  REBUILD GUIDE — when do you need `docker compose build <service>`?      │
+# ├────────────────────────────────┬─────────────────────────────────────────┤
+# │  REBUILD REQUIRED              │  NO REBUILD — live via bind-mount       │
+# ├────────────────────────────────┼─────────────────────────────────────────┤
+# │  requirements.txt changed      │  maestro/**/*.py  (uvicorn --reload)    │
+# │  Dockerfile changed            │  agentception/**/*.py  (uvicorn --reload)│
+# │  New top-level dir added       │  tests/**/*.py                          │
+# │  (not yet in volumes below)    │  storpheus/**/*.py                      │
+# │                                │  scripts/**, tools/**, alembic/**       │
+# │                                │  /worktrees/<id>/**  (worktrees)        │
+# └────────────────────────────────┴─────────────────────────────────────────┘
 #
 # Bind-mounts shadow the COPY'd code in the image — host edits are
-# immediately visible inside the container with zero restart needed.
+# immediately visible inside the container.  Both maestro and agentception
+# run uvicorn with --reload so Python changes hot-reload without any restart.
 # The baked image layer only matters for dependencies (wheels/pip installs).
 
 services:
@@ -50,6 +48,15 @@ services:
       - ${HOME}/.cursor/worktrees/maestro:/worktrees
 
   agentception:
+    # Enable hot-reload so Python code changes on the host take effect without
+    # `docker compose restart agentception`.  Uvicorn watches /app/agentception/
+    # (which is bind-mounted from ./agentception/) for .py file changes.
+    command: >
+      uvicorn agentception.app:app
+        --host 0.0.0.0
+        --port 7777
+        --reload
+        --reload-dir /app/agentception
     environment:
       # Host keychain token passed in so gh CLI works inside the container.
       # The hosts.yml mount is read-only and contains no token when the host


### PR DESCRIPTION
## Root cause

Two bugs:

**1. Template logic:** `unclaimedCount() === 0` evaluated to true in two distinct situations:
- All issues in the active phase are genuinely claimed (correct to show badge)
- `state.board_issues` is empty because `ac_issues` hasn't been populated yet by the poller (incorrect — was showing "All claimed ✓" falsely on first load)

**2. No hot-reload in dev:** uvicorn was running without `--reload`, so Python code changes (DB lifespan wiring, new route handlers) required `docker compose restart agentception` to take effect. This made it look like the DB integration wasn't working.

## Fix

**overview.html** — three mutually exclusive board states:
```
unclaimedCount() > 0                      → "Start Wave" button
board has issues AND unclaimedCount() = 0 → "All claimed ✓"
board_issues empty                        → "Syncing…"
```

**docker-compose.override.yml** — add `--reload --reload-dir /app/agentception` so Python changes hot-reload without any manual restart.

## Verification

SSE is broadcasting correctly:
```
active_label: ac-ui/0-critical-bugs | board_issues: 4 | issues_open: 30
```