### PR TITLE
chore: ignore CSS source map build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,6 @@ stori_tourdeforce/*.db
 .agent-task
 .session-id
 .coord-*
+
+# CSS source maps (generated build artifacts)
+**/*.css.map


### PR DESCRIPTION
Adds `**/*.css.map` to .gitignore. Source maps are generated by Sass during compilation and should not be tracked — they will be regenerated automatically.