### PR TITLE
fix(agentception): brand links to overview; spinner on phase switch

### DIFF
--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -1357,3 +1357,33 @@ main {
 .badge--red    { background: rgba(248,81,73,0.15);  color: var(--danger); }
 .badge--grey   { background: rgba(139,148,158,0.15);color: var(--text-muted); }
 .badge--purple { background: rgba(124,58,237,0.15); color: var(--accent); }
+
+/* ── Brand link — nav logo that routes back to overview ── */
+a.brand {
+  text-decoration: none;
+  color: var(--accent);
+}
+a.brand:hover { color: var(--accent-hover); }
+
+/* ── Board loading spinner — shown while a phase switch is in flight ── */
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+.board-spinner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 2rem 1rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+.board-spinner__ring {
+  width: 2rem;
+  height: 2rem;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}

--- a/agentception/templates/base.html
+++ b/agentception/templates/base.html
@@ -25,7 +25,7 @@
 <body class="layout">
 
   <nav class="topnav" role="navigation" aria-label="Main navigation">
-    <span class="brand">⚡ AgentCeption</span>
+    <a href="/" class="brand">⚡ AgentCeption</a>
     <a href="/"
        class="{% if request.url.path == '/' %}active{% endif %}">
       Overview

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -11,6 +11,7 @@
 <div
   x-data='pipelineDashboard({{ state.model_dump() | tojson }})'
   x-init="connect()"
+  @phase-switching.window="boardLoading = true"
 >
 
   {# ── Pipeline summary bar ──────────────────────────────────────────────── #}
@@ -504,7 +505,13 @@
         "Analyze" uses Alpine fetch so the button works inside x-for without
         HTMX needing to re-process dynamically generated DOM nodes.
       #}
-      <div x-show="state.board_issues && state.board_issues.length > 0" class="mt-2">
+      {# Spinner — visible while a phase switch is in flight (before page reloads) #}
+      <div x-show="boardLoading" class="board-spinner mt-2">
+        <div class="board-spinner__ring"></div>
+        <span>Switching phase…</span>
+      </div>
+
+      <div x-show="!boardLoading && state.board_issues && state.board_issues.length > 0" class="mt-2">
         <h3 class="section-subtitle">
           Open Issues
           <span class="badge badge-count" x-text="state.board_issues ? state.board_issues.length : 0"></span>
@@ -551,7 +558,7 @@
 
       {# Empty board state — only visible while ac_issues is warming up #}
       <div
-        x-show="!state.board_issues || state.board_issues.length === 0"
+        x-show="!boardLoading && (!state.board_issues || state.board_issues.length === 0)"
         class="mt-2 text-muted empty-state"
       >
         <p>No open unclaimed issues in the active phase.</p>
@@ -632,6 +639,7 @@ function pipelineDashboard(initial) {
   return {
     state: initial,
     connected: false,
+    boardLoading: false,
     _es: null,
 
     connect() {
@@ -849,6 +857,8 @@ function phaseSwitcher(initialLabel, allLabels, initialPinned) {
 
     async selectLabel(label) {
       this.open = false;
+      // Signal the board to show a spinner immediately — before the fetch + reload.
+      this.$dispatch('phase-switching');
       try {
         const res = await fetch('/api/control/active-label', {
           method: 'PUT',
@@ -859,7 +869,6 @@ function phaseSwitcher(initialLabel, allLabels, initialPinned) {
           const data = await res.json();
           this.current = data.label;
           this.pinned = data.pinned;
-          // Reload the page so the board sidebar reflects the new phase.
           window.location.reload();
         }
       } catch (_) {}
@@ -867,6 +876,8 @@ function phaseSwitcher(initialLabel, allLabels, initialPinned) {
 
     async selectAuto() {
       this.open = false;
+      // Signal the board to show a spinner immediately — before the fetch + reload.
+      this.$dispatch('phase-switching');
       try {
         const res = await fetch('/api/control/active-label', { method: 'DELETE' });
         if (res.ok) {


### PR DESCRIPTION
## Summary
- `⚡ AgentCeption` brand text in the top-nav is now an `<a href="/">` — clicking it from any page returns to the Overview
- When selecting a phase from the dropdown, the board issues section immediately replaces with a spinning ring + "Switching phase…" text, so there's no flash of stale data while the fetch + reload are in flight

## How it works
- `pipelineDashboard` gains a `boardLoading: false` flag; the parent Alpine div listens for `@phase-switching.window`
- `phaseSwitcher.selectLabel` and `selectAuto` both dispatch `phase-switching` before calling `fetch` — the spinner is visible for the ~500ms between click and `window.location.reload()`
- CSS: new `.board-spinner` / `.board-spinner__ring` with a `spin` keyframe added to `app.css`