### PR TITLE
feat(agentception): live project switching without service restart

### DIFF
--- a/.cursor/pipeline-config.json
+++ b/.cursor/pipeline-config.json
@@ -15,5 +15,14 @@
     "target_role": "python-developer",
     "variant_a_file": ".cursor/roles/python-developer.md",
     "variant_b_file": ".cursor/roles/python-developer-v2.md"
-  }
+  },
+  "active_project": "maestro",
+  "projects": [
+    {
+      "name": "maestro",
+      "gh_repo": "cgcardona/maestro",
+      "repo_dir": "/repo",
+      "worktrees_dir": "/worktrees"
+    }
+  ]
 }

--- a/agentception/config.py
+++ b/agentception/config.py
@@ -7,6 +7,10 @@ When ``pipeline-config.json`` contains a ``projects`` list and an
 ``active_project`` name, the model validator applies the matching project's
 ``gh_repo``, ``repo_dir``, and ``worktrees_dir`` values over the env-var
 defaults.  This is the primary mechanism for multi-repo generalisation (AC-601).
+
+:func:`settings.reload` re-applies the active project on demand.  The poller
+calls it at the top of every tick so a project switch via the GUI takes effect
+within one polling interval — no service restart required.
 """
 from __future__ import annotations
 
@@ -20,12 +24,41 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 logger = logging.getLogger(__name__)
 
 
+def _resolve_project(raw: dict[str, object], target: AgentCeptionSettings) -> None:
+    """Apply the active project's path overrides from *raw* onto *target* in-place.
+
+    Extracted as a module-level helper so both the Pydantic validator and
+    :meth:`AgentCeptionSettings.reload` can share identical logic without
+    duplication.
+    """
+    active_name: object = raw.get("active_project")
+    projects: object = raw.get("projects", [])
+    if not isinstance(projects, list) or not active_name:
+        return
+    for proj in projects:
+        if not isinstance(proj, dict) or proj.get("name") != active_name:
+            continue
+        if "gh_repo" in proj and isinstance(proj["gh_repo"], str):
+            target.gh_repo = proj["gh_repo"]
+        if "repo_dir" in proj and isinstance(proj["repo_dir"], str):
+            target.repo_dir = Path(proj["repo_dir"])
+        if "worktrees_dir" in proj and isinstance(proj["worktrees_dir"], str):
+            wd = proj["worktrees_dir"]
+            if wd.startswith("~/"):
+                wd = str(Path.home()) + wd[1:]
+            target.worktrees_dir = Path(wd)
+        break
+
+
 class AgentCeptionSettings(BaseSettings):
     """Runtime configuration for the AgentCeption dashboard service.
 
     Path settings are resolved in order:
     1. Environment variables (``AC_REPO_DIR``, ``AC_WORKTREES_DIR``, etc.)
     2. Active project from ``pipeline-config.json`` (overrides env vars when present)
+
+    Call :meth:`reload` to pick up a changed ``active_project`` at runtime
+    without restarting the service.
     """
 
     model_config = SettingsConfigDict(env_prefix="AC_")
@@ -63,24 +96,32 @@ class AgentCeptionSettings(BaseSettings):
             return self
         if not isinstance(raw, dict):
             return self
-        active_name: object = raw.get("active_project")
-        projects: object = raw.get("projects", [])
-        if not isinstance(projects, list) or not active_name:
-            return self
-        for proj in projects:
-            if not isinstance(proj, dict) or proj.get("name") != active_name:
-                continue
-            if "gh_repo" in proj and isinstance(proj["gh_repo"], str):
-                self.gh_repo = proj["gh_repo"]
-            if "repo_dir" in proj and isinstance(proj["repo_dir"], str):
-                self.repo_dir = Path(proj["repo_dir"])
-            if "worktrees_dir" in proj and isinstance(proj["worktrees_dir"], str):
-                wd = proj["worktrees_dir"]
-                if wd.startswith("~/"):
-                    wd = str(Path.home()) + wd[1:]
-                self.worktrees_dir = Path(wd)
-            break
+        _resolve_project(raw, self)
         return self
+
+    def reload(self) -> None:
+        """Re-read ``pipeline-config.json`` and apply the active project's paths in-place.
+
+        Called by the poller at the start of each tick and by the
+        ``switch-project`` API endpoint so project switches take effect
+        within one polling interval — no service restart required.
+
+        This method is synchronous: reading a small local JSON file is fast
+        enough that wrapping it in an executor would add more overhead than
+        it saves.
+        """
+        config_path = self.repo_dir / ".cursor" / "pipeline-config.json"
+        if not config_path.exists():
+            return
+        try:
+            raw: object = json.loads(config_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("⚠️ Could not read pipeline-config.json during reload: %s", exc)
+            return
+        if not isinstance(raw, dict):
+            return
+        _resolve_project(raw, self)
+        logger.debug("✅ Settings reloaded — gh_repo=%s repo_dir=%s", self.gh_repo, self.repo_dir)
 
 
 settings = AgentCeptionSettings()

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -338,6 +338,10 @@ async def tick() -> PipelineState:
     """
     global _state
 
+    # Reload active project from pipeline-config.json so a project switch
+    # via the GUI takes effect within one polling interval — no restart needed.
+    settings.reload()
+
     worktrees = await list_active_worktrees()
     github = await build_github_board()
     agents = await merge_agents(worktrees, github)

--- a/agentception/routes/api.py
+++ b/agentception/routes/api.py
@@ -233,9 +233,9 @@ async def update_config(body: PipelineConfig) -> PipelineConfig:
 async def switch_project_endpoint(body: SwitchProjectRequest) -> PipelineConfig:
     """Switch the active project in ``pipeline-config.json``.
 
-    Sets ``active_project`` to *body.project_name* and persists the updated
-    config.  The dashboard reloads paths (``gh_repo``, ``repo_dir``,
-    ``worktrees_dir``) for the new project on the next service restart.
+    Sets ``active_project`` to *body.project_name*, persists the updated
+    config, then immediately reloads ``settings`` so the poller targets the
+    new repo on its very next tick — no service restart required.
 
     Parameters
     ----------
@@ -254,7 +254,12 @@ async def switch_project_endpoint(body: SwitchProjectRequest) -> PipelineConfig:
         When *project_name* does not match any configured project.
     """
     try:
-        return await switch_project(body.project_name)
+        result = await switch_project(body.project_name)
+        # Apply the new project's paths immediately — readers pick them up
+        # on the very next call without waiting for a service restart.
+        from agentception.config import settings
+        settings.reload()
+        return result
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 

--- a/agentception/templates/base.html
+++ b/agentception/templates/base.html
@@ -44,6 +44,7 @@
       multiple projects.  Fetches /api/config on mount, POSTs on change.
     #}
     <div
+      id="project-switcher"
       class="project-switcher"
       x-data="projectSwitcher()"
       x-init="load()"

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -412,8 +412,8 @@
         <template x-if="waveResult">
           <div class="wave-result mt-1">
             <p class="text-success">
-              ✅ <strong x-text="waveResult.spawned.length"></strong> worktree(s) created.
-              Launch a Cursor Task for each path below.
+              ✅ <strong x-text="waveResult.spawned.length"></strong> agent worktree<span x-text="waveResult.spawned.length === 1 ? '' : 's'"></span> launching.
+              Open each path in Cursor to start the agents.
             </p>
             <template x-for="s in waveResult.spawned" :key="s.spawned">
               <div class="wave-worktree-row">


### PR DESCRIPTION
## Summary

- **Wave copy fix**: success message now reads "N agent worktrees launching. Open each path in Cursor to start the agents." instead of the clunky "Launch a Cursor Task for each path below."
- **Live project switching**: `AgentCeptionSettings.reload()` re-reads `pipeline-config.json` in-place; the poller calls it every tick and `switch_project_endpoint` calls it immediately on switch — no restart required.
- **projects in pipeline-config.json**: Added `active_project: "maestro"` and a `projects` array so the nav project-switcher dropdown renders correctly.
- **id on project-switcher div**: Added `id="project-switcher"` to satisfy the existing test assertion.

## How switching works now

1. User opens the **Project** dropdown in the nav (visible because `projects.length > 0`).
2. Selects a different project → `POST /api/config/switch-project` → config written to disk → `settings.reload()` called immediately.
3. Within ≤5 seconds, the next poller tick calls `settings.reload()` again and starts targeting the new `gh_repo` / `repo_dir` / `worktrees_dir`.
4. No container restart needed.

## Test plan
- [x] `mypy agentception/` — 64 files, 0 issues
- [x] `test_agentception_pipeline_config.py` — 14/14 passed
- [x] `test_agentception_ui_config.py` — 9/9 passed (including `test_nav_shows_project_dropdown`)