### PR TITLE
redesign Overview page: expandable agent cards, live transcripts, board status badges

### DIFF
--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -1116,6 +1116,322 @@ main {
   color: #fff;
 }
 
+/* ── Agent card: expandable header + body ────────────────────────── */
+
+.agent-card__header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s;
+}
+
+.agent-card__header:hover {
+  background: rgba(255, 255, 255, 0.025);
+}
+
+/* Rotate chevron when card is open */
+.agent-card__chevron {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  transition: transform 0.2s var(--ease-out);
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.agent-card__chevron--open {
+  transform: rotate(90deg);
+}
+
+/* Expandable body panel */
+.agent-card__body {
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* ── Transcript feed ─────────────────────────────────────────────── */
+
+.transcript-feed {
+  max-height: 380px;
+  overflow-y: auto;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+
+.transcript-msg {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  align-items: flex-start;
+}
+
+.transcript-msg--assistant {
+  background: rgba(139, 92, 246, 0.05);
+  border-left: 2px solid rgba(139, 92, 246, 0.25);
+  border-radius: 0 var(--radius-sm, 4px) var(--radius-sm, 4px) 0;
+  padding: 0.375rem 0.5rem 0.375rem 0.5rem;
+}
+
+.transcript-msg--user {
+  padding: 0.25rem 0;
+}
+
+.transcript-msg__icon {
+  font-size: 0.875rem;
+  flex-shrink: 0;
+  width: 1.25rem;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.transcript-msg__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.transcript-msg__role {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.1rem;
+}
+
+.transcript-msg__text {
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+}
+
+.transcript-loading,
+.transcript-empty {
+  padding: 0.5rem 0;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.transcript-error {
+  padding: 0.5rem 0;
+  font-size: 0.8125rem;
+  color: var(--danger);
+  text-align: center;
+}
+
+/* "Agent is working…" thinking indicator */
+.transcript-thinking {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+.transcript-thinking__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #3b82f6;
+  flex-shrink: 0;
+  animation: pulse-dot 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 0.3; transform: scale(0.75); }
+  50%       { opacity: 1;   transform: scale(1.15); }
+}
+
+/* ── Task details grid in expanded card ──────────────────────────── */
+
+.agent-task-details {
+  border-top: 1px solid var(--border-subtle);
+  padding: 0.625rem 1rem;
+}
+
+.agent-task-details__title {
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 0.4rem;
+}
+
+.agent-task-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.2rem 0.75rem;
+  font-size: 0.75rem;
+}
+
+.agent-task-grid__key {
+  color: var(--text-muted);
+  font-weight: 500;
+  white-space: nowrap;
+  line-height: 1.5;
+}
+
+.agent-task-grid__value {
+  font-family: var(--font-mono);
+  color: var(--text-secondary, var(--text-primary));
+  word-break: break-all;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.5;
+}
+
+/* ── Quick action bar at bottom of expanded card ─────────────────── */
+
+.agent-card-actions {
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--border-subtle);
+  flex-wrap: wrap;
+  background: rgba(255, 255, 255, 0.01);
+}
+
+/* ── Animated pulse dot for active agent statuses ────────────────── */
+
+.agent-pulse {
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: pulse-ring 1.8s ease-out infinite;
+}
+
+.agent-pulse--implementing {
+  background: #3b82f6;
+}
+
+.agent-pulse--reviewing {
+  background: var(--warning, #f59e0b);
+}
+
+@keyframes pulse-ring {
+  0%   { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7); }
+  60%  { box-shadow: 0 0 0 5px rgba(59, 130, 246, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); }
+}
+
+/* ── Role name + meta chips inside agent header ───────────────────── */
+
+.agent-role-name {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+}
+
+.agent-meta-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-decoration: none;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.4;
+  transition: background 0.12s, color 0.12s;
+}
+
+.agent-meta-chip--issue {
+  background: rgba(139, 92, 246, 0.1);
+  color: var(--accent-bright);
+  border: 1px solid rgba(139, 92, 246, 0.25);
+}
+
+.agent-meta-chip--issue:hover {
+  background: rgba(139, 92, 246, 0.22);
+  color: #fff;
+}
+
+.agent-meta-chip--pr {
+  background: rgba(34, 197, 94, 0.09);
+  color: var(--success);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+}
+
+.agent-meta-chip--pr:hover {
+  background: rgba(34, 197, 94, 0.2);
+  color: #fff;
+}
+
+.agent-branch-chip {
+  font-size: 0.6875rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Board issue status badges ───────────────────────────────────── */
+
+.issue-card-status {
+  margin: 0.3rem 0;
+}
+
+.issue-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 99px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-decoration: none;
+  transition: background 0.12s, color 0.12s;
+}
+
+.issue-status-badge--available {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+}
+
+.issue-status-badge--implementing {
+  background: rgba(59, 130, 246, 0.1);
+  color: #60a5fa;
+  border: 1px solid rgba(59, 130, 246, 0.28);
+}
+
+.issue-status-badge--pr {
+  background: rgba(34, 197, 94, 0.1);
+  color: var(--success);
+  border: 1px solid rgba(34, 197, 94, 0.28);
+}
+
+.issue-status-badge--pr:hover {
+  background: rgba(34, 197, 94, 0.2);
+  color: #fff;
+}
+
+/* Wave result: branch name */
+.wave-branch {
+  font-size: 0.6875rem;
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+}
+
 /* ── Badges ──────────────────────────────────────────────────────── */
 
 .badge {

--- a/agentception/static/app.js
+++ b/agentception/static/app.js
@@ -11,6 +11,7 @@
  * Function index:
  *   projectSwitcher()                         — nav project dropdown
  *   pipelineDashboard(initial)                — overview SSE board
+ *   agentCard()                               — expandable agent row with live transcript
  *   phaseSwitcher(label, labels, pinned)      — phase dropdown
  *   pipelineControl(paused)                   — pause/resume toggle
  *   waveControl()                             — start-wave button
@@ -111,6 +112,112 @@ function pipelineDashboard(initial) {
       if (secs < 60)   return secs + 's ago';
       if (secs < 3600) return Math.floor(secs / 60) + 'm ago';
       return Math.floor(secs / 3600) + 'h ago';
+    },
+
+    /** Find the first live agent working on a given issue number (for board cross-reference). */
+    agentForIssue(issueNumber) {
+      if (!this.state || !this.state.agents) return null;
+      return this.state.agents.find(a => a.issue_number === issueNumber) || null;
+    },
+
+    /** Sum of message_count across all currently tracked agents. */
+    totalMsgCount() {
+      if (!this.state || !this.state.agents) return 0;
+      return this.state.agents.reduce((sum, a) => sum + (a.message_count || 0), 0);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Overview — expandable agent card with live transcript
+// ---------------------------------------------------------------------------
+
+/**
+ * Powers each agent row in the Agent Tree.
+ *
+ * The card manages its own expansion state and the on-demand transcript fetch.
+ * Reactive agent data (status, issue_number, etc.) lives in the parent SSE
+ * scope and is passed in via x-effect so re-fetching triggers automatically
+ * when message_count changes.
+ *
+ * Usage in template:
+ *   <div x-data="agentCard()" x-effect="checkRefresh(agent, agent.message_count)">
+ */
+function agentCard() {
+  return {
+    expanded:         false,
+    transcript:       [],
+    transcriptLoading: false,
+    transcriptError:  null,
+    showKillModal:    false,
+    _prevMsgCount:    0,
+
+    /** Toggle expand/collapse; fetch transcript on first open. */
+    toggle(agentId) {
+      this.expanded = !this.expanded;
+      if (this.expanded && this.transcript.length === 0) {
+        this.fetchTranscript(agentId);
+      }
+    },
+
+    /**
+     * Fetch the agent's transcript from the REST endpoint.
+     * Called on expand and when message_count changes while expanded.
+     */
+    async fetchTranscript(agentId) {
+      this.transcriptLoading = true;
+      this.transcriptError   = null;
+      try {
+        const res = await fetch(`/api/agents/${encodeURIComponent(agentId)}/transcript`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        // API may return an array directly or {messages:[]} — handle both.
+        this.transcript = Array.isArray(data) ? data : (data.messages || []);
+        this._scrollFeed();
+      } catch (err) {
+        this.transcriptError = err.message || 'Failed to load transcript';
+      } finally {
+        this.transcriptLoading = false;
+      }
+    },
+
+    /**
+     * Called from x-effect="checkRefresh(agent, agent.message_count)".
+     * The explicit agent.message_count arg makes Alpine track it as a dependency
+     * so this re-runs on every SSE tick where the count changed.
+     */
+    checkRefresh(agent, msgCount) {
+      const count = msgCount || 0;
+      if (this.expanded && count !== this._prevMsgCount) {
+        this.fetchTranscript(agent.id);
+      }
+      this._prevMsgCount = count;
+    },
+
+    /** Scroll the transcript feed to the latest message. */
+    _scrollFeed() {
+      this.$nextTick(() => {
+        const feed = this.$el.querySelector('.transcript-feed');
+        if (feed) feed.scrollTop = feed.scrollHeight;
+      });
+    },
+
+    /** Format a kebab-case role name as Title Case words. */
+    formatRole(role) {
+      return (role || '').split('-')
+        .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+    },
+
+    /** True for statuses that mean the agent is actively working. */
+    isActive(status) {
+      return status === 'implementing' || status === 'reviewing';
+    },
+
+    /** Clip long text for compact transcript preview. */
+    truncate(text, maxLen) {
+      if (!text) return '';
+      return text.length > maxLen ? text.slice(0, maxLen) + '…' : text;
     },
   };
 }

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -90,9 +90,13 @@
       <span class="summary-label">Closed today</span>
       <span class="summary-value" style="color:var(--accent-bright);" x-text="state.closed_issues_count ?? 0"></span>
     </div>
-    <div class="summary-item" x-show="(state.stale_branches || []).length > 0">
-      <span class="summary-label" style="color:var(--warning);">Stale branches</span>
-      <span class="summary-value" style="color:var(--warning);" x-text="(state.stale_branches || []).length"></span>
+    <div class="summary-item" :style="(state.stale_branches || []).length > 0 ? 'opacity:1' : 'opacity:0.45'">
+      <span class="summary-label" :style="(state.stale_branches || []).length > 0 ? 'color:var(--warning)' : ''">Stale branches</span>
+      <span class="summary-value" :style="(state.stale_branches || []).length > 0 ? 'color:var(--warning)' : ''" x-text="(state.stale_branches || []).length"></span>
+    </div>
+    <div class="summary-item">
+      <span class="summary-label">Messages</span>
+      <span class="summary-value" style="color:var(--accent-bright);" x-text="totalMsgCount()"></span>
     </div>
     <div class="summary-item">
       <span class="summary-label">Last polled</span>
@@ -202,51 +206,178 @@
       <h2 class="section-title">Agent Tree</h2>
 
       <div id="tree">
+
+        {# Empty state #}
         <div x-show="state.agents.length === 0" class="empty-state text-muted">
-          No active agents.
+          <p>The pipeline is idle.</p>
+          <p class="text-sm mt-1">Start a wave or spawn an agent to begin.</p>
         </div>
 
+        {# Root agent cards — each is an expandable agentCard() component #}
         <template x-for="agent in state.agents" :key="agent.id">
-          <div class="agent-row" :class="'agent-row--status-' + agent.status" x-data="{ showKillModal: false }">
-            <div class="agent-row-header">
+          <div
+            class="agent-row"
+            :class="'agent-row--status-' + agent.status"
+            x-data="agentCard()"
+            x-effect="checkRefresh(agent, agent.message_count)"
+          >
+
+            {# ── Collapsed header (click to expand) ──────────────────────── #}
+            <div class="agent-card__header" @click="toggle(agent.id)">
+
+              {# Animated pulse for active statuses #}
+              <span
+                class="agent-pulse"
+                :class="'agent-pulse--' + agent.status"
+                x-show="isActive(agent.status)"
+              ></span>
+
+              {# Status badge #}
               <span
                 class="status-badge"
                 :class="'status-badge--' + agent.status"
                 x-text="agent.status"
               ></span>
+
+              {# Role (formatted) #}
+              <span class="agent-role-name" x-text="formatRole(agent.role)"></span>
+
+              {# Issue chip #}
               <a
-                :href="'/agents/' + agent.id"
-                class="agent-role"
-                x-text="agent.role"
-              ></a>
-              <span class="agent-meta" x-show="agent.issue_number != null">
-                #<span x-text="agent.issue_number"></span>
+                x-show="agent.issue_number != null"
+                :href="GH_BASE_URL + '/issues/' + agent.issue_number"
+                class="agent-meta-chip agent-meta-chip--issue"
+                target="_blank" rel="noopener noreferrer"
+                @click.stop
+              >#<span x-text="agent.issue_number"></span></a>
+
+              {# PR chip #}
+              <a
+                x-show="agent.pr_number != null"
+                :href="GH_BASE_URL + '/pull/' + agent.pr_number"
+                class="agent-meta-chip agent-meta-chip--pr"
+                target="_blank" rel="noopener noreferrer"
+                @click.stop
+              >PR&nbsp;#<span x-text="agent.pr_number"></span></a>
+
+              {# Branch #}
+              <code
+                class="agent-branch-chip text-muted"
+                x-show="agent.branch"
+                x-text="agent.branch"
+              ></code>
+
+              {# Message count #}
+              <span class="agent-meta text-muted" x-show="agent.message_count > 0">
+                <span x-text="agent.message_count"></span> msgs
               </span>
-              <span class="agent-meta" x-show="agent.pr_number != null">
-                PR&nbsp;<span x-text="agent.pr_number"></span>
-              </span>
-              <span
-                class="agent-meta text-muted"
-                x-show="agent.batch_id != null"
-                x-text="agent.batch_id"
-              ></span>
+
+              {# Last activity #}
               <span
                 class="agent-meta text-muted"
                 x-show="agent.last_activity_mtime > 0"
                 x-text="relativeTime(agent.last_activity_mtime)"
               ></span>
 
-              {# Kill button — only for IMPLEMENTING / REVIEWING / STALE agents with a worktree #}
+              {# Expand chevron — auto-margin pushes it to the far right #}
+              <span
+                class="agent-card__chevron"
+                :class="{ 'agent-card__chevron--open': expanded }"
+              >›</span>
+
+              {# Kill button — revealed on row hover #}
               <button
                 class="btn-kill-inline"
                 x-show="agent.worktree_path != null && ['implementing','reviewing','stale'].includes(agent.status)"
-                @click.prevent="showKillModal = true"
+                @click.stop="showKillModal = true"
                 title="Kill agent"
                 aria-label="Kill agent"
               >✕</button>
             </div>
 
-            {# Inline kill confirmation for this row #}
+            {# ── Expanded body ─────────────────────────────────────────────── #}
+            <div class="agent-card__body" x-show="expanded" x-transition>
+
+              {# Transcript feed #}
+              <div class="transcript-feed">
+
+                <div x-show="transcriptLoading" class="transcript-loading">
+                  Loading transcript…
+                </div>
+
+                <div
+                  x-show="transcriptError"
+                  class="transcript-error"
+                  x-text="transcriptError"
+                ></div>
+
+                <template x-for="(msg, idx) in transcript" :key="idx">
+                  <div class="transcript-msg" :class="'transcript-msg--' + msg.role">
+                    <span class="transcript-msg__icon" x-text="msg.role === 'user' ? '🧑' : '🤖'"></span>
+                    <div class="transcript-msg__body">
+                      <div class="transcript-msg__role" x-text="msg.role"></div>
+                      <div class="transcript-msg__text" x-text="truncate(msg.text, 500)"></div>
+                    </div>
+                  </div>
+                </template>
+
+                {# "Thinking" spinner — visible when agent is active #}
+                <div
+                  class="transcript-thinking"
+                  x-show="isActive(agent.status) && !transcriptLoading"
+                >
+                  <span class="transcript-thinking__dot"></span>
+                  <span>Agent is working…</span>
+                </div>
+
+                {# Empty state #}
+                <div
+                  x-show="!transcriptLoading && !transcriptError && transcript.length === 0 && !isActive(agent.status)"
+                  class="transcript-empty"
+                >No transcript recorded yet.</div>
+
+              </div>
+
+              {# Task details table #}
+              <div class="agent-task-details">
+                <div class="agent-task-details__title">Task Details</div>
+                <div class="agent-task-grid">
+                  <span class="agent-task-grid__key">Branch</span>
+                  <span class="agent-task-grid__value" x-text="agent.branch || '—'"></span>
+                  <span class="agent-task-grid__key">Batch</span>
+                  <span class="agent-task-grid__value" x-text="agent.batch_id || '—'"></span>
+                  <span class="agent-task-grid__key">Worktree</span>
+                  <span class="agent-task-grid__value" x-text="agent.worktree_path || '—'"></span>
+                  <span class="agent-task-grid__key">Messages</span>
+                  <span class="agent-task-grid__value" x-text="agent.message_count || 0"></span>
+                </div>
+              </div>
+
+              {# Quick action links #}
+              <div class="agent-card-actions">
+                <a
+                  x-show="agent.issue_number"
+                  :href="GH_BASE_URL + '/issues/' + agent.issue_number"
+                  target="_blank" rel="noopener noreferrer"
+                  class="btn btn-sm btn-secondary"
+                  @click.stop
+                >View Issue ↗</a>
+                <a
+                  x-show="agent.pr_number"
+                  :href="GH_BASE_URL + '/pull/' + agent.pr_number"
+                  target="_blank" rel="noopener noreferrer"
+                  class="btn btn-sm btn-secondary"
+                  @click.stop
+                >View PR ↗</a>
+                <a
+                  :href="'/agents/' + agent.id"
+                  class="btn btn-sm btn-secondary"
+                  @click.stop
+                >Full Detail →</a>
+              </div>
+            </div>
+
+            {# ── Kill confirmation modal ───────────────────────────────────── #}
             <div
               class="modal-backdrop"
               x-show="showKillModal"
@@ -256,7 +387,9 @@
               aria-modal="true"
             >
               <div class="modal-box">
-                <h2 class="modal-title">Kill agent<span x-show="agent.issue_number != null"> for issue #<span x-text="agent.issue_number"></span></span>?</h2>
+                <h2 class="modal-title">
+                  Kill agent<span x-show="agent.issue_number != null"> for issue #<span x-text="agent.issue_number"></span></span>?
+                </h2>
                 <p class="modal-body">
                   Removes the worktree and clears the <code>agent:wip</code> label.
                   The issue will be available for re-claim.
@@ -269,77 +402,86 @@
                     hx-target="closest .agent-row"
                     hx-swap="outerHTML"
                     @click="showKillModal = false"
-                  >
-                    Confirm Kill
-                  </button>
+                  >Confirm Kill</button>
                 </div>
               </div>
             </div>
 
-            {# Nested children (one level — recursive nesting deferred to AC-007) #}
+            {# ── Child agents (one level deep) ────────────────────────────── #}
             <template x-if="agent.children && agent.children.length > 0">
               <div class="agent-children">
                 <template x-for="child in agent.children" :key="child.id">
-                  <div class="agent-row agent-row--child" :class="'agent-row--status-' + child.status" x-data="{ showKillModal: false }">
-                    <div class="agent-row-header">
-                      <span
-                        class="status-badge"
-                        :class="'status-badge--' + child.status"
-                        x-text="child.status"
-                      ></span>
-                      <a
-                        :href="'/agents/' + child.id"
-                        class="agent-role"
-                        x-text="child.role"
-                      ></a>
-                      <span class="agent-meta" x-show="child.issue_number != null">
-                        #<span x-text="child.issue_number"></span>
-                      </span>
-
-                      {# Kill button for child agents #}
-                      <button
-                        class="btn-kill-inline"
-                        x-show="child.worktree_path != null && ['implementing','reviewing','stale'].includes(child.status)"
-                        @click.prevent="showKillModal = true"
-                        title="Kill agent"
-                        aria-label="Kill agent"
-                      >✕</button>
+                  <div
+                    class="agent-row agent-row--child"
+                    :class="'agent-row--status-' + child.status"
+                    x-data="agentCard()"
+                    x-effect="checkRefresh(child, child.message_count)"
+                  >
+                    <div class="agent-card__header" @click="toggle(child.id)">
+                      <span class="agent-pulse" :class="'agent-pulse--' + child.status" x-show="isActive(child.status)"></span>
+                      <span class="status-badge" :class="'status-badge--' + child.status" x-text="child.status"></span>
+                      <span class="agent-role-name" x-text="formatRole(child.role)"></span>
+                      <a x-show="child.issue_number != null" :href="GH_BASE_URL + '/issues/' + child.issue_number" class="agent-meta-chip agent-meta-chip--issue" target="_blank" rel="noopener noreferrer" @click.stop>#<span x-text="child.issue_number"></span></a>
+                      <a x-show="child.pr_number != null" :href="GH_BASE_URL + '/pull/' + child.pr_number" class="agent-meta-chip agent-meta-chip--pr" target="_blank" rel="noopener noreferrer" @click.stop>PR&nbsp;#<span x-text="child.pr_number"></span></a>
+                      <code class="agent-branch-chip text-muted" x-show="child.branch" x-text="child.branch"></code>
+                      <span class="agent-meta text-muted" x-show="child.message_count > 0"><span x-text="child.message_count"></span> msgs</span>
+                      <span class="agent-meta text-muted" x-show="child.last_activity_mtime > 0" x-text="relativeTime(child.last_activity_mtime)"></span>
+                      <span class="agent-card__chevron" :class="{ 'agent-card__chevron--open': expanded }">›</span>
+                      <button class="btn-kill-inline" x-show="child.worktree_path != null && isActive(child.status)" @click.stop="showKillModal = true" title="Kill agent" aria-label="Kill agent">✕</button>
                     </div>
 
-                    {# Inline kill confirmation for child row #}
-                    <div
-                      class="modal-backdrop"
-                      x-show="showKillModal"
-                      x-cloak
-                      @keydown.escape.window="showKillModal = false"
-                      role="dialog"
-                      aria-modal="true"
-                    >
+                    <div class="agent-card__body" x-show="expanded" x-transition>
+                      <div class="transcript-feed">
+                        <div x-show="transcriptLoading" class="transcript-loading">Loading transcript…</div>
+                        <div x-show="transcriptError" class="transcript-error" x-text="transcriptError"></div>
+                        <template x-for="(msg, idx) in transcript" :key="idx">
+                          <div class="transcript-msg" :class="'transcript-msg--' + msg.role">
+                            <span class="transcript-msg__icon" x-text="msg.role === 'user' ? '🧑' : '🤖'"></span>
+                            <div class="transcript-msg__body">
+                              <div class="transcript-msg__role" x-text="msg.role"></div>
+                              <div class="transcript-msg__text" x-text="truncate(msg.text, 500)"></div>
+                            </div>
+                          </div>
+                        </template>
+                        <div class="transcript-thinking" x-show="isActive(child.status) && !transcriptLoading">
+                          <span class="transcript-thinking__dot"></span>
+                          <span>Agent is working…</span>
+                        </div>
+                        <div x-show="!transcriptLoading && !transcriptError && transcript.length === 0 && !isActive(child.status)" class="transcript-empty">No transcript recorded yet.</div>
+                      </div>
+                      <div class="agent-task-details">
+                        <div class="agent-task-details__title">Task Details</div>
+                        <div class="agent-task-grid">
+                          <span class="agent-task-grid__key">Branch</span><span class="agent-task-grid__value" x-text="child.branch || '—'"></span>
+                          <span class="agent-task-grid__key">Batch</span><span class="agent-task-grid__value" x-text="child.batch_id || '—'"></span>
+                          <span class="agent-task-grid__key">Messages</span><span class="agent-task-grid__value" x-text="child.message_count || 0"></span>
+                        </div>
+                      </div>
+                      <div class="agent-card-actions">
+                        <a x-show="child.pr_number" :href="GH_BASE_URL + '/pull/' + child.pr_number" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-secondary" @click.stop>View PR ↗</a>
+                        <a :href="'/agents/' + child.id" class="btn btn-sm btn-secondary" @click.stop>Full Detail →</a>
+                      </div>
+                    </div>
+
+                    <div class="modal-backdrop" x-show="showKillModal" x-cloak @keydown.escape.window="showKillModal = false" role="dialog" aria-modal="true">
                       <div class="modal-box">
                         <h2 class="modal-title">Kill agent<span x-show="child.issue_number != null"> for issue #<span x-text="child.issue_number"></span></span>?</h2>
-                        <p class="modal-body">
-                          Removes the worktree and clears the <code>agent:wip</code> label.
-                        </p>
+                        <p class="modal-body">Removes the worktree and clears the <code>agent:wip</code> label.</p>
                         <div class="modal-actions">
                           <button class="btn btn-secondary" @click="showKillModal = false">Cancel</button>
-                          <button
-                            class="btn btn-danger"
-                            :hx-post="'/api/control/kill/' + child.id"
-                            hx-target="closest .agent-row"
-                            hx-swap="outerHTML"
-                            @click="showKillModal = false"
-                          >
-                            Confirm Kill
-                          </button>
+                          <button class="btn btn-danger" :hx-post="'/api/control/kill/' + child.id" hx-target="closest .agent-row" hx-swap="outerHTML" @click="showKillModal = false">Confirm Kill</button>
                         </div>
                       </div>
                     </div>
+
                   </div>
                 </template>
               </div>
             </template>
+
           </div>
         </template>
+
       </div>
     </section>
 
@@ -408,17 +550,19 @@
           </template>
         </div>
 
-        {# Wave launch result #}
+        {# Wave launch result — no Cursor instructions; agent tree updates via SSE #}
         <template x-if="waveResult">
           <div class="wave-result mt-1">
             <p class="text-success">
-              ✅ <strong x-text="waveResult.spawned.length"></strong> agent worktree<span x-text="waveResult.spawned.length === 1 ? '' : 's'"></span> launching.
-              Open each path in Cursor to start the agents.
+              ✅ Wave launched —
+              <strong x-text="waveResult.spawned.length"></strong>
+              agent<span x-text="waveResult.spawned.length === 1 ? '' : 's'"></span>
+              claimed. Agent tree updates automatically.
             </p>
             <template x-for="s in waveResult.spawned" :key="s.spawned">
               <div class="wave-worktree-row">
                 <span class="wave-issue-num">#<span x-text="s.spawned"></span></span>
-                <code class="wave-worktree-path" x-text="s.host_worktree"></code>
+                <code class="wave-branch" x-text="s.branch"></code>
               </div>
             </template>
             <template x-if="waveResult.skipped.length > 0">
@@ -533,6 +677,29 @@
             <div class="issue-card-labels" x-show="issue.labels && issue.labels.length > 0">
               <template x-for="lbl in (issue.labels || [])" :key="lbl">
                 <span class="label-chip label-chip--small" x-text="lbl"></span>
+              </template>
+            </div>
+            {#
+              Status slot — cross-references board_issues[].claimed with state.agents[]
+              to determine whether the issue is available, being implemented, or has a PR.
+              agentForIssue() is a helper on the parent pipelineDashboard scope.
+            #}
+            <div class="issue-card-status">
+              <template x-if="!issue.claimed">
+                <span class="issue-status-badge issue-status-badge--available">Available</span>
+              </template>
+              <template x-if="issue.claimed">
+                <template x-if="agentForIssue(issue.number) && agentForIssue(issue.number).pr_number">
+                  <a
+                    :href="GH_BASE_URL + '/pull/' + agentForIssue(issue.number).pr_number"
+                    class="issue-status-badge issue-status-badge--pr"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >PR #<span x-text="agentForIssue(issue.number).pr_number"></span> open ↗</a>
+                </template>
+                <template x-if="!(agentForIssue(issue.number) && agentForIssue(issue.number).pr_number)">
+                  <span class="issue-status-badge issue-status-badge--implementing">Implementing</span>
+                </template>
               </template>
             </div>
             <div class="issue-card-actions">


### PR DESCRIPTION
## Summary

- **Expandable agent cards** — each row in the Agent Tree now click-opens a panel showing the live transcript feed and task details table. `agentCard()` Alpine component handles expand/collapse state, transcript fetching, and auto-refresh when `message_count` changes via SSE.
- **Remove "Open in Cursor" instructions** — wave result panel now shows only the claimed issue numbers and branch names; no paths, no manual steps required.
- **Board status badges** — each issue card on the GitHub Board now shows an inline status chip: _Available_ (grey), _Implementing_ (blue), or _PR #N open_ (green link to PR), derived client-side by cross-referencing `board_issues[].claimed` with `state.agents[]`.
- **Summary bar: Messages KPI** — new always-visible counter summing `message_count` across all active agents. Stale branches KPI is now always visible (dimmed when zero).

## Test plan

- [ ] Start a wave — verify wave result shows "Wave launched — N agents claimed" with branch names only (no paths, no Cursor instructions)
- [ ] Click any agent row → card expands, transcript loads, task details appear
- [ ] While agent is active, watch message count increment in summary bar and transcript auto-refresh
- [ ] Board issue cards show correct status badge per claim state
- [ ] Summary bar shows Messages and Stale Branches KPIs