### PR TITLE
fix(agentception): add types-PyYAML to resolve mypy import-untyped error

### DIFF
--- a/agentception/pyproject.toml
+++ b/agentception/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "pytest-anyio>=0.0.0",
     "mypy>=1.8.0",
     "types-aiofiles>=23.2.0",
+    "types-PyYAML>=6.0.0",
 ]
 
 [project.scripts]
@@ -51,7 +52,7 @@ show_error_codes = true
 # Third-party stubs are not always available; suppress missing-import noise
 # for libraries that ship without inline types.
 [[tool.mypy.overrides]]
-module = ["sqlalchemy.*", "alembic.*", "asyncpg.*", "aiosqlite.*", "yaml"]
+module = ["sqlalchemy.*", "alembic.*", "asyncpg.*", "aiosqlite.*"]
 ignore_missing_imports = true
 
 # pytest decorators are untyped by design; relaxing this keeps test files clean.

--- a/agentception/requirements.txt
+++ b/agentception/requirements.txt
@@ -19,3 +19,4 @@ pytest-anyio>=0.0.0
 anyio>=4.0.0
 mypy>=1.8.0
 types-aiofiles>=23.2.0
+types-PyYAML>=6.0.0


### PR DESCRIPTION
## Summary
- Adds `types-PyYAML>=6.0.0` to `agentception/requirements.txt` and `agentception/pyproject.toml` dev deps
- Removes the `yaml` entry from the mypy suppress override in `pyproject.toml` (no longer needed once stubs are present)
- `mypy agentception/` now reports **0 issues** across all 64 source files

## Test plan
- [x] `docker compose exec agentception mypy agentception/` → `Success: no issues found in 64 source files`