### PR TITLE
fix: normalize agent IDs to basename in all URL construction paths

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -195,19 +195,36 @@ async def get_agent_run_history(
 async def get_agent_run_detail(
     run_id: str,
 ) -> dict[str, Any] | None:
-    """Return a single agent run with its transcript messages."""
+    """Return a single agent run with its transcript messages.
+
+    Accepts either the bare basename (e.g. ``issue-732``) or the legacy full
+    worktree path (e.g. ``/worktrees/issue-732``) so that old DB records
+    written before the basename normalisation are still resolvable.
+    """
     try:
         async with get_session() as session:
             run_result = await session.execute(
                 select(ACAgentRun).where(ACAgentRun.id == run_id)
             )
             run = run_result.scalar_one_or_none()
+
+            # Fall back: old records stored the full worktree path as the PK.
+            # Try to find a row whose path ends with the given basename.
+            if run is None and "/" not in run_id:
+                run_result2 = await session.execute(
+                    select(ACAgentRun).where(
+                        ACAgentRun.worktree_path.like(f"%/{run_id}")
+                    )
+                )
+                run = run_result2.scalar_one_or_none()
+
             if run is None:
                 return None
 
+            actual_run_id = run.id
             msg_result = await session.execute(
                 select(ACAgentMessage)
-                .where(ACAgentMessage.agent_run_id == run_id)
+                .where(ACAgentMessage.agent_run_id == actual_run_id)
                 .order_by(ACAgentMessage.sequence_index)
             )
             messages = msg_result.scalars().all()

--- a/agentception/templates/agents.html
+++ b/agentception/templates/agents.html
@@ -48,12 +48,12 @@
       </h2>
       <div class="agents-grid">
         {% for node in section_agents %}
-        <a href="/agents/{{ node.id }}" class="agent-card agent-card--{{ node.status.value }}">
+        <a href="/agents/{{ node.id | basename }}" class="agent-card agent-card--{{ node.status.value }}">
           <div class="agent-card-header">
             <span class="status-badge status-badge--{{ node.status.value }}">
               {{ node.status.value }}
             </span>
-            <code class="agent-card-id">{{ node.id[:8] }}</code>
+            <code class="agent-card-id">{{ (node.id | basename)[:8] }}</code>
           </div>
 
           <div class="agent-card-role">{{ node.role }}</div>
@@ -129,7 +129,7 @@
             </td>
             <td>
               {% if run.id %}
-              <a href="/agents/{{ run.id }}" class="text-accent">{{ run.role or '—' }}</a>
+              <a href="/agents/{{ run.id | basename }}" class="text-accent">{{ run.role or '—' }}</a>
               {% else %}
               {{ run.role or '—' }}
               {% endif %}

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -215,7 +215,7 @@
                 x-text="agent.status"
               ></span>
               <a
-                :href="'/agents/' + encodeURIComponent(agent.id)"
+                :href="'/agents/' + encodeURIComponent(agent.id.split('/').pop())"
                 class="agent-role"
                 x-text="agent.role"
               ></a>
@@ -288,7 +288,7 @@
                         x-text="child.status"
                       ></span>
                       <a
-                        :href="'/agents/' + encodeURIComponent(child.id)"
+                        :href="'/agents/' + encodeURIComponent(child.id.split('/').pop())"
                         class="agent-role"
                         x-text="child.role"
                       ></a>


### PR DESCRIPTION
## Summary
- **Root cause**: `ACAgentRun.id` in the DB stores the full worktree path (e.g. `/worktrees/issue-732`). Templates embedded this directly in URLs, producing `href="/agents//worktrees/issue-732"` — a double-slash 404.
- **`agents.html`**: Apply Jinja `|basename` filter to both `node.id` (live cards) and `run.id` (run history table) when constructing `href`.
- **`overview.html`**: Use `agent.id.split('/').pop()` in Alpine JS href bindings for both parent agents and children.
- **`db/queries.py`**: `get_agent_run_detail` now falls back to a `worktree_path LIKE '%/run_id'` query when the exact ID lookup finds nothing — making old full-path DB records resolvable by their basename.

## Test plan
- [x] `curl localhost:7777/agents` — all `href` values are clean basenames (e.g. `/agents/issue-732`)
- [x] `curl -I localhost:7777/agents/issue-732` — returns 200
- [x] mypy clean