### PR TITLE
feat(agentception): cognitive architecture visualization on agent cards and detail pages

### DIFF
--- a/.cursor/role-versions.json
+++ b/.cursor/role-versions.json
@@ -1,12 +1,22 @@
 {
   "versions": {
     "cto": {
-      "current": "0.1.1",
+      "current": "v3",
       "history": [
         {
           "sha": "cafecafecafecafecafecafecafecafecafecafe",
           "label": "0.1.1",
           "timestamp": 1772478292
+        },
+        {
+          "sha": "abcdef1234567890abcdef1234567890abcdef12",
+          "label": "v2",
+          "timestamp": 1772481061
+        },
+        {
+          "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "label": "v3",
+          "timestamp": 1772481061
         }
       ]
     }

--- a/agentception/models.py
+++ b/agentception/models.py
@@ -63,6 +63,7 @@ class AgentNode(BaseModel):
     message_count: int = 0
     last_activity_mtime: float = 0.0
     children: list[AgentNode] = []
+    cognitive_arch: str | None = None
 
 
 class StaleClaim(BaseModel):
@@ -175,6 +176,7 @@ class TaskFile(BaseModel):
     attempt_n: int = 0
     required_output: str | None = None
     on_block: str | None = None
+    cognitive_arch: str | None = None
 
 
 class AbModeConfig(BaseModel):

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -154,6 +154,7 @@ async def merge_agents(
                 branch=tf.branch,
                 batch_id=tf.batch_id,
                 worktree_path=tf.worktree,
+                cognitive_arch=tf.cognitive_arch,
             )
         )
 

--- a/agentception/readers/worktrees.py
+++ b/agentception/readers/worktrees.py
@@ -144,6 +144,7 @@ def _build_task_file(fields: dict[str, str], worktree_path: Path) -> TaskFile:
         "attempt_n": _parse_int(fields.get("ATTEMPT_N")) or 0,
         "required_output": fields.get("REQUIRED_OUTPUT"),
         "on_block": fields.get("ON_BLOCK"),
+        "cognitive_arch": fields.get("COGNITIVE_ARCH"),
     }
     cleaned = {k: v for k, v in raw.items() if v is not None}
     return TaskFile.model_validate(cleaned)

--- a/agentception/routes/roles.py
+++ b/agentception/routes/roles.py
@@ -341,6 +341,124 @@ async def get_atoms() -> AtomsResponse:
     return AtomsResponse(atoms=atoms)
 
 
+# ---------------------------------------------------------------------------
+# Cognitive architecture resolver — used by agent detail pages
+# ---------------------------------------------------------------------------
+
+# Archetype-to-emoji mapping for visual personality display.
+_ARCHETYPE_EMOJI: dict[str, str] = {
+    "the_visionary": "🔮",
+    "the_architect": "🏛️",
+    "the_hacker": "⚡",
+    "the_guardian": "🛡️",
+    "the_scholar": "📚",
+    "the_mentor": "🧑‍🏫",
+    "the_operator": "⚙️",
+    "the_pragmatist": "🔧",
+}
+
+# Atom dimension labels for display.
+_ATOM_LABELS: dict[str, str] = {
+    "epistemic_style": "Epistemic Style",
+    "creativity_level": "Creativity",
+    "quality_bar": "Quality Bar",
+    "scope_instinct": "Scope Instinct",
+    "collaboration_posture": "Collaboration",
+    "communication_style": "Communication",
+    "cognitive_rhythm": "Cognitive Rhythm",
+    "mental_model": "Mental Model",
+    "uncertainty_handling": "Uncertainty",
+    "error_posture": "Error Posture",
+}
+
+
+def resolve_cognitive_arch(cognitive_arch_str: str | None) -> dict[str, object]:
+    """Parse a COGNITIVE_ARCH string and return a rich display dict.
+
+    The string format is ``figure_id:skill1:skill2`` where the first token
+    is an optional figure ID and subsequent tokens are skill domain IDs.
+
+    Returns a dict with:
+    - ``raw``: the original string
+    - ``figure_id``: first token (or None if only skills)
+    - ``skill_domains``: list of skill domain IDs
+    - ``display_name``: human-readable name from the figure YAML (or figure_id)
+    - ``archetype``: the archetype the figure extends (or None)
+    - ``archetype_emoji``: emoji for the archetype
+    - ``description``: full description from the figure YAML (or "")
+    - ``overrides``: dict of atom dimension overrides
+    - ``atom_labels``: dict mapping dimension key → human label
+    - ``prompt_prefix``: first 300 chars of the prompt injection prefix
+    - ``is_named_figure``: True when a figure YAML was resolved
+    """
+    if not cognitive_arch_str:
+        return _empty_arch()
+
+    parts = [p.strip() for p in cognitive_arch_str.split(":") if p.strip()]
+    if not parts:
+        return _empty_arch()
+
+    # First part might be a figure ID or a skill domain.  We disambiguate by
+    # checking whether a figure YAML exists for it.
+    figures_dir = _ARCHETYPES_DIR / "figures"
+    first = parts[0]
+    figure_yaml = figures_dir / f"{first}.yaml"
+    skill_parts = parts[1:] if figure_yaml.exists() else parts
+    figure_id = first if figure_yaml.exists() else None
+
+    result: dict[str, object] = {
+        "raw": cognitive_arch_str,
+        "figure_id": figure_id,
+        "skill_domains": skill_parts,
+        "display_name": figure_id or "Custom",
+        "archetype": None,
+        "archetype_emoji": "🤖",
+        "description": "",
+        "overrides": {},
+        "atom_labels": _ATOM_LABELS,
+        "prompt_prefix": "",
+        "is_named_figure": False,
+    }
+
+    if figure_id and figure_yaml.exists():
+        try:
+            raw = yaml.safe_load(figure_yaml.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                archetype = str(raw.get("extends", ""))
+                injection = raw.get("prompt_injection", {})
+                prefix = str(injection.get("prefix", "")) if isinstance(injection, dict) else ""
+                overrides_raw = raw.get("overrides", {})
+                overrides = {str(k): str(v) for k, v in overrides_raw.items()} if isinstance(overrides_raw, dict) else {}
+
+                result["display_name"] = str(raw.get("display_name", figure_id))
+                result["archetype"] = archetype
+                result["archetype_emoji"] = _ARCHETYPE_EMOJI.get(archetype, "🤖")
+                result["description"] = str(raw.get("description", "")).strip()
+                result["overrides"] = overrides
+                result["prompt_prefix"] = prefix.strip()[:600]
+                result["is_named_figure"] = True
+        except Exception:
+            logger.warning("⚠️ Failed to load figure YAML for: %s", figure_id)
+
+    return result
+
+
+def _empty_arch() -> dict[str, object]:
+    return {
+        "raw": None,
+        "figure_id": None,
+        "skill_domains": [],
+        "display_name": "Unknown",
+        "archetype": None,
+        "archetype_emoji": "🤖",
+        "description": "",
+        "overrides": {},
+        "atom_labels": _ATOM_LABELS,
+        "prompt_prefix": "",
+        "is_named_figure": False,
+    }
+
+
 @router.get("/{slug}", summary="Get content and metadata for a single role file")
 async def get_role(slug: str) -> RoleContent:
     """Return the full file content and metadata for a managed slug.

--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -66,6 +66,15 @@ def _format_number(n: int) -> str:
 _TEMPLATES.env.filters["format_ts"] = _format_ts
 _TEMPLATES.env.filters["format_number"] = _format_number
 
+
+def _dirname(path: str) -> str:
+    """Return the parent directory of a path string (equivalent to os.path.dirname)."""
+    import os
+    return os.path.dirname(path)
+
+
+_TEMPLATES.env.filters["dirname"] = _dirname
+
 router = APIRouter(tags=["ui"])
 
 
@@ -329,6 +338,9 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
             for m in db_messages
         ]
 
+    from agentception.routes.roles import resolve_cognitive_arch
+    persona = resolve_cognitive_arch(node.cognitive_arch if node else None)
+
     return _TEMPLATES.TemplateResponse(
         request,
         "agent.html",
@@ -337,6 +349,7 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
             "agent_id": agent_id,
             "messages": messages,
             "db_run": db_run,
+            "persona": persona,
         },
     )
 
@@ -564,6 +577,39 @@ async def templates_ui(request: Request) -> HTMLResponse:
         request,
         "templates.html",
         {"stored_templates": stored},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cognitive architecture detail page
+# ---------------------------------------------------------------------------
+
+
+@router.get("/cognitive-arch/{arch_id}", response_class=HTMLResponse)
+async def cognitive_arch_detail(request: Request, arch_id: str) -> HTMLResponse:
+    """Cognitive architecture detail page — full visualisation of a figure or composed arch.
+
+    ``arch_id`` is a URL-safe version of the COGNITIVE_ARCH string, with colons
+    replaced by hyphens (e.g. ``steve_jobs-python-fastapi`` for
+    ``steve_jobs:python:fastapi``).  The route normalises both forms so links
+    from agent cards work regardless of encoding.
+    """
+    from agentception.routes.roles import resolve_cognitive_arch
+
+    # Accept both colon-separated (raw) and hyphen-separated (URL-safe) forms.
+    arch_str = arch_id.replace("-", ":") if ":" not in arch_id else arch_id
+    # But figure IDs use underscores — only replace hyphens that are between parts.
+    # Re-split on colons to normalise; if no colons, try underscore-safe split.
+    persona = resolve_cognitive_arch(arch_str)
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "cognitive_arch.html",
+        {
+            "arch_id": arch_id,
+            "arch_str": arch_str,
+            "persona": persona,
+        },
     )
 
 

--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -2377,3 +2377,479 @@ main {
   display: flex;
   gap: 0.375rem;
 }
+
+/* ══════════════════════════════════════════════════════════════
+   Cognitive Architecture — shared tokens & components
+   ══════════════════════════════════════════════════════════════ */
+
+/* Per-archetype accent colours used for avatars, cards, etc. */
+:root {
+  --arch-visionary:  #9b59b6;
+  --arch-architect:  #3498db;
+  --arch-hacker:     #f39c12;
+  --arch-guardian:   #27ae60;
+  --arch-scholar:    #1abc9c;
+  --arch-mentor:     #e67e22;
+  --arch-operator:   #95a5a6;
+  --arch-pragmatist: #e74c3c;
+  --arch-default:    #6c757d;
+}
+
+/* ── Agent card — persona avatar (in overview cards) ────────── */
+
+.card-persona-avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  flex-shrink: 0;
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-default);
+  transition: transform 0.15s ease;
+}
+
+.agent-card__header:hover .card-persona-avatar { transform: scale(1.08); }
+
+.card-persona-avatar--visionary  { border-color: var(--arch-visionary);  background: rgba(155,89,182,.15); }
+.card-persona-avatar--architect  { border-color: var(--arch-architect);  background: rgba(52,152,219,.15); }
+.card-persona-avatar--hacker     { border-color: var(--arch-hacker);     background: rgba(243,156,18,.15); }
+.card-persona-avatar--guardian   { border-color: var(--arch-guardian);   background: rgba(39,174,96,.15); }
+.card-persona-avatar--scholar    { border-color: var(--arch-scholar);    background: rgba(26,188,156,.15); }
+.card-persona-avatar--mentor     { border-color: var(--arch-mentor);     background: rgba(230,126,34,.15); }
+.card-persona-avatar--operator   { border-color: var(--arch-operator);   background: rgba(149,165,166,.12); }
+.card-persona-avatar--pragmatist { border-color: var(--arch-pragmatist); background: rgba(231,76,60,.15); }
+.card-persona-avatar--default    { border-color: var(--border-default);  background: var(--bg-elevated); }
+
+/* Role + persona name stacked inside card header */
+.agent-role-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.agent-persona-sub {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Card cognitive-arch mini-panel (expanded body) ─────────── */
+
+.card-arch-panel {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 0.6rem 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.card-arch-panel__header {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.35rem;
+}
+
+.card-arch-panel__archetype {
+  font-size: 0.68rem;
+  color: var(--accent-muted);
+  background: rgba(124,106,247,.12);
+  border-radius: 4px;
+  padding: 0.1rem 0.35rem;
+}
+
+.card-arch-panel__skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-bottom: 0.35rem;
+}
+
+.card-arch-panel__link {
+  font-size: 0.7rem;
+  color: var(--accent-bright);
+  text-decoration: none;
+}
+.card-arch-panel__link:hover { text-decoration: underline; }
+
+/* ── Skill tag — shared, two sizes ─────────────────────────── */
+
+.cog-skill-tag {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(22,153,255,.1);
+  border: 1px solid rgba(22,153,255,.25);
+  color: #60b4ff;
+  border-radius: 4px;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.73rem;
+  font-family: var(--font-mono);
+}
+
+.cog-skill-tag--sm { font-size: 0.65rem; padding: 0.1rem 0.35rem; }
+
+/* ── Agent detail page — hero row ───────────────────────────── */
+
+.agent-hero-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.agent-persona-avatar {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
+  flex-shrink: 0;
+  background: var(--bg-elevated);
+  border: 2px solid var(--border-default);
+}
+
+.agent-persona-avatar--visionary  { border-color: var(--arch-visionary);  background: rgba(155,89,182,.18); }
+.agent-persona-avatar--architect  { border-color: var(--arch-architect);  background: rgba(52,152,219,.18); }
+.agent-persona-avatar--hacker     { border-color: var(--arch-hacker);     background: rgba(243,156,18,.18); }
+.agent-persona-avatar--guardian   { border-color: var(--arch-guardian);   background: rgba(39,174,96,.18); }
+.agent-persona-avatar--scholar    { border-color: var(--arch-scholar);    background: rgba(26,188,156,.18); }
+.agent-persona-avatar--mentor     { border-color: var(--arch-mentor);     background: rgba(230,126,34,.18); }
+.agent-persona-avatar--operator   { border-color: var(--arch-operator);   background: rgba(149,165,166,.15); }
+.agent-persona-avatar--pragmatist { border-color: var(--arch-pragmatist); background: rgba(231,76,60,.18); }
+.agent-persona-avatar--default    { border-color: var(--border-default);  background: var(--bg-elevated); }
+
+.agent-hero-body { flex: 1; min-width: 0; }
+
+.agent-persona-line {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.2rem 0 0.5rem;
+  flex-wrap: wrap;
+}
+
+.agent-persona-name {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.agent-persona-archetype {
+  font-size: 0.72rem;
+  color: var(--accent-muted);
+  background: rgba(124,106,247,.12);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+}
+
+.agent-persona-link {
+  font-size: 0.72rem;
+  color: var(--accent-bright);
+  text-decoration: none;
+  margin-left: auto;
+}
+.agent-persona-link:hover { text-decoration: underline; }
+
+/* ── Cognitive architecture panel (on agent detail page) ─────── */
+
+.cog-panel {
+  padding: 1rem 1.25rem;
+}
+
+.cog-panel__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.cog-panel__title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+.cog-panel__sub {
+  font-size: 0.72rem;
+  color: var(--accent-muted);
+  background: rgba(124,106,247,.12);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+}
+
+.cog-panel__detail-link {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--accent-bright);
+  text-decoration: none;
+}
+.cog-panel__detail-link:hover { text-decoration: underline; }
+
+.cog-panel__desc {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin: 0 0 0.75rem;
+}
+
+.cog-panel__body {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.cog-panel__section-label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+  margin-bottom: 0.35rem;
+}
+
+.cog-atoms-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.cog-atom-pill {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.7rem;
+}
+
+.cog-atom-pill__key {
+  color: var(--text-muted);
+  font-size: 0.62rem;
+}
+
+.cog-atom-pill__val {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.cog-skills-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+/* ── Cognitive architecture standalone page (/cognitive-arch/*) ─ */
+
+.cog-hero {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  padding: 1.5rem;
+}
+
+.cog-hero__avatar-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.cog-hero__avatar {
+  width: 6rem;
+  height: 6rem;
+  border-radius: 50%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-elevated);
+  border: 3px solid var(--border-default);
+  position: relative;
+}
+
+.cog-hero__avatar--visionary  { border-color: var(--arch-visionary);  background: rgba(155,89,182,.22); }
+.cog-hero__avatar--architect  { border-color: var(--arch-architect);  background: rgba(52,152,219,.22); }
+.cog-hero__avatar--hacker     { border-color: var(--arch-hacker);     background: rgba(243,156,18,.22); }
+.cog-hero__avatar--guardian   { border-color: var(--arch-guardian);   background: rgba(39,174,96,.22); }
+.cog-hero__avatar--scholar    { border-color: var(--arch-scholar);    background: rgba(26,188,156,.22); }
+.cog-hero__avatar--mentor     { border-color: var(--arch-mentor);     background: rgba(230,126,34,.22); }
+.cog-hero__avatar--operator   { border-color: var(--arch-operator);   background: rgba(149,165,166,.2); }
+.cog-hero__avatar--pragmatist { border-color: var(--arch-pragmatist); background: rgba(231,76,60,.22); }
+.cog-hero__avatar--default    { border-color: var(--border-strong);   background: var(--bg-elevated); }
+
+.cog-hero__emoji    { font-size: 2.5rem; line-height: 1; }
+.cog-hero__initials { font-size: 0.65rem; color: var(--text-muted); font-weight: 700; margin-top: -0.2rem; }
+
+.cog-hero__named-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  background: rgba(124,106,247,.18);
+  color: var(--accent-bright);
+  border-radius: 4px;
+  padding: 0.15rem 0.5rem;
+}
+
+.cog-hero__named-badge--custom {
+  background: rgba(26,188,156,.14);
+  color: #4ecdc4;
+}
+
+.cog-hero__info { flex: 1; min-width: 0; }
+
+.cog-hero__name-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.4rem;
+}
+
+.cog-hero__name {
+  font-size: 1.7rem;
+  font-weight: 800;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.cog-hero__archetype-chip {
+  font-size: 0.75rem;
+  color: var(--accent-muted);
+  background: rgba(124,106,247,.12);
+  border-radius: 5px;
+  padding: 0.15rem 0.5rem;
+  white-space: nowrap;
+}
+
+.cog-hero__desc {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0 0 0.75rem;
+  max-width: 60ch;
+}
+
+.cog-hero__raw-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.cog-hero__raw-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.cog-hero__raw-value {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+}
+
+/* Columns for cog-arch standalone page */
+.cog-columns {
+  display: grid;
+  grid-template-columns: 1fr 1.5fr;
+  gap: 1rem;
+}
+@media (max-width: 800px) { .cog-columns { grid-template-columns: 1fr; } }
+
+/* Atoms grid on standalone page */
+.cog-atoms-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.5rem;
+  padding: 0.75rem;
+}
+
+.cog-atom {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+}
+
+.cog-atom__label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 0.2rem;
+}
+
+.cog-atom__value {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+/* Prompt panel */
+.cog-prompt__preview {
+  max-height: 8rem;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+  position: relative;
+}
+
+.cog-prompt__preview--expanded { max-height: 60rem; }
+
+.cog-prompt__text {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.cog-prompt__toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--accent-bright);
+  font-size: 0.75rem;
+  padding: 0.4rem 0;
+  display: block;
+  margin-top: 0.25rem;
+}
+.cog-prompt__toggle:hover { text-decoration: underline; }
+
+/* Skills on standalone page */
+.cog-skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  padding: 0.5rem;
+}
+
+/* Footer row on cog-arch page */
+.cog-footer {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}

--- a/agentception/static/app.js
+++ b/agentception/static/app.js
@@ -219,6 +219,92 @@ function agentCard() {
       if (!text) return '';
       return text.length > maxLen ? text.slice(0, maxLen) + '…' : text;
     },
+
+    /**
+     * Parse a COGNITIVE_ARCH string into display-ready fields.
+     * Format: "figure_id:skill1:skill2"
+     * Returns an object with emoji, displayName, archetype, archetypeKey, skillDomains.
+     */
+    parseArch(archStr) {
+      if (!archStr) return { emoji: '🤖', displayName: '', archetype: '', archetypeKey: 'default', skillDomains: [], figureId: null };
+
+      const FIGURE_MAP = {
+        steve_jobs:         { name: 'Steve Jobs',          emoji: '🔮', archetype: 'The Visionary',   key: 'visionary' },
+        satya_nadella:      { name: 'Satya Nadella',       emoji: '🏛️', archetype: 'The Architect',   key: 'architect' },
+        jeff_bezos:         { name: 'Jeff Bezos',          emoji: '⚙️', archetype: 'The Operator',    key: 'operator' },
+        werner_vogels:      { name: 'Werner Vogels',       emoji: '🏛️', archetype: 'The Architect',   key: 'architect' },
+        linus_torvalds:     { name: 'Linus Torvalds',      emoji: '⚡', archetype: 'The Hacker',      key: 'hacker' },
+        margaret_hamilton:  { name: 'Margaret Hamilton',   emoji: '🛡️', archetype: 'The Guardian',    key: 'guardian' },
+        bjarne_stroustrup:  { name: 'Bjarne Stroustrup',   emoji: '⚡', archetype: 'The Hacker',      key: 'hacker' },
+        martin_fowler:      { name: 'Martin Fowler',       emoji: '📚', archetype: 'The Scholar',     key: 'scholar' },
+        kent_beck:          { name: 'Kent Beck',           emoji: '🔧', archetype: 'The Pragmatist',  key: 'pragmatist' },
+        yann_lecun:         { name: 'Yann LeCun',          emoji: '📚', archetype: 'The Scholar',     key: 'scholar' },
+        andrej_karpathy:    { name: 'Andrej Karpathy',     emoji: '📚', archetype: 'The Scholar',     key: 'scholar' },
+        turing:             { name: 'Alan Turing',         emoji: '📚', archetype: 'The Scholar',     key: 'scholar' },
+        hopper:             { name: 'Grace Hopper',        emoji: '🧑‍🏫', archetype: 'The Mentor',   key: 'mentor' },
+        dijkstra:           { name: 'Edsger Dijkstra',     emoji: '📚', archetype: 'The Scholar',     key: 'scholar' },
+        knuth:              { name: 'Donald Knuth',        emoji: '📚', archetype: 'The Scholar',     key: 'scholar' },
+        ritchie:            { name: 'Dennis Ritchie',      emoji: '⚡', archetype: 'The Hacker',      key: 'hacker' },
+        guido_van_rossum:   { name: 'Guido van Rossum',   emoji: '🔧', archetype: 'The Pragmatist',  key: 'pragmatist' },
+        mccarthy:           { name: 'John McCarthy',       emoji: '📚', archetype: 'The Scholar',     key: 'scholar' },
+        lovelace:           { name: 'Ada Lovelace',        emoji: '🔮', archetype: 'The Visionary',   key: 'visionary' },
+        von_neumann:        { name: 'John von Neumann',    emoji: '📚', archetype: 'The Scholar',     key: 'scholar' },
+        shannon:            { name: 'Claude Shannon',      emoji: '📚', archetype: 'The Scholar',     key: 'scholar' },
+        feynman:            { name: 'Richard Feynman',     emoji: '📚', archetype: 'The Scholar',     key: 'scholar' },
+        einstein:           { name: 'Albert Einstein',     emoji: '🔮', archetype: 'The Visionary',   key: 'visionary' },
+        hamming:            { name: 'Richard Hamming',     emoji: '📚', archetype: 'The Scholar',     key: 'scholar' },
+        bruce_schneier:     { name: 'Bruce Schneier',      emoji: '🛡️', archetype: 'The Guardian',    key: 'guardian' },
+      };
+
+      const ARCHETYPE_MAP = {
+        the_visionary:  { emoji: '🔮', name: 'The Visionary',  key: 'visionary' },
+        the_architect:  { emoji: '🏛️', name: 'The Architect',  key: 'architect' },
+        the_hacker:     { emoji: '⚡', name: 'The Hacker',     key: 'hacker' },
+        the_guardian:   { emoji: '🛡️', name: 'The Guardian',   key: 'guardian' },
+        the_scholar:    { emoji: '📚', name: 'The Scholar',    key: 'scholar' },
+        the_mentor:     { emoji: '🧑‍🏫', name: 'The Mentor',  key: 'mentor' },
+        the_operator:   { emoji: '⚙️', name: 'The Operator',   key: 'operator' },
+        the_pragmatist: { emoji: '🔧', name: 'The Pragmatist', key: 'pragmatist' },
+      };
+
+      const parts = archStr.split(':').map(p => p.trim()).filter(Boolean);
+      const first = parts[0];
+      const figData = FIGURE_MAP[first];
+
+      if (figData) {
+        return {
+          figureId: first,
+          displayName: figData.name,
+          emoji: figData.emoji,
+          archetype: figData.archetype,
+          archetypeKey: figData.key,
+          skillDomains: parts.slice(1),
+        };
+      }
+
+      // Check if first part is an archetype
+      const archData = ARCHETYPE_MAP[first];
+      if (archData) {
+        return {
+          figureId: null,
+          displayName: archData.name,
+          emoji: archData.emoji,
+          archetype: archData.name,
+          archetypeKey: archData.key,
+          skillDomains: parts.slice(1),
+        };
+      }
+
+      // Unknown — treat all parts as skill domains
+      return {
+        figureId: null,
+        displayName: parts.join(' · '),
+        emoji: '🤖',
+        archetype: '',
+        archetypeKey: 'default',
+        skillDomains: parts,
+      };
+    },
   };
 }
 

--- a/agentception/telemetry.py
+++ b/agentception/telemetry.py
@@ -255,4 +255,5 @@ def _task_file_to_agent_node(tf: TaskFile) -> AgentNode:
         branch=tf.branch,
         batch_id=tf.batch_id,
         worktree_path=tf.worktree,
+        cognitive_arch=tf.cognitive_arch,
     )

--- a/agentception/templates/agent.html
+++ b/agentception/templates/agent.html
@@ -23,44 +23,70 @@
 </div>
 
 {% else %}
-{# ── Agent header ────────────────────────────────────────────────────────── #}
-<div class="agent-detail-header card">
-  <div class="agent-detail-title">
-    <span class="status-badge status-badge--{{ node.status.value }}" aria-label="Status">{{ node.status.value }}</span>
-    <h1 class="agent-detail-role">{{ node.role }}</h1>
-  </div>
 
-  <div class="agent-detail-meta">
-    {% if node.batch_id %}
-      <span class="meta-chip">
-        <span class="meta-label">Batch</span>
-        <code class="meta-value">{{ node.batch_id }}</code>
-      </span>
-    {% endif %}
-    {% if node.issue_number %}
-      <span class="meta-chip">
-        <span class="meta-label">Issue</span>
-        <a href="{{ gh_base_url }}/issues/{{ node.issue_number }}"
-           target="_blank" rel="noopener" class="meta-value">#{{ node.issue_number }}</a>
-      </span>
-    {% endif %}
-    {% if node.pr_number %}
-      <span class="meta-chip">
-        <span class="meta-label">PR</span>
-        <a href="{{ gh_base_url }}/pull/{{ node.pr_number }}"
-           target="_blank" rel="noopener" class="meta-value">#{{ node.pr_number }}</a>
-      </span>
-    {% endif %}
-    {% if node.branch %}
-      <span class="meta-chip">
-        <span class="meta-label">Branch</span>
-        <code class="meta-value">{{ node.branch }}</code>
-      </span>
-    {% endif %}
-    <span class="meta-chip">
-      <span class="meta-label">Messages</span>
-      <span class="meta-value">{{ node.message_count }}</span>
-    </span>
+{# ── Agent header + persona hero ─────────────────────────────────────────── #}
+<div class="agent-detail-header card">
+  <div class="agent-hero-row">
+
+    {# Persona avatar #}
+    <div class="agent-persona-avatar agent-persona-avatar--{{ persona.archetype | replace('the_','') if persona.archetype else 'default' }}">
+      <span class="agent-persona-emoji">{{ persona.archetype_emoji }}</span>
+    </div>
+
+    <div class="agent-hero-body">
+      <div class="agent-detail-title">
+        <span class="status-badge status-badge--{{ node.status.value }}" aria-label="Status">{{ node.status.value }}</span>
+        <h1 class="agent-detail-role">{{ node.role | replace('-', ' ') | title }}</h1>
+      </div>
+
+      {# Persona line #}
+      <div class="agent-persona-line">
+        <span class="agent-persona-name">{{ persona.display_name }}</span>
+        {% if persona.archetype %}
+          <span class="agent-persona-archetype">{{ persona.archetype | replace('_', ' ') | title }}</span>
+        {% endif %}
+        {% if persona.raw %}
+          <a href="/cognitive-arch/{{ persona.raw | urlencode }}"
+             class="agent-persona-link" title="View full cognitive architecture">
+            View Architecture →
+          </a>
+        {% endif %}
+      </div>
+
+      {# Meta chips #}
+      <div class="agent-detail-meta">
+        {% if node.batch_id %}
+          <span class="meta-chip">
+            <span class="meta-label">Batch</span>
+            <code class="meta-value">{{ node.batch_id }}</code>
+          </span>
+        {% endif %}
+        {% if node.issue_number %}
+          <span class="meta-chip">
+            <span class="meta-label">Issue</span>
+            <a href="{{ gh_base_url }}/issues/{{ node.issue_number }}"
+               target="_blank" rel="noopener" class="meta-value">#{{ node.issue_number }}</a>
+          </span>
+        {% endif %}
+        {% if node.pr_number %}
+          <span class="meta-chip">
+            <span class="meta-label">PR</span>
+            <a href="{{ gh_base_url }}/pull/{{ node.pr_number }}"
+               target="_blank" rel="noopener" class="meta-value">#{{ node.pr_number }}</a>
+          </span>
+        {% endif %}
+        {% if node.branch %}
+          <span class="meta-chip">
+            <span class="meta-label">Branch</span>
+            <code class="meta-value">{{ node.branch }}</code>
+          </span>
+        {% endif %}
+        <span class="meta-chip">
+          <span class="meta-label">Messages</span>
+          <span class="meta-value">{{ node.message_count }}</span>
+        </span>
+      </div>
+    </div>
   </div>
 
   {# ── Quick actions ──────────────────────────────────────────────────────── #}
@@ -77,6 +103,12 @@
         View PR on GitHub ↗
       </a>
     {% endif %}
+    {% if persona.raw %}
+      <a href="/cognitive-arch/{{ persona.raw | urlencode }}"
+         class="btn btn-secondary">
+        {{ persona.archetype_emoji }} Cognitive Architecture
+      </a>
+    {% endif %}
 
     {# Kill button — only shown for active agents that have a worktree slug #}
     {% if node.worktree_path %}
@@ -84,7 +116,6 @@
       Kill Agent
     </button>
 
-    {# Confirmation modal — rendered inline so no extra fetch is needed #}
     <div
       class="modal-backdrop"
       x-show="showKillModal"
@@ -116,12 +147,60 @@
         </div>
       </div>
     </div>
-
-    {# Result area — HTMX writes the server response here after kill #}
     <div id="result"></div>
     {% endif %}
   </div>
 </div>
+
+{# ── Cognitive Architecture panel ────────────────────────────────────────── #}
+{% if persona.is_named_figure or persona.raw %}
+<div class="cog-panel card mt-2">
+  <div class="cog-panel__header">
+    <span class="cog-panel__emoji">{{ persona.archetype_emoji }}</span>
+    <div>
+      <div class="cog-panel__title">{{ persona.display_name }}</div>
+      {% if persona.archetype %}
+        <div class="cog-panel__sub">{{ persona.archetype | replace('_', ' ') | title }}</div>
+      {% endif %}
+    </div>
+    {% if persona.raw %}
+      <a href="/cognitive-arch/{{ persona.raw | urlencode }}"
+         class="cog-panel__detail-link">Full Architecture Page →</a>
+    {% endif %}
+  </div>
+
+  {% if persona.description %}
+  <p class="cog-panel__desc">{{ persona.description | truncate(280) }}</p>
+  {% endif %}
+
+  <div class="cog-panel__body">
+    {% if persona.overrides %}
+    <div class="cog-panel__atoms">
+      <div class="cog-panel__section-label">Cognitive Atoms</div>
+      <div class="cog-atoms-row">
+        {% for dim, val in persona.overrides.items() %}
+        <div class="cog-atom-pill">
+          <span class="cog-atom-pill__key">{{ dim | replace('_', ' ') }}</span>
+          <span class="cog-atom-pill__val">{{ val | replace('_', ' ') }}</span>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
+    {% if persona.skill_domains %}
+    <div class="cog-panel__skills">
+      <div class="cog-panel__section-label">Skill Domains</div>
+      <div class="cog-skills-row">
+        {% for skill in persona.skill_domains %}
+        <span class="cog-skill-tag">{{ skill | replace('_', ' ') | title }}</span>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+  </div>
+</div>
+{% endif %}
 
 {# ── Two-column body ─────────────────────────────────────────────────────── #}
 <div class="agent-detail-columns mt-2">
@@ -146,6 +225,16 @@
               <span class="status-badge status-badge--{{ node.status.value }}">{{ node.status.value }}</span>
             </td>
           </tr>
+          {% if node.cognitive_arch %}
+          <tr>
+            <td class="task-key">cognitive_arch</td>
+            <td class="task-value">
+              <a href="/cognitive-arch/{{ node.cognitive_arch | urlencode }}">
+                <code>{{ node.cognitive_arch }}</code>
+              </a>
+            </td>
+          </tr>
+          {% endif %}
           {% if node.issue_number %}
           <tr>
             <td class="task-key">issue_number</td>
@@ -218,7 +307,7 @@
           :class="expanded ? 'message-body--expanded' : 'message-body--collapsed'"
           @click="expanded = !expanded"
         >
-          <pre class="message-text">{{ msg.text | truncate(400, True, '…') }}</pre>
+          <pre class="message-text">{{ msg.text | truncate(400, True, '…') if msg.text is defined else msg.content | truncate(400, True, '…') }}</pre>
         </div>
         <button
           class="message-expand-btn"
@@ -231,7 +320,6 @@
     </div>
 
     <script>
-    // Auto-scroll to the last message on page load so users see the most recent activity.
     document.addEventListener('DOMContentLoaded', function () {
       const container = document.getElementById('transcript');
       if (container) {

--- a/agentception/templates/cognitive_arch.html
+++ b/agentception/templates/cognitive_arch.html
@@ -1,0 +1,123 @@
+{% extends "base.html" %}
+
+{% block title %}
+  AgentCeption — Cognitive Architecture: {{ persona.display_name }}
+{% endblock %}
+
+{% block content %}
+
+{# ── Breadcrumb ─────────────────────────────────────────────────────────── #}
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">← Overview</a>
+  <span class="breadcrumb-sep">/</span>
+  <a href="/roles">Cognitive Architecture</a>
+  <span class="breadcrumb-sep">/</span>
+  <span class="breadcrumb-current">{{ persona.display_name }}</span>
+</nav>
+
+{# ── Hero ────────────────────────────────────────────────────────────────── #}
+<div class="cog-hero card mt-2">
+  <div class="cog-hero__avatar-wrap">
+    <div class="cog-hero__avatar cog-hero__avatar--{{ persona.archetype | replace('the_','') if persona.archetype else 'default' }}">
+      <span class="cog-hero__emoji">{{ persona.archetype_emoji }}</span>
+      {% if persona.display_name %}
+        <span class="cog-hero__initials">
+          {{ persona.display_name.split()[0][0] }}{% if persona.display_name.split() | length > 1 %}{{ persona.display_name.split()[-1][0] }}{% endif %}
+        </span>
+      {% endif %}
+    </div>
+    {% if persona.is_named_figure %}
+      <span class="cog-hero__named-badge">Named Figure</span>
+    {% else %}
+      <span class="cog-hero__named-badge cog-hero__named-badge--custom">Composed</span>
+    {% endif %}
+  </div>
+
+  <div class="cog-hero__info">
+    <div class="cog-hero__name-row">
+      <h1 class="cog-hero__name">{{ persona.display_name }}</h1>
+      {% if persona.archetype %}
+        <span class="cog-hero__archetype-chip">{{ persona.archetype | replace('_', ' ') | title }}</span>
+      {% endif %}
+    </div>
+
+    {% if persona.description %}
+      <p class="cog-hero__desc">{{ persona.description }}</p>
+    {% endif %}
+
+    {% if persona.raw %}
+      <div class="cog-hero__raw-row">
+        <span class="cog-hero__raw-label">COGNITIVE_ARCH</span>
+        <code class="cog-hero__raw-value">{{ persona.raw }}</code>
+      </div>
+    {% endif %}
+  </div>
+</div>
+
+{# ── Two-column body ─────────────────────────────────────────────────────── #}
+<div class="cog-columns mt-2">
+
+  {# ── Left: atom overrides ─────────────────────────────────────────────── #}
+  <section class="cog-atoms-panel" aria-label="Cognitive atom overrides">
+    <h2 class="section-title">Cognitive Atoms</h2>
+
+    {% if persona.overrides %}
+    <div class="card cog-atoms-grid">
+      {% for dim, val in persona.overrides.items() %}
+      <div class="cog-atom">
+        <div class="cog-atom__label">
+          {{ persona.atom_labels.get(dim, dim | replace('_', ' ') | title) }}
+        </div>
+        <div class="cog-atom__value">{{ val | replace('_', ' ') | title }}</div>
+      </div>
+      {% endfor %}
+    </div>
+    {% else %}
+    <div class="card">
+      <p class="text-muted">No atom overrides — using archetype defaults.</p>
+    </div>
+    {% endif %}
+
+    {% if persona.skill_domains %}
+    <h2 class="section-title mt-2">Skill Domains</h2>
+    <div class="card">
+      <div class="cog-skills">
+        {% for skill in persona.skill_domains %}
+        <span class="cog-skill-tag">{{ skill | replace('_', ' ') | title }}</span>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+  </section>
+
+  {# ── Right: prompt prefix ─────────────────────────────────────────────── #}
+  <section class="cog-prompt-panel" aria-label="Prompt injection prefix">
+    <h2 class="section-title">Prompt Injection</h2>
+
+    {% if persona.prompt_prefix %}
+    <div class="card" x-data="{ expanded: false }">
+      <div class="cog-prompt__preview" :class="expanded ? 'cog-prompt__preview--expanded' : ''">
+        <pre class="cog-prompt__text">{{ persona.prompt_prefix }}</pre>
+      </div>
+      <button
+        class="cog-prompt__toggle"
+        @click="expanded = !expanded"
+        x-text="expanded ? '▲ Collapse' : '▼ Show full prompt'"
+      ></button>
+    </div>
+    {% else %}
+    <div class="card">
+      <p class="text-muted">No prompt injection configured for this architecture.</p>
+    </div>
+    {% endif %}
+  </section>
+
+</div>{# .cog-columns #}
+
+{# ── Footer actions ──────────────────────────────────────────────────────── #}
+<div class="cog-footer mt-2">
+  <a href="/roles" class="btn btn-secondary">← Explore All Architectures</a>
+  <a href="/" class="btn btn-secondary">View Live Agents</a>
+</div>
+
+{% endblock %}

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -232,15 +232,31 @@
                 x-show="isActive(agent.status)"
               ></span>
 
+              {# Persona avatar — emoji circle derived from cognitive_arch #}
+              <div
+                class="card-persona-avatar"
+                :class="'card-persona-avatar--' + parseArch(agent.cognitive_arch).archetypeKey"
+                :title="parseArch(agent.cognitive_arch).displayName"
+              >
+                <span x-text="parseArch(agent.cognitive_arch).emoji"></span>
+              </div>
+
+              {# Role + persona name stacked #}
+              <div class="agent-role-stack">
+                <span class="agent-role-name" x-text="formatRole(agent.role)"></span>
+                <span
+                  class="agent-persona-sub"
+                  x-show="agent.cognitive_arch"
+                  x-text="parseArch(agent.cognitive_arch).displayName"
+                ></span>
+              </div>
+
               {# Status badge #}
               <span
                 class="status-badge"
                 :class="'status-badge--' + agent.status"
                 x-text="agent.status"
               ></span>
-
-              {# Role (formatted) #}
-              <span class="agent-role-name" x-text="formatRole(agent.role)"></span>
 
               {# Issue chip #}
               <a
@@ -338,6 +354,33 @@
 
               </div>
 
+              {# Cognitive Architecture mini-panel #}
+              <template x-if="agent.cognitive_arch">
+                <div class="card-arch-panel">
+                  <div class="card-arch-panel__header">
+                    <span x-text="parseArch(agent.cognitive_arch).emoji"></span>
+                    <strong x-text="parseArch(agent.cognitive_arch).displayName"></strong>
+                    <span
+                      class="card-arch-panel__archetype"
+                      x-show="parseArch(agent.cognitive_arch).archetype"
+                      x-text="parseArch(agent.cognitive_arch).archetype"
+                    ></span>
+                  </div>
+                  <template x-if="parseArch(agent.cognitive_arch).skillDomains.length > 0">
+                    <div class="card-arch-panel__skills">
+                      <template x-for="skill in parseArch(agent.cognitive_arch).skillDomains" :key="skill">
+                        <span class="cog-skill-tag cog-skill-tag--sm" x-text="skill.replace(/_/g, ' ')"></span>
+                      </template>
+                    </div>
+                  </template>
+                  <a
+                    :href="'/cognitive-arch/' + encodeURIComponent(agent.cognitive_arch)"
+                    class="card-arch-panel__link"
+                    @click.stop
+                  >View Architecture →</a>
+                </div>
+              </template>
+
               {# Task details table #}
               <div class="agent-task-details">
                 <div class="agent-task-details__title">Task Details</div>
@@ -369,6 +412,13 @@
                   class="btn btn-sm btn-secondary"
                   @click.stop
                 >View PR ↗</a>
+                <a
+                  x-show="agent.cognitive_arch"
+                  :href="'/cognitive-arch/' + encodeURIComponent(agent.cognitive_arch)"
+                  class="btn btn-sm btn-secondary"
+                  @click.stop
+                  x-text="parseArch(agent.cognitive_arch).emoji + ' Architecture'"
+                ></a>
                 <a
                   :href="'/agents/' + agent.id"
                   class="btn btn-sm btn-secondary"


### PR DESCRIPTION
## Summary

- **Fixes 500 error** on `/agents/<id>`: `dirname` Jinja2 filter was missing, now registered in `ui.py`
- **Threads cognitive_arch** through the entire data pipeline: `TaskFile` → `AgentNode` → SSE → UI
- **New `/cognitive-arch/{arch_id}` page**: full-screen visualization of any cognitive architecture — large avatar, atom overrides grid, skill domain tags, collapsible prompt injection prefix
- **Agent detail page** (`/agents/<id>`): hero row with persona avatar + archetype chip, inline cognitive arch panel with atoms and skills, quick-link button to the arch page
- **Overview agent cards**: archetype-colored persona avatar circle and persona display name in collapsed mode; expanded mode shows a mini arch panel with skill tags and a "View Architecture →" link

## How it works

The `COGNITIVE_ARCH=` field from each `.agent-task` file (e.g. `steve_jobs:python:fastapi`) is now parsed server-side by `resolve_cognitive_arch()` in `routes/roles.py`, which reads the figure YAML to return display name, archetype, emoji, atom overrides, skill domains, and prompt prefix.

Client-side, the new `parseArch()` helper in `agentCard()` maps figure IDs and archetype strings to emoji and display names from a hard-coded registry — no extra API call needed for the cards.

## Test plan

- [x] `GET /agents/issue-732` → 200 (was 500)
- [x] `GET /cognitive-arch/steve_jobs:python:fastapi` → 200
- [x] `GET /` → 200, agent cards show persona avatar
- [x] mypy: 64 files, 0 errors
- [x] 74 tests pass (ui_agent, worktrees, poller, roles, scaffold)