### PR TITLE
fix(agentception): fix Alpine x-data quoting for tojson object injection

### DIFF
--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -132,7 +132,7 @@
     dismisses the banner on success.  "Dismiss" hides without applying.
   #}
   <div
-    x-data="scalingAdvisor({{ scaling_advice | tojson }})"
+    x-data='scalingAdvisor({{ scaling_advice | tojson }})'
     x-show="!dismissed && recommendation !== null && recommendation.action !== 'no_change'"
     x-cloak
     class="alert-banner alert-banner--info"
@@ -171,7 +171,7 @@
     page reload.  Alpine.js manages the fetch lifecycle.
   #}
   <div
-    x-data="prViolations({{ pr_violations | tojson }})"
+    x-data='prViolations({{ pr_violations | tojson }})'
   >
     <template x-for="v in violations" :key="v.pr_number">
       <div class="alert-banner alert-banner--violation" role="alert">


### PR DESCRIPTION
## Summary
- `x-data="scalingAdvisor({{ scaling_advice | tojson }})"` — when `scaling_advice` is a non-null object, `tojson` emits JSON with inner double quotes that break the double-quoted HTML attribute. Alpine never initialises the component, leaving `applying`, `applyError`, `dismissed`, and `recommendation` all undefined → the console errors in the screenshot.
- Same issue on `prViolations`.
- Fix: switch both attributes to single-quote delimiters (`x-data='...'`), matching what `pipelineDashboard` already does correctly on line 12.
- `pipelineControl` (line 109) was safe — `poller_paused` is a boolean so `tojson` emits `true`/`false` with no inner quotes.

## Test plan
- [ ] Refresh the overview page while the poller has scaling advice and PR violations populated — confirm zero Alpine expression errors in the console
- [ ] Scaling advisor banner shows/dismisses correctly
- [ ] PR violation banners render correctly