### PR TITLE
fix: /api/config 500, waveControl init, tagline Amplify Yourself

### DIFF
--- a/agentception/models.py
+++ b/agentception/models.py
@@ -211,7 +211,7 @@ class ProjectConfig(BaseModel):
     gh_repo: str
     repo_dir: str
     worktrees_dir: str
-    cursor_project_id: str
+    cursor_project_id: str | None = None
     active_labels_order: list[str] = []
 
 

--- a/agentception/static/app.js
+++ b/agentception/static/app.js
@@ -211,6 +211,10 @@ function waveControl() {
     waveResult: null,
     waveError: null,
 
+    init() {
+      // Data flows from the parent pipelineDashboard scope via SSE — no polling needed here.
+    },
+
     unclaimedCount() {
       const issues = this.state?.board_issues;
       if (!issues) return 0;

--- a/agentception/templates/base.html
+++ b/agentception/templates/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>{% block title %}AgentCeption{% endblock %}</title>
+  <title>{% block title %}AgentCeption — Amplify Yourself{% endblock %}</title>
 
   <!-- Inline SVG favicon — no 404 on /favicon.ico -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='8' fill='%238b5cf6'/><text x='50%25' y='56%25' dominant-baseline='middle' text-anchor='middle' font-size='18' font-family='monospace' fill='white'>⚡</text></svg>" />
@@ -25,7 +25,7 @@
 <body class="layout">
 
   <nav class="topnav" role="navigation" aria-label="Main navigation">
-    <a href="/" class="brand">⚡ AgentCeption</a>
+    <a href="/" class="brand" title="Amplify Yourself">⚡ AgentCeption</a>
 
     <a href="/"         class="{% if request.url.path == '/' %}active{% endif %}">Overview</a>
     <a href="/agents"   class="{% if request.url.path.startswith('/agents') %}active{% endif %}">Agents</a>
@@ -71,7 +71,7 @@
   <main role="main">
     {% block content %}
     <div class="card">
-      <p class="text-muted">Welcome to <strong>AgentCeption</strong> — the Maestro pipeline dashboard.</p>
+      <p class="text-muted">Welcome to <strong>AgentCeption</strong> — <em>Amplify Yourself.</em></p>
       <p class="mt-1 text-muted">Select a section from the navigation above to get started.</p>
     </div>
     {% endblock %}

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}AgentCeption — Overview{% endblock %}
+{% block title %}AgentCeption — Amplify Yourself{% endblock %}
 
 {% block content %}
 {#


### PR DESCRIPTION
## Bugs fixed

### 1. GET /api/config → 500 Internal Server Error
`ProjectConfig.cursor_project_id` was a required `str` field. The `projects` entry added in PR #771 did not include it, so Pydantic validation failed on every request to `/api/config`. This broke:
- The project-switcher `load()` call on every page
- `configPanel` init fetch
- Any other consumer of `/api/config`

**Fix:** `cursor_project_id: str | None = None` — the field is informational and optional.

### 2. Alpine Expression Error: init is not defined
`overview.html` has `x-init="init()"` on the `wave-control-card` div. The `init()` method was present in the old inline `<script>` block but was accidentally dropped when `waveControl()` was extracted to `app.js`.

**Fix:** Restored `init()` stub to `waveControl()` in `app.js`.

## Tagline
"**AgentCeption — Amplify Yourself**" added to:
- `<title>` tag (all pages via base.html default, plus overview.html override)
- Brand link `title` tooltip in the nav
- Default welcome card copy