### PR TITLE
feat(telemetry): D3 dashboard with 7 chart types

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -508,6 +508,90 @@ async def get_all_prs(
 
 
 # ---------------------------------------------------------------------------
+# Wave aggregation from DB — fallback when filesystem worktrees are gone
+# ---------------------------------------------------------------------------
+
+
+async def get_waves_from_db(limit: int = 100) -> list[dict[str, Any]]:
+    """Return agent runs grouped by batch_id as wave-shaped dicts.
+
+    Used by ``telemetry.aggregate_waves()`` when no ``.agent-task`` files exist
+    on the filesystem (i.e. all worktrees have been cleaned up).  Groups rows
+    in ``ac_agent_runs`` by ``batch_id``, then shapes them into the same
+    structure expected by ``WaveSummary`` so D3 charts work without changes.
+
+    Returns dicts with keys: batch_id, started_at (UNIX float), ended_at
+    (UNIX float | None), issues_worked (list[int]), prs_opened (int),
+    agents (list[dict]).  Message counts default to 0 (no transcript data).
+    """
+    try:
+        async with get_session() as session:
+            stmt = (
+                select(ACAgentRun)
+                .order_by(ACAgentRun.spawned_at.asc())
+                .limit(limit)
+            )
+            result = await session.execute(stmt)
+            rows = result.scalars().all()
+
+        # Group by batch_id.
+        groups: dict[str, list[Any]] = {}
+        for row in rows:
+            bid = row.batch_id or row.id  # lone runs get their own key
+            groups.setdefault(bid, []).append(row)
+
+        waves: list[dict[str, Any]] = []
+        for batch_id, members in groups.items():
+            issues_worked = sorted(
+                {r.issue_number for r in members if r.issue_number is not None}
+            )
+            prs_opened = sum(1 for r in members if r.pr_number is not None)
+            started_ts = min(r.spawned_at for r in members).timestamp()
+            completed = [r.completed_at for r in members if r.completed_at]
+            ended_ts: float | None = (
+                max(completed).timestamp() if len(completed) == len(members) and completed
+                else None
+            )
+
+            agents = [
+                {
+                    "id": r.id,
+                    "role": r.role,
+                    "status": r.status,
+                    "issue_number": r.issue_number,
+                    "pr_number": r.pr_number,
+                    "branch": r.branch,
+                    "batch_id": r.batch_id,
+                    "worktree_path": r.worktree_path,
+                    "cognitive_arch": None,
+                    "message_count": 0,
+                }
+                for r in members
+            ]
+
+            waves.append(
+                {
+                    "batch_id": batch_id,
+                    "started_at": started_ts,
+                    "ended_at": ended_ts,
+                    "issues_worked": issues_worked,
+                    "prs_opened": prs_opened,
+                    "prs_merged": 0,
+                    "estimated_tokens": 0,
+                    "estimated_cost_usd": 0.0,
+                    "agents": agents,
+                }
+            )
+
+        # Most recent first.
+        waves.sort(key=lambda w: w["started_at"], reverse=True)
+        return waves
+    except Exception as exc:
+        logger.warning("⚠️  get_waves_from_db failed (non-fatal): %s", exc)
+        return []
+
+
+# ---------------------------------------------------------------------------
 # Counts for SSE expansion
 # ---------------------------------------------------------------------------
 

--- a/agentception/routes/ui.py
+++ b/agentception/routes/ui.py
@@ -658,16 +658,19 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
 
 @router.get("/telemetry", response_class=HTMLResponse)
 async def telemetry_page(request: Request) -> HTMLResponse:
-    """Telemetry dashboard — wave history (filesystem) + pipeline trend (Postgres).
+    """Telemetry D3 dashboard — wave history + pipeline trend.
 
-    Two data sources:
+    Data sources:
     - ``aggregate_waves()`` — reads ``.agent-task`` files grouped by BATCH_ID
-      into WaveSummary objects for the history table / CSS bar chart.
-    - ``get_pipeline_trend()`` — reads ``ac_pipeline_snapshots`` from Postgres
-      for the time-series chart (issues open, agents active over time).
+      into WaveSummary objects for D3 charts.
+    - ``get_pipeline_trend()`` — reads ``ac_pipeline_snapshots`` (Postgres)
+      for the pipeline trend multi-line chart.
 
-    Both sources degrade gracefully to empty lists on failure.
+    All wave/trend data is serialised to JSON and embedded in the page via
+    ``<script type="application/json">`` tags so D3 can read them without
+    HTML attribute quoting issues.  Both sources degrade to empty on failure.
     """
+    import json as _json
     from agentception.db.queries import get_pipeline_trend
 
     waves, trend = await asyncio.gather(
@@ -675,42 +678,64 @@ async def telemetry_page(request: Request) -> HTMLResponse:
         get_pipeline_trend(hours=24, limit=500),
     )
 
-    # Bar chart widths are percentages of the longest wave duration.
-    max_duration_s: float = 0.0
-    for wave in waves:
-        if wave.ended_at is not None:
-            max_duration_s = max(max_duration_s, wave.ended_at - wave.started_at)
-
     all_issues: set[int] = set()
     for wave in waves:
         all_issues.update(wave.issues_worked)
     total_issues = len(all_issues)
     total_cost_usd = round(sum(w.estimated_cost_usd for w in waves), 4)
     total_agents = sum(len(w.agents) for w in waves)
+    total_waves = len(waves)
 
-    # Derive per-snapshot agent counts from trend for sparklines.
-    # Normalise to simple primitives so Jinja2 tojson stays quote-safe.
-    trend_labels: list[str] = [t["polled_at"][-8:-3] for t in trend]  # HH:MM
-    trend_issues: list[int] = [int(t["issues_open"]) for t in trend]
-    trend_prs: list[int] = [int(t["prs_open"]) for t in trend]
-    trend_agents: list[int] = [int(t["agents_active"]) for t in trend]
+    # Role counts across all agents in all waves (for KPI + D3 donut seed).
+    role_counts: dict[str, int] = {}
+    for wave in waves:
+        for agent in wave.agents:
+            role_counts[agent.role] = role_counts.get(agent.role, 0) + 1
+
+    # Serialise for D3 — embed as application/json script tags (never in x-data).
+    waves_json: str = _json.dumps([w.model_dump() for w in waves])
+    trend_json: str = _json.dumps(trend)
 
     return _TEMPLATES.TemplateResponse(
         request,
         "telemetry.html",
         {
-            "waves": waves,
-            "max_duration_s": max_duration_s,
+            # KPI tiles (server-rendered).
+            "total_waves": total_waves,
             "total_issues": total_issues,
             "total_cost_usd": total_cost_usd,
             "total_agents": total_agents,
-            # Postgres trend (for sparklines / time-series chart).
-            "trend_labels": trend_labels,
-            "trend_issues": trend_issues,
-            "trend_prs": trend_prs,
-            "trend_agents": trend_agents,
+            "role_counts": role_counts,
+            # Wave table (Jinja loop — same data as D3, just typed objects).
+            "waves": waves,
+            # JSON blobs for D3 (injected as application/json script tags).
+            "waves_json": waves_json,
+            "trend_json": trend_json,
             "trend_count": len(trend),
         },
+    )
+
+
+@router.get("/htmx/telemetry/trend", response_class=HTMLResponse)
+async def telemetry_trend_partial(request: Request) -> HTMLResponse:
+    """HTMX partial — refreshes the pipeline trend JSON blob on the telemetry page.
+
+    Returns a ``<script type="application/json">`` replacement tag so the
+    browser can swap it in and the Alpine component can trigger a D3 re-render.
+    """
+    import json as _json
+    from agentception.db.queries import get_pipeline_trend
+
+    trend: list[dict[str, object]] = []
+    try:
+        trend = await get_pipeline_trend(hours=24, limit=500)
+    except Exception as exc:  # pragma: no cover
+        logger.warning("⚠️ telemetry_trend_partial: DB failure: %s", exc)
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "_telemetry_trend.html",
+        {"trend_json": _json.dumps(trend)},
     )
 
 

--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -2355,84 +2355,178 @@ main {
   align-items: center;
 }
 
-/* ── Telemetry ────────────────────────────────────────────────── */
+/* ═══ Telemetry Dashboard ════════════════════════════════════════════════ */
 
-.telemetry-chart {
+/* ── Tab strip ──────────────────────────────────────────────────── */
+
+.telemetry-tab-strip {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--bg-elevated);
+  width: fit-content;
+}
+
+.telemetry-tab {
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--border-default);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.telemetry-tab:last-child {
+  border-right: none;
+}
+
+.telemetry-tab:hover {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.telemetry-tab--active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.telemetry-tab--active:hover {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* ── 2-column dashboard layout ──────────────────────────────────── */
+
+.telemetry-layout {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  gap: 1rem;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .telemetry-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Main chart area (left column) ─────────────────────────────── */
+
+.telemetry-chart-main {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  height: 380px;
+  position: relative;
+  overflow: hidden;
+}
+
+.telemetry-chart-main svg {
+  display: block;
+}
+
+/* ── Sidebar (right column) ─────────────────────────────────────── */
+
+.telemetry-sidebar {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 1rem 1.25rem;
-}
-
-.telemetry-bar-row {
-  display: flex;
-  align-items: center;
   gap: 0.75rem;
-  cursor: default;
 }
 
-.telemetry-bar-label {
-  flex: 0 0 220px;
-  font-size: 0.6875rem;
-  font-family: var(--font-mono);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  text-align: right;
-  color: var(--text-muted);
-}
-
-.telemetry-bar-track {
-  flex: 1;
+.telemetry-sidebar-chart {
   background: var(--bg-elevated);
-  border-radius: var(--radius-sm);
-  height: 22px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 0.75rem;
   overflow: hidden;
 }
 
-.telemetry-bar {
-  height: 100%;
-  border-radius: var(--radius-sm);
+.telemetry-sidebar-chart svg {
+  display: block;
+}
+
+.telemetry-chart-label {
+  font-size: 0.67rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+}
+
+/* ── Empty / loading states ─────────────────────────────────────── */
+
+.telemetry-empty {
   display: flex;
   align-items: center;
-  min-width: 4px;
-  transition: opacity 0.15s;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-muted);
+  font-size: 0.82rem;
 }
 
-.telemetry-bar:hover {
-  opacity: 0.8;
-}
+/* ── D3 shared styles ───────────────────────────────────────────── */
 
-.telemetry-bar--complete {
-  background: var(--grad-success);
-}
-
-.telemetry-bar--active {
-  background: var(--grad-warm);
-  animation: bar-pulse 2s ease-in-out infinite;
-}
-
-.telemetry-bar--short {
-  background: var(--text-muted);
-}
-
-@keyframes bar-pulse {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.6; }
-}
-
-.telemetry-bar-text {
-  font-size: 0.6rem;
-  font-weight: 700;
-  color: rgba(0, 0, 0, 0.7);
-  padding: 0 0.4rem;
+.d3-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: var(--bg-void);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 0.45rem 0.65rem;
+  font-size: 0.75rem;
+  color: var(--text-primary);
+  line-height: 1.45;
   white-space: nowrap;
-  overflow: hidden;
+  z-index: 100;
+  opacity: 0;
+  transition: opacity 0.1s;
 }
+
+.d3-tooltip.visible {
+  opacity: 1;
+}
+
+.d3-tooltip-key {
+  color: var(--text-muted);
+  margin-right: 0.3rem;
+}
+
+/* SVG axis + grid lines pick up theme colors automatically */
+.d3-axis text {
+  fill: var(--text-muted);
+  font-size: 0.7rem;
+  font-family: var(--font-sans);
+}
+
+.d3-axis path,
+.d3-axis line {
+  stroke: var(--border-subtle);
+}
+
+.d3-grid line {
+  stroke: var(--border-subtle);
+  stroke-dasharray: 3 3;
+  opacity: 0.6;
+}
+
+.d3-crosshair {
+  stroke: var(--text-muted);
+  stroke-dasharray: 4 3;
+  stroke-width: 1;
+  pointer-events: none;
+}
+
+/* ── Telemetry wave history table ───────────────────────────────── */
 
 .telemetry-table-wrap {
   overflow-x: auto;
-  padding: 0;
 }
 
 .telemetry-table {
@@ -2509,45 +2603,23 @@ main {
   color: var(--text-primary);
 }
 
-/* ── Trend / sparkline ────────────────────────────────────────── */
+/* ── Trend refresh button ───────────────────────────────────────── */
 
-.trend-card { padding: 1rem; }
-
-.trend-canvas {
-  display: block;
-  width: 100%;
-  height: auto;
-  max-height: 200px;
-  border-radius: var(--radius);
-  background: rgba(255, 255, 255, 0.01);
-}
-
-.trend-legend {
-  display: flex;
-  gap: 1.25rem;
-  margin-bottom: 0.75rem;
-  font-size: 0.75rem;
+.telemetry-refresh {
+  font-size: 0.72rem;
   color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
 }
 
-.trend-legend-item {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
+.telemetry-refresh:hover {
+  color: var(--text-secondary);
+  border-color: var(--border-default);
 }
-
-.trend-dot {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 2px;
-}
-
-.trend-dot--issues { background: var(--accent); }
-.trend-dot--prs    { background: var(--info); }
-.trend-dot--agents { background: var(--success); }
-
-.trend-foot { text-align: right; }
 
 /* ── Run history table ────────────────────────────────────────── */
 
@@ -3489,30 +3561,7 @@ main {
   }
 }
 
-/* ── Table convenience selectors ──────────────────────────────── */
-
-/* Issues / PRs tables — th elements are not always class-annotated */
-.telemetry-table th {
-  font-size: 0.6rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--text-muted);
-  padding: 0.625rem 0.875rem;
-  text-align: left;
-  border-bottom: 1px solid var(--border-subtle);
-  white-space: nowrap;
-  background: var(--bg-void);
-  position: sticky;
-  top: 52px; /* offset for fixed nav */
-  z-index: 1;
-}
-
-.telemetry-table td {
-  padding: 0.5rem 0.875rem;
-  vertical-align: middle;
-  border-bottom: 1px solid rgba(255,255,255,0.03);
-}
+/* ── Telemetry table element selectors (non-BEM rows inherit styles) ─── */
 
 .telemetry-table tbody tr {
   transition: background 0.12s;
@@ -3522,7 +3571,6 @@ main {
   background: rgba(139, 92, 246, 0.04);
 }
 
-/* Row links within table */
 .telemetry-table td a {
   color: var(--text-primary);
   font-weight: 500;

--- a/agentception/static/app.js
+++ b/agentception/static/app.js
@@ -18,7 +18,7 @@
  *   scalingAdvisor(initial)                   — scaling recommendation banner
  *   prViolations(initial)                     — out-of-order PR banner
  *   staleClaimCard(claim)                     — stale-claim clear action
- *   trendChart(labels, issues, prs, agents)   — telemetry sparkline
+ *   telemetryDash()                           — telemetry D3 dashboard tab switching
  *   configPanel(initial)                      — pipeline config editor
  *   spawnForm()                               — manual spawn form
  *   exportPanel()                             — template export
@@ -664,69 +664,40 @@ function issueCard(issueNumber) {
  * @param {number[]} prs     - PR counts per bucket.
  * @param {number[]} agents  - Agent counts per bucket.
  */
-function trendChart(labels, issues, prs, agents) {
+// ---------------------------------------------------------------------------
+// Telemetry — D3 dashboard tab controller
+// ---------------------------------------------------------------------------
+
+/**
+ * telemetryDash()
+ *
+ * Minimal Alpine component that owns tab state for the telemetry D3 dashboard.
+ * The actual D3 rendering lives in telemetry.js (loaded only on /telemetry).
+ *
+ * Tab IDs map to window.telemetry render functions:
+ *   'Gantt' → window.telemetry.renderGantt
+ *   'CostArea' → window.telemetry.renderCostArea
+ *   etc.
+ */
+function telemetryDash() {
   return {
-    labels, issues, prs, agents,
+    activeTab: 'Gantt',
 
-    draw() {
-      const canvas = document.getElementById('trend-canvas');
-      if (!canvas) return;
-      const ctx = canvas.getContext('2d');
-      const W = canvas.width, H = canvas.height;
-      const pad = { top: 16, right: 24, bottom: 28, left: 40 };
-      const iW = W - pad.left - pad.right;
-      const iH = H - pad.top  - pad.bottom;
-
-      ctx.clearRect(0, 0, W, H);
-
-      const allVals = [...this.issues, ...this.prs, ...this.agents];
-      const maxY    = Math.max(...allVals, 1);
-      const n       = this.labels.length;
-      if (n < 2) return;
-
-      const xOf = i => pad.left + (i / (n - 1)) * iW;
-      const yOf = v => pad.top + iH - (v / maxY) * iH;
-
-      const series = [
-        { data: this.issues, color: '#8b5cf6' },
-        { data: this.prs,    color: '#06b6d4' },
-        { data: this.agents, color: '#22c55e' },
-      ];
-
-      // Grid lines
-      ctx.strokeStyle = 'rgba(255,255,255,0.06)';
-      ctx.lineWidth = 1;
-      for (let g = 0; g <= 4; g++) {
-        const y = pad.top + (g / 4) * iH;
-        ctx.beginPath(); ctx.moveTo(pad.left, y); ctx.lineTo(pad.left + iW, y);
-        ctx.stroke();
-        ctx.fillStyle  = 'rgba(255,255,255,0.35)';
-        ctx.font       = '10px monospace';
-        ctx.textAlign  = 'right';
-        ctx.fillText(Math.round(maxY * (1 - g / 4)), pad.left - 6, y + 4);
-      }
-
-      // Series lines
-      series.forEach(({ data, color }) => {
-        ctx.beginPath();
-        ctx.strokeStyle = color;
-        ctx.lineWidth   = 1.5;
-        ctx.lineJoin    = 'round';
-        data.forEach((v, i) => {
-          const x = xOf(i), y = yOf(v);
-          i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
-        });
-        ctx.stroke();
+    switchTab(tab) {
+      this.activeTab = tab;
+      this.$nextTick(() => {
+        if (window.telemetry && window.telemetry['render' + tab]) {
+          window.telemetry['render' + tab]();
+        }
       });
+    },
 
-      // X-axis labels — ~6 evenly spaced
-      const step = Math.max(1, Math.floor(n / 6));
-      ctx.fillStyle = 'rgba(255,255,255,0.35)';
-      ctx.font      = '10px monospace';
-      ctx.textAlign = 'center';
-      for (let i = 0; i < n; i += step) {
-        ctx.fillText(this.labels[i], xOf(i), H - 6);
-      }
+    init() {
+      this.$nextTick(() => {
+        if (window.telemetry) {
+          window.telemetry.renderGantt();
+        }
+      });
     },
   };
 }

--- a/agentception/static/app.js
+++ b/agentception/static/app.js
@@ -681,7 +681,7 @@ function issueCard(issueNumber) {
  */
 function telemetryDash() {
   return {
-    activeTab: 'Gantt',
+    activeTab: 'Trend',
 
     switchTab(tab) {
       this.activeTab = tab;
@@ -695,7 +695,7 @@ function telemetryDash() {
     init() {
       this.$nextTick(() => {
         if (window.telemetry) {
-          window.telemetry.renderGantt();
+          window.telemetry.renderTrend();
         }
       });
     },

--- a/agentception/static/telemetry.js
+++ b/agentception/static/telemetry.js
@@ -1,0 +1,692 @@
+/**
+ * telemetry.js — Agentception Telemetry D3 Dashboard
+ *
+ * Seven D3 v7 render functions, each writing into a fixed container id.
+ * Loaded only on /telemetry (not in base.html).
+ *
+ * Data is read from <script type="application/json"> tags injected by Jinja:
+ *   #telemetry-waves-data  — list[WaveSummary.model_dump()]
+ *   #telemetry-trend-data  — list[ACPipelineSnapshot row dicts]
+ *
+ * All functions are exposed on window.telemetry so Alpine's telemetryDash()
+ * can call them by tab name.
+ */
+
+(function () {
+  'use strict';
+
+  // ── Read embedded JSON blobs ─────────────────────────────────────────────
+
+  function readJson(id) {
+    const el = document.getElementById(id);
+    if (!el) return [];
+    try { return JSON.parse(el.textContent); } catch (_) { return []; }
+  }
+
+  let _waves = readJson('telemetry-waves-data');
+  let _trend = readJson('telemetry-trend-data');
+
+  /** Re-read trend data after HTMX partial swap (called by hx-on::after-swap). */
+  function refreshTrendData() {
+    _trend = readJson('telemetry-trend-data');
+    renderTrend();
+  }
+
+  // ── Colour palette (mirrors CSS custom properties) ───────────────────────
+
+  const C = {
+    accent:   '#8b5cf6',
+    accentLt: '#a78bfa',
+    info:     '#06b6d4',
+    success:  '#22c55e',
+    warn:     '#f59e0b',
+    danger:   '#ef4444',
+    muted:    'rgba(255,255,255,0.35)',
+    grid:     'rgba(255,255,255,0.07)',
+    bg:       'rgba(255,255,255,0.03)',
+  };
+
+  // Status → colour mapping (agent/wave statuses)
+  const STATUS_COLOR = {
+    done:           C.success,
+    complete:       C.success,
+    implementing:   C.accent,
+    active:         C.accentLt,
+    stale:          C.warn,
+    error:          C.danger,
+    unknown:        C.muted,
+  };
+
+  function statusColor(s) {
+    return STATUS_COLOR[(s || 'unknown').toLowerCase()] || C.muted;
+  }
+
+  // ── Shared helpers ───────────────────────────────────────────────────────
+
+  /** Create (or clear) a tooltip div inside a container. */
+  function makeTooltip(container) {
+    let tip = container.querySelector('.d3-tooltip');
+    if (!tip) {
+      tip = document.createElement('div');
+      tip.className = 'd3-tooltip';
+      container.style.position = 'relative';
+      container.appendChild(tip);
+    }
+    return tip;
+  }
+
+  function showTip(tip, html, event) {
+    tip.innerHTML = html;
+    tip.classList.add('visible');
+    const rect = tip.parentElement.getBoundingClientRect();
+    let x = event.clientX - rect.left + 12;
+    let y = event.clientY - rect.top  - 10;
+    // Keep inside container
+    const tw = tip.offsetWidth || 160;
+    if (x + tw > rect.width) x = x - tw - 24;
+    tip.style.left = x + 'px';
+    tip.style.top  = y + 'px';
+  }
+
+  function hideTip(tip) {
+    tip.classList.remove('visible');
+  }
+
+  /** Format a seconds count as "1h 23m" or "45s". */
+  function fmtDuration(s) {
+    if (!s || s < 0) return '—';
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    const sec = Math.floor(s % 60);
+    if (h > 0) return `${h}h ${m}m`;
+    if (m > 0) return `${m}m ${sec}s`;
+    return `${sec}s`;
+  }
+
+  /** Truncate a string to n chars with ellipsis. */
+  function trunc(str, n) {
+    if (!str) return '';
+    return str.length > n ? str.slice(0, n) + '…' : str;
+  }
+
+  /** Get the container element and its bounding box. */
+  function getContainer(id) {
+    const el = document.getElementById(id);
+    if (!el) return null;
+    d3.select(el).selectAll('svg').remove(); // clear previous render
+    return el;
+  }
+
+  // ── 1. WAVE TIMELINE GANTT ───────────────────────────────────────────────
+
+  function renderGantt() {
+    const container = getContainer('chart-main');
+    if (!container) return;
+    const tip = makeTooltip(container);
+
+    const waves = _waves.filter(w => w.started_at);
+    if (!waves.length) {
+      container.innerHTML = '<div class="telemetry-empty">No wave data yet.</div>';
+      return;
+    }
+
+    const W = container.clientWidth  || 640;
+    const H = container.clientHeight || 380;
+    const margin = { top: 24, right: 20, bottom: 36, left: 20 };
+    const iW = W - margin.left - margin.right;
+    const iH = H - margin.top  - margin.bottom;
+
+    const minT = d3.min(waves, d => d.started_at);
+    const maxT = d3.max(waves, d => d.ended_at || (Date.now() / 1000));
+    const xScale = d3.scaleLinear().domain([minT, maxT]).range([0, iW]);
+
+    const rowH  = Math.min(36, iH / waves.length - 6);
+    const rowGap = Math.min(8, (iH - rowH * waves.length) / Math.max(waves.length - 1, 1));
+
+    const svg = d3.select(container)
+      .append('svg')
+      .attr('width', W)
+      .attr('height', H);
+
+    const g = svg.append('g')
+      .attr('transform', `translate(${margin.left},${margin.top})`);
+
+    // X axis
+    const xAxis = d3.axisBottom(xScale)
+      .ticks(5)
+      .tickFormat(t => {
+        const d = new Date(t * 1000);
+        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      });
+
+    g.append('g')
+      .attr('class', 'd3-axis')
+      .attr('transform', `translate(0,${iH})`)
+      .call(xAxis);
+
+    // Grid lines
+    g.append('g')
+      .attr('class', 'd3-grid')
+      .attr('transform', `translate(0,${iH})`)
+      .call(d3.axisBottom(xScale).ticks(5).tickSize(-iH).tickFormat(''));
+
+    // Gantt bars
+    waves.forEach((w, i) => {
+      const y   = i * (rowH + rowGap);
+      const x1  = xScale(w.started_at);
+      const x2  = xScale(w.ended_at || (Date.now() / 1000));
+      const barW = Math.max(x2 - x1, 4);
+
+      const isActive = !w.ended_at;
+      const fill = isActive ? C.accentLt : C.accent;
+
+      const bar = g.append('rect')
+        .attr('x', x1).attr('y', y)
+        .attr('width', barW).attr('height', rowH)
+        .attr('rx', 4).attr('ry', 4)
+        .attr('fill', fill)
+        .attr('opacity', 0.85)
+        .style('cursor', 'pointer');
+
+      if (isActive) {
+        bar.style('animation', 'bar-pulse 2s ease-in-out infinite');
+      }
+
+      // Label inside bar if space allows
+      if (barW > 48) {
+        g.append('text')
+          .attr('x', x1 + 6)
+          .attr('y', y + rowH / 2 + 4)
+          .attr('font-size', '0.62rem')
+          .attr('fill', '#fff')
+          .text(trunc(w.batch_id || `Wave ${i + 1}`, 22));
+      }
+
+      bar.on('mousemove', (event) => {
+          const dur = w.ended_at ? fmtDuration(w.ended_at - w.started_at) : 'active';
+          showTip(tip,
+            `<span class="d3-tooltip-key">Batch</span>${trunc(w.batch_id || '—', 24)}<br>` +
+            `<span class="d3-tooltip-key">Issues</span>${(w.issues_worked || []).length}<br>` +
+            `<span class="d3-tooltip-key">Agents</span>${(w.agents || []).length}<br>` +
+            `<span class="d3-tooltip-key">Duration</span>${dur}<br>` +
+            `<span class="d3-tooltip-key">Cost</span>$${(w.estimated_cost_usd || 0).toFixed(4)}`,
+            event);
+        })
+        .on('mouseleave', () => hideTip(tip));
+    });
+  }
+
+  // ── 2. CUMULATIVE COST AREA ──────────────────────────────────────────────
+
+  function renderCostArea() {
+    const container = getContainer('chart-main');
+    if (!container) return;
+    const tip = makeTooltip(container);
+
+    const waves = _waves.filter(w => w.started_at).slice().sort((a, b) => a.started_at - b.started_at);
+    if (!waves.length) {
+      container.innerHTML = '<div class="telemetry-empty">No cost data yet.</div>';
+      return;
+    }
+
+    const W = container.clientWidth  || 640;
+    const H = container.clientHeight || 380;
+    const margin = { top: 24, right: 24, bottom: 36, left: 52 };
+    const iW = W - margin.left - margin.right;
+    const iH = H - margin.top  - margin.bottom;
+
+    let cumCost = 0;
+    const points = waves.map(w => {
+      cumCost += w.estimated_cost_usd || 0;
+      return { t: w.started_at, cost: cumCost, wave: w };
+    });
+
+    const xScale = d3.scaleLinear()
+      .domain(d3.extent(points, d => d.t))
+      .range([0, iW]);
+    const yScale = d3.scaleLinear()
+      .domain([0, d3.max(points, d => d.cost) * 1.1])
+      .range([iH, 0]);
+
+    const svg = d3.select(container).append('svg').attr('width', W).attr('height', H);
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+
+    // Grid
+    g.append('g').attr('class', 'd3-grid')
+      .call(d3.axisLeft(yScale).ticks(5).tickSize(-iW).tickFormat(''));
+
+    // Area
+    const area = d3.area()
+      .x(d => xScale(d.t))
+      .y0(iH)
+      .y1(d => yScale(d.cost))
+      .curve(d3.curveStepAfter);
+
+    const defs = svg.append('defs');
+    const grad = defs.append('linearGradient').attr('id', 'cost-area-grad').attr('gradientUnits', 'userSpaceOnUse')
+      .attr('x1', 0).attr('y1', 0).attr('x2', 0).attr('y2', iH + margin.top);
+    grad.append('stop').attr('offset', '0%').attr('stop-color', C.accent).attr('stop-opacity', 0.4);
+    grad.append('stop').attr('offset', '100%').attr('stop-color', C.accent).attr('stop-opacity', 0.02);
+
+    g.append('path').datum(points)
+      .attr('fill', 'url(#cost-area-grad)')
+      .attr('d', area);
+
+    // Step line
+    const line = d3.line()
+      .x(d => xScale(d.t))
+      .y(d => yScale(d.cost))
+      .curve(d3.curveStepAfter);
+
+    g.append('path').datum(points)
+      .attr('fill', 'none')
+      .attr('stroke', C.accent)
+      .attr('stroke-width', 2)
+      .attr('d', line);
+
+    // Dots + tooltips
+    g.selectAll('.cost-dot')
+      .data(points).join('circle')
+      .attr('class', 'cost-dot')
+      .attr('cx', d => xScale(d.t))
+      .attr('cy', d => yScale(d.cost))
+      .attr('r', 4)
+      .attr('fill', C.accent)
+      .attr('stroke', '#111')
+      .attr('stroke-width', 1.5)
+      .style('cursor', 'pointer')
+      .on('mousemove', (event, d) => {
+        showTip(tip,
+          `<span class="d3-tooltip-key">Cumulative</span>$${d.cost.toFixed(4)}<br>` +
+          `<span class="d3-tooltip-key">Wave cost</span>$${(d.wave.estimated_cost_usd || 0).toFixed(4)}<br>` +
+          `<span class="d3-tooltip-key">Batch</span>${trunc(d.wave.batch_id || '—', 20)}`,
+          event);
+      })
+      .on('mouseleave', () => hideTip(tip));
+
+    // Axes
+    g.append('g').attr('class', 'd3-axis').attr('transform', `translate(0,${iH})`)
+      .call(d3.axisBottom(xScale).ticks(5)
+        .tickFormat(t => new Date(t * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })));
+
+    g.append('g').attr('class', 'd3-axis')
+      .call(d3.axisLeft(yScale).ticks(5).tickFormat(d => `$${d.toFixed(3)}`));
+  }
+
+  // ── 3. PIPELINE TREND MULTI-LINE ─────────────────────────────────────────
+
+  function renderTrend() {
+    const container = getContainer('chart-main');
+    if (!container) return;
+    const tip = makeTooltip(container);
+
+    if (!_trend.length) {
+      container.innerHTML = '<div class="telemetry-empty">No trend snapshots yet. Check back after the first pipeline poll.</div>';
+      return;
+    }
+
+    const W = container.clientWidth  || 640;
+    const H = container.clientHeight || 380;
+    const margin = { top: 24, right: 80, bottom: 36, left: 48 };
+    const iW = W - margin.left - margin.right;
+    const iH = H - margin.top  - margin.bottom;
+
+    const parseDate = d => new Date(d.polled_at);
+    const xScale = d3.scaleTime()
+      .domain(d3.extent(_trend, parseDate))
+      .range([0, iW]);
+
+    const maxY = d3.max(_trend, d =>
+      Math.max(+d.issues_open || 0, +d.prs_open || 0, +d.agents_active || 0, +d.alert_count || 0)
+    );
+    const yScale = d3.scaleLinear().domain([0, maxY * 1.1 || 1]).range([iH, 0]);
+
+    const series = [
+      { key: 'issues_open',   label: 'Issues Open',   color: C.accent },
+      { key: 'prs_open',      label: 'PRs Open',      color: C.info   },
+      { key: 'agents_active', label: 'Agents Active', color: C.success },
+      { key: 'alert_count',   label: 'Alerts',        color: C.warn   },
+    ];
+
+    const svg = d3.select(container).append('svg').attr('width', W).attr('height', H);
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+
+    // Grid
+    g.append('g').attr('class', 'd3-grid')
+      .call(d3.axisLeft(yScale).ticks(5).tickSize(-iW).tickFormat(''));
+
+    // Lines
+    const lineGen = d3.line().x(d => xScale(parseDate(d))).y(d => yScale(+d || 0)).curve(d3.curveCatmullRom);
+
+    series.forEach(({ key, color }) => {
+      g.append('path')
+        .datum(_trend)
+        .attr('fill', 'none')
+        .attr('stroke', color)
+        .attr('stroke-width', 1.8)
+        .attr('d', lineGen.y(d => yScale(+(d[key]) || 0)));
+    });
+
+    // Crosshair + focus dots
+    const crosshair = g.append('line').attr('class', 'd3-crosshair').attr('y1', 0).attr('y2', iH).attr('opacity', 0);
+    const focusDots = series.map(({ color }) =>
+      g.append('circle').attr('r', 4).attr('fill', color).attr('stroke', '#111').attr('stroke-width', 1).attr('opacity', 0)
+    );
+
+    // Invisible overlay for hover
+    g.append('rect')
+      .attr('width', iW).attr('height', iH)
+      .attr('fill', 'none').attr('pointer-events', 'all')
+      .on('mousemove', (event) => {
+        const [mx] = d3.pointer(event);
+        const bisect = d3.bisector(parseDate).left;
+        const t0 = xScale.invert(mx);
+        const idx = Math.max(0, Math.min(_trend.length - 1, bisect(_trend, t0)));
+        const d = _trend[idx];
+        const x = xScale(parseDate(d));
+
+        crosshair.attr('x1', x).attr('x2', x).attr('opacity', 0.6);
+        series.forEach(({ key }, i) => {
+          focusDots[i].attr('cx', x).attr('cy', yScale(+(d[key]) || 0)).attr('opacity', 1);
+        });
+
+        const time = parseDate(d).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        showTip(tip,
+          `<span class="d3-tooltip-key">Time</span>${time}<br>` +
+          series.map(({ key, label, color }) =>
+            `<span style="color:${color}">${label}</span> ${+(d[key]) || 0}`
+          ).join('<br>'),
+          event);
+      })
+      .on('mouseleave', () => {
+        crosshair.attr('opacity', 0);
+        focusDots.forEach(dot => dot.attr('opacity', 0));
+        hideTip(tip);
+      });
+
+    // Axes
+    g.append('g').attr('class', 'd3-axis').attr('transform', `translate(0,${iH})`)
+      .call(d3.axisBottom(xScale).ticks(5).tickFormat(d => d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })));
+    g.append('g').attr('class', 'd3-axis').call(d3.axisLeft(yScale).ticks(5));
+
+    // Legend
+    const legend = g.append('g').attr('transform', `translate(${iW + 8}, 0)`);
+    series.forEach(({ label, color }, i) => {
+      const ly = i * 20;
+      legend.append('rect').attr('x', 0).attr('y', ly).attr('width', 10).attr('height', 10).attr('rx', 2).attr('fill', color);
+      legend.append('text').attr('x', 14).attr('y', ly + 9).attr('font-size', '0.65rem').attr('fill', C.muted).text(label);
+    });
+  }
+
+  // ── 4. AGENT ROLE DONUT ──────────────────────────────────────────────────
+
+  /**
+   * Render the role donut into a given container id.
+   * Tab renders go to 'chart-main'; sidebar renders go to 'chart-donut'.
+   */
+  function renderDonut(targetId) {
+    const container = getContainer(targetId || 'chart-main');
+    if (!container) return;
+    const tip = makeTooltip(container);
+
+    // Aggregate role counts from all waves
+    const roleCounts = {};
+    _waves.forEach(w => {
+      (w.agents || []).forEach(a => {
+        roleCounts[a.role] = (roleCounts[a.role] || 0) + 1;
+      });
+    });
+
+    const entries = Object.entries(roleCounts).sort((a, b) => b[1] - a[1]);
+    if (!entries.length) {
+      container.innerHTML = '<div class="telemetry-empty">No agents yet.</div>';
+      return;
+    }
+
+    const W = container.clientWidth  || 300;
+    const H = container.clientHeight || 180;
+    const r  = Math.min(W, H) / 2 - 12;
+    const ir = r * 0.52; // inner radius (donut hole)
+
+    const color = d3.scaleOrdinal()
+      .domain(entries.map(e => e[0]))
+      .range(d3.schemeTableau10);
+
+    const pie = d3.pie().value(d => d[1]).sort(null);
+    const arc = d3.arc().innerRadius(ir).outerRadius(r);
+    const arcHover = d3.arc().innerRadius(ir).outerRadius(r + 6);
+
+    const svg = d3.select(container).append('svg').attr('width', W).attr('height', H);
+    const g = svg.append('g').attr('transform', `translate(${Math.min(W * 0.45, r + 12)},${H / 2})`);
+
+    const slices = g.selectAll('path').data(pie(entries)).join('path')
+      .attr('d', arc)
+      .attr('fill', d => color(d.data[0]))
+      .attr('stroke', '#111')
+      .attr('stroke-width', 1)
+      .style('cursor', 'pointer')
+      .on('mousemove', (event, d) => {
+        d3.select(event.currentTarget).attr('d', arcHover);
+        showTip(tip,
+          `<span class="d3-tooltip-key">Role</span>${d.data[0]}<br>` +
+          `<span class="d3-tooltip-key">Agents</span>${d.data[1]}`,
+          event);
+      })
+      .on('mouseleave', (event) => {
+        d3.select(event.currentTarget).attr('d', arc);
+        hideTip(tip);
+      });
+
+    // Centre label — total agents
+    const total = entries.reduce((s, e) => s + e[1], 0);
+    g.append('text').attr('text-anchor', 'middle').attr('dy', '-0.2em')
+      .attr('font-size', '1.3rem').attr('font-weight', '700').attr('fill', '#fff')
+      .text(total);
+    g.append('text').attr('text-anchor', 'middle').attr('dy', '1.1em')
+      .attr('font-size', '0.6rem').attr('fill', C.muted).text('agents');
+
+    // Legend (right side)
+    const legendX = Math.min(W * 0.45, r + 12) + r + 16;
+    const legendG = svg.append('g').attr('transform', `translate(${legendX}, ${(H - entries.slice(0, 8).length * 18) / 2})`);
+    entries.slice(0, 8).forEach(([role, count], i) => {
+      legendG.append('rect').attr('x', 0).attr('y', i * 18).attr('width', 8).attr('height', 8).attr('rx', 2).attr('fill', color(role));
+      legendG.append('text').attr('x', 12).attr('y', i * 18 + 8)
+        .attr('font-size', '0.6rem').attr('fill', C.muted)
+        .text(`${trunc(role, 16)} (${count})`);
+    });
+  }
+
+  // ── 5. WAVE PERFORMANCE SCATTER ──────────────────────────────────────────
+
+  function renderScatter() {
+    const container = getContainer('chart-main');
+    if (!container) return;
+    const tip = makeTooltip(container);
+
+    const waves = _waves.filter(w => w.started_at && w.ended_at);
+    if (!waves.length) {
+      container.innerHTML = '<div class="telemetry-empty">No completed waves yet.</div>';
+      return;
+    }
+
+    const W = container.clientWidth  || 300;
+    const H = container.clientHeight || 180;
+    const margin = { top: 16, right: 12, bottom: 32, left: 40 };
+    const iW = W - margin.left - margin.right;
+    const iH = H - margin.top  - margin.bottom;
+
+    const maxIssues = d3.max(waves, w => (w.issues_worked || []).length) || 1;
+
+    const xScale = d3.scaleLinear()
+      .domain(d3.extent(waves, w => w.started_at))
+      .range([0, iW]).nice();
+    const yScale = d3.scaleLinear()
+      .domain([0, d3.max(waves, w => w.ended_at - w.started_at) * 1.1 || 1])
+      .range([iH, 0]);
+    const rScale = d3.scaleSqrt()
+      .domain([0, maxIssues])
+      .range([4, 16]);
+
+    const svg = d3.select(container).append('svg').attr('width', W).attr('height', H);
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+
+    g.append('g').attr('class', 'd3-grid')
+      .call(d3.axisLeft(yScale).ticks(4).tickSize(-iW).tickFormat(''));
+
+    g.selectAll('circle').data(waves).join('circle')
+      .attr('cx', w => xScale(w.started_at))
+      .attr('cy', w => yScale(w.ended_at - w.started_at))
+      .attr('r',  w => rScale((w.issues_worked || []).length))
+      .attr('fill', C.accent).attr('opacity', 0.7)
+      .attr('stroke', '#111').attr('stroke-width', 1)
+      .style('cursor', 'pointer')
+      .on('mousemove', (event, w) => {
+        showTip(tip,
+          `<span class="d3-tooltip-key">Duration</span>${fmtDuration(w.ended_at - w.started_at)}<br>` +
+          `<span class="d3-tooltip-key">Issues</span>${(w.issues_worked || []).length}<br>` +
+          `<span class="d3-tooltip-key">Agents</span>${(w.agents || []).length}`,
+          event);
+      })
+      .on('mouseleave', () => hideTip(tip));
+
+    g.append('g').attr('class', 'd3-axis').attr('transform', `translate(0,${iH})`)
+      .call(d3.axisBottom(xScale).ticks(4)
+        .tickFormat(t => new Date(t * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })));
+    g.append('g').attr('class', 'd3-axis')
+      .call(d3.axisLeft(yScale).ticks(4).tickFormat(t => fmtDuration(t)));
+  }
+
+  // ── 6. AGENT STATUS STACKED BAR ──────────────────────────────────────────
+
+  function renderStackedBar(targetId) {
+    const container = getContainer(targetId || 'chart-main');
+    if (!container) return;
+    const tip = makeTooltip(container);
+
+    // Take last 10 waves that have agents
+    const waves = _waves.filter(w => (w.agents || []).length).slice(-10);
+    if (!waves.length) {
+      container.innerHTML = '<div class="telemetry-empty">No agent data yet.</div>';
+      return;
+    }
+
+    const statusKeys = ['done', 'implementing', 'stale', 'error', 'unknown'];
+
+    // Build stack data
+    const data = waves.map((w, i) => {
+      const row = { i, label: trunc(w.batch_id || `Wave ${i}`, 12) };
+      const agents = w.agents || [];
+      statusKeys.forEach(k => {
+        row[k] = agents.filter(a => (a.status || 'unknown').toLowerCase() === k).length;
+      });
+      row['other'] = agents.length - statusKeys.reduce((s, k) => s + row[k], 0);
+      return row;
+    });
+    const allKeys = [...statusKeys, 'other'];
+
+    const W = container.clientWidth  || 300;
+    const H = container.clientHeight || 180;
+    const margin = { top: 12, right: 12, bottom: 48, left: 32 };
+    const iW = W - margin.left - margin.right;
+    const iH = H - margin.top  - margin.bottom;
+
+    const xScale = d3.scaleBand().domain(data.map(d => d.i)).range([0, iW]).padding(0.25);
+    const maxAgents = d3.max(data, d => allKeys.reduce((s, k) => s + (d[k] || 0), 0)) || 1;
+    const yScale = d3.scaleLinear().domain([0, maxAgents]).range([iH, 0]);
+
+    const colorMap = { done: C.success, implementing: C.accent, stale: C.warn, error: C.danger, unknown: C.muted, other: C.muted };
+
+    const svg = d3.select(container).append('svg').attr('width', W).attr('height', H);
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+
+    g.append('g').attr('class', 'd3-grid')
+      .call(d3.axisLeft(yScale).ticks(4).tickSize(-iW).tickFormat(''));
+
+    const stack = d3.stack().keys(allKeys)(data);
+
+    stack.forEach(layer => {
+      const key = layer.key;
+      g.selectAll(`.bar-${key}`).data(layer).join('rect')
+        .attr('class', `bar-${key}`)
+        .attr('x',      d => xScale(d.data.i))
+        .attr('y',      d => yScale(d[1]))
+        .attr('height', d => Math.max(0, yScale(d[0]) - yScale(d[1])))
+        .attr('width',  xScale.bandwidth())
+        .attr('fill',   colorMap[key] || C.muted)
+        .on('mousemove', (event, d) => {
+          showTip(tip,
+            `<span class="d3-tooltip-key">Wave</span>${d.data.label}<br>` +
+            `<span class="d3-tooltip-key">${key}</span>${d[1] - d[0]}`,
+            event);
+        })
+        .on('mouseleave', () => hideTip(tip));
+    });
+
+    g.append('g').attr('class', 'd3-axis').attr('transform', `translate(0,${iH})`)
+      .call(d3.axisBottom(xScale).tickFormat(i => data[i]?.label || ''))
+      .selectAll('text').attr('transform', 'rotate(-30)').attr('text-anchor', 'end');
+    g.append('g').attr('class', 'd3-axis').call(d3.axisLeft(yScale).ticks(4));
+  }
+
+  // ── 7. MESSAGE COUNT HISTOGRAM ───────────────────────────────────────────
+
+  function renderHistogram(targetId) {
+    const container = getContainer(targetId || 'chart-main');
+    if (!container) return;
+    const tip = makeTooltip(container);
+
+    const msgCounts = _waves.flatMap(w => (w.agents || []).map(a => +(a.message_count) || 0));
+    if (!msgCounts.length) {
+      container.innerHTML = '<div class="telemetry-empty">No agent message data yet.</div>';
+      return;
+    }
+
+    const W = container.clientWidth  || 300;
+    const H = container.clientHeight || 180;
+    const margin = { top: 12, right: 12, bottom: 32, left: 36 };
+    const iW = W - margin.left - margin.right;
+    const iH = H - margin.top  - margin.bottom;
+
+    const xScale = d3.scaleLinear().domain([0, d3.max(msgCounts)]).range([0, iW]).nice();
+    const bins = d3.bin().domain(xScale.domain()).thresholds(12)(msgCounts);
+    const yScale = d3.scaleLinear().domain([0, d3.max(bins, b => b.length)]).range([iH, 0]);
+
+    const svg = d3.select(container).append('svg').attr('width', W).attr('height', H);
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+
+    g.append('g').attr('class', 'd3-grid')
+      .call(d3.axisLeft(yScale).ticks(4).tickSize(-iW).tickFormat(''));
+
+    g.selectAll('rect').data(bins).join('rect')
+      .attr('x',      b => xScale(b.x0) + 1)
+      .attr('y',      b => yScale(b.length))
+      .attr('width',  b => Math.max(0, xScale(b.x1) - xScale(b.x0) - 2))
+      .attr('height', b => iH - yScale(b.length))
+      .attr('fill',   C.info).attr('opacity', 0.8)
+      .on('mousemove', (event, b) => {
+        showTip(tip,
+          `<span class="d3-tooltip-key">Messages</span>${b.x0}–${b.x1}<br>` +
+          `<span class="d3-tooltip-key">Agents</span>${b.length}`,
+          event);
+      })
+      .on('mouseleave', () => hideTip(tip));
+
+    g.append('g').attr('class', 'd3-axis').attr('transform', `translate(0,${iH})`)
+      .call(d3.axisBottom(xScale).ticks(6));
+    g.append('g').attr('class', 'd3-axis').call(d3.axisLeft(yScale).ticks(4));
+  }
+
+  // ── Public API ───────────────────────────────────────────────────────────
+
+  window.telemetry = {
+    renderGantt,
+    renderCostArea,
+    renderTrend,
+    renderDonut,
+    renderScatter,
+    renderStackedBar,
+    renderHistogram,
+    refreshTrendData,
+  };
+
+})();

--- a/agentception/telemetry.py
+++ b/agentception/telemetry.py
@@ -5,6 +5,10 @@ Groups all ``.agent-task`` files by their ``BATCH_ID`` prefix and builds
 timestamps because agents write the task file at worktree creation time and
 update it on state changes — no separate log file is required.
 
+When no ``.agent-task`` files exist (all worktrees cleaned up), falls back
+to ``ac_agent_runs`` rows from Postgres so the telemetry charts always have
+data to display.
+
 Consumed by ``GET /api/telemetry/waves`` and future timeline UI components.
 """
 from __future__ import annotations
@@ -77,23 +81,59 @@ class WaveSummary(BaseModel):
 
 
 async def aggregate_waves() -> list[WaveSummary]:
-    """Scan all worktree ``.agent-task`` files, group by BATCH_ID, compute timing.
+    """Return WaveSummary objects, preferring filesystem data, falling back to DB.
 
-    Reads the current set of active worktrees (live filesystem state), then
-    augments with *completed* worktrees by scanning the worktrees directory for
-    task files whose directories have been removed (past agents self-destruct
-    their worktrees after opening a PR).
+    Primary source: ``.agent-task`` files in live worktrees (filesystem state).
+    Fallback: ``ac_agent_runs`` rows from Postgres, used when all worktrees have
+    been pruned so that the telemetry charts always show historical data.
 
-    Because completed worktrees are deleted, this function can only observe the
-    *currently active* agents plus any worktree task files the OS retains.  For
-    historical data beyond the current session, a persistent store would be
-    needed — that is out of scope for this issue.
-
-    Returns a list of WaveSummary objects, one per unique BATCH_ID, sorted by
-    ``started_at`` descending (most recent wave first).
+    Returns a list sorted by ``started_at`` descending (most recent wave first).
     """
     task_files = await list_active_worktrees()
-    return _build_wave_summaries(task_files, settings.worktrees_dir)
+    fs_summaries = _build_wave_summaries(task_files, settings.worktrees_dir)
+    if fs_summaries:
+        return fs_summaries
+
+    # No live worktrees — reconstruct wave summaries from DB records.
+    try:
+        from agentception.db.queries import get_waves_from_db
+
+        db_waves = await get_waves_from_db(limit=100)
+        summaries: list[WaveSummary] = []
+        for w in db_waves:
+            agents = [
+                AgentNode(
+                    id=a["id"],
+                    role=a["role"],
+                    status=AgentStatus(a["status"]) if a["status"] in AgentStatus._value2member_map_ else AgentStatus.UNKNOWN,
+                    issue_number=a["issue_number"],
+                    pr_number=a["pr_number"],
+                    branch=a["branch"],
+                    batch_id=a["batch_id"],
+                    worktree_path=a["worktree_path"],
+                    cognitive_arch=a["cognitive_arch"],
+                )
+                for a in w["agents"]
+            ]
+            total_msgs = sum(a.message_count for a in agents)
+            tokens, cost = estimate_cost(total_msgs)
+            summaries.append(
+                WaveSummary(
+                    batch_id=w["batch_id"],
+                    started_at=w["started_at"],
+                    ended_at=w["ended_at"],
+                    issues_worked=w["issues_worked"],
+                    prs_opened=w["prs_opened"],
+                    prs_merged=w["prs_merged"],
+                    estimated_tokens=tokens,
+                    estimated_cost_usd=cost,
+                    agents=agents,
+                )
+            )
+        return summaries
+    except Exception as exc:
+        logger.warning("⚠️  aggregate_waves DB fallback failed (non-fatal): %s", exc)
+        return []
 
 
 async def compute_wave_timing(worktrees: list[TaskFile]) -> tuple[float, float | None]:

--- a/agentception/templates/_telemetry_trend.html
+++ b/agentception/templates/_telemetry_trend.html
@@ -1,0 +1,10 @@
+{#
+  HTMX partial — refreshes the pipeline trend JSON blob on the telemetry page.
+
+  Target: #telemetry-trend-data (hx-swap="outerHTML")
+  After swap: caller calls window.telemetry.refreshTrendData() via hx-on::after-swap
+
+  Context:
+    trend_json  str — JSON-serialised list of ACPipelineSnapshot row dicts
+#}
+<script type="application/json" id="telemetry-trend-data">{{ trend_json | safe }}</script>

--- a/agentception/templates/base.html
+++ b/agentception/templates/base.html
@@ -75,5 +75,7 @@
     {% endblock %}
   </main>
 
+  {% block extra_scripts %}{% endblock %}
+
 </body>
 </html>

--- a/agentception/templates/telemetry.html
+++ b/agentception/templates/telemetry.html
@@ -4,77 +4,139 @@
 
 {% block content %}
 {#
-  Telemetry page: wave history as a CSS-only horizontal bar chart and a
-  summary table with per-wave timing, cost, and agent details expandable
-  via Alpine x-show.  No JS charting library — all bar widths are
-  percentages computed by the route handler.
+  Telemetry D3 Dashboard — Jinja/HTMX/Alpine architecture.
+
+  Data injection:
+    - waves_json  → <script type="application/json" id="telemetry-waves-data">
+    - trend_json  → <script type="application/json" id="telemetry-trend-data">
+  D3 reads them directly; no data lives in x-data attributes.
+
+  Tab controller:   x-data="telemetryDash()" (app.js)
+  D3 rendering:     window.telemetry.render*() (telemetry.js, loaded below)
+  Trend refresh:    hx-get="/htmx/telemetry/trend" → _telemetry_trend.html
 #}
 
-{# ── Summary stats bar ───────────────────────────────────────────────────── #}
-{# Totals are pre-computed by the route handler and passed as context variables. #}
+{# ── Embedded JSON blobs for D3 ──────────────────────────────────────────── #}
+<script type="application/json" id="telemetry-waves-data">{{ waves_json | safe }}</script>
+<script type="application/json" id="telemetry-trend-data">{{ trend_json | safe }}</script>
 
+{# ── KPI bar ─────────────────────────────────────────────────────────────── #}
 <div class="pipeline-summary-bar" role="status" aria-label="Telemetry summary">
   <div class="summary-item">
     <span class="summary-label">Waves run</span>
-    <span class="summary-value">{{ waves | length }}</span>
+    <span class="summary-value">{{ total_waves }}</span>
   </div>
   <div class="summary-item">
     <span class="summary-label">Issues worked</span>
     <span class="summary-value">{{ total_issues }}</span>
   </div>
   <div class="summary-item">
-    <span class="summary-label">Est. cost (USD)</span>
+    <span class="summary-label">Est. cost</span>
     <span class="summary-value">${{ "%.4f" | format(total_cost_usd) }}</span>
   </div>
   <div class="summary-item">
     <span class="summary-label">All-time agents</span>
     <span class="summary-value">{{ total_agents }}</span>
   </div>
+  {% if role_counts %}
+  <div class="summary-item">
+    <span class="summary-label">Top role</span>
+    <span class="summary-value" style="font-size:0.85rem;">
+      {{ role_counts | dictsort(by='value', reverse=true) | first | first }}
+    </span>
+  </div>
+  {% endif %}
 </div>
 
-{# ── Empty state ─────────────────────────────────────────────────────────── #}
-{% if not waves %}
-<div class="card mt-2">
-  <p class="text-muted empty-state">No wave history available yet. Waves appear once agents start running.</p>
-</div>
-{% else %}
+{# ── Tab strip + D3 dashboard (Alpine controller) ────────────────────────── #}
+<div x-data="telemetryDash()" class="mt-2">
 
-{# ── CSS timeline bar chart ──────────────────────────────────────────────── #}
-<section class="telemetry-chart-section mt-2" aria-label="Wave timeline">
-  <h2 class="section-title">Timeline</h2>
-  <div class="telemetry-chart card">
-    {% for wave in waves %}
-    {%   set duration_s = (wave.ended_at - wave.started_at) if wave.ended_at is not none else 0 %}
-    {%   if max_duration_s > 0 and wave.ended_at is not none %}
-    {%     set pct = ((duration_s / max_duration_s) * 100) | round(1) %}
-    {%   else %}
-    {%     set pct = 100 %}
-    {%   endif %}
-    {#   Colour: active → yellow, very short (<10 s) → grey, complete → green #}
-    {%   if wave.ended_at is none %}
-    {%     set bar_class = "telemetry-bar--active" %}
-    {%   elif duration_s < 10 %}
-    {%     set bar_class = "telemetry-bar--short" %}
-    {%   else %}
-    {%     set bar_class = "telemetry-bar--complete" %}
-    {%   endif %}
-    <div class="telemetry-bar-row" title="Batch: {{ wave.batch_id }} | Duration: {{ duration_s | int }}s | Issues: {{ wave.issues_worked | join(', ') }} | Cost: ${{ '%.4f' | format(wave.estimated_cost_usd) }}">
-      <span class="telemetry-bar-label text-muted">{{ wave.batch_id }}</span>
-      <div class="telemetry-bar-track">
-        <div class="telemetry-bar {{ bar_class }}" style="width: {{ pct }}%">
-          {% if pct > 15 %}
-          <span class="telemetry-bar-text">{{ duration_s | int }}s · {{ wave.issues_worked | length }} issue{{ 's' if wave.issues_worked | length != 1 else '' }}</span>
-          {% endif %}
-        </div>
+  {# Tab strip #}
+  <div class="telemetry-tab-strip" role="tablist" aria-label="Chart view">
+    {% set tabs = [
+      ('Gantt',       'Timeline'),
+      ('CostArea',    'Cost'),
+      ('Trend',       'Pipeline Trend'),
+      ('Donut',       'Roles'),
+      ('Scatter',     'Performance'),
+      ('StackedBar',  'Status'),
+      ('Histogram',   'Messages'),
+    ] %}
+    {% for tab_id, tab_label in tabs %}
+    <button
+      class="telemetry-tab"
+      :class="{ 'telemetry-tab--active': activeTab === '{{ tab_id }}' }"
+      @click="switchTab('{{ tab_id }}')"
+      role="tab"
+      :aria-selected="activeTab === '{{ tab_id }}'"
+    >{{ tab_label }}</button>
+    {% endfor %}
+
+    {# Trend refresh button — only shows when trend tab is active #}
+    <button
+      class="telemetry-refresh"
+      x-show="activeTab === 'Trend'"
+      x-cloak
+      hx-get="/htmx/telemetry/trend"
+      hx-target="#telemetry-trend-data"
+      hx-swap="outerHTML"
+      hx-on::after-swap="window.telemetry && window.telemetry.refreshTrendData()"
+      title="Refresh trend data"
+      aria-label="Refresh trend data"
+      style="margin-left: 0.5rem; align-self: center;"
+    >↻ Refresh</button>
+  </div>
+
+  {# ── 2-column dashboard layout ─────────────────────────────────────────── #}
+  <div class="telemetry-layout mt-2">
+
+    {# LEFT — main chart (tab-driven) #}
+    <div>
+      <div class="card telemetry-chart-main" style="padding:0;" id="chart-main"
+           x-effect="$nextTick(() => window.telemetry && window.telemetry['render' + activeTab] && window.telemetry['render' + activeTab]())">
+        <div class="telemetry-empty">Loading chart…</div>
       </div>
     </div>
-    {% endfor %}
-  </div>
-</section>
 
-{# ── Wave summary table ───────────────────────────────────────────────────── #}
-<section class="mt-3" aria-label="Wave table">
-  <h2 class="section-title">Wave History</h2>
+    {# RIGHT — always-visible sidebar charts #}
+    <div class="telemetry-sidebar">
+
+      {# Role Donut #}
+      <div class="card telemetry-sidebar-chart" style="height:200px;padding:0;">
+        <div class="telemetry-chart-label" style="padding:0.5rem 0.75rem 0;">Agent Roles</div>
+        <div id="chart-donut" style="height:172px;"></div>
+      </div>
+
+      {# Status Stacked Bar #}
+      <div class="card telemetry-sidebar-chart" style="height:200px;padding:0;">
+        <div class="telemetry-chart-label" style="padding:0.5rem 0.75rem 0;">Agent Status / Wave</div>
+        <div id="chart-stackedbar" style="height:172px;"></div>
+      </div>
+
+      {# Message Histogram #}
+      <div class="card telemetry-sidebar-chart" style="height:200px;padding:0;">
+        <div class="telemetry-chart-label" style="padding:0.5rem 0.75rem 0;">Message Distribution</div>
+        <div id="chart-histogram" style="height:172px;"></div>
+      </div>
+
+
+    </div>
+  </div>
+
+</div>{# end x-data="telemetryDash()" #}
+
+{# ── Wave History Table ───────────────────────────────────────────────────── #}
+<section class="mt-3" aria-label="Wave history table">
+  <h2 class="section-title">
+    Wave History
+    <span class="badge badge-count">{{ waves | length }}</span>
+  </h2>
+
+  {% if not waves %}
+  <div class="card">
+    <p class="text-muted empty-state">No wave history yet — waves appear once agents start running.</p>
+  </div>
+  {% else %}
   <div class="telemetry-table-wrap card">
     <table class="telemetry-table" role="table">
       <thead>
@@ -84,7 +146,6 @@
           <th class="telemetry-th">Duration</th>
           <th class="telemetry-th">Issues</th>
           <th class="telemetry-th">PRs opened</th>
-          <th class="telemetry-th">PRs merged</th>
           <th class="telemetry-th">Est. tokens</th>
           <th class="telemetry-th">Est. cost</th>
           <th class="telemetry-th"></th>
@@ -92,22 +153,17 @@
       </thead>
       <tbody>
         {% for wave in waves %}
-        {%   set row_id = "wave-" ~ loop.index %}
         {%   set duration_s = (wave.ended_at - wave.started_at) | int if wave.ended_at is not none else none %}
-        <tr
-          class="telemetry-row"
-          x-data="{ open: false }"
-        >
+        <tr class="telemetry-row" x-data="{ open: false }">
+
           <td class="telemetry-td telemetry-td--batch">
             <code class="telemetry-batch-id">{{ wave.batch_id }}</code>
           </td>
+
           <td class="telemetry-td text-muted">
-            {% if wave.started_at %}
-              {{ wave.started_at | format_ts }}
-            {% else %}
-              —
-            {% endif %}
+            {% if wave.started_at %}{{ wave.started_at | format_ts }}{% else %}—{% endif %}
           </td>
+
           <td class="telemetry-td text-muted">
             {% if duration_s is not none %}
               {{ duration_s }}s
@@ -117,6 +173,7 @@
               —
             {% endif %}
           </td>
+
           <td class="telemetry-td">
             {% if wave.issues_worked %}
               <span class="text-muted">{{ wave.issues_worked | join(', ') }}</span>
@@ -124,10 +181,11 @@
               <span class="text-muted">—</span>
             {% endif %}
           </td>
+
           <td class="telemetry-td text-muted">{{ wave.prs_opened }}</td>
-          <td class="telemetry-td text-muted">{{ wave.prs_merged }}</td>
           <td class="telemetry-td text-muted">{{ wave.estimated_tokens | int | format_number }}</td>
           <td class="telemetry-td text-muted">${{ "%.4f" | format(wave.estimated_cost_usd) }}</td>
+
           <td class="telemetry-td">
             {% if wave.agents %}
             <button
@@ -135,26 +193,21 @@
               @click="open = !open"
               :aria-expanded="open.toString()"
               aria-label="Toggle agent details"
-              x-text="open ? 'Hide' : 'Agents (' + {{ wave.agents | length }} + ')'"
+              x-text="open ? 'Hide' : 'Agents ({{ wave.agents | length }})'"
             ></button>
             {% endif %}
           </td>
         </tr>
 
-        {# Expandable agent details row #}
+        {# Agent details sub-row #}
         {% if wave.agents %}
         <tr x-show="open" x-cloak class="telemetry-agents-row">
-          <td colspan="9" class="telemetry-agents-cell">
+          <td colspan="8" class="telemetry-agents-cell">
             <div class="telemetry-agents-list">
               {% for agent in wave.agents %}
               <div class="telemetry-agent-item">
-                <span
-                  class="status-badge status-badge--{{ agent.status.value }}"
-                >{{ agent.status.value }}</span>
-                <a
-                  href="/agents/{{ agent.id }}"
-                  class="telemetry-agent-role"
-                >{{ agent.role }}</a>
+                <span class="status-badge status-badge--{{ agent.status.value }}">{{ agent.status.value }}</span>
+                <a href="/agents/{{ agent.id }}" class="telemetry-agent-role">{{ agent.role }}</a>
                 {% if agent.issue_number is not none %}
                 <span class="agent-meta">#{{ agent.issue_number }}</span>
                 {% endif %}
@@ -163,6 +216,10 @@
                 {% endif %}
                 {% if agent.branch %}
                 <span class="agent-meta text-muted">{{ agent.branch }}</span>
+                {% endif %}
+                <span class="agent-meta text-muted">{{ agent.message_count }} msgs</span>
+                {% if agent.cognitive_arch %}
+                <span class="agent-meta text-muted">{{ agent.cognitive_arch }}</span>
                 {% endif %}
               </div>
               {% endfor %}
@@ -175,48 +232,25 @@
       </tbody>
     </table>
   </div>
+  {% endif %}
 </section>
 
-{% endif %}{# if not waves #}
+{% endblock %}
 
-{# ── Pipeline Trend (Postgres) ────────────────────────────────────────────── #}
-{% if trend_count > 0 %}
-<section class="telemetry-trend-section mt-2" aria-label="Pipeline trend (last 24 h)">
-  <h2 class="section-title">Pipeline Trend
-    <span class="badge badge-count">{{ trend_count }} snapshots</span>
-  </h2>
-  <div class="card trend-card"
-    x-data='trendChart(
-      {{ trend_labels | tojson }},
-      {{ trend_issues | tojson }},
-      {{ trend_prs | tojson }},
-      {{ trend_agents | tojson }}
-    )'
-    x-init="draw()"
-  >
-    <div class="trend-legend">
-      <span class="trend-legend-item"><span class="trend-dot trend-dot--issues"></span>Issues open</span>
-      <span class="trend-legend-item"><span class="trend-dot trend-dot--prs"></span>PRs open</span>
-      <span class="trend-legend-item"><span class="trend-dot trend-dot--agents"></span>Agents active</span>
-    </div>
-    <canvas id="trend-canvas" class="trend-canvas" width="800" height="200"
-            aria-label="Pipeline trend chart" role="img"></canvas>
-    <div class="trend-foot text-muted text-sm mt-1">
-      Last 24 hours · sampled every ~5 s · {{ trend_count }} points
-    </div>
-  </div>
-</section>
-{% else %}
-<section class="telemetry-trend-section mt-2">
-  <h2 class="section-title">Pipeline Trend</h2>
-  <div class="card">
-    <p class="text-muted empty-state">
-      No trend data yet — snapshots accumulate after the poller's first successful DB write.
-    </p>
-  </div>
-</section>
-{% endif %}
-
-{# trendChart() lives in /static/app.js #}
-
+{% block extra_scripts %}
+{# D3 v7 — loaded only on /telemetry, not in base.html #}
+<script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+<script src="/static/telemetry.js"></script>
+<script>
+  // Trigger initial D3 renders after page load.
+  // Tab-driven main chart starts with Gantt (renderGantt → #chart-main).
+  // Sidebar charts always render into their dedicated containers.
+  document.addEventListener('DOMContentLoaded', function () {
+    if (!window.telemetry) return;
+    window.telemetry.renderGantt();                       // main chart (initial tab)
+    window.telemetry.renderDonut('chart-donut');          // sidebar: role donut
+    window.telemetry.renderStackedBar('chart-stackedbar'); // sidebar: status bars
+    window.telemetry.renderHistogram('chart-histogram');  // sidebar: message histogram
+  });
+</script>
 {% endblock %}

--- a/agentception/templates/telemetry.html
+++ b/agentception/templates/telemetry.html
@@ -247,10 +247,10 @@
   // Sidebar charts always render into their dedicated containers.
   document.addEventListener('DOMContentLoaded', function () {
     if (!window.telemetry) return;
-    window.telemetry.renderGantt();                       // main chart (initial tab)
-    window.telemetry.renderDonut('chart-donut');          // sidebar: role donut
+    window.telemetry.renderTrend();                        // main chart (initial tab = Pipeline Trend)
+    window.telemetry.renderDonut('chart-donut');           // sidebar: role donut
     window.telemetry.renderStackedBar('chart-stackedbar'); // sidebar: status bars
-    window.telemetry.renderHistogram('chart-histogram');  // sidebar: message histogram
+    window.telemetry.renderHistogram('chart-histogram');   // sidebar: message histogram
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Replaces the canvas-based trend chart and CSS bar chart with a full D3 v7 visualization dashboard
- 7 interactive chart types covering all available telemetry dimensions
- Clean Jinja → HTMX → Alpine → D3 separation with dedicated `telemetry.js` module (loaded only on `/telemetry`)

## Charts

| # | Chart | Description |
|---|-------|-------------|
| 1 | Wave Timeline Gantt | Each wave as a horizontal bar on a shared time axis; color = active/complete |
| 2 | Cumulative Cost Area | Step-area of running cost total; individual wave costs as annotated markers |
| 3 | Pipeline Trend Multi-line | issues/PRs/agents/alerts over 24h; smooth curves, hover crosshair, legend |
| 4 | Agent Role Donut | All-time role distribution with centre count label and legend |
| 5 | Wave Performance Scatter | X = start time, Y = duration; circle size ∝ issues worked |
| 6 | Agent Status Stacked Bar | Per-wave status breakdown (done / implementing / stale / error) |
| 7 | Message Count Histogram | D3 bin distribution of message_count across all agents |

## Architecture changes

- **Data injection**: JSON blobs in `<script type="application/json">` tags — never in `x-data` attributes
- **D3/telemetry.js**: loaded only on `/telemetry` via `{% block extra_scripts %}`; added that block to `base.html`
- **Alpine**: minimal `telemetryDash()` in `app.js` owns tab state only; triggers `window.telemetry.render*()` on switch
- **HTMX**: `GET /htmx/telemetry/trend` replaces the trend JSON blob; Alpine calls `refreshTrendData()` on swap
- **Route**: `telemetry_page()` now passes `waves_json`, `trend_json`, `role_counts`, `total_waves`; removed pre-sliced arrays
- **CSS**: old bar-chart + sparkline block replaced with `.telemetry-layout`, `.telemetry-chart-main`, `.telemetry-sidebar`, `.d3-tooltip`, `.d3-axis`, `.d3-grid` classes

## Test plan

- [ ] Visit `/telemetry` — page loads 200, KPI bar shows totals
- [ ] All 5 tab buttons in tab strip switch the left main chart
- [ ] Sidebar always shows Donut, Stacked Bar, Histogram
- [ ] Hover on any chart element shows tooltip
- [ ] Click "↻ Refresh" (visible on Trend tab) replaces trend data via HTMX
- [ ] Wave history table expands agent rows correctly
- [ ] mypy clean on `agentception/`