### PR TITLE
refactor: eliminate all agent-ID compatibility shims — pristine API throughout

### DIFF
--- a/agentception/db/models.py
+++ b/agentception/db/models.py
@@ -94,7 +94,7 @@ class ACAgentRun(Base):
     __tablename__ = "ac_agent_runs"
 
     id: Mapped[str] = mapped_column(String(512), primary_key=True)
-    """Worktree path (unique per run) or generated UUID for manual spawns."""
+    """Worktree basename (e.g. ``issue-732``) or generated UUID for manual spawns."""
 
     wave_id: Mapped[str | None] = mapped_column(
         String(128), ForeignKey("ac_waves.id"), nullable=True, index=True

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -197,9 +197,8 @@ async def get_agent_run_detail(
 ) -> dict[str, Any] | None:
     """Return a single agent run with its transcript messages.
 
-    Accepts either the bare basename (e.g. ``issue-732``) or the legacy full
-    worktree path (e.g. ``/worktrees/issue-732``) so that old DB records
-    written before the basename normalisation are still resolvable.
+    ``run_id`` is the worktree basename (e.g. ``issue-732``), which is the
+    primary key stored in ``ac_agent_runs``.
     """
     try:
         async with get_session() as session:
@@ -207,24 +206,12 @@ async def get_agent_run_detail(
                 select(ACAgentRun).where(ACAgentRun.id == run_id)
             )
             run = run_result.scalar_one_or_none()
-
-            # Fall back: old records stored the full worktree path as the PK.
-            # Try to find a row whose path ends with the given basename.
-            if run is None and "/" not in run_id:
-                run_result2 = await session.execute(
-                    select(ACAgentRun).where(
-                        ACAgentRun.worktree_path.like(f"%/{run_id}")
-                    )
-                )
-                run = run_result2.scalar_one_or_none()
-
             if run is None:
                 return None
 
-            actual_run_id = run.id
             msg_result = await session.execute(
                 select(ACAgentMessage)
-                .where(ACAgentMessage.agent_run_id == actual_run_id)
+                .where(ACAgentMessage.agent_run_id == run_id)
                 .order_by(ACAgentMessage.sequence_index)
             )
             messages = msg_result.scalars().all()

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -140,8 +140,8 @@ async def merge_agents(
         else:
             status = AgentStatus.UNKNOWN
 
-        # Use worktree basename (e.g. "issue-732") as the ID — the full
-        # absolute path would produce a double-slash in /agents/{id} URLs.
+        # Agent ID is the worktree basename (e.g. "issue-732"). This is the
+        # canonical identifier used in URLs, DB PKs, and API responses.
         node_id = (
             Path(tf.worktree).name if tf.worktree else None
         ) or (f"issue-{tf.issue_number}" if tf.issue_number else None) or "unknown"

--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
-import os
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
@@ -33,9 +32,6 @@ logger = logging.getLogger(__name__)
 
 _HERE = Path(__file__).parent
 _TEMPLATES = Jinja2Templates(directory=str(_HERE.parent / "templates"))
-# Register path filters used by agent.html kill-endpoint modal.
-_TEMPLATES.env.filters["basename"] = os.path.basename
-_TEMPLATES.env.filters["dirname"] = os.path.dirname
 
 
 def _timestamp_to_date(ts: float) -> str:
@@ -93,33 +89,19 @@ def _issue_is_claimed(iss: dict[str, object]) -> bool:
 
 
 def _find_agent(state: PipelineState | None, agent_id: str) -> AgentNode | None:
-    """Search the agent tree for an AgentNode matching ``agent_id``.
+    """Search the live agent tree for an AgentNode by its ID.
 
-    Matches on ``node.id`` (the worktree basename, e.g. ``issue-732``) or on
-    the basename of ``node.worktree_path`` so that URLs generated before the
-    basename normalisation are still resolved correctly.
-
-    Searches root agents first, then their children (one level deep).
+    ``agent_id`` is the worktree basename (e.g. ``issue-732``), which is the
+    canonical ID assigned by the poller.  Searches root agents then children.
     Returns ``None`` when the state is empty or no match is found.
     """
     if state is None:
         return None
-
-    def _matches(node: AgentNode) -> bool:
-        if node.id == agent_id:
-            return True
-        # Also match by worktree_path basename for backwards compatibility.
-        if node.worktree_path:
-            from pathlib import Path as _Path
-            if _Path(node.worktree_path).name == agent_id:
-                return True
-        return False
-
     for agent in state.agents:
-        if _matches(agent):
+        if agent.id == agent_id:
             return agent
         for child in agent.children:
-            if _matches(child):
+            if child.id == agent_id:
                 return child
     return None
 
@@ -314,9 +296,9 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
             status_code=404,
         )
 
-    # If the agent left the live poller state but exists in the DB (historical
-    # run), synthesize a lightweight AgentNode so the template can render its
-    # normal detail view without needing two code paths.
+    # Agent has left the live poller state (worktree gone) but exists in the
+    # DB.  Synthesise a lightweight AgentNode so the template renders its full
+    # detail view without a separate code path.
     if node is None and db_run is not None:
         from agentception.models import AgentStatus as _AgentStatus
         raw_status = str(db_run.get("status", "unknown")).lower()
@@ -324,9 +306,8 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
             synth_status = _AgentStatus(raw_status)
         except ValueError:
             synth_status = _AgentStatus.UNKNOWN
-        raw_id = str(db_run.get("id", agent_id))
         node = AgentNode(
-            id=Path(raw_id).name if "/" in raw_id else raw_id,
+            id=str(db_run.get("id", agent_id)),
             role=str(db_run.get("role", "unknown")),
             status=synth_status,
             issue_number=db_run.get("issue_number"),  # type: ignore[arg-type]

--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -19,11 +19,6 @@
   --bg-overlay:   #172038;
   --bg-glass:     rgba(10, 16, 32, 0.72);
 
-  /* Legacy aliases — keep templates working unchanged */
-  --bg-primary:   var(--bg-base);
-  --bg-secondary: var(--bg-surface);
-  --bg-tertiary:  var(--bg-elevated);
-
   /* Borders */
   --border-subtle:  #15223a;
   --border-default: #1f3050;
@@ -1121,7 +1116,7 @@ main {
   color: #fff;
 }
 
-/* ── Status badges (legacy .badge-* — keep for templates) ─────── */
+/* ── Badges ──────────────────────────────────────────────────────── */
 
 .badge {
   display: inline-flex;
@@ -1134,12 +1129,7 @@ main {
   letter-spacing: 0.06em;
 }
 
-.badge-implementing { background: rgba(59,130,246,0.15); color: #60a5fa; border: 1px solid rgba(59,130,246,0.25); }
-.badge-reviewing    { background: var(--warning-dim); color: var(--warning); border: 1px solid var(--warning-border); }
-.badge-done         { background: var(--success-dim); color: var(--success); border: 1px solid var(--success-border); }
-.badge-stale        { background: var(--danger-dim);  color: var(--danger);  border: 1px solid var(--danger-border); }
-.badge-unknown      { background: var(--bg-elevated);  color: var(--text-muted); border: 1px solid var(--border-subtle); }
-.badge-count        { background: var(--bg-overlay); color: var(--text-secondary); border: 1px solid var(--border-default); }
+.badge-count { background: var(--bg-overlay); color: var(--text-secondary); border: 1px solid var(--border-default); }
 
 /* Semantic variants */
 .badge--green  { background: var(--success-dim);   color: var(--success);  border: 1px solid var(--success-border); }

--- a/agentception/templates/agent.html
+++ b/agentception/templates/agent.html
@@ -106,7 +106,7 @@
           <button class="btn btn-secondary" @click="showKillModal = false">Cancel</button>
           <button
             class="btn btn-danger"
-            hx-post="/api/control/kill/{{ node.worktree_path | basename }}"
+            hx-post="/api/control/kill/{{ node.id }}"
             hx-target="#result"
             hx-swap="innerHTML"
             @click="showKillModal = false"

--- a/agentception/templates/agents.html
+++ b/agentception/templates/agents.html
@@ -48,12 +48,12 @@
       </h2>
       <div class="agents-grid">
         {% for node in section_agents %}
-        <a href="/agents/{{ node.id | basename }}" class="agent-card agent-card--{{ node.status.value }}">
+        <a href="/agents/{{ node.id }}" class="agent-card agent-card--{{ node.status.value }}">
           <div class="agent-card-header">
             <span class="status-badge status-badge--{{ node.status.value }}">
               {{ node.status.value }}
             </span>
-            <code class="agent-card-id">{{ (node.id | basename)[:8] }}</code>
+            <code class="agent-card-id">{{ node.id[:8] }}</code>
           </div>
 
           <div class="agent-card-role">{{ node.role }}</div>
@@ -129,7 +129,7 @@
             </td>
             <td>
               {% if run.id %}
-              <a href="/agents/{{ run.id | basename }}" class="text-accent">{{ run.role or '—' }}</a>
+              <a href="/agents/{{ run.id }}" class="text-accent">{{ run.role or '—' }}</a>
               {% else %}
               {{ run.role or '—' }}
               {% endif %}

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -215,7 +215,7 @@
                 x-text="agent.status"
               ></span>
               <a
-                :href="'/agents/' + encodeURIComponent(agent.id.split('/').pop())"
+                :href="'/agents/' + agent.id"
                 class="agent-role"
                 x-text="agent.role"
               ></a>
@@ -265,7 +265,7 @@
                   <button class="btn btn-secondary" @click="showKillModal = false">Cancel</button>
                   <button
                     class="btn btn-danger"
-                    :hx-post="'/api/control/kill/' + agent.worktree_path.split('/').pop()"
+                    :hx-post="'/api/control/kill/' + agent.id"
                     hx-target="closest .agent-row"
                     hx-swap="outerHTML"
                     @click="showKillModal = false"
@@ -288,7 +288,7 @@
                         x-text="child.status"
                       ></span>
                       <a
-                        :href="'/agents/' + encodeURIComponent(child.id.split('/').pop())"
+                        :href="'/agents/' + child.id"
                         class="agent-role"
                         x-text="child.role"
                       ></a>
@@ -324,7 +324,7 @@
                           <button class="btn btn-secondary" @click="showKillModal = false">Cancel</button>
                           <button
                             class="btn btn-danger"
-                            :hx-post="'/api/control/kill/' + child.worktree_path.split('/').pop()"
+                            :hx-post="'/api/control/kill/' + child.id"
                             hx-target="closest .agent-row"
                             hx-swap="outerHTML"
                             @click="showKillModal = false"

--- a/agentception/tests/test_agentception_github.py
+++ b/agentception/tests/test_agentception_github.py
@@ -279,7 +279,7 @@ async def test_get_issue_body_returns_string() -> None:
 
     with patch(
         "agentception.readers.github.asyncio.create_subprocess_exec",
-        return_value=_make_process(json.dumps(expected_body).encode()),
+        return_value=_make_process(json.dumps({"body": expected_body}).encode()),
     ):
         result = await get_issue_body(42)
 

--- a/agentception/tests/test_agentception_scaling.py
+++ b/agentception/tests/test_agentception_scaling.py
@@ -461,6 +461,10 @@ def test_banner_hidden_when_dismissed_markup_present() -> None:
     assert response.status_code == 200
     html = response.text
     # Banner container with Alpine dismissed-state guard must be rendered.
-    assert "scalingAdvisor()" in html, "Alpine scalingAdvisor component must be in the page"
-    assert "/api/intelligence/scaling-advice/apply" in html, "Apply endpoint URL must be in the page"
+    # scalingAdvisor() is defined in app.js; the HTML uses it via x-data invocation.
+    assert "scalingAdvisor(" in html, "Alpine scalingAdvisor x-data invocation must be in the page"
+    # Apply logic (POST /api/intelligence/scaling-advice/apply) lives in app.js,
+    # invoked via @click="apply()". Verify the button and app.js are present.
+    assert '@click="apply()"' in html, "Apply button must delegate to scalingAdvisor.apply()"
+    assert "/static/app.js" in html, "app.js must be loaded for scalingAdvisor to work"
     assert "Dismiss" in html, "Dismiss button must be rendered"

--- a/agentception/tests/test_agentception_ui_config.py
+++ b/agentception/tests/test_agentception_ui_config.py
@@ -91,8 +91,8 @@ def test_config_page_shows_current_values(client: TestClient) -> None:
         response = client.get("/config")
 
     body = response.text
-    # The page must contain the Alpine.js data binding entry point.
-    assert "configPanel()" in body
+    # The page must invoke configPanel via x-data (function defined in app.js).
+    assert "configPanel(" in body
     # Sliders must be present.
     assert 'id="slider-eng-vps"' in body
     assert 'id="slider-qa-vps"' in body
@@ -109,7 +109,7 @@ def test_config_page_shows_current_values(client: TestClient) -> None:
 
 
 def test_config_page_contains_api_put_endpoint(client: TestClient) -> None:
-    """GET /config renders JavaScript that calls PUT /api/config on save."""
+    """GET /config page loads app.js which calls PUT /api/config on save."""
     with patch(
         "agentception.routes.ui.read_pipeline_config",
         new_callable=AsyncMock,
@@ -117,8 +117,10 @@ def test_config_page_contains_api_put_endpoint(client: TestClient) -> None:
     ):
         response = client.get("/config")
 
-    assert "PUT" in response.text
-    assert "/api/config" in response.text
+    # The PUT /api/config call lives in app.js; verify the script is loaded
+    # and the x-data binding that connects to it is present in the HTML.
+    assert "/static/app.js" in response.text
+    assert "configPanel(" in response.text
 
 
 def test_config_page_nav_link_active(client: TestClient) -> None:

--- a/agentception/tests/test_agentception_ui_overview.py
+++ b/agentception/tests/test_agentception_ui_overview.py
@@ -79,10 +79,13 @@ def test_overview_contains_tree_element(client: TestClient, empty_state: Pipelin
 
 
 def test_overview_sse_connect_attribute(client: TestClient, empty_state: PipelineState) -> None:
-    """GET / HTML must wire the EventSource to /events for live updates."""
+    """GET / HTML must load app.js, which wires the EventSource to /events."""
     with patch("agentception.routes.ui.get_state", return_value=empty_state):
         response = client.get("/")
-    assert "EventSource('/events')" in response.text
+    # EventSource logic lives in app.js; verify the script is loaded and
+    # the pipelineDashboard x-data binding is present in the HTML.
+    assert "/static/app.js" in response.text
+    assert "pipelineDashboard(" in response.text
 
 
 def test_overview_contains_summary_bar(client: TestClient, empty_state: PipelineState) -> None:


### PR DESCRIPTION
## Summary

The original bug (full worktree paths stored as DB PKs) led to three layers of accumulated workarounds:
1. A `LIKE` fallback branch in `get_agent_run_detail`
2. A dual-match (by ID and by worktree basename) in `_find_agent`
3. `| basename` Jinja filters and `.split('/').pop()` Alpine bindings throughout templates

This PR removes every shim by fixing the root cause directly.

## What Changed

### Data migration
- Ran `UPDATE ac_agent_runs SET id = regexp_replace(id, '^.*/', '')` to normalise the 5 existing DB rows from full paths (`/worktrees/issue-731`) to basenames (`issue-731`). FK order respected; messages table was empty.

### Code (net −33 lines)
- **`db/queries.py`**: `get_agent_run_detail` — drop LIKE fallback and `actual_run_id` indirection. Straight PK lookup only.
- **`db/models.py`**: Fix `ACAgentRun.id` docstring ("Worktree path" → "basename").
- **`routes/ui.py`**: `_find_agent` — direct `id ==` comparison only. `agent_detail` synthesis — remove path-normalisation on `raw_id`. Remove `os` import and unused `basename`/`dirname` Jinja filter registrations.
- **`poller.py`**: Rewrite workaround comment as statement of design intent.
- **`agents.html`**: Remove `| basename` filter from `node.id` and `run.id` hrefs.
- **`overview.html`**: Remove `.split('/').pop()` from agent/child id hrefs and kill-button bindings — use `agent.id` / `child.id` directly.
- **`agent.html`**: Kill button uses `node.id` instead of `node.worktree_path | basename`.
- **`app.css`**: Remove 3 unused `--bg-primary/secondary/tertiary` aliases and 5 dead `.badge-implementing/reviewing/done/stale/unknown` classes.

### Tests (4 pre-existing regressions fixed)
- Assertions on inline JS (moved to `app.js` in a prior refactor) updated to check `x-data` invocation attributes and `/static/app.js` script tag.
- `test_get_issue_body_returns_string`: mock now returns `{"body": "..."}` matching the function's documented gh output shape.

## Test plan
- [x] 322/322 tests pass
- [x] mypy clean (4 files)
- [x] `curl localhost:7777/agents` — all hrefs are clean basenames
- [x] `curl -I localhost:7777/agents/issue-731` — 200