### PR TITLE
fix(agentception): trigger fresh tick on page load; rm -rf fallback in kill

### DIFF
--- a/agentception/routes/control.py
+++ b/agentception/routes/control.py
@@ -85,12 +85,22 @@ async def kill_agent(slug: str) -> dict[str, str]:
     issue_number = _parse_issue_number(worktree)
 
     # Step 1: force-remove the worktree.
+    # git worktree remove only works when the metadata in .git/worktrees/ is
+    # intact. If it fails (e.g. metadata was already cleaned from the host
+    # side), fall back to a direct rm -rf so the directory is always gone.
     repo_dir = str(settings.repo_dir)
     rc, stdout, stderr = await _run(
         ["git", "-C", repo_dir, "worktree", "remove", "--force", str(worktree)]
     )
     if rc != 0:
-        logger.warning("⚠️ git worktree remove exited %d: %s", rc, stderr.strip())
+        logger.warning("⚠️ git worktree remove exited %d: %s — trying rm -rf fallback", rc, stderr.strip())
+        if worktree.exists():
+            import shutil as _shutil
+            try:
+                await asyncio.get_event_loop().run_in_executor(None, _shutil.rmtree, str(worktree))
+                logger.info("✅ rm -rf fallback removed %s", worktree)
+            except OSError as rm_err:
+                logger.warning("⚠️ rm -rf fallback failed for %s: %s", worktree, rm_err)
 
     # Step 2: clear agent:wip on the related issue (best-effort).
     if issue_number is not None:

--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -23,7 +23,7 @@ from agentception.intelligence.dag import DependencyDAG, build_dag
 from agentception.intelligence.guards import PRViolation, detect_out_of_order_prs
 from agentception.intelligence.scaling import ScalingRecommendation, compute_recommendation
 from agentception.models import AgentNode, PipelineConfig, PipelineState, RoleMeta, VALID_ROLES
-from agentception.poller import get_state
+from agentception.poller import get_state, tick as _poller_tick
 from agentception.readers.pipeline_config import read_pipeline_config
 from agentception.readers.transcripts import read_transcript_messages
 from agentception.routes.roles import list_roles
@@ -127,6 +127,11 @@ async def overview(request: Request) -> HTMLResponse:
     - ``poller_paused`` — sentinel file presence check (no network call).
     - Phase labels and pin — from ``pipeline-config.json`` + memory store.
     """
+    # Fire an immediate tick in the background so the SSE stream delivers
+    # fresh data within seconds of the page loading — eliminates up-to-5s
+    # staleness on hard refresh without adding latency to the initial render.
+    asyncio.get_event_loop().create_task(_poller_tick())
+
     state = get_state() or PipelineState.empty()
     all_phase_labels: list[str] = []
     label_is_pinned: bool = False


### PR DESCRIPTION
## Summary
- Overview route fires an immediate background `tick()` on every page load so the SSE stream delivers fresh data within seconds of a hard refresh (eliminates up to 5s staleness)
- `kill_agent` falls back to `shutil.rmtree` when `git worktree remove` fails — prevents zombie worktree directories that keep appearing as UNKNOWN agents

## Root cause
`git worktree remove --force` run **on the host** cleans `.git/worktrees/` metadata but cannot reach `/worktrees/issue-*` inside the Docker container (separate volume). The container's directories and `.agent-task` files survive, so the poller keeps reporting UNKNOWN agents on every 5s tick even though the issues are closed and labels cleared. Fixed by `rm -rf` inside the container; `kill_agent` now handles this automatically.

## Test plan
- [ ] Refresh overview page — agents clear within 1-2 seconds via SSE
- [ ] Kill an agent via GUI — worktree directory is gone from `/worktrees/` inside container even if git metadata was already pruned