### PR TITLE
fix(agents): agent detail 404 from double-slash URL

### DIFF
--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -140,7 +140,11 @@ async def merge_agents(
         else:
             status = AgentStatus.UNKNOWN
 
-        node_id = tf.worktree or f"issue-{tf.issue_number}" or "unknown"
+        # Use worktree basename (e.g. "issue-732") as the ID — the full
+        # absolute path would produce a double-slash in /agents/{id} URLs.
+        node_id = (
+            Path(tf.worktree).name if tf.worktree else None
+        ) or (f"issue-{tf.issue_number}" if tf.issue_number else None) or "unknown"
         nodes.append(
             AgentNode(
                 id=node_id,

--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -95,17 +95,31 @@ def _issue_is_claimed(iss: dict[str, object]) -> bool:
 def _find_agent(state: PipelineState | None, agent_id: str) -> AgentNode | None:
     """Search the agent tree for an AgentNode matching ``agent_id``.
 
-    Searches root agents first, then their children (one level deep, matching
-    the current tree depth supported by the poller). Returns ``None`` when the
-    state is empty or the ID is not found.
+    Matches on ``node.id`` (the worktree basename, e.g. ``issue-732``) or on
+    the basename of ``node.worktree_path`` so that URLs generated before the
+    basename normalisation are still resolved correctly.
+
+    Searches root agents first, then their children (one level deep).
+    Returns ``None`` when the state is empty or no match is found.
     """
     if state is None:
         return None
+
+    def _matches(node: AgentNode) -> bool:
+        if node.id == agent_id:
+            return True
+        # Also match by worktree_path basename for backwards compatibility.
+        if node.worktree_path:
+            from pathlib import Path as _Path
+            if _Path(node.worktree_path).name == agent_id:
+                return True
+        return False
+
     for agent in state.agents:
-        if agent.id == agent_id:
+        if _matches(agent):
             return agent
         for child in agent.children:
-            if child.id == agent_id:
+            if _matches(child):
                 return child
     return None
 


### PR DESCRIPTION
AgentNode.id was the full worktree path (`/worktrees/issue-732`). Appended to `/agents/` this produced `/agents//worktrees/issue-732`. Fixed by using `Path(worktree).name` as the ID (`issue-732`), plus a backwards-compatible `_find_agent` matcher.