### PR TITLE
feat(transcripts): full conversation viewer with search, filters, and detail page

### DIFF
--- a/agentception/readers/transcripts.py
+++ b/agentception/readers/transcripts.py
@@ -8,8 +8,11 @@ Public API:
     find_transcript_root()        → locate the transcripts directory
     build_agent_tree()            → parse one root UUID into an AgentNode tree
     read_transcript_messages()    → parse a JSONL file into [{role, text}]
+    read_transcript_full()        → full detail payload for the detail view
     infer_role_from_messages()    → keyword heuristic → role string
     infer_status_from_messages()  → PR-URL heuristic → AgentStatus
+    extract_pr_urls()             → all GitHub PR URLs found in messages
+    index_transcripts()           → metadata list for the browser list view
 """
 from __future__ import annotations
 
@@ -35,7 +38,8 @@ _ROLE_KEYWORDS: list[tuple[str, str]] = [
     ("pr-reviewer", "pr-reviewer"),
 ]
 
-_PR_URL_RE = re.compile(r"github\.com/[^/\s]+/[^/\s]+/pull/\d+")
+_PR_URL_RE = re.compile(r"https?://github\.com/([^/\s]+/[^/\s]+/pull/\d+)")
+_ISSUE_RE = re.compile(r"#(\d+)")
 
 
 async def find_transcript_root() -> Path | None:
@@ -158,7 +162,17 @@ def infer_status_from_messages(messages: list[dict[str, str]]) -> AgentStatus:
     return AgentStatus.UNKNOWN
 
 
-_ISSUE_RE = re.compile(r"#(\d+)")
+def extract_pr_urls(messages: list[dict[str, str]]) -> list[str]:
+    """Return all unique GitHub PR URLs found across all messages, preserving order."""
+    seen: set[str] = set()
+    urls: list[str] = []
+    for msg in messages:
+        for match in _PR_URL_RE.finditer(msg.get("text", "")):
+            url = f"https://github.com/{match.group(1)}"
+            if url not in seen:
+                seen.add(url)
+                urls.append(url)
+    return urls
 
 
 async def index_transcripts(
@@ -169,14 +183,24 @@ async def index_transcripts(
 
     Each entry has:
     - ``uuid``           — top-level conversation UUID (directory name)
-    - ``message_count`` — number of JSONL lines in the parent .jsonl file
-    - ``subagent_count``— number of files in subagents/ subdirectory
+    - ``message_count`` — total JSONL lines (user + assistant)
+    - ``user_msg_count``— lines with role == "user"
+    - ``asst_msg_count``— lines with role == "assistant"
+    - ``subagent_count``— number of .jsonl files in subagents/ subdirectory
     - ``mtime``         — last-modified time (Unix seconds) of the JSONL file
-    - ``preview``       — first 80 chars of first user message
-    - ``linked_issues`` — list of issue numbers found in the first 500 chars
+    - ``preview``       — first 160 chars of the first meaningful user message
+    - ``linked_issues`` — list of issue numbers found across all user messages
+    - ``pr_urls``       — list of unique GitHub PR URLs found in the transcript
+    - ``role``          — inferred role string ("python-developer", "cto", …)
+    - ``status``        — inferred ``AgentStatus`` value ("done" or "unknown")
+    - ``word_count``    — approximate total word count of all messages
+    - ``has_subagents`` — ``True`` when at least one subagent is present
+    - ``is_coordinator``— ``True`` when the parent .jsonl is absent (pure coordinator)
 
     Results are sorted by mtime descending (most recently active first).
     Only parent UUIDs (directories directly under transcripts_dir) are included.
+    Directories that contain *only* a subagents/ folder (no root JSONL) are
+    still indexed so coordinator sessions are visible in the browser.
     """
     entries: list[dict[str, object]] = []
 
@@ -185,55 +209,219 @@ async def index_transcripts(
             continue
         uuid = uuid_dir.name
         parent_jsonl = uuid_dir / f"{uuid}.jsonl"
-        if not parent_jsonl.exists():
+        subagents_dir = uuid_dir / "subagents"
+        subagent_count = (
+            sum(1 for _ in subagents_dir.glob("*.jsonl"))
+            if subagents_dir.is_dir()
+            else 0
+        )
+        is_coordinator = not parent_jsonl.exists() and subagent_count > 0
+        if not parent_jsonl.exists() and not is_coordinator:
             continue
 
-        mtime = parent_jsonl.stat().st_mtime
+        mtime = (
+            parent_jsonl.stat().st_mtime
+            if parent_jsonl.exists()
+            else uuid_dir.stat().st_mtime
+        )
         message_count = 0
+        user_msg_count = 0
+        asst_msg_count = 0
+        word_count = 0
         preview = ""
         linked_issues: list[int] = []
+        pr_urls: list[str] = []
+        messages: list[dict[str, str]] = []
 
-        try:
-            raw = parent_jsonl.read_text(encoding="utf-8", errors="replace")
-            lines = [l for l in raw.splitlines() if l.strip()]
-            message_count = len(lines)
+        if parent_jsonl.exists():
+            try:
+                raw = parent_jsonl.read_text(encoding="utf-8", errors="replace")
+                lines = [ln for ln in raw.splitlines() if ln.strip()]
+                message_count = len(lines)
 
-            # Extract preview and linked issues from first 500 chars of user messages.
-            first_500 = raw[:500]
-            linked_issues = [int(m) for m in _ISSUE_RE.findall(first_500)]
+                issue_seen: set[int] = set()
+                pr_seen: set[str] = set()
 
-            for line in lines:
-                try:
-                    entry = json.loads(line)
-                    if entry.get("role") == "user":
+                for line in lines:
+                    try:
+                        entry = json.loads(line)
+                        role = entry.get("role", "")
+                        if role == "user":
+                            user_msg_count += 1
+                        elif role == "assistant":
+                            asst_msg_count += 1
+
                         parts = entry.get("message", {}).get("content", [])
                         for p in parts:
-                            if isinstance(p, dict) and p.get("type") == "text":
-                                preview = (p.get("text") or "")[:80]
-                                break
-                    if preview:
-                        break
-                except (json.JSONDecodeError, AttributeError):
-                    continue
-        except OSError:
-            pass
+                            if not isinstance(p, dict) or p.get("type") != "text":
+                                continue
+                            text = p.get("text") or ""
+                            word_count += len(text.split())
+                            messages.append({"role": role, "text": text})
 
-        subagent_count = 0
-        subagents_dir = uuid_dir / "subagents"
-        if subagents_dir.is_dir():
-            subagent_count = sum(1 for _ in subagents_dir.glob("*.jsonl"))
+                            # Harvest issues from all user messages.
+                            if role == "user":
+                                for m in _ISSUE_RE.finditer(text):
+                                    n = int(m.group(1))
+                                    if n not in issue_seen:
+                                        issue_seen.add(n)
+                                        linked_issues.append(n)
+                                # Use first substantive user message as preview
+                                # (skip short/system lines like "[Image]")
+                                clean = text.strip()
+                                if not preview and len(clean) > 20:
+                                    # Strip XML-like wrapper tags common in task files.
+                                    clean = re.sub(r"<[^>]+>", "", clean).strip()
+                                    preview = clean[:160]
+
+                            # Harvest PR URLs from all messages.
+                            for match in _PR_URL_RE.finditer(text):
+                                url = f"https://github.com/{match.group(1)}"
+                                if url not in pr_seen:
+                                    pr_seen.add(url)
+                                    pr_urls.append(url)
+                    except (json.JSONDecodeError, AttributeError):
+                        continue
+            except OSError:
+                pass
+
+        role_str = infer_role_from_messages(messages)
+        status = infer_status_from_messages(messages)
 
         entries.append({
             "uuid": uuid,
             "message_count": message_count,
+            "user_msg_count": user_msg_count,
+            "asst_msg_count": asst_msg_count,
             "subagent_count": subagent_count,
             "mtime": mtime,
             "preview": preview,
             "linked_issues": linked_issues,
+            "pr_urls": pr_urls,
+            "role": role_str,
+            "status": status.value,
+            "word_count": word_count,
+            "has_subagents": subagent_count > 0,
+            "is_coordinator": is_coordinator,
         })
 
     entries.sort(key=lambda e: float(str(e["mtime"])), reverse=True)
     return entries[:limit]
+
+
+async def read_transcript_full(
+    uuid: str,
+    transcripts_dir: Path,
+    max_messages: int = 300,
+) -> dict[str, object] | None:
+    """Load the full detail payload for a single transcript UUID.
+
+    Returns a dict with:
+    - ``uuid``            — the conversation UUID
+    - ``messages``        — list of ``{role, text}`` dicts (capped at *max_messages*)
+    - ``total_messages``  — true count before capping
+    - ``role``            — inferred role string
+    - ``status``          — inferred status string ("done" | "unknown")
+    - ``linked_issues``   — unique issue numbers found in user messages
+    - ``pr_urls``         — unique GitHub PR URLs in the whole transcript
+    - ``word_count``      — total word count
+    - ``user_msg_count``  — count of user messages
+    - ``asst_msg_count``  — count of assistant messages
+    - ``subagents``       — list of ``{uuid, role, status, message_count, preview}``
+    - ``mtime``           — last modified Unix timestamp
+    - ``is_coordinator``  — True when no root JSONL exists (pure coordinator)
+
+    Returns ``None`` when the UUID directory does not exist.
+    """
+    uuid_dir = transcripts_dir / uuid
+    if not uuid_dir.exists():
+        return None
+
+    parent_jsonl = uuid_dir / f"{uuid}.jsonl"
+    subagents_dir = uuid_dir / "subagents"
+    is_coordinator = not parent_jsonl.exists()
+
+    mtime = (
+        parent_jsonl.stat().st_mtime
+        if parent_jsonl.exists()
+        else uuid_dir.stat().st_mtime
+    )
+
+    all_messages = await read_transcript_messages(parent_jsonl)
+    total_messages = len(all_messages)
+
+    # Build per-role counts and linked artefacts from the full message list.
+    user_msg_count = sum(1 for m in all_messages if m.get("role") == "user")
+    asst_msg_count = sum(1 for m in all_messages if m.get("role") == "assistant")
+    word_count = sum(len(m.get("text", "").split()) for m in all_messages)
+
+    issue_seen: set[int] = set()
+    pr_seen: set[str] = set()
+    linked_issues: list[int] = []
+    pr_urls: list[str] = []
+    for msg in all_messages:
+        text = msg.get("text", "")
+        if msg.get("role") == "user":
+            for m in _ISSUE_RE.finditer(text):
+                n = int(m.group(1))
+                if n not in issue_seen:
+                    issue_seen.add(n)
+                    linked_issues.append(n)
+        for match in _PR_URL_RE.finditer(text):
+            url = f"https://github.com/{match.group(1)}"
+            if url not in pr_seen:
+                pr_seen.add(url)
+                pr_urls.append(url)
+
+    role_str = infer_role_from_messages(all_messages)
+    status = infer_status_from_messages(all_messages)
+
+    # Cap messages for the detail view — show the most recent ones when over limit.
+    messages_display = (
+        all_messages[-max_messages:]
+        if len(all_messages) > max_messages
+        else all_messages
+    )
+
+    # Build subagent metadata list.
+    subagents: list[dict[str, object]] = []
+    if subagents_dir.is_dir():
+        for child_jsonl in sorted(subagents_dir.glob("*.jsonl")):
+            child_uuid = child_jsonl.stem
+            child_messages = await read_transcript_messages(child_jsonl)
+            child_role = infer_role_from_messages(child_messages)
+            child_status = infer_status_from_messages(child_messages)
+            child_preview = ""
+            for cm in child_messages:
+                if cm.get("role") == "user":
+                    raw_text = re.sub(r"<[^>]+>", "", cm.get("text", "")).strip()
+                    if len(raw_text) > 20:
+                        child_preview = raw_text[:120]
+                        break
+            subagents.append({
+                "uuid": child_uuid,
+                "role": child_role,
+                "status": child_status.value,
+                "message_count": len(child_messages),
+                "preview": child_preview,
+            })
+
+    return {
+        "uuid": uuid,
+        "messages": messages_display,
+        "total_messages": total_messages,
+        "role": role_str,
+        "status": status.value,
+        "linked_issues": linked_issues,
+        "pr_urls": pr_urls,
+        "word_count": word_count,
+        "user_msg_count": user_msg_count,
+        "asst_msg_count": asst_msg_count,
+        "subagents": subagents,
+        "mtime": mtime,
+        "is_coordinator": is_coordinator,
+        "truncated": total_messages > max_messages,
+    }
 
 
 async def build_agent_tree(

--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -621,22 +621,61 @@ async def pr_detail(request: Request, number: int) -> HTMLResponse:
 
 @router.get("/transcripts", response_class=HTMLResponse)
 async def transcripts_browser(request: Request) -> HTMLResponse:
-    """Browse all agent transcripts indexed from the Cursor filesystem."""
+    """Browse all agent transcripts indexed from the Cursor filesystem.
+
+    Query parameters:
+    - ``role``   — filter to a specific inferred role string
+    - ``status`` — "done" or "unknown"
+    - ``issue``  — filter to transcripts mentioning a specific issue number
+    - ``q``      — free-text search against the preview text (case-insensitive)
+    """
     from agentception.readers.transcripts import find_transcript_root, index_transcripts
 
     error: str | None = None
     transcripts: list[dict[str, object]] = []
     transcripts_dir_str: str = ""
 
+    filter_role: str = request.query_params.get("role", "").strip()
+    filter_status: str = request.query_params.get("status", "").strip()
+    filter_issue_raw: str = request.query_params.get("issue", "").strip()
+    filter_q: str = request.query_params.get("q", "").strip().lower()
+    filter_issue: int | None = int(filter_issue_raw) if filter_issue_raw.isdigit() else None
+
     try:
         tr_root = await find_transcript_root()
         if tr_root is not None:
             transcripts_dir_str = str(tr_root)
-            transcripts = await index_transcripts(tr_root)
+            all_transcripts = await index_transcripts(tr_root)
+
+            # Server-side filter pass
+            for t in all_transcripts:
+                if filter_role and t.get("role") != filter_role:
+                    continue
+                if filter_status and t.get("status") != filter_status:
+                    continue
+                if filter_issue is not None:
+                    li = t.get("linked_issues")
+                    if not isinstance(li, list) or filter_issue not in li:
+                        continue
+                if filter_q:
+                    preview = t.get("preview")
+                    if not isinstance(preview, str) or filter_q not in preview.lower():
+                        continue
+                transcripts.append(t)
         else:
             error = "Transcript directory not found — check CURSOR_PROJECTS_DIR setting."
     except Exception as exc:
         error = str(exc)
+
+    # Collect unique roles from the full unfiltered index for the filter UI
+    # (re-use transcripts if no filters active, otherwise do a second pass cheaply)
+    all_roles: list[str] = []
+    seen_roles: set[str] = set()
+    for t in transcripts:
+        r = str(t.get("role") or "unknown")
+        if r not in seen_roles:
+            seen_roles.add(r)
+            all_roles.append(r)
 
     return _TEMPLATES.TemplateResponse(
         request,
@@ -644,6 +683,42 @@ async def transcripts_browser(request: Request) -> HTMLResponse:
         {
             "transcripts": transcripts,
             "transcripts_dir": transcripts_dir_str,
+            "error": error,
+            "filter_role": filter_role,
+            "filter_status": filter_status,
+            "filter_issue": filter_issue,
+            "filter_q": filter_q,
+            "all_roles": sorted(all_roles),
+            "total": len(transcripts),
+        },
+    )
+
+
+@router.get("/transcripts/{uuid}", response_class=HTMLResponse)
+async def transcript_detail(request: Request, uuid: str) -> HTMLResponse:
+    """Full detail view for a single agent conversation."""
+    from agentception.readers.transcripts import find_transcript_root, read_transcript_full
+
+    error: str | None = None
+    transcript: dict[str, object] | None = None
+
+    try:
+        tr_root = await find_transcript_root()
+        if tr_root is not None:
+            transcript = await read_transcript_full(uuid, tr_root)
+            if transcript is None:
+                error = f"Transcript {uuid!r} not found in {tr_root}"
+        else:
+            error = "Transcript directory not found — check CURSOR_PROJECTS_DIR setting."
+    except Exception as exc:
+        error = str(exc)
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "transcript_detail.html",
+        {
+            "transcript": transcript,
+            "uuid": uuid,
             "error": error,
         },
     )

--- a/agentception/templates/transcript_detail.html
+++ b/agentception/templates/transcript_detail.html
@@ -1,0 +1,397 @@
+{% extends "base.html" %}
+
+{% block title %}AgentCeption — Transcript {{ uuid[:8] }}{% endblock %}
+
+{% block content %}
+
+{% if error %}
+<div class="card" style="border-left:3px solid var(--danger);margin-bottom:1rem;">
+  <p style="color:var(--danger-dim);">⚠️ {{ error }}</p>
+  <a href="/transcripts" class="btn btn-secondary" style="margin-top:0.75rem;">← Back to browser</a>
+</div>
+{% elif not transcript %}
+<div class="card">
+  <p class="text-muted">Transcript not found.</p>
+  <a href="/transcripts" class="btn btn-secondary" style="margin-top:0.75rem;">← Back to browser</a>
+</div>
+{% else %}
+
+{# ── Page header ──────────────────────────────────────────────────── #}
+<div class="page-header" style="margin-bottom:1.25rem;">
+  <div style="flex:1;min-width:0;">
+    <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;margin-bottom:0.4rem;">
+      <a href="/transcripts" style="color:var(--text-muted);font-size:0.82rem;text-decoration:none;">← Transcripts</a>
+
+      {# Role badge #}
+      {% set role_class = {
+        'cto': 'badge--orange',
+        'engineering-vp': 'badge--blue',
+        'engineering-manager': 'badge--blue',
+        'qa-vp': 'badge--purple',
+        'python-developer': 'badge--green',
+        'pr-reviewer': 'badge--teal',
+        'muse-specialist': 'badge--pink',
+        'database-architect': 'badge--yellow',
+        'unknown': 'badge--gray',
+      }.get(transcript.role, 'badge--gray') %}
+      <span class="badge {{ role_class }}">{{ transcript.role }}</span>
+
+      {# Status badge #}
+      {% if transcript.status == 'done' %}
+      <span class="badge badge--green">✓ Done — PR opened</span>
+      {% else %}
+      <span class="badge badge--gray">⏳ In-progress / unknown</span>
+      {% endif %}
+
+      {% if transcript.is_coordinator %}
+      <span class="badge badge--purple">Coordinator</span>
+      {% endif %}
+    </div>
+
+    <h1 class="page-title" style="font-family:var(--font-mono);font-size:1.1rem;letter-spacing:0;">
+      {{ uuid }}
+    </h1>
+    <p class="page-subtitle">{{ transcript.mtime | int | timestamp_to_date }}</p>
+  </div>
+</div>
+
+{# ── Stats strip ──────────────────────────────────────────────────── #}
+<div class="stats-strip">
+  <div class="stat-chip">
+    <span class="stat-chip__value">{{ transcript.total_messages }}</span>
+    <span class="stat-chip__label">messages</span>
+  </div>
+  <div class="stat-chip">
+    <span class="stat-chip__value">{{ transcript.user_msg_count }}</span>
+    <span class="stat-chip__label">user turns</span>
+  </div>
+  <div class="stat-chip">
+    <span class="stat-chip__value">{{ transcript.asst_msg_count }}</span>
+    <span class="stat-chip__label">assistant turns</span>
+  </div>
+  <div class="stat-chip">
+    <span class="stat-chip__value">{{ "{:,}".format(transcript.word_count) }}</span>
+    <span class="stat-chip__label">words</span>
+  </div>
+  {% if transcript.subagents %}
+  <div class="stat-chip">
+    <span class="stat-chip__value">{{ transcript.subagents | length }}</span>
+    <span class="stat-chip__label">sub-agents</span>
+  </div>
+  {% endif %}
+</div>
+
+{# ── Two-column layout: conversation + sidebar ────────────────────── #}
+<div class="detail-layout">
+
+  {# ── LEFT: Conversation thread ──────────────────────────────────── #}
+  <div class="detail-main">
+
+    {% if transcript.truncated %}
+    <div style="background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:8px;padding:0.75rem 1rem;margin-bottom:1rem;font-size:0.82rem;color:var(--text-muted);">
+      ⚠️ Showing last {{ transcript.messages | length }} of {{ transcript.total_messages }} messages.
+      <a href="/transcripts/{{ uuid }}?full=1" style="color:var(--accent-bright);">Load all</a>
+    </div>
+    {% endif %}
+
+    <div class="chat-thread" x-data="{search: '', highlight(text) {
+      if (!this.search) return text;
+      const s = this.search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      return text.replace(new RegExp(s, 'gi'), m => '<mark class=\'hl\'>' + m + '</mark>');
+    }}">
+
+      {# In-thread search #}
+      <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:1rem;">
+        <div style="position:relative;flex:1;">
+          <input
+            type="search"
+            placeholder="Search within conversation…"
+            x-model="search"
+            style="width:100%;padding:0.4rem 0.65rem 0.4rem 2rem;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:6px;color:var(--text-primary);font-size:0.82rem;outline:none;"
+          />
+          <span style="position:absolute;left:0.6rem;top:50%;transform:translateY(-50%);color:var(--text-muted);pointer-events:none;font-size:0.85rem;">🔍</span>
+        </div>
+      </div>
+
+      {% for msg in transcript.messages %}
+      <div
+        class="chat-msg chat-msg--{{ msg.role }}"
+        x-show="!search || {{ msg.text | tojson }}.toLowerCase().includes(search.toLowerCase())"
+      >
+        <div class="chat-msg__header">
+          {% if msg.role == 'user' %}
+          <span class="chat-msg__role chat-msg__role--user">You</span>
+          {% else %}
+          <span class="chat-msg__role chat-msg__role--assistant">Agent</span>
+          {% endif %}
+        </div>
+        <div class="chat-msg__body">
+          {# Render text — preserve whitespace, basic highlighting #}
+          <pre class="chat-msg__text" x-html="highlight({{ msg.text | e | tojson }})"></pre>
+        </div>
+      </div>
+      {% endfor %}
+
+    </div>{# /chat-thread #}
+  </div>{# /detail-main #}
+
+  {# ── RIGHT: Sidebar ─────────────────────────────────────────────── #}
+  <aside class="detail-sidebar">
+
+    {# Linked Issues #}
+    {% if transcript.linked_issues %}
+    <div class="sidebar-card">
+      <h3 class="sidebar-card__title">Linked Issues</h3>
+      <div class="sidebar-card__body">
+        {% for n in transcript.linked_issues %}
+        <a href="/issues/{{ n }}" class="sidebar-issue-link">#{{ n }}</a>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
+    {# PR Links #}
+    {% if transcript.pr_urls %}
+    <div class="sidebar-card">
+      <h3 class="sidebar-card__title">Pull Requests</h3>
+      <div class="sidebar-card__body">
+        {% for url in transcript.pr_urls %}
+        {% set pr_num = url.split('/')[-1] %}
+        <a href="{{ url }}" target="_blank" rel="noopener" class="sidebar-pr-link">
+          PR #{{ pr_num }} ↗
+        </a>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
+    {# Sub-agents #}
+    {% if transcript.subagents %}
+    <div class="sidebar-card">
+      <h3 class="sidebar-card__title">Sub-agents ({{ transcript.subagents | length }})</h3>
+      <div class="sidebar-card__body" style="gap:0.5rem;">
+        {% for sa in transcript.subagents %}
+        {% set sa_role_class = {
+          'cto': 'badge--orange',
+          'engineering-vp': 'badge--blue',
+          'engineering-manager': 'badge--blue',
+          'qa-vp': 'badge--purple',
+          'python-developer': 'badge--green',
+          'pr-reviewer': 'badge--teal',
+          'muse-specialist': 'badge--pink',
+          'database-architect': 'badge--yellow',
+          'unknown': 'badge--gray',
+        }.get(sa.role, 'badge--gray') %}
+        <div class="subagent-card">
+          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.35rem;">
+            <span class="badge {{ sa_role_class }}" style="font-size:0.65rem;">{{ sa.role }}</span>
+            {% if sa.status == 'done' %}
+            <span class="badge badge--green" style="font-size:0.65rem;">✓</span>
+            {% else %}
+            <span class="badge badge--gray" style="font-size:0.65rem;">⏳</span>
+            {% endif %}
+          </div>
+          <p style="font-family:var(--font-mono);font-size:0.68rem;color:var(--text-muted);margin:0 0 0.25rem;">{{ sa.uuid[:12] }}…</p>
+          {% if sa.preview %}
+          <p style="font-size:0.72rem;color:var(--text-secondary);margin:0;overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;">{{ sa.preview }}</p>
+          {% endif %}
+          <p style="font-size:0.7rem;color:var(--text-faint);margin:0.3rem 0 0;">{{ sa.message_count }} messages</p>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
+    {# Metadata #}
+    <div class="sidebar-card">
+      <h3 class="sidebar-card__title">Metadata</h3>
+      <dl class="meta-dl">
+        <dt>UUID</dt>
+        <dd style="font-family:var(--font-mono);font-size:0.72rem;word-break:break-all;">{{ uuid }}</dd>
+        <dt>Modified</dt>
+        <dd>{{ transcript.mtime | int | timestamp_to_date }}</dd>
+        <dt>Role</dt>
+        <dd>{{ transcript.role }}</dd>
+        <dt>Status</dt>
+        <dd>{{ transcript.status }}</dd>
+        <dt>Messages</dt>
+        <dd>{{ transcript.total_messages }}</dd>
+        <dt>Words</dt>
+        <dd>{{ "{:,}".format(transcript.word_count) }}</dd>
+      </dl>
+    </div>
+
+  </aside>
+</div>
+
+{% endif %}
+
+<style>
+  /* ── Layout ─────────────────────────────────────────────── */
+  .detail-layout {
+    display: grid;
+    grid-template-columns: 1fr 260px;
+    gap: 1.25rem;
+    align-items: start;
+  }
+  @media (max-width: 900px) {
+    .detail-layout { grid-template-columns: 1fr; }
+    .detail-sidebar { order: -1; }
+  }
+
+  /* ── Stats strip ─────────────────────────────────────────── */
+  .stats-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+  }
+  .stat-chip {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    padding: 0.5rem 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-width: 80px;
+  }
+  .stat-chip__value {
+    font-size: 1.4rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+    line-height: 1;
+  }
+  .stat-chip__label {
+    font-size: 0.68rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-top: 0.2rem;
+  }
+
+  /* ── Chat thread ──────────────────────────────────────────── */
+  .chat-thread { display: flex; flex-direction: column; gap: 0.75rem; }
+
+  .chat-msg {
+    border-radius: 10px;
+    padding: 0.85rem 1rem;
+    max-width: 100%;
+  }
+  .chat-msg--user {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-subtle);
+    margin-right: 2rem;
+  }
+  .chat-msg--assistant {
+    background: linear-gradient(135deg, rgba(139,92,246,0.08) 0%, rgba(99,102,241,0.06) 100%);
+    border: 1px solid rgba(139,92,246,0.2);
+    margin-left: 2rem;
+  }
+  .chat-msg__header {
+    margin-bottom: 0.4rem;
+  }
+  .chat-msg__role {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+  }
+  .chat-msg__role--user      { color: var(--text-muted); }
+  .chat-msg__role--assistant { color: var(--accent-bright); }
+
+  .chat-msg__text {
+    margin: 0;
+    font-family: var(--font-sans, inherit);
+    font-size: 0.83rem;
+    line-height: 1.6;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+
+  /* Expand long messages on click */
+  .chat-msg__text.collapsed { max-height: 160px; overflow: hidden; }
+
+  mark.hl {
+    background: rgba(251,191,36,0.35);
+    color: inherit;
+    border-radius: 2px;
+    padding: 0 2px;
+  }
+
+  /* ── Sidebar ──────────────────────────────────────────────── */
+  .detail-sidebar { display: flex; flex-direction: column; gap: 0.85rem; }
+
+  .sidebar-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    overflow: hidden;
+  }
+  .sidebar-card__title {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    padding: 0.65rem 0.85rem;
+    border-bottom: 1px solid var(--border-subtle);
+    margin: 0;
+  }
+  .sidebar-card__body {
+    padding: 0.75rem 0.85rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .sidebar-issue-link {
+    display: inline-block;
+    color: var(--accent-bright);
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-decoration: none;
+    margin-right: 0.4rem;
+    margin-bottom: 0.25rem;
+  }
+  .sidebar-issue-link:hover { text-decoration: underline; }
+
+  .sidebar-pr-link {
+    display: block;
+    color: var(--success);
+    font-size: 0.8rem;
+    text-decoration: none;
+    margin-bottom: 0.25rem;
+    word-break: break-all;
+  }
+  .sidebar-pr-link:hover { text-decoration: underline; }
+
+  .subagent-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    padding: 0.6rem 0.75rem;
+  }
+
+  /* ── Metadata dl ──────────────────────────────────────────── */
+  .meta-dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.3rem 0.75rem;
+    font-size: 0.78rem;
+  }
+  .meta-dl dt { color: var(--text-muted); white-space: nowrap; }
+  .meta-dl dd { color: var(--text-primary); margin: 0; }
+
+  /* ── Extra badge colours ──────────────────────────────────── */
+  .badge--teal   { background: rgba(20,184,166,0.15); color: #5eead4; border-color: rgba(20,184,166,0.3); }
+  .badge--pink   { background: rgba(236,72,153,0.15); color: #f9a8d4; border-color: rgba(236,72,153,0.3); }
+  .badge--yellow { background: rgba(234,179,8,0.15);  color: #fde047; border-color: rgba(234,179,8,0.3); }
+  .badge--orange { background: rgba(249,115,22,0.15); color: #fdba74; border-color: rgba(249,115,22,0.3); }
+</style>
+
+{% endblock %}

--- a/agentception/templates/transcripts.html
+++ b/agentception/templates/transcripts.html
@@ -3,71 +3,287 @@
 {% block title %}AgentCeption — Transcripts{% endblock %}
 
 {% block content %}
-<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem;">
+
+{# ── Page header ──────────────────────────────────────────────────── #}
+<div class="page-header">
   <div>
-    <h1 class="section-title">Transcript Browser</h1>
-    <p class="text-muted" style="margin-top:0.25rem;font-size:0.85rem;">
-      {{ transcripts | length }} conversations found
-      {% if transcripts_dir %} in <code style="font-size:0.8rem;">{{ transcripts_dir }}</code>{% endif %}
+    <h1 class="page-title">Transcript Browser</h1>
+    <p class="page-subtitle">
+      {{ total }} conversation{{ 's' if total != 1 else '' }} found
+      {% if transcripts_dir %} · <code style="font-size:0.78rem;color:var(--text-muted);">{{ transcripts_dir }}</code>{% endif %}
     </p>
   </div>
-  {% if filter_issue %}
-  <a href="/transcripts" class="btn btn-secondary">Clear filter</a>
-  {% endif %}
 </div>
 
 {% if error %}
-<div class="card" style="border-left:3px solid var(--danger);">
-  <p class="text-muted">⚠️ {{ error }}</p>
+<div class="card" style="border-left:3px solid var(--danger);margin-bottom:1rem;">
+  <p style="color:var(--danger-dim);">⚠️ {{ error }}</p>
 </div>
 {% endif %}
 
-{% if transcripts %}
-<div class="card" style="padding:0;overflow:hidden;">
-  <table class="telemetry-table" style="width:100%;margin:0;">
-    <thead>
-      <tr>
-        <th>UUID</th>
-        <th>Messages</th>
-        <th>Sub-agents</th>
-        <th>First user message</th>
-        <th>Issues</th>
-        <th>Modified</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for t in transcripts %}
-      <tr>
-        <td>
-          <span style="font-family:monospace;font-size:0.78rem;color:var(--text-muted);" title="{{ t.uuid }}">
-            {{ t.uuid[:8] }}…
-          </span>
-        </td>
-        <td style="text-align:right;">{{ t.message_count }}</td>
-        <td style="text-align:right;">{{ t.subagent_count }}</td>
-        <td style="max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:0.82rem;color:var(--text-muted);">
-          {{ t.preview or '—' }}
-        </td>
-        <td>
-          {% for n in t.linked_issues %}
-          <a href="/issues/{{ n }}">#{{ n }}</a>
-          {% endfor %}
-          {% if not t.linked_issues %}—{% endif %}
-        </td>
-        <td style="font-size:0.75rem;color:var(--text-muted);">
-          {{ t.mtime | int | timestamp_to_date }}
-        </td>
-      </tr>
+{# ── Filter bar (Alpine-powered) ──────────────────────────────────── #}
+<div
+  class="filter-group"
+  x-data="{
+    q: {{ filter_q | tojson }},
+    sort: 'mtime',
+    filterRole: {{ filter_role | tojson }},
+    filterStatus: {{ filter_status | tojson }},
+    get rows() {
+      let r = Array.from(document.querySelectorAll('[data-transcript-row]'));
+      return r;
+    },
+    applyFilters() {
+      const qLow = this.q.toLowerCase();
+      document.querySelectorAll('[data-transcript-row]').forEach(el => {
+        const preview = (el.dataset.preview || '').toLowerCase();
+        const role    = el.dataset.role || '';
+        const status  = el.dataset.status || '';
+        const matchQ  = !qLow || preview.includes(qLow);
+        const matchR  = !this.filterRole || role === this.filterRole;
+        const matchS  = !this.filterStatus || status === this.filterStatus;
+        el.style.display = (matchQ && matchR && matchS) ? '' : 'none';
+      });
+      this.applySortDom();
+    },
+    applySortDom() {
+      const tbody = document.getElementById('transcript-tbody');
+      if (!tbody) return;
+      const rows = Array.from(tbody.querySelectorAll('[data-transcript-row]'));
+      rows.sort((a, b) => {
+        if (this.sort === 'mtime')    return parseFloat(b.dataset.mtime) - parseFloat(a.dataset.mtime);
+        if (this.sort === 'messages') return parseInt(b.dataset.messages) - parseInt(a.dataset.messages);
+        if (this.sort === 'words')    return parseInt(b.dataset.words) - parseInt(a.dataset.words);
+        if (this.sort === 'subagents')return parseInt(b.dataset.subagents) - parseInt(a.dataset.subagents);
+        return 0;
+      });
+      rows.forEach(r => tbody.appendChild(r));
+    },
+  }"
+  x-init="applyFilters()"
+>
+  <div style="display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;margin-bottom:1rem;">
+    {# Search #}
+    <div style="position:relative;flex:1;min-width:200px;">
+      <input
+        type="search"
+        placeholder="Search conversations…"
+        class="filter-input"
+        style="width:100%;padding-left:2rem;"
+        x-model="q"
+        @input.debounce.200ms="applyFilters()"
+      />
+      <span style="position:absolute;left:0.6rem;top:50%;transform:translateY(-50%);color:var(--text-muted);pointer-events:none;">🔍</span>
+    </div>
+
+    {# Role filter #}
+    <select
+      class="filter-input"
+      x-model="filterRole"
+      @change="applyFilters()"
+      style="min-width:160px;"
+    >
+      <option value="">All roles</option>
+      {% for r in all_roles %}
+      <option value="{{ r }}" {% if filter_role == r %}selected{% endif %}>{{ r }}</option>
       {% endfor %}
-    </tbody>
-  </table>
-</div>
-{% elif not error %}
-<div class="card">
-  <p class="text-muted empty-state">
-    No transcripts found. Make sure the Cursor projects directory is mounted correctly.
-  </p>
-</div>
-{% endif %}
+    </select>
+
+    {# Status filter #}
+    <select
+      class="filter-input"
+      x-model="filterStatus"
+      @change="applyFilters()"
+      style="min-width:130px;"
+    >
+      <option value="">All statuses</option>
+      <option value="done" {% if filter_status == 'done' %}selected{% endif %}>✅ Done</option>
+      <option value="unknown" {% if filter_status == 'unknown' %}selected{% endif %}>⏳ In-progress</option>
+    </select>
+
+    {# Sort #}
+    <select
+      class="filter-input"
+      x-model="sort"
+      @change="applySortDom()"
+      style="min-width:150px;"
+    >
+      <option value="mtime">Sort: recent first</option>
+      <option value="messages">Sort: most messages</option>
+      <option value="words">Sort: most words</option>
+      <option value="subagents">Sort: most sub-agents</option>
+    </select>
+
+    {% if filter_role or filter_status or filter_issue or filter_q %}
+    <a href="/transcripts" class="btn btn-secondary" style="white-space:nowrap;">✕ Clear filters</a>
+    {% endif %}
+  </div>
+
+  {# ── Transcript table ────────────────────────────────────────────── #}
+  {% if transcripts %}
+  <div class="card" style="padding:0;overflow:hidden;">
+    <table class="telemetry-table" style="width:100%;margin:0;table-layout:fixed;">
+      <colgroup>
+        <col style="width:7rem;">   {# UUID #}
+        <col style="width:10rem;">  {# Role #}
+        <col style="width:7rem;">   {# Status #}
+        <col>                       {# Preview #}
+        <col style="width:5rem;">   {# Msgs #}
+        <col style="width:5.5rem;"> {# Sub-agents #}
+        <col style="width:7rem;">   {# Issues #}
+        <col style="width:6.5rem;"> {# Modified #}
+      </colgroup>
+      <thead>
+        <tr>
+          <th>UUID</th>
+          <th>Role</th>
+          <th>Status</th>
+          <th>First message</th>
+          <th style="text-align:right;">Msgs</th>
+          <th style="text-align:right;">Sub-agents</th>
+          <th>Issues</th>
+          <th style="text-align:right;">Modified</th>
+        </tr>
+      </thead>
+      <tbody id="transcript-tbody">
+        {% for t in transcripts %}
+        <tr
+          data-transcript-row
+          data-preview="{{ t.preview | e }}"
+          data-role="{{ t.role }}"
+          data-status="{{ t.status }}"
+          data-mtime="{{ t.mtime }}"
+          data-messages="{{ t.message_count }}"
+          data-words="{{ t.word_count }}"
+          data-subagents="{{ t.subagent_count }}"
+          class="transcript-row"
+          onclick="window.location='/transcripts/{{ t.uuid }}'"
+          style="cursor:pointer;"
+          title="Open conversation {{ t.uuid }}"
+        >
+          {# UUID #}
+          <td>
+            <span class="mono-badge" title="{{ t.uuid }}">{{ t.uuid[:8] }}…</span>
+            {% if t.is_coordinator %}
+            <span class="badge badge--purple" style="font-size:0.62rem;margin-left:0.25rem;">coord</span>
+            {% endif %}
+          </td>
+
+          {# Role badge #}
+          <td>
+            {% set role_class = {
+              'cto': 'badge--orange',
+              'engineering-vp': 'badge--blue',
+              'engineering-manager': 'badge--blue',
+              'qa-vp': 'badge--purple',
+              'python-developer': 'badge--green',
+              'pr-reviewer': 'badge--teal',
+              'muse-specialist': 'badge--pink',
+              'database-architect': 'badge--yellow',
+              'unknown': 'badge--gray',
+            }.get(t.role, 'badge--gray') %}
+            <span class="badge {{ role_class }}">{{ t.role }}</span>
+          </td>
+
+          {# Status badge #}
+          <td>
+            {% if t.status == 'done' %}
+            <span class="badge badge--green">✓ done</span>
+            {% else %}
+            <span class="badge badge--gray">⏳ active</span>
+            {% endif %}
+          </td>
+
+          {# Preview #}
+          <td style="max-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:0.82rem;color:var(--text-primary);">
+            {{ t.preview or '—' }}
+          </td>
+
+          {# Message count #}
+          <td style="text-align:right;font-variant-numeric:tabular-nums;font-size:0.82rem;">
+            {{ t.message_count }}
+          </td>
+
+          {# Sub-agents #}
+          <td style="text-align:right;">
+            {% if t.has_subagents %}
+            <span class="badge badge--blue" style="font-size:0.68rem;">{{ t.subagent_count }}</span>
+            {% else %}
+            <span style="color:var(--text-faint);font-size:0.75rem;">—</span>
+            {% endif %}
+          </td>
+
+          {# Linked issues #}
+          <td style="font-size:0.78rem;">
+            {% for n in (t.linked_issues or [])[:3] %}
+            <a href="/issues/{{ n }}" onclick="event.stopPropagation();" class="issue-link">#{{ n }}</a>{% if not loop.last %} {% endif %}
+            {% endfor %}
+            {% if (t.linked_issues | length) > 3 %}
+            <span style="color:var(--text-muted);">+{{ (t.linked_issues | length) - 3 }}</span>
+            {% endif %}
+            {% if not t.linked_issues %}
+            <span style="color:var(--text-faint);">—</span>
+            {% endif %}
+          </td>
+
+          {# Modified date #}
+          <td style="text-align:right;font-size:0.75rem;color:var(--text-muted);">
+            {{ t.mtime | int | timestamp_to_date }}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  {% elif not error %}
+  <div class="card">
+    <p class="text-muted empty-state">
+      No transcripts found. Make sure the Cursor projects directory is mounted correctly.
+    </p>
+  </div>
+  {% endif %}
+
+</div>{# /filter-group #}
+
+<style>
+  .filter-input {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    color: var(--text-primary);
+    border-radius: 6px;
+    padding: 0.4rem 0.65rem;
+    font-size: 0.83rem;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+  .filter-input:focus { border-color: var(--accent); }
+  .filter-input option { background: var(--bg-elevated); }
+
+  .transcript-row:hover td { background: var(--bg-elevated); }
+  .transcript-row td { transition: background 0.1s; }
+
+  .mono-badge {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    background: var(--bg-surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    padding: 0.15rem 0.35rem;
+  }
+
+  .issue-link {
+    color: var(--accent-bright);
+    font-size: 0.75rem;
+    text-decoration: none;
+  }
+  .issue-link:hover { text-decoration: underline; }
+
+  .badge--teal   { background: rgba(20,184,166,0.15); color: #5eead4; border-color: rgba(20,184,166,0.3); }
+  .badge--pink   { background: rgba(236,72,153,0.15); color: #f9a8d4; border-color: rgba(236,72,153,0.3); }
+  .badge--yellow { background: rgba(234,179,8,0.15);  color: #fde047; border-color: rgba(234,179,8,0.3); }
+  .badge--orange { background: rgba(249,115,22,0.15); color: #fdba74; border-color: rgba(249,115,22,0.3); }
+</style>
 
 {% endblock %}


### PR DESCRIPTION
## Summary

Complete overhaul of the Transcripts UX — from a read-only table of UUIDs to a fully interactive conversation browser.

### Reader enhancements
- `index_transcripts` now returns 12 fields per entry: **role**, **status**, **pr_urls**, **word_count**, **user_msg_count**, **asst_msg_count**, **has_subagents**, **is_coordinator** + improved previews (160 chars, strips XML tags, scans all user messages for issues)
- New `read_transcript_full()` loads the complete detail payload for a single UUID: all messages (capped at 300, most-recent when over limit), sub-agent cards, linked issues, PR URLs, stats
- **Coordinator sessions** (subagents-only, no root JSONL) are now indexed and shown with a "coord" badge
- `extract_pr_urls()` helper

### New routes
- `GET /transcripts` — now accepts `?role=`, `?status=`, `?issue=`, `?q=` for server-side filtering
- `GET /transcripts/{uuid}` — new detail route

### List view (`transcripts.html`)
- **Clickable rows** → detail page
- **Role badges** colour-coded (cto=orange, python-developer=green, pr-reviewer=teal, etc.)
- **Status badges** (✓ done / ⏳ active)
- **Client-side search** via Alpine.js (debounced 200ms), role + status dropdowns
- **4-way sort**: recent first, most messages, most words, most sub-agents
- Issue chips link to `/issues/{n}`
- Sub-agent count badge

### Detail view (`transcript_detail.html` — new)
- **Stats strip**: total messages, user turns, assistant turns, word count, sub-agent count
- **Full chat thread**: alternating user/assistant bubbles with distinct backgrounds; long messages scroll at 400px max
- **In-thread search** with live Alpine.js text highlighting
- **Sidebar**: linked issues, PR links (→ GitHub), sub-agent cards with role/status/preview, metadata grid
- Truncation banner with "Load all" link when over 300-message cap

## Test plan
- [x] `mypy agentception/readers/transcripts.py agentception/routes/ui.py` — clean
- [x] `test_agentception_transcripts.py` — 21/21 passed
- [x] Live: `GET /transcripts` returns 637 rows with role/status badges
- [x] Live: `GET /transcripts/23df554c-...` renders stats-strip + chat thread + sidebar