### PR TITLE
feat(agentception): Mission Control spawn, agents refactor, URL cleanup, and UI polish

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -176,6 +176,8 @@ async def get_agent_run_history(
                 "worktree_path": row.worktree_path,
                 "role": row.role,
                 "status": row.status,
+                "attempt_number": row.attempt_number,
+                "spawn_mode": row.spawn_mode,
                 "batch_id": row.batch_id,
                 "spawned_at": row.spawned_at.isoformat(),
                 "last_activity_at": (

--- a/agentception/routes/api.py
+++ b/agentception/routes/api.py
@@ -840,7 +840,16 @@ async def delete_worktree(slug: str) -> DeleteWorktreeResult:
     pruned = False
     error: str | None = None
 
-    # Remove the worktree (--force bypasses the lock we set at creation time).
+    # Unlock first — locked worktrees silently resist `remove --force`.
+    if wt.get("locked"):
+        unlock_proc = await asyncio.create_subprocess_exec(
+            "git", "-C", repo_dir, "worktree", "unlock", wt_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await unlock_proc.communicate()
+
+    # Remove the worktree directory (--force handles dirty working trees).
     proc = await asyncio.create_subprocess_exec(
         "git", "-C", repo_dir, "worktree", "remove", "--force", wt_path,
         stdout=asyncio.subprocess.PIPE,

--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -33,6 +33,30 @@ logger = logging.getLogger(__name__)
 _HERE = Path(__file__).parent
 _TEMPLATES = Jinja2Templates(directory=str(_HERE.parent / "templates"))
 
+# Ordered category map for the spawn Mission Control role picker.
+# Each entry: slug → (category_name, sort_position_within_category)
+_ROLE_CATEGORY_MAP: dict[str, tuple[str, int]] = {
+    "python-developer":     ("Backend", 0),
+    "api-developer":        ("Backend", 1),
+    "database-architect":   ("Backend", 2),
+    "systems-programmer":   ("Backend", 3),
+    "frontend-developer":   ("Frontend", 0),
+    "mobile-developer":     ("Frontend", 1),
+    "full-stack-developer": ("Frontend", 2),
+    "test-engineer":        ("Quality", 0),
+    "pr-reviewer":          ("Quality", 1),
+    "technical-writer":     ("Quality", 2),
+    "devops-engineer":      ("Infrastructure", 0),
+    "security-engineer":    ("Infrastructure", 1),
+    "ml-engineer":          ("Data / AI", 0),
+    "data-engineer":        ("Data / AI", 1),
+    "architect":            ("Architecture", 0),
+}
+
+_CATEGORY_ORDER: list[str] = [
+    "Backend", "Frontend", "Quality", "Infrastructure", "Data / AI", "Architecture",
+]
+
 
 def _timestamp_to_date(ts: float) -> str:
     try:
@@ -57,7 +81,7 @@ def _md_to_html(text: str) -> str:
     - ``tables``       — GFM-style tables
     """
     import re
-    import markdown as _md
+    import markdown as _md  # type: ignore[import-untyped]
     from markupsafe import Markup
 
     # Insert a blank line before bullet/numbered list items that follow a
@@ -79,6 +103,36 @@ _TEMPLATES.env.filters["markdown"] = _md_to_html
 from agentception.config import settings as _settings
 _TEMPLATES.env.globals["gh_repo"] = _settings.gh_repo
 _TEMPLATES.env.globals["gh_base_url"] = f"https://github.com/{_settings.gh_repo}"
+
+
+def _parse_iso(s: object) -> datetime.datetime | None:
+    """Parse an ISO-8601 datetime string, returning None on failure."""
+    if not isinstance(s, str):
+        return None
+    try:
+        return datetime.datetime.fromisoformat(s.rstrip("Z"))
+    except ValueError:
+        return None
+
+
+def _fmt_duration(seconds: float) -> str:
+    """Format a duration in seconds as a human-readable string."""
+    if seconds < 60:
+        return f"{int(seconds)}s"
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m {int(seconds % 60)}s"
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    return f"{h}h {m}m"
+
+
+def _fmt_elapsed(spawned_iso: object) -> str:
+    """Return a human-readable elapsed time string from an ISO spawn timestamp to now."""
+    dt = _parse_iso(spawned_iso)
+    if dt is None:
+        return ""
+    delta = datetime.datetime.utcnow() - dt
+    return _fmt_duration(max(0.0, delta.total_seconds()))
 
 
 def _format_ts(ts: float) -> str:
@@ -269,16 +323,17 @@ async def agents_list(request: Request) -> HTMLResponse:
     completed agents are visible even after their worktrees are removed.
 
     Data enrichments served to the template:
+    - ``agents``        — live in-memory agents enriched with persona + elapsed/staleness.
     - ``stats``         — KPI counts (total, active, done, success_rate, avg_duration_s).
-    - ``batches``       — run history grouped by batch_id, newest batch first.
+    - ``batches``       — run history grouped by batch_id with per-batch success rate.
     - ``all_roles``     — unique roles seen in history (for filter dropdown).
     - ``all_statuses``  — unique statuses seen (for filter chips).
     """
-    import datetime
     from agentception.db.queries import get_agent_run_history
     from agentception.routes.roles import resolve_cognitive_arch
 
     state = get_state() or PipelineState.empty()
+    now_utc = datetime.datetime.utcnow()
 
     # Flatten root + children into one list for the listing view.
     all_agents: list[AgentNode] = []
@@ -286,13 +341,28 @@ async def agents_list(request: Request) -> HTMLResponse:
         all_agents.append(agent)
         all_agents.extend(agent.children)
 
-    # Enrich each live agent with persona data for the card display.
+    # Enrich each live agent with persona + runtime context.
     agents_enriched: list[dict[str, object]] = []
     for ag in all_agents:
         persona = resolve_cognitive_arch(ag.cognitive_arch)
+        elapsed = ""
+        is_stale_idle = False
+        spawned_dt = _parse_iso(ag.spawned_at.isoformat() if hasattr(ag, "spawned_at") and ag.spawned_at else None)
+        if spawned_dt:
+            elapsed = _fmt_duration((now_utc - spawned_dt).total_seconds())
+        last_activity_dt = _parse_iso(
+            ag.last_activity_at.isoformat()
+            if hasattr(ag, "last_activity_at") and ag.last_activity_at
+            else None
+        )
+        if last_activity_dt:
+            idle_s = (now_utc - last_activity_dt).total_seconds()
+            is_stale_idle = idle_s > 900  # >15 min without activity
         agents_enriched.append({
             "node": ag,
             "persona": persona,
+            "elapsed": elapsed,
+            "is_stale_idle": is_stale_idle,
         })
 
     # Fetch full history from Postgres.
@@ -303,23 +373,6 @@ async def agents_list(request: Request) -> HTMLResponse:
         logger.debug("DB agent run history fetch skipped: %s", exc)
 
     # ── Compute duration + enrich each history row ────────────────────────
-    def _parse_iso(s: object) -> datetime.datetime | None:
-        if not isinstance(s, str):
-            return None
-        try:
-            return datetime.datetime.fromisoformat(s.rstrip("Z"))
-        except ValueError:
-            return None
-
-    def _fmt_duration(seconds: float) -> str:
-        if seconds < 60:
-            return f"{int(seconds)}s"
-        if seconds < 3600:
-            return f"{int(seconds // 60)}m {int(seconds % 60)}s"
-        h = int(seconds // 3600)
-        m = int((seconds % 3600) // 60)
-        return f"{h}h {m}m"
-
     enriched_history: list[dict[str, object]] = []
     total_duration_s = 0.0
     completed_count = 0
@@ -354,6 +407,8 @@ async def agents_list(request: Request) -> HTMLResponse:
                 "runs": [],
                 "spawned_at": run.get("spawned_at"),
                 "spawned_fmt": run.get("spawned_fmt"),
+                # phase_label is derived from the batch_id string (e.g. "eng-20260302T…")
+                "phase_label": str(bid).split("-")[0] if bid != "ungrouped" else "",
             }
             seen_batches[bid] = batch_entry
             batches.append(batch_entry)
@@ -361,9 +416,18 @@ async def agents_list(request: Request) -> HTMLResponse:
         assert isinstance(batch_runs, list)
         batch_runs.append(run)
 
+    # Add per-batch success rate.
+    for batch in batches:
+        b_runs = batch["runs"]
+        assert isinstance(b_runs, list)
+        b_total = len(b_runs)
+        b_done = sum(1 for r in b_runs if isinstance(r, dict) and r.get("status") == "done")
+        batch["success_rate"] = round(b_done / b_total * 100) if b_total else 0
+
     # ── Aggregate KPI stats ───────────────────────────────────────────────
     total = len(enriched_history)
     done_count = sum(1 for r in enriched_history if r.get("status") == "done")
+    failed_count = sum(1 for r in enriched_history if r.get("status") in ("stale", "unknown"))
     success_rate = round(done_count / total * 100) if total else 0
     avg_duration_str = _fmt_duration(total_duration_s / completed_count) if completed_count else "—"
 
@@ -371,6 +435,7 @@ async def agents_list(request: Request) -> HTMLResponse:
         "total": total,
         "active": len(all_agents),
         "done": done_count,
+        "failed": failed_count,
         "success_rate": success_rate,
         "avg_duration": avg_duration_str,
     }
@@ -397,7 +462,112 @@ async def agents_list(request: Request) -> HTMLResponse:
 async def controls_hub(request: Request) -> Response:
     """Controls hub — redirects to the spawn form (the primary control action)."""
     from starlette.responses import RedirectResponse
-    return RedirectResponse(url="/control/spawn", status_code=302)
+    return RedirectResponse(url="/agents/spawn", status_code=302)
+
+
+@router.get("/control/spawn", response_class=HTMLResponse)
+async def spawn_form_legacy(request: Request) -> Response:
+    """Backwards-compat redirect — /control/spawn → /agents/spawn."""
+    from starlette.responses import RedirectResponse
+    return RedirectResponse(url="/agents/spawn", status_code=302)
+
+
+@router.get("/agents/spawn", response_class=HTMLResponse)
+async def spawn_form(request: Request) -> HTMLResponse:
+    """Mission Control — orchestration dashboard for spawning agents.
+
+    Renders all three spawn modes (single agent, wave, coordinator) with a
+    visual issue board and role card picker. Fetches issues and board counts
+    concurrently; falls back gracefully when the DB is unavailable.
+    """
+    from agentception.db.queries import (
+        get_board_issues as _get_board_issues,
+        get_board_counts as _get_board_counts,
+    )
+    from agentception.config import settings as _cfg
+
+    error: str | None = None
+    issues: list[dict[str, object]] = []
+    board_counts: dict[str, int] = {"total": 0, "claimed": 0, "unclaimed": 0}
+
+    try:
+        issues_raw, counts = await asyncio.gather(
+            _get_board_issues(repo=_cfg.gh_repo, include_claimed=True),
+            _get_board_counts(repo=_cfg.gh_repo),
+        )
+        issues = list(issues_raw)
+        board_counts = counts
+    except Exception as exc:  # pragma: no cover — DB failure path
+        error = f"Could not load issues: {exc}"
+
+    state = get_state()
+    active_label: str = (state.active_label or "") if state else ""
+
+    # Build role groups in category order for the Jinja role card grid.
+    # We produce a list of {category, roles} dicts to preserve the
+    # canonical category ordering (_CATEGORY_ORDER) — Jinja's groupby
+    # filter sorts alphabetically and would scramble the order.
+    _cat_buckets: dict[str, list[dict[str, str]]] = {c: [] for c in _CATEGORY_ORDER}
+    for slug in VALID_ROLES:
+        cat, pos = _ROLE_CATEGORY_MAP.get(slug, ("Other", 99))
+        entry: dict[str, str] = {
+            "slug": slug,
+            "label": slug.replace("-", " ").title(),
+            "category": cat,
+        }
+        _cat_buckets.setdefault(cat, []).append(entry)
+    # Sort roles within each category by their defined position.
+    for cat in _cat_buckets:
+        _cat_buckets[cat].sort(key=lambda r: _ROLE_CATEGORY_MAP.get(r["slug"], ("", 99))[1])
+
+    role_groups: list[dict[str, object]] = [
+        {"category": cat, "roles": _cat_buckets[cat]}
+        for cat in _CATEGORY_ORDER
+        if _cat_buckets.get(cat)
+    ]
+    # Flat roles list for the wave-mode <select> (all roles, sorted by category then position).
+    roles_flat: list[dict[str, str]] = [
+        r
+        for g in role_groups
+        for r in (g["roles"] if isinstance(g["roles"], list) else [])
+    ]
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "spawn.html",
+        {
+            "issues": issues,
+            "role_groups": role_groups,
+            "roles_flat": roles_flat,
+            "active_label": active_label,
+            "board_counts": board_counts,
+            "error": error,
+        },
+    )
+
+
+@router.get("/agents/spawn/issues", response_class=HTMLResponse)
+async def spawn_issues_partial(request: Request) -> HTMLResponse:
+    """HTMX partial — refreshes the issue board inside the spawn Mission Control.
+
+    Returns just the issue card list so the browser can swap it in without a
+    full page reload (hx-target="#spawn-issue-list").
+    """
+    from agentception.db.queries import get_board_issues as _get_board_issues
+    from agentception.config import settings as _cfg
+
+    issues: list[dict[str, object]] = []
+    try:
+        issues_raw = await _get_board_issues(repo=_cfg.gh_repo, include_claimed=True)
+        issues = list(issues_raw)
+    except Exception as exc:  # pragma: no cover
+        logger.warning("⚠️ spawn_issues_partial: DB failure: %s", exc)
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "_spawn_issues.html",
+        {"issues": issues},
+    )
 
 
 @router.get("/agents/{agent_id}", response_class=HTMLResponse)
@@ -860,35 +1030,6 @@ async def brain_dump_recent_runs(request: Request) -> HTMLResponse:
     )
 
 
-@router.get("/control/spawn", response_class=HTMLResponse)
-async def spawn_form(request: Request) -> HTMLResponse:
-    """Issue picker form for manually spawning a new engineer agent.
-
-    Reads unclaimed open issues from ``ac_issues`` (Postgres) so the picker
-    stays fast and consistent with the board sidebar.  Falls back to an empty
-    list with an error banner when the DB is unavailable.
-    """
-    from agentception.db.queries import get_board_issues as _get_board_issues
-    from agentception.config import settings as _cfg
-
-    error: str | None = None
-    issues: list[dict[str, object]] = []
-    try:
-        issues = await _get_board_issues(repo=_cfg.gh_repo, include_claimed=False)
-    except Exception as exc:  # pragma: no cover — DB failure path
-        error = f"Could not load issues: {exc}"
-
-    return _TEMPLATES.TemplateResponse(
-        request,
-        "spawn.html",
-        {
-            "issues": issues,
-            "roles": sorted(VALID_ROLES),
-            "error": error,
-        },
-    )
-
-
 @router.get("/templates", response_class=HTMLResponse)
 async def templates_ui(request: Request) -> HTMLResponse:
     """Template marketplace — export and import pipeline configuration bundles.
@@ -1122,43 +1263,25 @@ async def transcript_detail(request: Request, uuid: str) -> HTMLResponse:
 
 @router.get("/worktrees", response_class=HTMLResponse)
 async def worktrees_page(request: Request) -> HTMLResponse:
-    """Live view of git worktrees, local branches, and stash."""
-    from agentception.readers.git import list_git_branches, list_git_stash, list_git_worktrees
+    """Agent Sandboxes — live view of git worktrees as isolated code environments."""
+    from agentception.readers.git import list_git_worktrees
 
     worktrees: list[dict[str, object]] = []
-    branches: list[dict[str, object]] = []
-    stash: list[dict[str, object]] = []
 
     try:
-        worktrees, branches, stash = await asyncio.gather(
-            list_git_worktrees(),
-            list_git_branches(),
-            list_git_stash(),
-        )
+        worktrees = await list_git_worktrees()
     except Exception as exc:
         logger.warning("⚠️  Worktrees page git read failed: %s", exc)
 
-    # Mark branches as stale: agent branch with no live worktree checked out.
-    live_branches: set[str] = {
-        str(wt.get("branch", ""))
-        for wt in worktrees
-        if wt.get("branch") and not wt.get("is_main")
-    }
-    for b in branches:
-        b["is_stale"] = bool(b.get("is_agent_branch")) and str(b.get("name", "")) not in live_branches
-
-    stale_count = sum(1 for b in branches if b.get("is_stale"))
+    main_wt = next((wt for wt in worktrees if wt.get("is_main")), None)
     agent_worktrees = [wt for wt in worktrees if not wt.get("is_main")]
 
     return _TEMPLATES.TemplateResponse(
         request,
         "worktrees.html",
         {
-            "worktrees": worktrees,
+            "main_wt": main_wt,
             "agent_worktrees": agent_worktrees,
-            "branches": branches,
-            "stash": stash,
-            "stale_count": stale_count,
             "gh_repo": _settings.gh_repo,
         },
     )
@@ -1319,7 +1442,8 @@ def _resolve_schema(
         return _resolve_schema(schema_root, resolved, depth + 1)
     if "allOf" in schema:
         merged: dict[str, object] = {}
-        for sub in schema.get("allOf", []):
+        all_of = schema.get("allOf", [])
+        for sub in (all_of if isinstance(all_of, list) else []):
             if isinstance(sub, dict):
                 merged.update(_resolve_schema(schema_root, sub, depth + 1))
         return merged
@@ -1336,7 +1460,8 @@ def _schema_to_fields(
     props: dict[str, object] = {}
     if isinstance(resolved.get("properties"), dict):
         props = resolved["properties"]  # type: ignore[assignment]
-    required_set: set[str] = set(resolved.get("required", []))  # type: ignore[arg-type]
+    required_raw = resolved.get("required", [])
+    required_set: set[str] = set(required_raw) if isinstance(required_raw, list) else set()
     fields: list[dict[str, object]] = []
     for name, prop in props.items():
         if not isinstance(prop, dict):
@@ -1350,9 +1475,10 @@ def _schema_to_fields(
             else:
                 type_str = "array"
         elif "anyOf" in prop:
+            any_of = prop.get("anyOf", [])
             parts_list = [
                 _resolve_schema(schema_root, t, depth + 1).get("type", "")
-                for t in prop.get("anyOf", [])
+                for t in (any_of if isinstance(any_of, list) else [])
                 if isinstance(t, dict)
             ]
             type_str = " | ".join(str(p) for p in parts_list if p and p != "null") or "any"
@@ -1479,8 +1605,9 @@ def _build_schema_models(schema_root: dict[str, object]) -> list[dict[str, objec
 
     Excludes low-signal FastAPI-generated error types.
     """
+    components = schema_root.get("components", {})
     raw: dict[str, object] = (
-        schema_root.get("components", {}).get("schemas", {})  # type: ignore[union-attr]
+        components.get("schemas", {}) if isinstance(components, dict) else {}
     )
     skip = {"HTTPValidationError", "ValidationError"}
     models: list[dict[str, object]] = []

--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -313,26 +313,14 @@ main {
 .summary-item--warn { opacity: 1; }
 .summary-item--warn .summary-label { color: var(--warning); }
 .summary-item--warn .summary-value  { color: var(--warning); }
-
-/* Sweep button inside stale summary-item */
-.sweep-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: 0.3rem;
-  padding: 0 0.3rem;
-  height: 16px;
-  font-size: 0.65rem;
-  background: rgba(251,191,36,0.15);
-  border: 1px solid rgba(251,191,36,0.35);
-  border-radius: 3px;
-  color: var(--warning);
+.summary-item--clickable {
   cursor: pointer;
+  border-radius: 4px;
   transition: background 0.12s;
-  vertical-align: middle;
 }
-.sweep-btn:hover:not(:disabled) { background: rgba(251,191,36,0.28); }
-.sweep-btn:disabled { opacity: 0.5; cursor: default; }
+.summary-item--clickable:hover {
+  background: rgba(251,191,36,0.1);
+}
 
 .summary-label {
   font-size: 0.575rem;
@@ -1794,15 +1782,515 @@ main {
 
 /* ── Forms ────────────────────────────────────────────────────── */
 
+/* ═══ Spawn / Mission Control page ═══════════════════════════════════════ */
+
 .spawn-page {
-  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
-.spawn-form {
+/* ── Status bar ─────────────────────────────────────────────── */
+
+.spawn-status-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  flex-wrap: wrap;
+}
+
+.spawn-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+}
+
+.spawn-status-pill--phase {
+  color: var(--accent);
+  border-color: var(--accent-glow);
+  background: rgba(124, 106, 247, 0.08);
+}
+
+.spawn-status-pill--unclaimed {
+  color: var(--success);
+  border-color: rgba(74, 222, 128, 0.25);
+  background: rgba(74, 222, 128, 0.07);
+}
+
+.spawn-status-pill--claimed {
+  color: var(--warning);
+  border-color: var(--warning-border);
+  background: var(--warning-dim);
+}
+
+.spawn-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+/* ── Mode tabs ──────────────────────────────────────────────── */
+
+.spawn-tabs {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--bg-elevated);
+  width: fit-content;
+}
+
+.spawn-tab {
+  padding: 0.5rem 1.1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--border-default);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.spawn-tab:last-child {
+  border-right: none;
+}
+
+.spawn-tab:hover {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.spawn-tab--active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.spawn-tab--active:hover {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* ── Mode panels ────────────────────────────────────────────── */
+
+.spawn-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Single-agent layout: issue board left, role picker right */
+.spawn-single-layout {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 1rem;
+  align-items: start;
+}
+
+@media (max-width: 820px) {
+  .spawn-single-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Issue board ────────────────────────────────────────────── */
+
+.spawn-issue-board {
   display: flex;
   flex-direction: column;
   gap: 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  overflow: hidden;
 }
+
+.spawn-issue-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-void);
+}
+
+.spawn-issue-search {
+  flex: 1;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  font-family: var(--font-sans);
+  padding: 0.35rem 0.6rem;
+  transition: border-color 0.15s;
+}
+
+.spawn-issue-search:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.spawn-issue-search::placeholder {
+  color: var(--text-muted);
+}
+
+.spawn-issue-refresh {
+  padding: 0.35rem 0.6rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  line-height: 1;
+}
+
+.spawn-issue-refresh:hover {
+  color: var(--text-secondary);
+  border-color: var(--border-default);
+}
+
+.spawn-issue-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.spawn-issue-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+  transition: background 0.12s;
+  user-select: none;
+}
+
+.spawn-issue-card:last-child {
+  border-bottom: none;
+}
+
+.spawn-issue-card:hover:not(.spawn-issue-card--claimed) {
+  background: var(--bg-hover);
+}
+
+.spawn-issue-card--selected {
+  background: rgba(124, 106, 247, 0.1);
+  border-left: 3px solid var(--accent);
+}
+
+.spawn-issue-card--claimed {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.spawn-issue-num {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  padding-top: 0.1rem;
+  min-width: 2.8rem;
+}
+
+.spawn-issue-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.spawn-issue-title {
+  font-size: 0.82rem;
+  color: var(--text-primary);
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.spawn-issue-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.2rem;
+}
+
+.spawn-issue-phase {
+  font-size: 0.67rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: rgba(124, 106, 247, 0.1);
+  border: 1px solid rgba(124, 106, 247, 0.2);
+  border-radius: 999px;
+  padding: 0.1rem 0.45rem;
+}
+
+.spawn-issue-wip {
+  font-size: 0.67rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--warning);
+  background: var(--warning-dim);
+  border: 1px solid var(--warning-border);
+  border-radius: 999px;
+  padding: 0.1rem 0.45rem;
+}
+
+.spawn-issue-empty {
+  padding: 1.5rem 1rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+/* ── Role picker ────────────────────────────────────────────── */
+
+.spawn-role-picker {
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  overflow: hidden;
+}
+
+.spawn-role-section {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.spawn-role-section:last-child {
+  border-bottom: none;
+}
+
+.spawn-role-section-label {
+  font-size: 0.67rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 0.45rem 0.75rem 0.3rem;
+  background: var(--bg-void);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.spawn-role-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+  transition: background 0.12s;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.spawn-role-option:last-child {
+  border-bottom: none;
+}
+
+.spawn-role-option:hover {
+  background: var(--bg-hover);
+}
+
+.spawn-role-option--selected {
+  background: rgba(124, 106, 247, 0.1);
+}
+
+.spawn-role-radio {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  border: 2px solid var(--border-default);
+  flex-shrink: 0;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.spawn-role-option--selected .spawn-role-radio {
+  border-color: var(--accent);
+  background: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+
+.spawn-role-name {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.spawn-role-option--selected .spawn-role-name {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* ── Wave mode panel ────────────────────────────────────────── */
+
+.spawn-wave-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.spawn-wave-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  background: rgba(124, 106, 247, 0.06);
+  border: 1px solid rgba(124, 106, 247, 0.15);
+  border-radius: var(--radius);
+}
+
+.spawn-wave-count {
+  font-size: 2rem;
+  font-weight: 800;
+  color: var(--accent);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.spawn-wave-label {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.spawn-wave-label strong {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+/* ── Coordinator mode panel ─────────────────────────────────── */
+
+.spawn-coordinator-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.spawn-coordinator-desc {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  padding: 0.75rem 1rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+}
+
+.spawn-brain-dump {
+  width: 100%;
+  min-height: 120px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  padding: 0.75rem 1rem;
+  resize: vertical;
+  transition: border-color 0.15s;
+  line-height: 1.55;
+}
+
+.spawn-brain-dump:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.spawn-brain-dump::placeholder {
+  color: var(--text-muted);
+}
+
+/* ── Actions row ────────────────────────────────────────────── */
+
+.spawn-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.spawn-selection-summary {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.spawn-selection-summary strong {
+  color: var(--text-secondary);
+}
+
+/* ── Result panels ──────────────────────────────────────────── */
+
+.spawn-result {
+  border-left: 3px solid var(--success);
+}
+
+.spawn-result--wave {
+  border-left: 3px solid var(--accent);
+}
+
+.spawn-result--error {
+  border-left: 3px solid var(--danger, #f87171);
+}
+
+.spawn-result-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.3rem 1rem;
+  font-size: 0.82rem;
+}
+
+.spawn-result-key {
+  color: var(--text-muted);
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.spawn-result-val {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.77rem;
+  word-break: break-all;
+}
+
+.spawn-wave-results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+.spawn-wave-result-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.spawn-wave-result-skip {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+/* ── Shared form utilities ──────────────────────────────────── */
 
 .form-group {
   display: flex;
@@ -1842,10 +2330,6 @@ main {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-}
-
-.spawn-result {
-  border-left: 3px solid var(--success);
 }
 
 .agent-task-pre {
@@ -2200,53 +2684,46 @@ main {
   font-variant-numeric: tabular-nums;
 }
 
-/* ── Worktrees page ───────────────────────────────────────────── */
+/* ── Agent Sandboxes page (worktrees) ─────────────────────────── */
 
 /* Page header */
-.wt-page-header {
-  margin-bottom: 1.5rem;
+.env-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 2rem;
+  gap: 1rem;
 }
 
-.wt-page-title {
+.env-page-title {
   font-size: 1.35rem;
   font-weight: 700;
   color: var(--text-primary);
   margin: 0 0 0.375rem;
 }
 
-.wt-page-subtitle {
+.env-page-subtitle {
   font-size: 0.8125rem;
   color: var(--text-muted);
   margin: 0;
-  max-width: 60ch;
+  max-width: 58ch;
 }
 
-/* Summary bar */
-.wt-summary {
-  display: flex;
-  align-items: center;
-  gap: 2rem;
-  padding: 0.875rem 1.25rem;
-  background: var(--bg-surface);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius);
-  margin-bottom: 1.5rem;
-}
-
-.wt-summary-stat {
+.env-page-meta {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  align-items: flex-end;
+  flex-shrink: 0;
 }
 
-.wt-summary-value {
-  font-size: 1.375rem;
+.env-page-count {
+  font-size: 2rem;
   font-weight: 700;
-  color: var(--text-primary);
+  color: var(--accent);
   line-height: 1;
 }
 
-.wt-summary-label {
+.env-page-count-label {
   font-size: 0.7rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -2254,101 +2731,189 @@ main {
   color: var(--text-muted);
 }
 
-.wt-summary-actions {
-  margin-left: auto;
+/*
+  Tree container.
+
+  Layout: the vertical trunk line is a ::before pseudo-element on .env-tree.
+  It runs from below the trunk node dot to the bottom of the last branch.
+  Each .env-branch draws an L-shaped connector to that trunk via its own
+  ::before (horizontal) and the trunk line (vertical, shared).
+*/
+.env-tree {
+  position: relative;
+  padding-left: 1.5rem;         /* room for trunk line + connector arms */
 }
 
-/* Section layout */
-.wt-section {
-  margin-bottom: 2rem;
+/* Vertical trunk line */
+.env-tree::before {
+  content: '';
+  position: absolute;
+  left: 0.5rem;                 /* centre of the trunk dot */
+  top: 1.5rem;                  /* start below the trunk dot */
+  bottom: 1.75rem;              /* stop above the last branch connector */
+  width: 2px;
+  background: linear-gradient(
+    to bottom,
+    var(--accent) 0%,
+    rgba(124, 58, 237, 0.3) 70%,
+    transparent 100%
+  );
+  border-radius: 1px;
 }
 
-.wt-section-header {
+/* ── Trunk node (base environment) ───────────────────────────── */
+
+.env-trunk-node {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 1.25rem;
+  position: relative;
+  z-index: 1;
 }
 
-.wt-section-title {
+.env-trunk-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 3px solid var(--bg-base);
+  box-shadow: 0 0 0 2px var(--accent);
+  flex-shrink: 0;
+  margin-left: -0.125rem;       /* nudge to centre on trunk line */
+}
+
+.env-trunk-info {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  flex-wrap: wrap;
+}
+
+.env-trunk-branch {
+  font-family: var(--font-mono, monospace);
   font-size: 0.875rem;
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-muted);
-  margin: 0;
+  color: var(--text-primary);
 }
 
-.wt-section-count {
-  font-size: 0.75rem;
-  font-weight: 700;
+.env-trunk-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
   color: var(--text-muted);
   background: var(--bg-surface);
   border: 1px solid var(--border-subtle);
-  border-radius: 10px;
-  padding: 0.1em 0.55em;
+  border-radius: 4px;
+  padding: 0.15em 0.5em;
 }
 
-/* Worktree cards */
-.wt-cards {
+.env-trunk-sha {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.env-trunk-commit {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 40ch;
+}
+
+/* ── Branch item ──────────────────────────────────────────────── */
+
+.env-branch {
+  position: relative;
+  margin-bottom: 0.875rem;
+  transition: opacity 0.25s, transform 0.25s;
+}
+
+/* Horizontal arm from trunk to branch origin dot */
+.env-branch::before {
+  content: '';
+  position: absolute;
+  left: -1rem;                  /* from trunk line */
+  top: 1.125rem;                /* align with branch origin dot */
+  width: 1rem;
+  height: 2px;
+  background: rgba(124, 58, 237, 0.5);
+}
+
+/* Last branch: visually terminate trunk line here */
+.env-branch--last::after {
+  content: '';
+  position: absolute;
+  left: -1.0625rem;
+  top: 1.0625rem;
+  width: 8px;
+  height: 8px;
+  border-left: 2px solid rgba(124, 58, 237, 0.5);
+  border-bottom: 2px solid rgba(124, 58, 237, 0.5);
+  border-radius: 0 0 0 3px;
+}
+
+/* Branch origin dot — sits at the junction of trunk arm and branch content */
+.env-branch-origin-dot {
+  position: absolute;
+  left: -1.3125rem;
+  top: 0.8125rem;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--bg-base);
+  border: 2px solid var(--accent);
+  z-index: 1;
+}
+
+.env-branch--open .env-branch-origin-dot {
+  background: var(--accent);
+}
+
+/* The clickable head row */
+.env-branch-head {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.wt-card {
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
   background: var(--bg-surface);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius);
-  overflow: hidden;
-  transition: border-color 0.15s, box-shadow 0.15s;
-}
-
-.wt-card:hover {
-  border-color: var(--border-strong);
-}
-
-.wt-card--open {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 1px rgba(124, 58, 237, 0.15);
-}
-
-.wt-card--main {
-  border-left: 3px solid var(--text-muted);
-}
-
-.wt-card--agent {
-  border-left: 3px solid var(--accent);
-}
-
-/* Card header — always visible, clickable */
-.wt-card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.75rem 1rem;
   cursor: pointer;
   user-select: none;
-  gap: 1rem;
+  transition: border-color 0.15s, background 0.15s;
 }
 
-.wt-card-header-left {
-  display: flex;
-  align-items: center;
-  gap: 0.625rem;
-  min-width: 0;
+.env-branch-head:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover, var(--bg-surface));
+}
+
+.env-branch--open .env-branch-head {
+  border-color: var(--accent);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  background: rgba(124, 58, 237, 0.04);
+}
+
+/* Right side of branch head — name + actions */
+.env-branch-content {
   flex: 1;
+  min-width: 0;
 }
 
-.wt-card-header-right {
+.env-branch-top {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
-  flex-shrink: 0;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
-/* Type badges */
-.wt-badge {
+/* Badges */
+.env-badge {
   display: inline-flex;
   align-items: center;
   font-size: 0.65rem;
@@ -2360,38 +2925,41 @@ main {
   flex-shrink: 0;
 }
 
-.wt-badge--main    { background: rgba(100, 116, 139, 0.15); color: var(--text-muted); }
-.wt-badge--agent   { background: rgba(124, 58, 237, 0.15);  color: var(--accent); }
-.wt-badge--linked  { background: rgba(59, 130, 246, 0.15);  color: #60a5fa; }
-.wt-badge--stale   { background: rgba(245, 158, 11, 0.15);  color: #fbbf24; }
-.wt-badge--current { background: rgba(34, 197, 94, 0.15);   color: #4ade80; }
+.env-badge--issue  { background: rgba(124, 58, 237, 0.15); color: var(--accent); }
+.env-badge--custom { background: rgba(59, 130, 246, 0.15);  color: #60a5fa; }
 
-/* Lock icon */
-.wt-lock {
+.env-lock {
   font-size: 0.7rem;
-  opacity: 0.6;
+  opacity: 0.55;
   flex-shrink: 0;
 }
 
-/* Branch name in card header */
-.wt-card-branch {
+.env-branch-name {
   font-family: var(--font-mono, monospace);
   font-size: 0.8125rem;
-  color: var(--text-primary);
   font-weight: 600;
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1;
 }
 
-/* Age / metadata in header right */
-.wt-card-age {
+/* Actions cluster — pushed to right */
+.env-branch-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.env-age {
   font-size: 0.75rem;
   color: var(--text-muted);
 }
 
-/* GitHub link */
-.wt-card-gh-link {
+.env-gh-link {
   font-size: 0.75rem;
   font-weight: 600;
   color: var(--accent);
@@ -2400,85 +2968,66 @@ main {
   border: 1px solid rgba(124, 58, 237, 0.3);
   border-radius: 4px;
   transition: background 0.12s;
+  flex-shrink: 0;
 }
 
-.wt-card-gh-link:hover {
-  background: rgba(124, 58, 237, 0.12);
-}
+.env-gh-link:hover { background: rgba(124, 58, 237, 0.12); }
 
-/* Delete button */
-.wt-card-delete {
+.env-delete {
   opacity: 0;
   transition: opacity 0.15s;
 }
 
-.wt-card:hover .wt-card-delete {
-  opacity: 1;
-}
+.env-branch-head:hover .env-delete { opacity: 1; }
 
-/* Expand chevron */
-.wt-card-chevron {
+.env-chevron {
   font-size: 0.7rem;
   color: var(--text-muted);
   transition: transform 0.2s;
   display: inline-block;
 }
 
-.wt-card-chevron--open {
-  transform: rotate(180deg);
-}
+.env-chevron--open { transform: rotate(180deg); }
 
-/* Meta row — path, SHA, commit message */
-.wt-card-meta {
+/* HEAD commit preview row */
+.env-branch-commit-preview {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0 1rem 0.625rem;
+  margin-top: 0.375rem;
   font-size: 0.775rem;
   color: var(--text-muted);
-  overflow: hidden;
 }
 
-.wt-card-sha {
+.env-sha {
   font-family: var(--font-mono, monospace);
   font-size: 0.7rem;
+  color: var(--accent);
   flex-shrink: 0;
 }
 
-.wt-card-meta-sep {
-  opacity: 0.4;
-  flex-shrink: 0;
-}
-
-.wt-card-commit {
+.env-commit-msg {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
 }
 
-.wt-card-path {
-  font-family: var(--font-mono, monospace);
-  font-size: 0.68rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 22ch;
-  flex-shrink: 0;
-}
+/* ── Expandable body ──────────────────────────────────────────── */
 
-/* Expandable body */
-.wt-card-body {
-  border-top: 1px solid var(--border-subtle);
+.env-branch-body {
   background: var(--bg-base);
+  border: 1px solid var(--accent);
+  border-top: none;
+  border-bottom-left-radius: var(--radius);
+  border-bottom-right-radius: var(--radius);
+  overflow: hidden;
 }
 
-/* Detail panel content */
-.wt-detail {
-  padding: 1rem 1.25rem;
+.env-detail {
+  padding: 1.25rem 1.5rem;
 }
 
-.wt-detail-loading {
+.env-detail-loading {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -2487,96 +3036,140 @@ main {
   padding: 0.5rem 0;
 }
 
-/* Spinner */
-@keyframes wt-spin {
+@keyframes env-spin {
   to { transform: rotate(360deg); }
 }
 
-.wt-spinner {
+.env-spinner {
   display: inline-block;
   width: 12px;
   height: 12px;
   border: 2px solid var(--border-subtle);
   border-top-color: var(--accent);
   border-radius: 50%;
-  animation: wt-spin 0.7s linear infinite;
+  animation: env-spin 0.7s linear infinite;
+  flex-shrink: 0;
 }
 
-/* Detail sections */
-.wt-detail-section {
-  margin-bottom: 1.25rem;
+/* ── Commit chain (within expanded detail) ────────────────────── */
+
+.env-commit-section,
+.env-diff-section,
+.env-task-section {
+  margin-bottom: 1.5rem;
 }
 
-.wt-detail-section:last-child {
+.env-commit-section:last-child,
+.env-diff-section:last-child,
+.env-task-section:last-child {
   margin-bottom: 0;
 }
 
-.wt-detail-section-title {
+.env-detail-heading {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.625rem;
   font-size: 0.72rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-muted);
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.75rem;
 }
 
-.wt-detail-count {
+.env-detail-meta {
   font-weight: 400;
   text-transform: none;
   letter-spacing: 0;
   font-size: 0.75rem;
 }
 
-.wt-detail-empty {
+.env-detail-empty {
   font-size: 0.8125rem;
   color: var(--text-muted);
   font-style: italic;
   margin: 0;
 }
 
-/* Commit list */
-.wt-commits {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+/* Vertical dot chain of commits */
+.env-commit-chain {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
 }
 
-.wt-commit {
+.env-commit-node {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+/* Spine: dot + connecting line below it */
+.env-commit-spine {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  width: 14px;
+}
+
+.env-commit-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--bg-base);
+  border: 2px solid rgba(124, 58, 237, 0.5);
+  flex-shrink: 0;
+  margin-top: 0.2rem;
+}
+
+.env-commit-dot--head {
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.2);
+}
+
+/* Vertical connector between dots */
+.env-commit-line {
+  width: 2px;
+  flex: 1;
+  min-height: 1.25rem;
+  background: rgba(124, 58, 237, 0.25);
+  margin: 0.15rem 0;
+}
+
+/* Commit label */
+.env-commit-body {
   display: flex;
   align-items: baseline;
   gap: 0.625rem;
-  font-size: 0.8125rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  transition: background 0.1s;
+  padding: 0.05rem 0 0.875rem;
+  flex: 1;
+  min-width: 0;
 }
 
-.wt-commit:hover {
-  background: var(--bg-surface);
-}
-
-.wt-commit-sha {
+.env-commit-sha {
   font-family: var(--font-mono, monospace);
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   color: var(--accent);
   flex-shrink: 0;
 }
 
-.wt-commit-msg {
-  color: var(--text-secondary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.env-head-tag {
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  background: rgba(124, 58, 237, 0.12);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 3px;
+  padding: 0.1em 0.4em;
+  flex-shrink: 0;
 }
 
-/* Diff stat block */
-.wt-diff-stat {
+/* Diff stat + task file */
+.env-diff-stat,
+.env-task-file {
   font-family: var(--font-mono, monospace);
   font-size: 0.78rem;
   line-height: 1.65;
@@ -2590,122 +3183,24 @@ main {
   white-space: pre;
 }
 
-/* Task file */
-.wt-task-file {
-  font-family: var(--font-mono, monospace);
-  font-size: 0.78rem;
-  line-height: 1.65;
-  color: var(--text-secondary);
-  background: var(--bg-surface);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius);
-  padding: 0.75rem 1rem;
-  overflow-x: auto;
+.env-task-file {
   max-height: 280px;
   overflow-y: auto;
-  margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-/* Branches & stash tables */
-.wt-table-card {
-  padding: 0;
-  overflow: hidden;
-}
-
-.wt-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.8125rem;
-}
-
-.wt-table thead th {
-  padding: 0.5rem 0.875rem;
-  text-align: left;
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+/* Empty state */
+.env-empty {
+  padding: 2.5rem 1.5rem;
   color: var(--text-muted);
-  border-bottom: 1px solid var(--border-subtle);
-  background: var(--bg-surface);
+  font-size: 0.875rem;
+  text-align: center;
 }
 
-.wt-table tbody td {
-  padding: 0.5rem 0.875rem;
-  border-bottom: 1px solid var(--border-subtle);
-  color: var(--text-secondary);
-  vertical-align: middle;
-}
+.env-empty p { margin: 0.25rem 0; }
+.env-empty a { color: var(--accent); }
 
-.wt-table tbody tr:last-child td {
-  border-bottom: none;
-}
-
-.wt-row--current td {
-  background: rgba(124, 58, 237, 0.04);
-}
-
-.wt-row--stale {
-  opacity: 0.6;
-}
-
-.wt-row--stale td:first-child {
-  text-decoration: line-through;
-  text-decoration-color: var(--text-muted);
-}
-
-.wt-branch-name {
-  font-family: var(--font-mono, monospace);
-  font-size: 0.7875rem;
-  color: var(--text-primary);
-}
-
-.wt-sha {
-  font-family: var(--font-mono, monospace);
-  font-size: 0.72rem;
-  color: var(--text-muted);
-}
-
-.wt-current-marker {
-  color: var(--accent);
-  font-weight: 700;
-}
-
-.wt-stash-ref {
-  font-family: var(--font-mono, monospace);
-  font-size: 0.72rem;
-  color: var(--text-muted);
-}
-
-.wt-col-num {
-  text-align: right;
-  width: 2.5rem;
-}
-
-.wt-ahead { color: var(--success, #4ade80); }
-.wt-behind { color: var(--warning, #fbbf24); }
-
-.wt-commit-cell {
-  max-width: 280px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.wt-col-action {
-  text-align: right;
-  padding-right: 0.75rem;
-}
-
-.wt-empty {
-  color: var(--text-muted);
-  font-size: 0.8125rem;
-  font-style: italic;
-  margin: 0;
-  padding: 1rem;
-}
 
 /* ── Docs page ────────────────────────────────────────────────── */
 
@@ -5354,3 +5849,450 @@ main {
   .api-main { padding: 1rem; }
   .api-try-field { grid-template-columns: 1fr; }
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Agents page
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Layout ─────────────────────────────────────────────────── */
+.agents-page { display: flex; flex-direction: column; gap: 1.5rem; }
+
+.agents-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.agents-page-subtitle { margin-top: 0.25rem; font-size: 0.82rem; }
+
+/* ── KPI stats bar ─────────────────────────────────────────── */
+.agents-stats-bar {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+@media (max-width: 900px) { .agents-stats-bar { grid-template-columns: repeat(4, 1fr); } }
+@media (max-width: 500px) { .agents-stats-bar { grid-template-columns: repeat(2, 1fr); } }
+
+.agents-stat {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 0.65rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  text-align: center;
+  min-width: 0;
+}
+
+.agents-stat__value {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  white-space: nowrap;
+}
+.agents-stat__value--live   { color: var(--accent-bright); }
+.agents-stat__value--done   { color: var(--success); }
+.agents-stat__value--failed { color: var(--danger); }
+
+.agents-stat__label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+/* ── Toolbar ───────────────────────────────────────────────── */
+.agents-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 0.6rem 0.875rem;
+}
+
+.agents-filter-chips {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  flex: 1;
+}
+
+.filter-chip {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 20px;
+  padding: 0.2rem 0.65rem;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+.filter-chip:hover { border-color: var(--accent); color: var(--text-primary); }
+.filter-chip--active {
+  background: rgba(124,106,247,.18);
+  border-color: var(--accent);
+  color: var(--accent-bright);
+}
+.filter-chip--implementing { --chip-c: #3b82f6; }
+.filter-chip--reviewing    { --chip-c: var(--warning); }
+.filter-chip--done         { --chip-c: var(--success); }
+.filter-chip--stale        { --chip-c: var(--danger); }
+.filter-chip--unknown      { --chip-c: var(--text-muted); }
+.filter-chip.filter-chip--active.filter-chip--implementing { border-color: #3b82f6; color: #3b82f6; background: rgba(59,130,246,.12); }
+.filter-chip.filter-chip--active.filter-chip--reviewing    { border-color: var(--warning); color: var(--warning); background: rgba(234,179,8,.1); }
+.filter-chip.filter-chip--active.filter-chip--done         { border-color: var(--success); color: var(--success); background: rgba(34,197,94,.1); }
+.filter-chip.filter-chip--active.filter-chip--stale        { border-color: var(--danger);  color: var(--danger);  background: rgba(239,68,68,.1); }
+
+.filter-chip__count {
+  background: var(--bg-overlay);
+  border-radius: 8px;
+  padding: 0.05rem 0.35rem;
+  font-size: 0.65rem;
+}
+
+.agents-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.agents-select {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 5px;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+.agents-select:focus { border-color: var(--accent); outline: none; }
+
+.agents-search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.agents-search-icon {
+  position: absolute;
+  left: 0.5rem;
+  font-size: 0.75rem;
+  pointer-events: none;
+}
+
+.agents-search {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 5px;
+  color: var(--text-primary);
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem 0.25rem 1.75rem;
+  width: 200px;
+  transition: border-color 0.12s;
+}
+.agents-search:focus { border-color: var(--accent); outline: none; }
+
+.view-toggle {
+  display: flex;
+  border: 1px solid var(--border-default);
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.view-toggle__btn {
+  background: var(--bg-elevated);
+  border: none;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.view-toggle__btn:hover     { background: var(--bg-overlay); color: var(--text-primary); }
+.view-toggle__btn--active   { background: rgba(124,106,247,.2); color: var(--accent-bright); }
+
+/* ── Section headers ───────────────────────────────────────── */
+.agents-section { display: flex; flex-direction: column; gap: 0.75rem; }
+.agents-section-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: 0.4rem;
+  color: var(--text-secondary);
+}
+.section-title-icon   { font-size: 1rem; }
+.agents-section-subtitle { color: var(--text-muted); font-weight: 400; font-size: 0.75rem; }
+.badge-count--live    { background: rgba(22,153,255,.2); color: var(--accent-bright); }
+
+/* ── Empty states ──────────────────────────────────────────── */
+.agents-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 2.5rem 2rem;
+  text-align: center;
+}
+.agents-empty__icon  { font-size: 2.5rem; }
+.agents-empty__title { font-size: 1rem; font-weight: 700; color: var(--text-primary); }
+.agents-empty__body  { font-size: 0.82rem; color: var(--text-muted); max-width: 36ch; }
+
+/* ── Live agents grid ──────────────────────────────────────── */
+.agents-live-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.agent-live-card {
+  display: flex;
+  gap: 0.75rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid var(--border-strong);
+  border-radius: var(--radius);
+  padding: 0.875rem;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.12s;
+}
+.agent-live-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+  text-decoration: none;
+  color: inherit;
+}
+.agent-live-card--implementing { border-left-color: #3b82f6; }
+.agent-live-card--reviewing    { border-left-color: var(--warning); }
+.agent-live-card--done         { border-left-color: var(--success); }
+.agent-live-card--stale        { border-left-color: var(--danger); }
+.agent-live-card--unknown      { border-left-color: var(--border-strong); }
+.agent-live-card--stale-idle   {
+  border-left-color: var(--warning);
+  background: rgba(234,179,8,.04);
+}
+
+.agent-live-avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  flex-shrink: 0;
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-default);
+}
+.agent-live-avatar--visionary  { border-color: var(--arch-visionary);  background: rgba(155,89,182,.18); }
+.agent-live-avatar--architect  { border-color: var(--arch-architect);  background: rgba(52,152,219,.18); }
+.agent-live-avatar--hacker     { border-color: var(--arch-hacker);     background: rgba(243,156,18,.18); }
+.agent-live-avatar--guardian   { border-color: var(--arch-guardian);   background: rgba(39,174,96,.18); }
+.agent-live-avatar--scholar    { border-color: var(--arch-scholar);    background: rgba(26,188,156,.18); }
+.agent-live-avatar--mentor     { border-color: var(--arch-mentor);     background: rgba(230,126,34,.18); }
+.agent-live-avatar--operator   { border-color: var(--arch-operator);   background: rgba(149,165,166,.15); }
+.agent-live-avatar--pragmatist { border-color: var(--arch-pragmatist); background: rgba(231,76,60,.18); }
+.agent-live-avatar--default    { border-color: var(--border-default);  background: var(--bg-elevated); }
+
+.agent-live-body    { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 0.2rem; }
+.agent-live-top     { display: flex; align-items: center; gap: 0.4rem; }
+.agent-live-role    { font-size: 0.85rem; font-weight: 700; color: var(--text-primary); }
+.agent-live-persona { font-size: 0.72rem; color: var(--text-muted); }
+
+.agent-live-chips   { display: flex; flex-wrap: wrap; gap: 0.25rem; margin-top: 0.2rem; }
+.agent-live-branch  {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  background: var(--bg-elevated);
+  border-radius: 3px;
+  padding: 0.05rem 0.3rem;
+}
+
+.agent-live-footer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.3rem;
+}
+
+.agent-live-elapsed {
+  font-size: 0.68rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.agent-live-stale-badge {
+  font-size: 0.62rem;
+  font-weight: 600;
+  color: var(--warning);
+  background: rgba(234,179,8,.12);
+  border: 1px solid rgba(234,179,8,.3);
+  border-radius: 4px;
+  padding: 0.05rem 0.3rem;
+  letter-spacing: 0.03em;
+}
+
+.agent-sandbox-link {
+  margin-left: auto;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  opacity: 0.65;
+  transition: opacity 0.15s, color 0.15s;
+}
+.agent-sandbox-link:hover { opacity: 1; color: var(--accent-bright); }
+
+.agent-arch-link {
+  margin-left: auto;
+  text-decoration: none;
+  opacity: 0.6;
+  transition: opacity 0.15s;
+}
+.agent-arch-link:hover { opacity: 1; }
+
+/* ── History — batch groups ────────────────────────────────── */
+.agents-batches { display: flex; flex-direction: column; gap: 0.75rem; }
+
+.batch-group {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.batch-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.875rem;
+  cursor: pointer;
+  background: var(--bg-surface);
+  border-bottom: 1px solid transparent;
+  transition: background 0.12s;
+  flex-wrap: wrap;
+}
+.batch-header:hover { background: var(--bg-elevated); }
+
+.batch-chevron {
+  font-size: 1.2rem;
+  color: var(--text-muted);
+  transition: transform 0.18s;
+  flex-shrink: 0;
+}
+.batch-chevron--open { transform: rotate(90deg); }
+
+.batch-icon       { font-size: 0.9rem; }
+.batch-id         { font-size: 0.8rem; color: var(--text-primary); font-family: var(--font-mono); }
+.batch-meta       { font-size: 0.7rem; }
+.batch-count      { font-size: 0.65rem; }
+.batch-phase      {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent-bright);
+  background: rgba(124,106,247,.12);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+}
+.batch-success-rate {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--success);
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.batch-status-pills { display: flex; gap: 0.25rem; flex-wrap: wrap; }
+
+.batch-body { padding: 0.75rem; border-top: 1px solid var(--border-subtle); }
+
+/* ── History cards grid ────────────────────────────────────── */
+.agents-history-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.5rem;
+}
+
+.history-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-left: 3px solid var(--border-strong);
+  border-radius: 5px;
+  padding: 0.6rem 0.75rem;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.12s, background 0.12s;
+}
+.history-card:hover { border-color: var(--accent); background: var(--bg-overlay); text-decoration: none; color: inherit; }
+.history-card--implementing { border-left-color: #3b82f6; }
+.history-card--reviewing    { border-left-color: var(--warning); }
+.history-card--done         { border-left-color: var(--success); }
+.history-card--stale        { border-left-color: var(--danger); }
+.history-card--unknown      { border-left-color: var(--border-strong); }
+
+.history-card__top      { display: flex; align-items: center; justify-content: space-between; gap: 0.3rem; }
+.history-card__duration { font-size: 0.65rem; font-variant-numeric: tabular-nums; }
+.history-card__role     { font-size: 0.8rem; font-weight: 600; color: var(--text-primary); }
+.history-card__chips    { display: flex; flex-wrap: wrap; gap: 0.2rem; }
+.history-card__branch   { font-size: 0.62rem; font-family: var(--font-mono); color: var(--text-muted); }
+.history-card__date     { font-size: 0.62rem; }
+.history-card__meta     { display: flex; flex-wrap: wrap; gap: 0.3rem; align-items: center; margin-top: 0.1rem; }
+
+/* ── Retry + spawn mode badges ─────────────────────────────── */
+.run-attempt-badge {
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: var(--warning);
+  background: rgba(234,179,8,.12);
+  border: 1px solid rgba(234,179,8,.25);
+  border-radius: 4px;
+  padding: 0.05rem 0.3rem;
+  letter-spacing: 0.02em;
+}
+
+.run-spawn-mode {
+  font-size: 0.6rem;
+  font-weight: 600;
+  border-radius: 4px;
+  padding: 0.05rem 0.3rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.run-spawn-mode--wave   { color: var(--accent-bright); background: rgba(124,106,247,.12); border: 1px solid rgba(124,106,247,.2); }
+.run-spawn-mode--chain  { color: #3b82f6;              background: rgba(59,130,246,.1);   border: 1px solid rgba(59,130,246,.2); }
+.run-spawn-mode--manual { color: var(--text-muted);    background: var(--bg-elevated);    border: 1px solid var(--border-subtle); }
+
+/* ── History table ─────────────────────────────────────────── */
+.run-row:hover td { background: var(--bg-elevated); }
+.run-row--implementing td:first-child { border-left: 2px solid #3b82f6; }
+.run-row--reviewing    td:first-child { border-left: 2px solid var(--warning); }
+.run-row--done         td:first-child { border-left: 2px solid var(--success); }
+.run-row--stale        td:first-child { border-left: 2px solid var(--danger); }
+.run-row--unknown      td:first-child { border-left: 2px solid var(--border-strong); }
+.run-status-badge { font-size: 0.65rem; }
+.run-branch       { font-size: 0.68rem; }
+.run-date         { font-size: 0.7rem; white-space: nowrap; }
+.run-duration     { font-size: 0.7rem; white-space: nowrap; font-variant-numeric: tabular-nums; }

--- a/agentception/static/app.js
+++ b/agentception/static/app.js
@@ -826,43 +826,193 @@ function configPanel(initialConfig) {
 }
 
 // ---------------------------------------------------------------------------
-// Spawn — manual agent spawn form
+// Spawn — Mission Control orchestration dashboard
 // ---------------------------------------------------------------------------
 
 /**
- * Posts to POST /api/control/spawn and shows the worktree path on success.
+ * missionControl()
+ *
+ * Drives the spawn Mission Control page. Three modes:
+ *   - 'single'      → POST /api/control/spawn (one issue + role)
+ *   - 'wave'        → POST /api/control/spawn-wave (all unclaimed issues)
+ *   - 'coordinator' → POST /api/control/spawn-coordinator (brain dump)
+ *
+ * Data is hydrated from data-* attributes on $el inside init() so that
+ * server-side JSON (which uses double-quotes) never collides with the HTML
+ * x-data="..." attribute boundary.
  */
-function spawnForm() {
+function missionControl() {
   return {
-    issueNumber: '',
-    role: 'python-developer',
+    // ── Mode ──────────────────────────────────────────────────
+    mode: 'single',
+
+    // ── Single-agent state ────────────────────────────────────
+    selectedIssue: null,   // full issue object
+    selectedRole: 'python-developer',
+    searchQ: '',
+
+    // ── Wave state ────────────────────────────────────────────
+    waveRole: 'python-developer',
+
+    // ── Coordinator state ─────────────────────────────────────
+    brainDump: '',
+    labelPrefix: '',
+
+    // ── Shared ────────────────────────────────────────────────
     loading: false,
     result: null,
+    resultMode: null,   // which mode produced the result
     formError: null,
 
-    async submit() {
+    // ── Issue data (hydrated from data-* in init) ─────────────
+    issues: [],
+    activeLabel: '',
+    unclaimedCount: 0,
+
+    init() {
+      try {
+        this.issues = JSON.parse(this.$el.dataset.issues || '[]');
+      } catch (_) {
+        this.issues = [];
+      }
+      try {
+        this.activeLabel = JSON.parse(this.$el.dataset.activeLabel || '""');
+      } catch (_) {
+        this.activeLabel = '';
+      }
+      this.unclaimedCount = parseInt(this.$el.dataset.unclaimedCount || '0', 10);
+    },
+
+    // ── Computed ──────────────────────────────────────────────
+
+    /** Issues visible in the board after filtering (single mode). */
+    get filteredIssues() {
+      const q = this.searchQ.trim().toLowerCase();
+      if (!q) return this.issues;
+      return this.issues.filter(iss =>
+        String(iss.number).includes(q) ||
+        (iss.title || '').toLowerCase().includes(q) ||
+        (iss.phase_label || '').toLowerCase().includes(q)
+      );
+    },
+
+    /** Count of unclaimed issues (used in wave mode button label). */
+    get liveUnclaimedCount() {
+      return this.issues.filter(i => !i.claimed).length;
+    },
+
+    // ── Actions ───────────────────────────────────────────────
+
+    selectIssue(iss) {
+      if (iss.claimed) return;
+      this.selectedIssue = (this.selectedIssue?.number === iss.number) ? null : iss;
+    },
+
+    selectRole(slug) {
+      this.selectedRole = slug;
+    },
+
+    clearResult() {
       this.result    = null;
       this.formError = null;
-      this.loading   = true;
+      this.resultMode = null;
+    },
+
+    /** POST /api/control/spawn — spawn a single engineer agent. */
+    async submitSingle() {
+      if (!this.selectedIssue) return;
+      this.clearResult();
+      this.loading = true;
       try {
         const resp = await fetch('/api/control/spawn', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            issue_number: parseInt(this.issueNumber, 10),
-            role: this.role,
+            issue_number: this.selectedIssue.number,
+            role: this.selectedRole,
           }),
         });
         const data = await resp.json();
         if (!resp.ok) {
           this.formError = data.detail ?? `HTTP ${resp.status}`;
         } else {
-          this.result = data;
+          this.result     = data;
+          this.resultMode = 'single';
+          // Mark the issue claimed in local list so the board updates instantly.
+          this.issues = this.issues.map(i =>
+            i.number === this.selectedIssue.number ? { ...i, claimed: true } : i
+          );
         }
       } catch (err) {
         this.formError = `Network error: ${err.message}`;
       } finally {
         this.loading = false;
+      }
+    },
+
+    /** POST /api/control/spawn-wave — spawn all unclaimed issues at once. */
+    async submitWave() {
+      this.clearResult();
+      this.loading = true;
+      try {
+        const resp = await fetch(
+          `/api/control/spawn-wave?role=${encodeURIComponent(this.waveRole)}`,
+          { method: 'POST' }
+        );
+        const data = await resp.json();
+        if (!resp.ok) {
+          this.formError = data.detail ?? `HTTP ${resp.status}`;
+        } else {
+          this.result     = data;
+          this.resultMode = 'wave';
+          // Refresh local issue list to reflect newly claimed issues.
+          const spawnedNums = new Set((data.spawned || []).map(s => s.spawned));
+          this.issues = this.issues.map(i =>
+            spawnedNums.has(i.number) ? { ...i, claimed: true } : i
+          );
+        }
+      } catch (err) {
+        this.formError = `Network error: ${err.message}`;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    /** POST /api/control/spawn-coordinator — launch a coordinator brain-dump. */
+    async submitCoordinator() {
+      if (!this.brainDump.trim()) return;
+      this.clearResult();
+      this.loading = true;
+      try {
+        const resp = await fetch('/api/control/spawn-coordinator', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            brain_dump: this.brainDump,
+            label_prefix: this.labelPrefix,
+          }),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+          this.formError = data.detail ?? `HTTP ${resp.status}`;
+        } else {
+          this.result     = data;
+          this.resultMode = 'coordinator';
+        }
+      } catch (err) {
+        this.formError = `Network error: ${err.message}`;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    /** Called by HTMX after the issue list partial swaps in. */
+    onIssuesRefreshed(newIssues) {
+      this.issues = newIssues;
+      // Preserve selection if the selected issue still exists.
+      if (this.selectedIssue) {
+        const still = this.issues.find(i => i.number === this.selectedIssue.number);
+        this.selectedIssue = still ?? null;
       }
     },
   };
@@ -1510,18 +1660,18 @@ function apiEndpoint() {
 }
 
 // ---------------------------------------------------------------------------
-// Worktrees page — worktree card (expand / collapse + HTMX lazy-load)
+// Agent Sandboxes page — sandbox branch (expand / collapse + HTMX lazy-load)
 // ---------------------------------------------------------------------------
 
 /**
- * Per-card state for the worktrees page.
+ * Per-sandbox state for the Agent Sandboxes (worktrees) page.
  *
  * Handles:
  *   - toggle open/close with CSS transition
- *   - lazy HTMX detail load on first open (fires `detail-load` event once)
- *   - single-worktree delete via DELETE /api/worktrees/{slug}
+ *   - lazy HTMX detail load on first open (fires `detail-load` on the panel once)
+ *   - single-sandbox delete via DELETE /api/worktrees/{slug}
  */
-function worktreeCard(slug) {
+function envSandbox(slug) {
   return {
     slug,
     open: false,
@@ -1531,53 +1681,124 @@ function worktreeCard(slug) {
       this.open = !this.open;
       if (this.open && !this.loaded) {
         this.loaded = true;
-        const detail = document.getElementById('wt-detail-' + this.slug);
+        const detail = document.getElementById('env-detail-' + this.slug);
         if (detail) htmx.trigger(detail, 'detail-load');
       }
     },
 
     async deleteWorktree(s) {
-      if (!confirm(`Remove worktree "${s}"?\n\nThis deletes the working directory. The branch is kept.`)) return;
+      if (!confirm(`Remove sandbox "${s}"?\n\nThis deletes the working directory. The branch is kept.`)) return;
       const resp = await fetch(`/api/worktrees/${s}`, { method: 'DELETE' });
       if (resp.ok) {
-        // Animate the card out before reloading.
         this.$el.style.opacity = '0';
-        this.$el.style.transform = 'translateY(-4px)';
+        this.$el.style.transform = 'translateX(-6px)';
         setTimeout(() => location.reload(), 300);
       } else {
         const data = await resp.json().catch(() => ({}));
-        alert(`Failed to remove worktree: ${data.detail ?? resp.status}`);
+        alert(`Failed to remove sandbox: ${data.detail ?? resp.status}`);
       }
     },
   };
 }
 
-// ---------------------------------------------------------------------------
-// Worktrees page — branch manager (sweep + single-branch delete)
-// ---------------------------------------------------------------------------
-
-/**
- * Manages bulk-sweep and per-branch delete on the worktrees page.
- * Moved from the inline <script> in worktrees.html.
- */
-function branchManager() {
+/* ═══════════════════════════════════════════════════════════════
+   agentsPage(batches, ghBaseUrl)
+   Alpine component for the /agents listing page.
+   Handles client-side filtering, sorting, and view toggling of
+   the run history.  Live agents are server-rendered by Jinja.
+   ═══════════════════════════════════════════════════════════════ */
+function agentsPage(batches, ghBaseUrl) {
   return {
-    sweeping: false,
+    batches,
+    GH_BASE_URL: ghBaseUrl,
 
-    async deleteBranch(name) {
-      if (!confirm(`Delete branch "${name}"?`)) return;
-      const resp = await fetch('/api/control/sweep', { method: 'POST' });
-      if (resp.ok) location.reload();
-      else alert(`Failed: ${(await resp.json().catch(() => ({}))).detail ?? resp.status}`);
+    // Filter / sort / view state
+    activeStatus: '',
+    activeRole:   '',
+    searchQ:      '',
+    sortBy:       'newest',
+    view:         'cards',
+    openBatches:  {},   // batch_id → bool; undefined = open by default
+
+    init() {
+      // Open all batches by default.
+      this.batches.forEach(b => { this.openBatches[b.batch_id] = true; });
     },
 
-    async sweepAll() {
-      if (!confirm('Delete all stale agent branches and clear orphan labels?')) return;
-      this.sweeping = true;
-      const resp = await fetch('/api/control/sweep', { method: 'POST' });
-      this.sweeping = false;
-      if (resp.ok) location.reload();
-      else alert(`Sweep failed: ${(await resp.json().catch(() => ({}))).detail ?? resp.status}`);
+    clearFilters() {
+      this.activeStatus = '';
+      this.activeRole   = '';
+      this.searchQ      = '';
+    },
+
+    toggleBatch(id) {
+      this.openBatches[id] = !(this.openBatches[id] !== false);
+    },
+
+    /** Format a kebab-case role string as Title Case words. */
+    formatRole(role) {
+      return (role || '').split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+    },
+
+    /** Human-readable label for spawn_mode values. */
+    formatSpawnMode(mode) {
+      const labels = { wave: 'Wave', chain: 'Chain', manual: 'Manual' };
+      return labels[mode] ?? mode ?? '';
+    },
+
+    /** CSS modifier class for spawn_mode chip. */
+    spawnModeClass(mode) {
+      return mode ? `run-spawn-mode run-spawn-mode--${mode}` : '';
+    },
+
+    /** Per-batch success rate string, e.g. "83%". */
+    batchSuccessRate(runs) {
+      if (!runs.length) return '—';
+      const done = runs.filter(r => r.status === 'done').length;
+      return Math.round(done / runs.length * 100) + '%';
+    },
+
+    /** Match a single run against current filters. */
+    matchRun(run) {
+      if (this.activeStatus && run.status !== this.activeStatus) return false;
+      if (this.activeRole   && run.role   !== this.activeRole)   return false;
+      if (this.searchQ) {
+        const q = this.searchQ.toLowerCase();
+        const hay = [
+          run.id, run.role, run.branch, run.batch_id,
+          run.issue_number ? '#' + run.issue_number : '',
+          run.pr_number    ? '#' + run.pr_number    : '',
+          run.spawn_mode   ?? '',
+        ].join(' ').toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    },
+
+    /** Return filtered + sorted batches (only batches with ≥1 matching run). */
+    filteredBatches() {
+      let result = this.batches.map(batch => {
+        let runs = batch.runs.filter(r => this.matchRun(r));
+        if (this.sortBy === 'oldest')   runs = [...runs].reverse();
+        if (this.sortBy === 'issue')    runs = [...runs].sort((a, b) => (a.issue_number || 0) - (b.issue_number || 0));
+        if (this.sortBy === 'duration') runs = [...runs].sort((a, b) => (b.duration_s || 0) - (a.duration_s || 0));
+        return { ...batch, runs };
+      }).filter(b => b.runs.length > 0);
+
+      if (this.sortBy === 'oldest') result = [...result].reverse();
+      return result;
+    },
+
+    /** Total matching runs across all filtered batches. */
+    filteredTotal() {
+      return this.filteredBatches().reduce((n, b) => n + b.runs.length, 0);
+    },
+
+    /** Produce a status summary for a batch's runs [{status, count}, …]. */
+    batchStatusSummary(runs) {
+      const counts = {};
+      runs.forEach(r => { counts[r.status] = (counts[r.status] || 0) + 1; });
+      return Object.entries(counts).map(([status, count]) => ({ status, count }));
     },
   };
 }

--- a/agentception/templates/_spawn_issues.html
+++ b/agentception/templates/_spawn_issues.html
@@ -1,0 +1,40 @@
+{#
+  HTMX partial — issue card list for spawn Mission Control.
+
+  Swapped into #spawn-issue-list by hx-get="/agents/spawn/issues".
+  Alpine bindings (x-text, @click, :class) are re-evaluated automatically
+  after HTMX swaps because Alpine uses MutationObserver-based init.
+
+  Context:
+    issues  list[dict] — same shape as spawn.html (number, title, phase_label, claimed)
+#}
+{% if issues %}
+{% for iss in issues %}
+<div
+  class="spawn-issue-card{% if iss.claimed %} spawn-issue-card--claimed{% endif %}"
+  @click="selectIssue({{ iss | tojson }})"
+  :class="{
+    'spawn-issue-card--selected': selectedIssue?.number === {{ iss.number }},
+    'spawn-issue-card--claimed':  {{ 'true' if iss.claimed else 'false' }},
+  }"
+  role="option"
+  :aria-selected="selectedIssue?.number === {{ iss.number }}"
+  title="{{ iss.title | e }}{% if iss.claimed %} (agent:wip){% endif %}"
+>
+  <span class="spawn-issue-num">#{{ iss.number }}</span>
+  <div class="spawn-issue-body">
+    <div class="spawn-issue-title">{{ iss.title }}</div>
+    <div class="spawn-issue-meta">
+      {% if iss.phase_label %}
+      <span class="spawn-issue-phase">{{ iss.phase_label }}</span>
+      {% endif %}
+      {% if iss.claimed %}
+      <span class="spawn-issue-wip">wip</span>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endfor %}
+{% else %}
+<div class="spawn-issue-empty">No open issues found.</div>
+{% endif %}

--- a/agentception/templates/_worktree_detail.html
+++ b/agentception/templates/_worktree_detail.html
@@ -1,44 +1,54 @@
 {#
-  HTMX partial — rendered into the expandable body of a worktree card.
-  Receives: slug, found, branch, commits, diff_stat, task_content
+  HTMX partial — rendered into the expandable body of a sandbox branch.
+  Receives: slug, found, branch, commits (list[{sha, message}]), diff_stat, task_content
 #}
 {% if not found %}
-<p class="wt-detail-empty">Worktree not found.</p>
+<p class="env-detail-empty">Sandbox not found.</p>
 {% else %}
 
-{# ── Commits ahead of origin/dev ────────────────────────────────────────── #}
-<div class="wt-detail-section">
-  <h3 class="wt-detail-section-title">
-    Commits
-    <span class="wt-detail-count">{{ commits | length }} ahead of origin/dev</span>
+{# ── Commit chain ────────────────────────────────────────────────────────── #}
+<div class="env-commit-section">
+  <h3 class="env-detail-heading">
+    Commit History
+    <span class="env-detail-meta">
+      {% if commits %}{{ commits | length }} commit{{ 's' if commits | length != 1 }} ahead of dev{% else %}no commits ahead of dev{% endif %}
+    </span>
   </h3>
+
   {% if commits %}
-  <ul class="wt-commits">
+  <div class="env-commit-chain">
     {% for c in commits %}
-    <li class="wt-commit">
-      <code class="wt-commit-sha">{{ c.sha }}</code>
-      <span class="wt-commit-msg">{{ c.message }}</span>
-    </li>
+    <div class="env-commit-node{% if loop.last %} env-commit-node--head{% endif %}">
+      <div class="env-commit-spine">
+        <div class="env-commit-dot{% if loop.last %} env-commit-dot--head{% endif %}"></div>
+        {% if not loop.last %}<div class="env-commit-line"></div>{% endif %}
+      </div>
+      <div class="env-commit-body">
+        <code class="env-commit-sha">{{ c.sha }}</code>
+        <span class="env-commit-msg">{{ c.message }}</span>
+        {% if loop.last %}<span class="env-head-tag">HEAD</span>{% endif %}
+      </div>
+    </div>
     {% endfor %}
-  </ul>
+  </div>
   {% else %}
-  <p class="wt-detail-empty">No commits ahead of origin/dev.</p>
+  <p class="env-detail-empty">No commits ahead of origin/dev — this sandbox is in sync with the base.</p>
   {% endif %}
 </div>
 
-{# ── Diff stat vs origin/dev ─────────────────────────────────────────────── #}
+{# ── Changed files ───────────────────────────────────────────────────────── #}
 {% if diff_stat %}
-<div class="wt-detail-section">
-  <h3 class="wt-detail-section-title">Changed Files</h3>
-  <pre class="wt-diff-stat">{{ diff_stat }}</pre>
+<div class="env-diff-section">
+  <h3 class="env-detail-heading">Changed Files</h3>
+  <pre class="env-diff-stat">{{ diff_stat }}</pre>
 </div>
 {% endif %}
 
-{# ── Agent task file ─────────────────────────────────────────────────────── #}
+{# ── Agent task ──────────────────────────────────────────────────────────── #}
 {% if task_content %}
-<div class="wt-detail-section">
-  <h3 class="wt-detail-section-title">Agent Task</h3>
-  <pre class="wt-task-file">{{ task_content }}</pre>
+<div class="env-task-section">
+  <h3 class="env-detail-heading">Agent Task</h3>
+  <pre class="env-task-file">{{ task_content }}</pre>
 </div>
 {% endif %}
 

--- a/agentception/templates/agents.html
+++ b/agentception/templates/agents.html
@@ -6,15 +6,15 @@
 {# ═══════════════════════════════════════════════════════════
    Agents Command Centre
    Data flow:
-   · state.agents  — live in-memory (SSE-updated on overview; static snapshot here)
-   · batches       — run history grouped by batch_id (Postgres)
-   · stats         — KPI aggregates (Python-computed)
-   Alpine component: agentsPage() — filter, search, sort, view toggle
+   · agents        — live in-memory agents, enriched with persona + elapsed/staleness (Jinja, static)
+   · batches       — run history grouped by batch_id, passed as JSON to Alpine
+   · stats         — KPI aggregates (Python-computed, Jinja)
+   Alpine component: agentsPage(batches, ghBaseUrl) in app.js
    ═══════════════════════════════════════════════════════════ #}
 
 <div
   class="agents-page"
-  x-data="agentsPage()"
+  x-data="agentsPage({{ batches | tojson | e }}, {{ gh_base_url | tojson }})"
   x-init="init()"
 >
 
@@ -29,7 +29,7 @@
         Live pipeline agents and full run history — grouped by wave, filterable, searchable.
       </p>
     </div>
-    <a href="/control/spawn" class="btn btn-primary">+ Spawn Agent</a>
+    <a href="/agents/spawn" class="btn btn-primary">+ Spawn Agent</a>
   </div>
 
   {# ── KPI stats bar ───────────────────────────────────────────────────────── #}
@@ -45,6 +45,10 @@
     <div class="agents-stat">
       <div class="agents-stat__value agents-stat__value--done">{{ stats.done }}</div>
       <div class="agents-stat__label">Completed</div>
+    </div>
+    <div class="agents-stat">
+      <div class="agents-stat__value agents-stat__value--failed">{{ stats.failed }}</div>
+      <div class="agents-stat__label">Failed</div>
     </div>
     <div class="agents-stat">
       <div class="agents-stat__value">{{ stats.success_rate }}%</div>
@@ -143,16 +147,18 @@
         The pipeline is idle. Agents appear here when worktrees with
         <code>.agent-task</code> files are active.
       </p>
-      <a href="/control/spawn" class="btn btn-primary mt-1">Spawn an agent</a>
+      <a href="/agents/spawn" class="btn btn-primary mt-1">Spawn an agent</a>
     </div>
     {% else %}
     <div class="agents-live-grid">
       {% for item in agents %}
       {% set node = item.node %}
       {% set persona = item.persona %}
+      {% set elapsed = item.elapsed %}
+      {% set is_stale_idle = item.is_stale_idle %}
       <a
         href="/agents/{{ node.id }}"
-        class="agent-live-card agent-live-card--{{ node.status.value }}"
+        class="agent-live-card agent-live-card--{{ node.status.value }}{% if is_stale_idle %} agent-live-card--stale-idle{% endif %}"
         title="{{ node.role }}"
       >
         {# Persona avatar #}
@@ -161,17 +167,21 @@
         </div>
 
         <div class="agent-live-body">
-          {# Status + role #}
+          {# Status badge + pulse dot #}
           <div class="agent-live-top">
             <span class="status-badge status-badge--{{ node.status.value }}">{{ node.status.value }}</span>
             {% if node.status.value in ['implementing', 'reviewing'] %}
             <span class="agent-pulse agent-pulse--{{ node.status.value }}"></span>
             {% endif %}
+            {% if is_stale_idle %}
+            <span class="agent-live-stale-badge">idle</span>
+            {% endif %}
           </div>
+
           <div class="agent-live-role">{{ node.role | replace('-', ' ') | title }}</div>
           <div class="agent-live-persona">{{ persona.display_name }}</div>
 
-          {# Chips #}
+          {# Issue / PR / branch chips #}
           <div class="agent-live-chips">
             {% if node.issue_number %}
             <span class="agent-meta-chip agent-meta-chip--issue">#{{ node.issue_number }}</span>
@@ -184,13 +194,24 @@
             {% endif %}
           </div>
 
-          {# Message count / activity #}
+          {# Footer: elapsed time, message count, child count, sandbox link, arch link #}
           <div class="agent-live-footer">
+            {% if elapsed %}
+            <span class="agent-live-elapsed">{{ elapsed }}</span>
+            {% endif %}
             {% if node.message_count %}
-            <span class="text-muted" style="font-size:0.7rem">{{ node.message_count }} msgs</span>
+            <span class="text-muted" style="font-size:0.68rem">{{ node.message_count }} msgs</span>
             {% endif %}
             {% if node.children %}
-            <span class="text-muted" style="font-size:0.7rem">{{ node.children | length }} child{{ 'ren' if node.children | length != 1 }}</span>
+            <span class="text-muted" style="font-size:0.68rem">{{ node.children | length }} child{{ 'ren' if node.children | length != 1 }}</span>
+            {% endif %}
+            {% if node.worktree_path %}
+            <a
+              href="/worktrees"
+              class="agent-sandbox-link"
+              @click.prevent.stop="window.location='/worktrees'"
+              title="View in Agent Sandboxes"
+            >sandbox ↗</a>
             {% endif %}
             {% if persona.raw %}
             <a
@@ -230,6 +251,9 @@
             <span class="batch-icon">🌊</span>
             <strong class="batch-id" x-text="batch.batch_id"></strong>
             <span class="batch-meta text-muted" x-text="batch.spawned_fmt"></span>
+            <template x-if="batch.phase_label">
+              <span class="batch-phase" x-text="batch.phase_label"></span>
+            </template>
             <span class="batch-count badge badge-count" x-text="batch.runs.length + ' agent' + (batch.runs.length !== 1 ? 's' : '')"></span>
             <div class="batch-status-pills">
               <template x-for="s in batchStatusSummary(batch.runs)" :key="s.status">
@@ -240,6 +264,7 @@
                 ></span>
               </template>
             </div>
+            <span class="batch-success-rate" x-text="batchSuccessRate(batch.runs) + ' done'"></span>
           </div>
 
           {# Batch body — agent cards grid #}
@@ -272,6 +297,17 @@
                   </div>
 
                   <code class="history-card__branch text-muted" x-show="run.branch" x-text="run.branch"></code>
+
+                  {# Attempt badge + spawn mode chip #}
+                  <div class="history-card__meta">
+                    <template x-if="run.attempt_number > 1">
+                      <span class="run-attempt-badge" x-text="'×' + run.attempt_number"></span>
+                    </template>
+                    <template x-if="run.spawn_mode">
+                      <span :class="spawnModeClass(run.spawn_mode)" x-text="formatSpawnMode(run.spawn_mode)"></span>
+                    </template>
+                  </div>
+
                   <div class="history-card__date text-muted" x-text="run.spawned_fmt"></div>
                 </a>
               </template>
@@ -291,6 +327,8 @@
             <th>Issue</th>
             <th>PR</th>
             <th>Branch</th>
+            <th>Attempt</th>
+            <th>Mode</th>
             <th>Wave</th>
             <th>Spawned</th>
             <th>Duration</th>
@@ -325,6 +363,20 @@
                   <span x-show="!run.pr_number" class="text-muted">—</span>
                 </td>
                 <td><code class="text-muted run-branch" x-text="run.branch || '—'"></code></td>
+                <td>
+                  <template x-if="run.attempt_number > 1">
+                    <span class="run-attempt-badge" x-text="'×' + run.attempt_number"></span>
+                  </template>
+                  <span x-show="!run.attempt_number || run.attempt_number <= 1" class="text-muted">1</span>
+                </td>
+                <td>
+                  <span
+                    x-show="run.spawn_mode"
+                    :class="spawnModeClass(run.spawn_mode)"
+                    x-text="formatSpawnMode(run.spawn_mode)"
+                  ></span>
+                  <span x-show="!run.spawn_mode" class="text-muted">—</span>
+                </td>
                 <td><code class="text-muted" style="font-size:0.68rem" x-text="run.batch_id || '—'"></code></td>
                 <td class="text-muted run-date" x-text="run.spawned_fmt"></td>
                 <td class="text-muted run-duration" x-text="run.duration_str"></td>
@@ -357,455 +409,5 @@
   {% endif %}
 
 </div>{# .agents-page #}
-
-{# ── Inline data + Alpine component ─────────────────────────────────────── #}
-<script>
-const GH_BASE_URL = {{ gh_base_url | tojson }};
-
-// Serialise batches from server for Alpine to consume.
-const AGENTS_BATCHES = {{ batches | tojson }};
-
-function agentsPage() {
-  return {
-    // Filter / sort / view state
-    activeStatus: '',
-    activeRole:   '',
-    searchQ:      '',
-    sortBy:       'newest',
-    view:         'cards',
-    openBatches:  {},   // batch_id → bool; undefined = open by default
-
-    init() {
-      // Open all batches by default.
-      AGENTS_BATCHES.forEach(b => { this.openBatches[b.batch_id] = true; });
-    },
-
-    clearFilters() {
-      this.activeStatus = '';
-      this.activeRole   = '';
-      this.searchQ      = '';
-    },
-
-    toggleBatch(id) {
-      this.openBatches[id] = !(this.openBatches[id] !== false);
-    },
-
-    /** Format a kebab-case role as Title Case words. */
-    formatRole(role) {
-      return (role || '').split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
-    },
-
-    /** Match a single run against current filters. */
-    matchRun(run) {
-      if (this.activeStatus && run.status !== this.activeStatus) return false;
-      if (this.activeRole   && run.role   !== this.activeRole)   return false;
-      if (this.searchQ) {
-        const q = this.searchQ.toLowerCase();
-        const hay = [
-          run.id, run.role, run.branch, run.batch_id,
-          run.issue_number ? '#' + run.issue_number : '',
-          run.pr_number    ? '#' + run.pr_number    : '',
-        ].join(' ').toLowerCase();
-        if (!hay.includes(q)) return false;
-      }
-      return true;
-    },
-
-    /** Return filtered + sorted batches (only batches with ≥1 matching run). */
-    filteredBatches() {
-      let result = AGENTS_BATCHES.map(batch => {
-        let runs = batch.runs.filter(r => this.matchRun(r));
-        if (this.sortBy === 'oldest')   runs = [...runs].reverse();
-        if (this.sortBy === 'issue')    runs = [...runs].sort((a,b) => (a.issue_number||0) - (b.issue_number||0));
-        if (this.sortBy === 'duration') runs = [...runs].sort((a,b) => (b.duration_s||0)  - (a.duration_s||0));
-        return { ...batch, runs };
-      }).filter(b => b.runs.length > 0);
-
-      if (this.sortBy === 'oldest') result = [...result].reverse();
-      return result;
-    },
-
-    /** Total matching runs across all filtered batches. */
-    filteredTotal() {
-      return this.filteredBatches().reduce((n, b) => n + b.runs.length, 0);
-    },
-
-    /** Produce a status summary for a batch's runs [{status, count}, …]. */
-    batchStatusSummary(runs) {
-      const counts = {};
-      runs.forEach(r => { counts[r.status] = (counts[r.status] || 0) + 1; });
-      return Object.entries(counts).map(([status, count]) => ({ status, count }));
-    },
-  };
-}
-</script>
-
-<style>
-/* ── Agents page layout ────────────────────────────────────── */
-.agents-page { display: flex; flex-direction: column; gap: 1.5rem; }
-
-.agents-page-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.agents-page-subtitle { margin-top: 0.25rem; font-size: 0.82rem; }
-
-/* ── KPI stats bar ─────────────────────────────────────────── */
-.agents-stats-bar {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 0.5rem;
-}
-@media (max-width: 700px) { .agents-stats-bar { grid-template-columns: repeat(3, 1fr); } }
-
-.agents-stat {
-  background: var(--bg-surface);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius);
-  padding: 0.75rem 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  text-align: center;
-}
-
-.agents-stat__value {
-  font-size: 1.5rem;
-  font-weight: 800;
-  color: var(--text-primary);
-  font-variant-numeric: tabular-nums;
-  line-height: 1;
-}
-.agents-stat__value--live { color: var(--accent-bright); }
-.agents-stat__value--done { color: var(--success); }
-
-.agents-stat__label {
-  font-size: 0.68rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
-}
-
-/* ── Toolbar ───────────────────────────────────────────────── */
-.agents-toolbar {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  background: var(--bg-surface);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius);
-  padding: 0.6rem 0.875rem;
-}
-
-.agents-filter-chips {
-  display: flex;
-  gap: 0.35rem;
-  flex-wrap: wrap;
-  flex: 1;
-}
-
-.filter-chip {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: 20px;
-  padding: 0.2rem 0.65rem;
-  font-size: 0.72rem;
-  font-weight: 500;
-  color: var(--text-secondary);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
-}
-.filter-chip:hover { border-color: var(--accent); color: var(--text-primary); }
-.filter-chip--active {
-  background: rgba(124,106,247,.18);
-  border-color: var(--accent);
-  color: var(--accent-bright);
-}
-.filter-chip--implementing { --chip-c: #3b82f6; }
-.filter-chip--reviewing    { --chip-c: var(--warning); }
-.filter-chip--done         { --chip-c: var(--success); }
-.filter-chip--stale        { --chip-c: var(--danger); }
-.filter-chip--unknown      { --chip-c: var(--text-muted); }
-.filter-chip.filter-chip--active.filter-chip--implementing { border-color: #3b82f6; color: #3b82f6; background: rgba(59,130,246,.12); }
-.filter-chip.filter-chip--active.filter-chip--reviewing    { border-color: var(--warning); color: var(--warning); background: rgba(234,179,8,.1); }
-.filter-chip.filter-chip--active.filter-chip--done         { border-color: var(--success); color: var(--success); background: rgba(34,197,94,.1); }
-.filter-chip.filter-chip--active.filter-chip--stale        { border-color: var(--danger);  color: var(--danger);  background: rgba(239,68,68,.1); }
-
-.filter-chip__count {
-  background: var(--bg-overlay);
-  border-radius: 8px;
-  padding: 0.05rem 0.35rem;
-  font-size: 0.65rem;
-}
-
-.agents-toolbar-right {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex-shrink: 0;
-}
-
-.agents-select {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: 5px;
-  color: var(--text-secondary);
-  font-size: 0.75rem;
-  padding: 0.25rem 0.5rem;
-  cursor: pointer;
-}
-.agents-select:focus { border-color: var(--accent); outline: none; }
-
-.agents-search-wrap {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.agents-search-icon {
-  position: absolute;
-  left: 0.5rem;
-  font-size: 0.75rem;
-  pointer-events: none;
-}
-
-.agents-search {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: 5px;
-  color: var(--text-primary);
-  font-size: 0.75rem;
-  padding: 0.25rem 0.5rem 0.25rem 1.75rem;
-  width: 180px;
-  transition: border-color 0.12s, width 0.2s;
-}
-.agents-search:focus { border-color: var(--accent); outline: none; width: 220px; }
-
-.view-toggle {
-  display: flex;
-  border: 1px solid var(--border-default);
-  border-radius: 5px;
-  overflow: hidden;
-}
-
-.view-toggle__btn {
-  background: var(--bg-elevated);
-  border: none;
-  padding: 0.25rem 0.55rem;
-  font-size: 0.85rem;
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: background 0.12s, color 0.12s;
-}
-.view-toggle__btn:hover { background: var(--bg-overlay); color: var(--text-primary); }
-.view-toggle__btn--active { background: rgba(124,106,247,.2); color: var(--accent-bright); }
-
-/* ── Section headers ───────────────────────────────────────── */
-.agents-section { display: flex; flex-direction: column; gap: 0.75rem; }
-.agents-section-title {
-  font-size: 0.875rem;
-  font-weight: 600;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  border-bottom: 1px solid var(--border-subtle);
-  padding-bottom: 0.4rem;
-  color: var(--text-secondary);
-}
-.section-title-icon { font-size: 1rem; }
-.agents-section-subtitle { color: var(--text-muted); font-weight: 400; font-size: 0.75rem; }
-.badge-count--live { background: rgba(22,153,255,.2); color: var(--accent-bright); }
-
-/* ── Empty states ──────────────────────────────────────────── */
-.agents-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 2.5rem 2rem;
-  text-align: center;
-}
-.agents-empty__icon { font-size: 2.5rem; }
-.agents-empty__title { font-size: 1rem; font-weight: 700; color: var(--text-primary); }
-.agents-empty__body  { font-size: 0.82rem; color: var(--text-muted); max-width: 36ch; }
-
-/* ── Live agents grid ──────────────────────────────────────── */
-.agents-live-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 0.75rem;
-}
-
-.agent-live-card {
-  display: flex;
-  gap: 0.75rem;
-  background: var(--bg-surface);
-  border: 1px solid var(--border-default);
-  border-left: 3px solid var(--border-strong);
-  border-radius: var(--radius);
-  padding: 0.875rem;
-  text-decoration: none;
-  color: inherit;
-  transition: border-color 0.15s, box-shadow 0.15s, transform 0.12s;
-}
-.agent-live-card:hover {
-  border-color: var(--accent);
-  box-shadow: var(--shadow-md);
-  transform: translateY(-1px);
-  text-decoration: none;
-  color: inherit;
-}
-.agent-live-card--implementing { border-left-color: #3b82f6; }
-.agent-live-card--reviewing    { border-left-color: var(--warning); }
-.agent-live-card--done         { border-left-color: var(--success); }
-.agent-live-card--stale        { border-left-color: var(--danger); }
-.agent-live-card--unknown      { border-left-color: var(--border-strong); }
-
-.agent-live-avatar {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.2rem;
-  flex-shrink: 0;
-  background: var(--bg-elevated);
-  border: 1.5px solid var(--border-default);
-}
-.agent-live-avatar--visionary  { border-color: var(--arch-visionary);  background: rgba(155,89,182,.18); }
-.agent-live-avatar--architect  { border-color: var(--arch-architect);  background: rgba(52,152,219,.18); }
-.agent-live-avatar--hacker     { border-color: var(--arch-hacker);     background: rgba(243,156,18,.18); }
-.agent-live-avatar--guardian   { border-color: var(--arch-guardian);   background: rgba(39,174,96,.18); }
-.agent-live-avatar--scholar    { border-color: var(--arch-scholar);    background: rgba(26,188,156,.18); }
-.agent-live-avatar--mentor     { border-color: var(--arch-mentor);     background: rgba(230,126,34,.18); }
-.agent-live-avatar--operator   { border-color: var(--arch-operator);   background: rgba(149,165,166,.15); }
-.agent-live-avatar--pragmatist { border-color: var(--arch-pragmatist); background: rgba(231,76,60,.18); }
-.agent-live-avatar--default    { border-color: var(--border-default);  background: var(--bg-elevated); }
-
-.agent-live-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 0.2rem; }
-
-.agent-live-top { display: flex; align-items: center; gap: 0.4rem; }
-.agent-live-role   { font-size: 0.85rem; font-weight: 700; color: var(--text-primary); }
-.agent-live-persona { font-size: 0.72rem; color: var(--text-muted); }
-
-.agent-live-chips { display: flex; flex-wrap: wrap; gap: 0.25rem; margin-top: 0.2rem; }
-.agent-live-branch {
-  font-size: 0.65rem;
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  background: var(--bg-elevated);
-  border-radius: 3px;
-  padding: 0.05rem 0.3rem;
-}
-
-.agent-live-footer {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.3rem;
-}
-
-.agent-arch-link {
-  margin-left: auto;
-  text-decoration: none;
-  opacity: 0.6;
-  transition: opacity 0.15s;
-}
-.agent-arch-link:hover { opacity: 1; }
-
-/* ── History — batch groups ────────────────────────────────── */
-.agents-batches { display: flex; flex-direction: column; gap: 0.75rem; }
-
-.batch-group {
-  background: var(--bg-surface);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius);
-  overflow: hidden;
-}
-
-.batch-header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.6rem 0.875rem;
-  cursor: pointer;
-  background: var(--bg-surface);
-  border-bottom: 1px solid transparent;
-  transition: background 0.12s;
-  flex-wrap: wrap;
-}
-.batch-header:hover { background: var(--bg-elevated); }
-
-.batch-chevron {
-  font-size: 1.2rem;
-  color: var(--text-muted);
-  transition: transform 0.18s;
-  flex-shrink: 0;
-}
-.batch-chevron--open { transform: rotate(90deg); }
-
-.batch-icon { font-size: 0.9rem; }
-.batch-id { font-size: 0.8rem; color: var(--text-primary); font-family: var(--font-mono); }
-.batch-meta { font-size: 0.7rem; }
-.batch-count { font-size: 0.65rem; }
-.batch-status-pills { display: flex; gap: 0.25rem; margin-left: auto; flex-wrap: wrap; }
-
-.batch-body { padding: 0.75rem; border-top: 1px solid var(--border-subtle); }
-
-/* ── History cards grid ────────────────────────────────────── */
-.agents-history-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 0.5rem;
-}
-
-.history-card {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-subtle);
-  border-left: 3px solid var(--border-strong);
-  border-radius: 5px;
-  padding: 0.6rem 0.75rem;
-  text-decoration: none;
-  color: inherit;
-  transition: border-color 0.12s, background 0.12s;
-}
-.history-card:hover { border-color: var(--accent); background: var(--bg-overlay); text-decoration: none; color: inherit; }
-.history-card--implementing { border-left-color: #3b82f6; }
-.history-card--reviewing    { border-left-color: var(--warning); }
-.history-card--done         { border-left-color: var(--success); }
-.history-card--stale        { border-left-color: var(--danger); }
-.history-card--unknown      { border-left-color: var(--border-strong); }
-
-.history-card__top { display: flex; align-items: center; justify-content: space-between; gap: 0.3rem; }
-.history-card__duration { font-size: 0.65rem; font-variant-numeric: tabular-nums; }
-.history-card__role { font-size: 0.8rem; font-weight: 600; color: var(--text-primary); }
-.history-card__chips { display: flex; flex-wrap: wrap; gap: 0.2rem; }
-.history-card__branch { font-size: 0.62rem; font-family: var(--font-mono); color: var(--text-muted); }
-.history-card__date { font-size: 0.62rem; }
-
-/* ── History table ─────────────────────────────────────────── */
-.run-row:hover td { background: var(--bg-elevated); }
-.run-row--implementing td:first-child { border-left: 2px solid #3b82f6; }
-.run-row--reviewing    td:first-child { border-left: 2px solid var(--warning); }
-.run-row--done         td:first-child { border-left: 2px solid var(--success); }
-.run-row--stale        td:first-child { border-left: 2px solid var(--danger); }
-.run-row--unknown      td:first-child { border-left: 2px solid var(--border-strong); }
-.run-status-badge { font-size: 0.65rem; }
-.run-branch { font-size: 0.68rem; }
-.run-date   { font-size: 0.7rem; white-space: nowrap; }
-.run-duration { font-size: 0.7rem; white-space: nowrap; font-variant-numeric: tabular-nums; }
-</style>
 
 {% endblock %}

--- a/agentception/templates/base.html
+++ b/agentception/templates/base.html
@@ -27,12 +27,10 @@
   <nav class="topnav" role="navigation" aria-label="Main navigation">
     <a href="/" class="brand" title="The Singularity Is Here">⚡ Agentception</a>
 
-    <a href="/"         class="{% if request.url.path == '/' %}active{% endif %}">Overview</a>
-    <a href="/brain-dump" class="nav-cta {% if request.url.path.startswith('/brain-dump') %}active{% endif %}">🧠 Brain Dump</a>
+    <a href="/brain-dump" class="nav-cta {% if request.url.path.startswith('/brain-dump') %}active{% endif %}">Brain Dump</a>
     <a href="/agents"   class="{% if request.url.path.startswith('/agents') %}active{% endif %}">Agents</a>
     <a href="/telemetry" class="{% if request.url.path.startswith('/telemetry') %}active{% endif %}">Telemetry</a>
     <a href="/roles"    class="{% if request.url.path.startswith('/roles') %}active{% endif %}">Roles</a>
-    <a href="/controls" class="{% if request.url.path.startswith('/controls') %}active{% endif %}">Controls</a>
     <a href="/config"   class="{% if request.url.path.startswith('/config') %}active{% endif %}">Config</a>
     <a href="/dag"      class="{% if request.url.path.startswith('/dag') %}active{% endif %}">DAG</a>
     <a href="/ab-testing" class="{% if request.url.path.startswith('/ab-testing') %}active{% endif %}">A/B</a>

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -336,20 +336,16 @@
     </div>
     <div
       class="summary-item"
-      :class="(state.stale_branches || []).length > 0 ? 'summary-item--warn' : 'summary-item--dim'"
+      :class="[
+        (state.stale_branches || []).length > 0 ? 'summary-item--warn' : 'summary-item--dim',
+        (state.stale_branches || []).length > 0 && !sweeping ? 'summary-item--clickable' : ''
+      ]"
       x-data="sweepControl()"
+      @click="(state.stale_branches || []).length > 0 && !sweeping && sweep()"
+      :title="(state.stale_branches || []).length > 0 ? (sweeping ? 'Sweeping…' : 'Click to delete stale branches') : ''"
     >
-      <span class="summary-label">Stale</span>
+      <span class="summary-label" x-text="sweeping ? 'Sweeping…' : 'Stale'"></span>
       <span class="summary-value" x-text="(state.stale_branches || []).length"></span>
-      <button
-        class="sweep-btn"
-        x-show="(state.stale_branches || []).length > 0"
-        x-cloak
-        @click.stop="sweep()"
-        :disabled="sweeping"
-        :title="sweeping ? 'Sweeping…' : 'Delete all stale branches and clear orphan labels'"
-        x-text="sweeping ? '…' : '⌫'"
-      ></button>
     </div>
     <div class="summary-item">
       <span class="summary-label">Msgs</span>

--- a/agentception/templates/spawn.html
+++ b/agentception/templates/spawn.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 
-{% block title %}AgentCeption — Spawn Agent{% endblock %}
+{% block title %}AgentCeption — Mission Control{% endblock %}
 
 {% block content %}
 
 <nav class="breadcrumb" aria-label="Breadcrumb">
-  <a href="/">← Overview</a>
+  <a href="/agents">← Agents</a>
   <span class="breadcrumb-sep">/</span>
-  <span class="breadcrumb-current">Spawn Agent</span>
+  <span class="breadcrumb-current">Mission Control</span>
 </nav>
 
 {% if error %}
@@ -18,119 +18,357 @@
 {% endif %}
 
 {#
-  Alpine.js component manages the form submission and result/error display.
-  HTMX is not used here because we need to handle both success and error
-  states with structured JSON from POST /api/control/spawn.
+  Alpine root — missionControl() lives in /static/app.js.
+
+  Data is passed via data-* attributes with single-quote delimiters so that
+  the JSON values (which always use double-quotes) never collide with the HTML
+  attribute boundary. missionControl() reads them in its init() hook via $el.dataset.
 #}
 <div
-  x-data="spawnForm()"
   class="spawn-page"
+  x-data="missionControl()"
+  data-issues='{{ issues | tojson }}'
+  data-active-label='{{ active_label | tojson }}'
+  data-unclaimed-count="{{ board_counts.unclaimed }}"
 >
 
-  <h1 class="section-title">Spawn Agent</h1>
-  <p class="text-muted">
-    Manually seed a new engineer agent for an open, unclaimed issue.
-    The agent worktree and <code>.agent-task</code> file will be created;
-    you must then launch the Cursor Task pointed at the worktree path shown below.
-  </p>
+  {# ── Status bar ──────────────────────────────────────────────────── #}
+  <div class="spawn-status-bar">
+    {% if active_label %}
+    <span class="spawn-status-pill spawn-status-pill--phase">
+      <span class="spawn-status-dot"></span>
+      {{ active_label }}
+    </span>
+    {% endif %}
+    <span class="spawn-status-pill">
+      {{ board_counts.total }} open
+    </span>
+    <span class="spawn-status-pill spawn-status-pill--unclaimed">
+      <span class="spawn-status-dot"></span>
+      {{ board_counts.unclaimed }} unclaimed
+    </span>
+    {% if board_counts.claimed %}
+    <span class="spawn-status-pill spawn-status-pill--claimed">
+      <span class="spawn-status-dot"></span>
+      {{ board_counts.claimed }} in progress
+    </span>
+    {% endif %}
+  </div>
 
-  <div class="card mt-2">
-    <form @submit.prevent="submit" class="spawn-form" novalidate>
+  {# ── Mode tabs ────────────────────────────────────────────────────── #}
+  <div class="spawn-tabs" role="tablist" aria-label="Spawn mode">
+    <button
+      class="spawn-tab"
+      :class="{ 'spawn-tab--active': mode === 'single' }"
+      @click="mode = 'single'; clearResult()"
+      role="tab"
+      :aria-selected="mode === 'single'"
+    >Single Agent</button>
+    <button
+      class="spawn-tab"
+      :class="{ 'spawn-tab--active': mode === 'wave' }"
+      @click="mode = 'wave'; clearResult()"
+      role="tab"
+      :aria-selected="mode === 'wave'"
+    >Wave Spawn</button>
+    <button
+      class="spawn-tab"
+      :class="{ 'spawn-tab--active': mode === 'coordinator' }"
+      @click="mode = 'coordinator'; clearResult()"
+      role="tab"
+      :aria-selected="mode === 'coordinator'"
+    >Coordinator</button>
+  </div>
 
-      {# Issue picker #}
+  {# ═══════════════════════════════════════════════════════════════════
+     SINGLE AGENT PANEL
+     Issue board (left) + role picker (right) → POST /api/control/spawn
+  ════════════════════════════════════════════════════════════════════ #}
+  <div class="spawn-panel" x-show="mode === 'single'" x-cloak>
+
+    <div class="spawn-single-layout">
+
+      {# Issue board #}
+      <div class="spawn-issue-board">
+        <div class="spawn-issue-toolbar">
+          <input
+            class="spawn-issue-search"
+            type="search"
+            placeholder="Filter issues…"
+            x-model="searchQ"
+            aria-label="Filter issues"
+          >
+          <button
+            class="spawn-issue-refresh"
+            hx-get="/agents/spawn/issues"
+            hx-target="#spawn-issue-list"
+            hx-swap="innerHTML"
+            hx-indicator="#spawn-refresh-indicator"
+            title="Refresh issue list"
+            aria-label="Refresh issue list"
+          >↻</button>
+          <span id="spawn-refresh-indicator" class="htmx-indicator text-muted" style="font-size:0.75rem;">…</span>
+        </div>
+
+        <div class="spawn-issue-list" id="spawn-issue-list" role="listbox" aria-label="Issues">
+          <template x-if="filteredIssues.length === 0">
+            <div class="spawn-issue-empty">
+              {% if issues %}
+              No issues match your filter.
+              {% else %}
+              No open unclaimed issues found. All issues may already have <code>agent:wip</code>.
+              {% endif %}
+            </div>
+          </template>
+          <template x-for="iss in filteredIssues" :key="iss.number">
+            <div
+              class="spawn-issue-card"
+              :class="{
+                'spawn-issue-card--selected': selectedIssue?.number === iss.number,
+                'spawn-issue-card--claimed':  iss.claimed,
+              }"
+              @click="selectIssue(iss)"
+              role="option"
+              :aria-selected="selectedIssue?.number === iss.number"
+              :title="iss.claimed ? 'Already claimed (agent:wip)' : iss.title"
+            >
+              <span class="spawn-issue-num" x-text="'#' + iss.number"></span>
+              <div class="spawn-issue-body">
+                <div class="spawn-issue-title" x-text="iss.title"></div>
+                <div class="spawn-issue-meta">
+                  <template x-if="iss.phase_label">
+                    <span class="spawn-issue-phase" x-text="iss.phase_label"></span>
+                  </template>
+                  <template x-if="iss.claimed">
+                    <span class="spawn-issue-wip">wip</span>
+                  </template>
+                </div>
+              </div>
+            </div>
+          </template>
+        </div>
+      </div>
+
+      {# Role picker — pre-grouped by category in canonical order (server-side) #}
+      <div class="spawn-role-picker" role="radiogroup" aria-label="Agent role">
+        {% for group in role_groups %}
+        <div class="spawn-role-section">
+          <div class="spawn-role-section-label">{{ group.category }}</div>
+          {% for role in group.roles %}
+          <div
+            class="spawn-role-option"
+            :class="{ 'spawn-role-option--selected': selectedRole === '{{ role.slug }}' }"
+            @click="selectRole('{{ role.slug }}')"
+            role="radio"
+            :aria-checked="selectedRole === '{{ role.slug }}'"
+          >
+            <div class="spawn-role-radio"></div>
+            <span class="spawn-role-name">{{ role.label }}</span>
+          </div>
+          {% endfor %}
+        </div>
+        {% endfor %}
+      </div>
+
+    </div>{# end .spawn-single-layout #}
+
+    {# Action row #}
+    <div class="spawn-actions">
+      <button
+        class="btn btn-primary"
+        @click="submitSingle()"
+        :disabled="loading || !selectedIssue"
+        x-text="loading ? 'Spawning…' : (selectedIssue ? 'Spawn Agent → #' + selectedIssue.number : 'Select an issue')"
+      ></button>
+      <span class="spawn-selection-summary" x-show="selectedIssue">
+        <strong x-text="selectedRole"></strong> on <strong x-text="'#' + selectedIssue?.number"></strong>
+      </span>
+    </div>
+
+  </div>{# end single panel #}
+
+  {# ═══════════════════════════════════════════════════════════════════
+     WAVE SPAWN PANEL
+     Spawn all unclaimed issues at once → POST /api/control/spawn-wave
+  ════════════════════════════════════════════════════════════════════ #}
+  <div class="spawn-panel" x-show="mode === 'wave'" x-cloak>
+
+    <div class="spawn-wave-layout">
+
+      <div class="spawn-wave-info">
+        <div class="spawn-wave-count" x-text="liveUnclaimedCount"></div>
+        <div class="spawn-wave-label">
+          unclaimed issue<span x-text="liveUnclaimedCount === 1 ? '' : 's'"></span>
+          ready to spawn
+          {% if active_label %}
+          under <strong>{{ active_label }}</strong>
+          {% endif %}
+        </div>
+      </div>
+
       <div class="form-group">
-        <label class="form-label" for="issue_number">Issue</label>
-        {% if issues %}
-        <select
-          id="issue_number"
-          name="issue_number"
-          class="form-select"
-          x-model="issueNumber"
-          required
-        >
-          <option value="">— select an issue —</option>
-          {% for iss in issues %}
-          <option value="{{ iss.number }}">
-            #{{ iss.number }} — {{ iss.title }}
-          </option>
-          {% endfor %}
-        </select>
-        {% else %}
-        <p class="text-muted">
-          No open, unclaimed issues found{% if not error %} on GitHub{% endif %}.
-          All open issues may already have the <code>agent:wip</code> label.
-        </p>
-        {% endif %}
-      </div>
-
-      {# Role selector #}
-      <div class="form-group mt-1">
-        <label class="form-label" for="role">Role</label>
-        <select
-          id="role"
-          name="role"
-          class="form-select"
-          x-model="role"
-        >
-          {% for r in roles %}
-          <option value="{{ r }}" {% if r == "python-developer" %}selected{% endif %}>
-            {{ r }}
+        <label class="form-label" for="wave-role">Role for all agents</label>
+        <select id="wave-role" class="form-select" x-model="waveRole" style="max-width:320px">
+          {% for role in roles_flat %}
+          <option value="{{ role.slug }}" {% if role.slug == "python-developer" %}selected{% endif %}>
+            {{ role.label }}
           </option>
           {% endfor %}
         </select>
       </div>
 
-      <div class="form-actions mt-2">
+      <div class="spawn-actions">
         <button
-          type="submit"
           class="btn btn-primary"
-          :disabled="loading || !issueNumber"
-          x-text="loading ? 'Spawning…' : 'Spawn Agent'"
+          @click="submitWave()"
+          :disabled="loading || liveUnclaimedCount === 0"
+          x-text="loading ? 'Spawning wave…' : 'Spawn Wave (' + liveUnclaimedCount + ' agents)'"
         ></button>
       </div>
 
-    </form>
-  </div>
-
-  {# Error state #}
-  <template x-if="formError">
-    <div class="alert-banner mt-2" role="alert">
-      <span>❌</span>
-      <span x-text="formError"></span>
     </div>
-  </template>
 
-  {# Success state #}
-  <template x-if="result">
-    <div class="card mt-2 spawn-result" role="region" aria-label="Spawn result">
-      <h2 class="section-title">✅ Agent spawned for issue #<span x-text="result.spawned"></span></h2>
+  </div>{# end wave panel #}
 
-      <table class="task-table mt-1">
-        <tbody>
-          <tr>
-            <td class="task-key">Worktree</td>
-            <td class="task-value task-value--path"><code x-text="result.worktree"></code></td>
-          </tr>
-          <tr>
-            <td class="task-key">Branch</td>
-            <td class="task-value"><code x-text="result.branch"></code></td>
-          </tr>
-        </tbody>
-      </table>
+  {# ═══════════════════════════════════════════════════════════════════
+     COORDINATOR PANEL
+     Brain-dump → coordinator agent → POST /api/control/spawn-coordinator
+  ════════════════════════════════════════════════════════════════════ #}
+  <div class="spawn-panel" x-show="mode === 'coordinator'" x-cloak>
 
-      <div class="mt-2">
-        <h3 class="section-subtitle">.agent-task</h3>
-        <pre class="agent-task-pre" x-text="result.agent_task"></pre>
+    <div class="spawn-coordinator-layout">
+
+      <div class="spawn-coordinator-desc">
+        The coordinator ingests your brain dump, breaks it into phases and
+        tickets, and spawns sub-agents. It's the entry point for full
+        autonomous project execution — equivalent to handing a spec to your
+        engineering manager.
       </div>
 
-      <p class="text-muted mt-1">
-        Launch a Cursor Task rooted in the worktree path above to start the agent.
+      <div class="form-group">
+        <label class="form-label" for="brain-dump">Brain Dump</label>
+        <textarea
+          id="brain-dump"
+          class="spawn-brain-dump"
+          x-model="brainDump"
+          placeholder="Describe what you want to build, fix, or refactor. Be as detailed as you like — the coordinator will break this into actionable issues and phases."
+          rows="6"
+        ></textarea>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label" for="label-prefix">Label prefix <span class="text-muted">(optional)</span></label>
+        <input
+          id="label-prefix"
+          type="text"
+          class="form-select"
+          x-model="labelPrefix"
+          placeholder="e.g. sprint-42"
+          style="max-width:240px"
+        >
+      </div>
+
+      <div class="spawn-actions">
+        <button
+          class="btn btn-primary"
+          @click="submitCoordinator()"
+          :disabled="loading || !brainDump.trim()"
+          x-text="loading ? 'Spawning coordinator…' : 'Spawn Coordinator'"
+        ></button>
+      </div>
+
+    </div>
+
+  </div>{# end coordinator panel #}
+
+  {# ═══════════════════════════════════════════════════════════════════
+     RESULT / ERROR PANEL — shown below whichever panel ran
+  ════════════════════════════════════════════════════════════════════ #}
+
+  {# Error #}
+  <template x-if="formError">
+    <div class="card spawn-result spawn-result--error" role="alert">
+      <p style="margin:0; font-size:0.875rem;">
+        <strong>Error:</strong> <span x-text="formError"></span>
       </p>
     </div>
   </template>
 
-</div>
+  {# Single agent success #}
+  <template x-if="result && resultMode === 'single'">
+    <div class="card spawn-result" role="region" aria-label="Spawn result">
+      <h2 class="section-title" style="margin-bottom:0.75rem;">
+        Agent spawned — issue #<span x-text="result.spawned"></span>
+      </h2>
+      <div class="spawn-result-grid">
+        <span class="spawn-result-key">Branch</span>
+        <code class="spawn-result-val" x-text="result.branch"></code>
+        <span class="spawn-result-key">Worktree</span>
+        <code class="spawn-result-val" x-text="result.worktree"></code>
+        <span class="spawn-result-key">Host path</span>
+        <code class="spawn-result-val" x-text="result.host_worktree"></code>
+      </div>
+      <div class="mt-2">
+        <h3 class="section-subtitle">.agent-task</h3>
+        <pre class="agent-task-pre" x-text="result.agent_task"></pre>
+      </div>
+    </div>
+  </template>
 
-{# spawnForm() lives in /static/app.js #}
+  {# Wave success #}
+  <template x-if="result && resultMode === 'wave'">
+    <div class="card spawn-result spawn-result--wave" role="region" aria-label="Wave result">
+      <h2 class="section-title" style="margin-bottom:0.75rem;">
+        Wave spawned — <span x-text="result.spawned.length"></span> agent<span x-text="result.spawned.length === 1 ? '' : 's'"></span>
+        <template x-if="result.skipped.length">
+          <span class="text-muted" style="font-size:0.85em; font-weight:400;">
+            (<span x-text="result.skipped.length"></span> skipped)
+          </span>
+        </template>
+      </h2>
+      <div class="spawn-wave-results">
+        <template x-for="s in result.spawned" :key="s.spawned">
+          <div class="spawn-wave-result-item">
+            <span style="color:var(--success)">✓</span>
+            Issue #<span x-text="s.spawned"></span> →
+            <code style="font-size:0.77rem; color:var(--text-muted)" x-text="s.branch"></code>
+          </div>
+        </template>
+        <template x-for="s in result.skipped" :key="s.issue_number ?? s.number">
+          <div class="spawn-wave-result-skip">
+            ↷ Issue #<span x-text="s.issue_number ?? s.number"></span> skipped
+            <span x-text="s.reason ? '— ' + s.reason : ''"></span>
+          </div>
+        </template>
+      </div>
+    </div>
+  </template>
+
+  {# Coordinator success #}
+  <template x-if="result && resultMode === 'coordinator'">
+    <div class="card spawn-result" role="region" aria-label="Coordinator result">
+      <h2 class="section-title" style="margin-bottom:0.75rem;">
+        Coordinator spawned
+      </h2>
+      <div class="spawn-result-grid">
+        <span class="spawn-result-key">Slug</span>
+        <code class="spawn-result-val" x-text="result.slug"></code>
+        <span class="spawn-result-key">Branch</span>
+        <code class="spawn-result-val" x-text="result.branch"></code>
+        <span class="spawn-result-key">Worktree</span>
+        <code class="spawn-result-val" x-text="result.worktree"></code>
+        <span class="spawn-result-key">Host path</span>
+        <code class="spawn-result-val" x-text="result.host_worktree"></code>
+      </div>
+      <div class="mt-2">
+        <h3 class="section-subtitle">.agent-task</h3>
+        <pre class="agent-task-pre" x-text="result.agent_task"></pre>
+      </div>
+    </div>
+  </template>
+
+</div>{# end .spawn-page / x-data #}
+
+{# missionControl() lives in /static/app.js #}
 
 {% endblock %}

--- a/agentception/templates/worktrees.html
+++ b/agentception/templates/worktrees.html
@@ -1,250 +1,139 @@
 {% extends "base.html" %}
 
-{% block title %}Agentception — Worktrees & Git{% endblock %}
+{% block title %}Agentception — Agent Sandboxes{% endblock %}
 
 {% block content %}
 
 {# ── Page header ─────────────────────────────────────────────────────────── #}
-<div class="wt-page-header">
-  <h1 class="wt-page-title">Worktrees &amp; Git</h1>
-  <p class="wt-page-subtitle">
-    Each agent runs in an isolated Git worktree — a lightweight, fully-functional
-    copy of the repo checked out to its own branch.
-  </p>
+<div class="env-page-header">
+  <div>
+    <h1 class="env-page-title">Agent Sandboxes</h1>
+    <p class="env-page-subtitle">
+      Each agent operates in an isolated code environment. Click a sandbox to
+      inspect its commit history, changed files, and task.
+    </p>
+  </div>
+  <div class="env-page-meta">
+    <span class="env-page-count">{{ agent_worktrees | length }}</span>
+    <span class="env-page-count-label">active</span>
+  </div>
 </div>
 
-{# ── Summary bar ─────────────────────────────────────────────────────────── #}
-<div class="wt-summary">
-  <div class="wt-summary-stat">
-    <span class="wt-summary-value">{{ worktrees | length }}</span>
-    <span class="wt-summary-label">worktrees</span>
-  </div>
-  <div class="wt-summary-stat">
-    <span class="wt-summary-value">{{ agent_worktrees | length }}</span>
-    <span class="wt-summary-label">agent</span>
-  </div>
-  <div class="wt-summary-stat">
-    <span class="wt-summary-value">{{ stale_count }}</span>
-    <span class="wt-summary-label">stale branches</span>
-  </div>
-  <div class="wt-summary-stat">
-    <span class="wt-summary-value">{{ stash | length }}</span>
-    <span class="wt-summary-label">stash entries</span>
-  </div>
-  {% if stale_count > 0 %}
-  <div class="wt-summary-actions" x-data="branchManager()">
-    <button class="btn btn-sm btn-danger" @click="sweepAll()" :disabled="sweeping">
-      <span x-text="sweeping ? 'Sweeping…' : 'Sweep {{ stale_count }} stale'"></span>
-    </button>
-  </div>
-  {% endif %}
-</div>
+{# ── Branch tree ──────────────────────────────────────────────────────────── #}
+<div class="env-tree">
 
-{# ── Active Worktrees ─────────────────────────────────────────────────────── #}
-<section class="wt-section">
-  <h2 class="wt-section-title">Active Worktrees</h2>
+  {# ── Trunk: base environment ───────────────────────────────────────────── #}
+  <div class="env-trunk-node">
+    <div class="env-trunk-dot"></div>
+    <div class="env-trunk-info">
+      <code class="env-trunk-branch">{{ main_wt.branch if main_wt else 'dev' }}</code>
+      <span class="env-trunk-label">base environment</span>
+      {% if main_wt %}
+      <span class="env-trunk-sha" title="{{ main_wt.head_sha }}">{{ (main_wt.head_sha or '')[:7] }}</span>
+      <span class="env-trunk-commit">{{ main_wt.head_message or '' }}</span>
+      {% endif %}
+    </div>
+  </div>
 
-  {% if worktrees %}
-  <div class="wt-cards">
+  {# ── Agent sandboxes ───────────────────────────────────────────────────── #}
+  {% if agent_worktrees %}
 
-    {# Main worktree first, then agent worktrees #}
-    {% for wt in worktrees %}
+    {% for wt in agent_worktrees %}
+    {# Last branch gets the └ connector, others get ├ #}
+    {% set is_last = loop.last %}
+
     <div
-      class="wt-card{% if wt.is_main %} wt-card--main{% elif wt.is_agent_branch %} wt-card--agent{% endif %}"
-      x-data="worktreeCard('{{ wt.slug }}')"
-      :class="open ? 'wt-card--open' : ''"
+      class="env-branch{% if is_last %} env-branch--last{% endif %}"
+      x-data="envSandbox('{{ wt.slug }}')"
+      :class="open ? 'env-branch--open' : ''"
     >
-      {# ── Card header ─────────────────────────────────────────────────── #}
-      <div class="wt-card-header" @click="toggle()">
 
-        <div class="wt-card-header-left">
-          {# Type badge #}
-          {% if wt.is_main %}
-          <span class="wt-badge wt-badge--main">main</span>
-          {% elif wt.is_agent_branch and wt.issue_number %}
-          <span class="wt-badge wt-badge--agent">agent · #{{ wt.issue_number }}</span>
-          {% elif wt.is_agent_branch %}
-          <span class="wt-badge wt-badge--agent">agent</span>
-          {% else %}
-          <span class="wt-badge wt-badge--linked">linked</span>
-          {% endif %}
+      {# ── Branch connector + head row ──────────────────────────────────── #}
+      <div class="env-branch-head" @click="toggle()">
 
-          {# Lock indicator #}
-          {% if wt.locked %}
-          <span class="wt-lock" title="Locked — protected from auto-prune">🔒</span>
-          {% endif %}
+        {# Connector dot — sits on the trunk line #}
+        <div class="env-branch-origin-dot"></div>
 
-          {# Branch name #}
-          <code class="wt-card-branch">{{ wt.branch or '(detached HEAD)' }}</code>
-        </div>
+        {# Branch content #}
+        <div class="env-branch-content">
 
-        <div class="wt-card-header-right">
-          {# Activity age #}
-          {% if wt.task_mtime_str %}
-          <span class="wt-card-age">{{ wt.task_mtime_str }}</span>
-          {% endif %}
+          <div class="env-branch-top">
+            {# Type / issue badge #}
+            {% if wt.issue_number %}
+            <span class="env-badge env-badge--issue">issue · #{{ wt.issue_number }}</span>
+            {% else %}
+            <span class="env-badge env-badge--custom">sandbox</span>
+            {% endif %}
 
-          {# GitHub issue link #}
-          {% if wt.issue_number %}
-          <a
-            class="wt-card-gh-link"
-            href="https://github.com/{{ gh_repo }}/issues/{{ wt.issue_number }}"
-            target="_blank"
-            rel="noopener"
-            @click.stop
-            title="Open issue #{{ wt.issue_number }} on GitHub"
-          >#{{ wt.issue_number }} ↗</a>
-          {% endif %}
+            {# Lock indicator #}
+            {% if wt.locked %}
+            <span class="env-lock" title="Locked — protected from auto-prune">🔒</span>
+            {% endif %}
 
-          {# Delete button (not for main) #}
-          {% if not wt.is_main %}
-          <button
-            class="wt-card-delete btn btn-xs btn-danger"
-            @click.stop="deleteWorktree('{{ wt.slug }}')"
-            title="Remove worktree"
-          >✕</button>
-          {% endif %}
+            {# Branch name #}
+            <code class="env-branch-name">{{ wt.branch or '(detached HEAD)' }}</code>
 
-          {# Expand chevron #}
-          {% if not wt.is_main %}
-          <span class="wt-card-chevron" :class="open ? 'wt-card-chevron--open' : ''">▾</span>
-          {% endif %}
+            {# Actions — right side #}
+            <div class="env-branch-actions">
+              {% if wt.task_mtime_str %}
+              <span class="env-age">{{ wt.task_mtime_str }}</span>
+              {% endif %}
+
+              {% if wt.issue_number %}
+              <a
+                class="env-gh-link"
+                href="https://github.com/{{ gh_repo }}/issues/{{ wt.issue_number }}"
+                target="_blank"
+                rel="noopener"
+                @click.stop
+                title="View issue #{{ wt.issue_number }} on GitHub"
+              >#{{ wt.issue_number }} ↗</a>
+              {% endif %}
+
+              <button
+                class="env-delete btn btn-xs btn-danger"
+                @click.stop="deleteWorktree('{{ wt.slug }}')"
+                title="Remove sandbox"
+              >✕</button>
+
+              <span class="env-chevron" :class="open ? 'env-chevron--open' : ''">▾</span>
+            </div>
+          </div>
+
+          {# HEAD commit preview #}
+          <div class="env-branch-commit-preview">
+            <span class="env-sha">{{ (wt.head_sha or '')[:7] or '—' }}</span>
+            <span class="env-commit-msg">{{ wt.head_message or '—' }}</span>
+          </div>
+
         </div>
       </div>
 
-      {# ── Card meta row ───────────────────────────────────────────────── #}
-      <div class="wt-card-meta">
-        <span class="wt-card-sha" title="{{ wt.head_sha }}">{{ (wt.head_sha or '')[:7] or '—' }}</span>
-        <span class="wt-card-meta-sep">·</span>
-        <span class="wt-card-commit">{{ wt.head_message or '—' }}</span>
-        <span class="wt-card-meta-sep">·</span>
-        <span class="wt-card-path" title="{{ wt.path }}">{{ wt.path }}</span>
-      </div>
-
-      {# ── Expandable detail panel (HTMX, loaded on first open) ────────── #}
-      {% if not wt.is_main %}
-      <div class="wt-card-body" x-show="open" x-transition:enter="wt-card-body--enter" x-transition:leave="wt-card-body--leave">
+      {# ── Expandable detail panel (lazy HTMX) ──────────────────────────── #}
+      <div class="env-branch-body" x-show="open" x-transition>
         <div
-          id="wt-detail-{{ wt.slug }}"
-          class="wt-detail"
+          id="env-detail-{{ wt.slug }}"
+          class="env-detail"
           hx-get="/worktrees/{{ wt.slug }}/detail"
           hx-trigger="detail-load once"
           hx-swap="innerHTML"
         >
-          <div class="wt-detail-loading">
-            <span class="wt-spinner"></span> Loading worktree detail…
+          <div class="env-detail-loading">
+            <span class="env-spinner"></span> Loading sandbox detail…
           </div>
         </div>
       </div>
-      {% endif %}
 
     </div>
     {% endfor %}
 
-  </div>
   {% else %}
-  <div class="card"><p class="wt-empty">No worktrees found.</p></div>
+  <div class="env-empty">
+    <p>No agent sandboxes are currently active.</p>
+    <p>Start a wave from the <a href="/">Overview</a> or <a href="/brain-dump">Brain Dump</a> a new batch of work.</p>
+  </div>
   {% endif %}
-</section>
 
-{# ── Local Branches ───────────────────────────────────────────────────────── #}
-<section class="wt-section" x-data="branchManager()">
-  <div class="wt-section-header">
-    <h2 class="wt-section-title">Local Branches</h2>
-    <span class="wt-section-count">{{ branches | length }}</span>
-    {% set stale_branches = branches | selectattr('is_stale') | list %}
-    {% if stale_branches %}
-    <button class="btn btn-sm btn-danger" @click="sweepAll()" :disabled="sweeping">
-      <span x-text="sweeping ? 'Sweeping…' : 'Sweep {{ stale_branches | length }} stale'"></span>
-    </button>
-    {% endif %}
-  </div>
-
-  {% if branches %}
-  <div class="card wt-table-card">
-    <table class="wt-table">
-      <thead>
-        <tr>
-          <th>Branch</th>
-          <th>SHA</th>
-          <th>Latest Commit</th>
-          <th class="wt-col-num" title="Commits ahead of origin">↑</th>
-          <th class="wt-col-num" title="Commits behind origin">↓</th>
-          <th>Status</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for b in branches %}
-        <tr class="wt-row{% if b.is_current %} wt-row--current{% endif %}{% if b.is_stale %} wt-row--stale{% endif %}">
-          <td>
-            <code class="wt-branch-name">
-              {% if b.is_current %}<span class="wt-current-marker">*</span> {% endif %}{{ b.name }}
-            </code>
-          </td>
-          <td><span class="wt-sha">{{ (b.head_sha or '')[:7] or '—' }}</span></td>
-          <td class="wt-commit-cell">{{ b.head_message or '—' }}</td>
-          <td class="wt-col-num{% if b.ahead > 0 %} wt-ahead{% endif %}">{{ b.ahead }}</td>
-          <td class="wt-col-num{% if b.behind > 0 %} wt-behind{% endif %}">{{ b.behind }}</td>
-          <td>
-            {% if b.is_stale %}
-            <span class="wt-badge wt-badge--stale">stale</span>
-            {% elif b.is_current %}
-            <span class="wt-badge wt-badge--current">current</span>
-            {% elif b.is_agent_branch %}
-            <span class="wt-badge wt-badge--agent">agent</span>
-            {% endif %}
-          </td>
-          <td class="wt-col-action">
-            {% if b.is_stale and not b.is_current %}
-            <button
-              class="btn btn-xs btn-danger"
-              @click="deleteBranch('{{ b.name }}')"
-              title="Delete stale branch"
-            >⌫</button>
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  {% else %}
-  <div class="card"><p class="wt-empty">No local branches found.</p></div>
-  {% endif %}
-</section>
-
-{# ── Stash ────────────────────────────────────────────────────────────────── #}
-<section class="wt-section">
-  <div class="wt-section-header">
-    <h2 class="wt-section-title">Stash</h2>
-    <span class="wt-section-count">{{ stash | length }}</span>
-  </div>
-
-  {% if stash %}
-  <div class="card wt-table-card">
-    <table class="wt-table">
-      <thead>
-        <tr>
-          <th>Ref</th>
-          <th>Branch</th>
-          <th>Message</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for entry in stash %}
-        <tr class="wt-row">
-          <td><code class="wt-stash-ref">{{ entry.ref }}</code></td>
-          <td><code class="wt-branch-name">{{ entry.branch or '—' }}</code></td>
-          <td class="wt-commit-cell">{{ entry.message }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  {% else %}
-  <div class="card"><p class="wt-empty">Stash is empty.</p></div>
-  {% endif %}
-</section>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary

- **Mission Control spawn page** — `/agents/spawn` redesigned as a three-mode orchestration dashboard: Single Agent (visual issue board with filter + role card picker grouped by category), Wave Spawn, and Coordinator; all styles in `app.css`, all logic in `missionControl()` in `app.js`; server data passed via `data-*` attributes to prevent JSON/HTML attribute quoting collision
- **Agents page refactor** — stripped all inline `<style>`/`<script>`; `agentsPage()` moved to `app.js`; `attempt_number` + `spawn_mode` surfaced in history; elapsed time and staleness badges on live cards; per-batch success rate in group headers
- **Worktrees page** — redesigned as "Agent Sandboxes" with CSS-only git tree visualization; stash section removed
- **URL cleanup** — `/agents/spawn` is canonical; `/control/spawn` and `/controls` redirect for compat; breadcrumb corrected; route ordering fixed so specific paths beat the `/{agent_id}` wildcard
- **Nav & UI polish** — Overview and Controls links removed; Issues/PRs links removed; brain emoji removed; STALE stat on overview made fully clickable (sweep button removed); KPI bar wrapping fixed; search input fixed width

## Test plan

- [ ] Visit `/agents/spawn` — status bar, mode tabs, issue board, role picker all render
- [ ] Single Agent mode: select issue + role, click Spawn Agent, verify result panel
- [ ] Wave Spawn mode: verify unclaimed count, spawn wave, verify per-issue results
- [ ] Coordinator mode: enter brain dump, spawn, verify result
- [ ] Click ↻ refresh button on issue board — HTMX partial swaps in without full reload
- [ ] Visit `/control/spawn` — confirm 302 redirect to `/agents/spawn`
- [ ] Agents page: confirm no console errors, history shows attempt/spawn-mode columns
- [ ] Worktrees page: tree renders, expand/collapse works, delete button functions
- [ ] Overview STALE stat: click when stale branches exist, confirm sweep fires