### PR TITLE
feat(agentception): rebuild Config page with clean separation of concerns

### DIFF
--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -1,8 +1,3 @@
-/* !! GENERATED FILE — do not edit directly !!
-   Source: agentception/static/scss/app.scss
-   Compile: make css   (or: sass scss/app.scss app.css)
-   Watch:   make css-watch
-*/
 @charset "UTF-8";
 /* ══════════════════════════════════════════════════════════════
    AgentCeption — Mission Control Design System
@@ -6690,4 +6685,782 @@ main {
   font-variant-numeric: tabular-nums;
 }
 
-/*# sourceMappingURL=app.css.map */
+/* ═══ Pipeline Config Page ═══════════════════════════════════════════════════ */
+/* ── Page header ─────────────────────────────────────────────────────────── */
+.cfg-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.cfg-page-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.2rem;
+}
+
+.cfg-page-subtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.cfg-save-stamp {
+  font-size: 0.75rem;
+  color: var(--text-faint);
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Two-column layout ───────────────────────────────────────────────────── */
+.cfg-layout {
+  display: grid;
+  grid-template-columns: 188px 1fr;
+  grid-template-rows: 1fr auto;
+  gap: 0;
+  height: calc(100vh - 9rem);
+  min-height: 400px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+}
+
+/* ── Sidebar tab navigation ──────────────────────────────────────────────── */
+.cfg-sidebar {
+  grid-column: 1;
+  grid-row: 1/3;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated);
+  border-right: 1px solid var(--border-default);
+  padding: 0.75rem 0;
+  gap: 0.125rem;
+}
+
+.cfg-sidebar-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  padding: 0.25rem 1rem 0.5rem;
+}
+
+.cfg-tab-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  background: transparent;
+  border: none;
+  border-left: 2px solid transparent;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  text-align: left;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.cfg-tab-btn:hover {
+  background: rgba(139, 92, 246, 0.06);
+  color: var(--text-primary);
+}
+
+.cfg-tab-btn.active {
+  background: rgba(139, 92, 246, 0.1);
+  border-left-color: var(--accent);
+  color: var(--accent-bright);
+  font-weight: 600;
+}
+
+.cfg-tab-icon {
+  font-size: 0.9rem;
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
+.cfg-tab-badge {
+  margin-left: auto;
+  font-size: 0.65rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-full);
+  background: var(--accent-glow);
+  color: var(--accent-bright);
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.cfg-tab-badge.on {
+  background: var(--success-dim);
+  color: var(--success);
+}
+
+/* ── Content area ────────────────────────────────────────────────────────── */
+.cfg-content {
+  grid-column: 2;
+  grid-row: 1;
+  overflow-y: auto;
+  padding: 1.5rem 2rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-default) transparent;
+}
+
+.cfg-content::-webkit-scrollbar {
+  width: 5px;
+}
+
+.cfg-content::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.cfg-content::-webkit-scrollbar-thumb {
+  background: var(--border-default);
+  border-radius: var(--radius-full);
+}
+
+/* ── Panel sections ──────────────────────────────────────────────────────── */
+.cfg-panel-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin: 0 0 1.25rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.cfg-section {
+  margin-bottom: 2rem;
+}
+
+.cfg-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ── Allocation sliders ──────────────────────────────────────────────────── */
+.cfg-slider-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.cfg-slider-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem 1rem;
+  align-items: center;
+}
+
+.cfg-slider-label {
+  font-size: 0.84rem;
+  color: var(--text-primary);
+  font-weight: 500;
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.cfg-slider-hint {
+  font-size: 0.73rem;
+  color: var(--text-faint);
+  grid-column: 1;
+  grid-row: 2;
+  margin-top: -0.25rem;
+}
+
+.cfg-slider-value {
+  grid-column: 2;
+  grid-row: 1/3;
+  width: 2.5rem;
+  text-align: center;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  background: var(--accent-glow);
+  border-radius: var(--radius-sm);
+  padding: 0.15rem 0;
+  transition: transform 0.1s;
+}
+
+.cfg-slider-value.pulse {
+  transform: scale(1.15);
+}
+
+.cfg-slider-input {
+  grid-column: 1;
+  grid-row: 3;
+  width: 100%;
+  accent-color: var(--accent);
+  cursor: pointer;
+  height: 4px;
+  margin-top: 0.35rem;
+}
+
+/* ── Capacity meter ──────────────────────────────────────────────────────── */
+.cfg-capacity-card {
+  margin-top: 1.75rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+}
+
+.cfg-capacity-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.75rem;
+}
+
+.cfg-capacity-label {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.cfg-capacity-total {
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+
+.cfg-capacity-total span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-weight: 500;
+  font-family: var(--font-sans);
+  margin-left: 0.3rem;
+}
+
+.cfg-capacity-bar {
+  height: 10px;
+  border-radius: var(--radius-full);
+  background: var(--bg-overlay);
+  overflow: hidden;
+  display: flex;
+  gap: 2px;
+}
+
+.cfg-capacity-bar-eng {
+  height: 100%;
+  background: var(--grad-accent);
+  border-radius: var(--radius-full) 0 0 var(--radius-full);
+  transition: width 0.3s ease;
+  min-width: 0;
+}
+
+.cfg-capacity-bar-qa {
+  height: 100%;
+  background: var(--grad-warm);
+  border-radius: 0 var(--radius-full) var(--radius-full) 0;
+  transition: width 0.3s ease;
+  min-width: 0;
+}
+
+.cfg-capacity-legend {
+  display: flex;
+  gap: 1.25rem;
+  margin-top: 0.6rem;
+}
+
+.cfg-capacity-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.cfg-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.cfg-legend-dot.eng {
+  background: var(--accent);
+}
+
+.cfg-legend-dot.qa {
+  background: var(--warning);
+}
+
+/* ── Labels panel ────────────────────────────────────────────────────────── */
+.cfg-label-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+  min-height: 2rem;
+}
+
+.cfg-label-empty {
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--text-faint);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.cfg-label-item {
+  display: grid;
+  grid-template-columns: 1.75rem 1.5rem 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 0.45rem 0.6rem;
+  cursor: grab;
+  user-select: none;
+  transition: background 0.12s, border-color 0.12s, box-shadow 0.12s;
+}
+.cfg-label-item:active {
+  cursor: grabbing;
+}
+.cfg-label-item.drag-over {
+  border-color: var(--accent);
+  background: var(--accent-glow);
+  box-shadow: 0 0 0 1px var(--accent-dim);
+}
+
+.cfg-label-position {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  text-align: center;
+  background: var(--bg-overlay);
+  border-radius: var(--radius-xs);
+  padding: 0.1rem 0.3rem;
+}
+
+.cfg-drag-handle {
+  font-size: 0.85rem;
+  color: var(--text-faint);
+  text-align: center;
+  line-height: 1;
+  opacity: 0.6;
+  transition: opacity 0.1s;
+}
+.cfg-label-item:hover .cfg-drag-handle {
+  opacity: 1;
+}
+
+.cfg-label-text {
+  font-size: 0.8rem;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  word-break: break-all;
+  min-width: 0;
+}
+
+.cfg-btn-remove {
+  background: transparent;
+  border: none;
+  color: var(--text-faint);
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 0.15rem 0.35rem;
+  border-radius: var(--radius-xs);
+  line-height: 1;
+  transition: color 0.12s, background 0.12s;
+  flex-shrink: 0;
+}
+.cfg-btn-remove:hover {
+  color: var(--danger);
+  background: var(--danger-dim);
+}
+
+.cfg-label-add-row {
+  display: flex;
+  gap: 0.5rem;
+}
+.cfg-label-add-row input[type=text] {
+  flex: 1;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-family: var(--font-mono);
+  padding: 0.4rem 0.7rem;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.cfg-label-add-row input[type=text]::placeholder {
+  color: var(--text-faint);
+}
+.cfg-label-add-row input[type=text]:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+
+/* ── A/B Testing panel ───────────────────────────────────────────────────── */
+.cfg-ab-callout {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  background: var(--info-dim);
+  border: 1px solid var(--info-border);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.cfg-ab-callout-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+  margin-top: 0.05rem;
+}
+
+.cfg-ab-callout-text {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.cfg-ab-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding: 1rem 1.25rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  transition: border-color 0.2s;
+}
+.cfg-ab-toggle-row.ab-active {
+  border-color: var(--success-border);
+  background: var(--success-dim);
+}
+
+.cfg-ab-toggle-label {
+  flex: 1;
+}
+
+.cfg-ab-toggle-title {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 0.15rem;
+}
+
+.cfg-ab-toggle-desc {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* Accessible pill toggle */
+.cfg-toggle-switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.cfg-toggle-switch input[type=checkbox] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.cfg-toggle-track {
+  width: 44px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-default);
+  transition: background 0.2s, border-color 0.2s;
+  position: relative;
+}
+.cfg-toggle-switch input:checked + .cfg-toggle-track {
+  background: var(--success);
+  border-color: var(--success);
+}
+.cfg-toggle-track::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition: transform 0.2s, background 0.2s;
+}
+.cfg-toggle-switch input:checked + .cfg-toggle-track::after {
+  transform: translateX(20px);
+  background: #fff;
+}
+
+.cfg-ab-status {
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+.cfg-ab-status.on {
+  background: var(--success-dim);
+  color: var(--success);
+  border: 1px solid var(--success-border);
+}
+.cfg-ab-status.off {
+  background: var(--bg-overlay);
+  color: var(--text-faint);
+  border: 1px solid var(--border-subtle);
+}
+
+.cfg-ab-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cfg-ab-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.cfg-field-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.03em;
+}
+
+.cfg-field-hint {
+  font-size: 0.7rem;
+  color: var(--text-faint);
+}
+
+.cfg-text-input {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-family: var(--font-mono);
+  padding: 0.45rem 0.75rem;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  width: 100%;
+  box-sizing: border-box;
+}
+.cfg-text-input::placeholder {
+  color: var(--text-faint);
+}
+.cfg-text-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+
+/* ── Projects panel ──────────────────────────────────────────────────────── */
+.cfg-projects-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cfg-project-empty {
+  padding: 2rem;
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--text-faint);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius);
+}
+
+.cfg-project-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid transparent;
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+.cfg-project-card.active {
+  border-left-color: var(--accent);
+  box-shadow: var(--shadow-glow);
+  background: rgba(139, 92, 246, 0.04);
+}
+
+.cfg-project-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.cfg-project-name {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  flex: 1;
+}
+
+.cfg-active-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: var(--radius-full);
+  background: var(--accent-glow);
+  color: var(--accent-bright);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.cfg-project-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.cfg-project-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xs);
+  padding: 0.18rem 0.5rem;
+}
+.cfg-project-chip .chip-icon {
+  font-size: 0.7rem;
+  opacity: 0.7;
+}
+
+.cfg-project-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.cfg-project-cursor-id {
+  font-size: 0.7rem;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+}
+
+.cfg-switch-toast {
+  font-size: 0.78rem;
+  color: var(--success);
+  min-height: 1em;
+}
+
+/* ── Sticky save footer ──────────────────────────────────────────────────── */
+.cfg-footer {
+  grid-column: 2;
+  grid-row: 2;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.875rem 2rem;
+  background: var(--bg-glass);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-top: 1px solid var(--border-default);
+}
+
+.cfg-toast {
+  font-size: 0.82rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius-sm);
+  min-height: 1.6rem;
+  display: flex;
+  align-items: center;
+}
+.cfg-toast.ok {
+  background: var(--success-dim);
+  color: var(--success);
+  border: 1px solid var(--success-border);
+}
+.cfg-toast.err {
+  background: var(--danger-dim);
+  color: var(--danger);
+  border: 1px solid var(--danger-border);
+}
+
+.cfg-footer-spacer {
+  flex: 1;
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 680px) {
+  .cfg-layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+    height: auto;
+    min-height: unset;
+  }
+  .cfg-sidebar {
+    grid-column: 1;
+    grid-row: 1;
+    flex-direction: row;
+    border-right: none;
+    border-bottom: 1px solid var(--border-default);
+    padding: 0.5rem;
+    overflow-x: auto;
+  }
+  .cfg-sidebar-label {
+    display: none;
+  }
+  .cfg-tab-btn {
+    border-left: none;
+    border-bottom: 2px solid transparent;
+    padding: 0.4rem 0.75rem;
+    white-space: nowrap;
+    font-size: 0.78rem;
+  }
+  .cfg-tab-btn.active {
+    border-left-color: transparent;
+    border-bottom-color: var(--accent);
+  }
+  .cfg-content {
+    grid-column: 1;
+    grid-row: 2;
+    padding: 1rem;
+  }
+  .cfg-footer {
+    grid-column: 1;
+    grid-row: 3;
+  }
+}

--- a/agentception/static/app.js
+++ b/agentception/static/app.js
@@ -712,25 +712,60 @@ function telemetryDash() {
  *
  * @param {object|null} initialConfig - Server-rendered PipelineConfig dict.
  */
-function configPanel(initialConfig) {
-  const defaults = { max_eng_vps: 1, max_qa_vps: 1, pool_size_per_vp: 4, active_labels_order: [] };
+function configPanel() {
+  const defaults = {
+    max_eng_vps: 1,
+    max_qa_vps: 1,
+    pool_size_per_vp: 4,
+    active_labels_order: [],
+    ab_mode: { enabled: false, target_role: null, variant_a_file: null, variant_b_file: null },
+    projects: [],
+    active_project: null,
+  };
   return {
-    config: initialConfig || defaults,
+    // ── State ──────────────────────────────────────────────────────────────
+    config: { ...defaults },
+    lastSaved: null,
+    activeTab: 'allocation',
     newLabel: '',
     saving: false,
     toast: { msg: '', cls: '' },
+    projectSaving: null,
+    savedAt: null,
     _dragIdx: null,
 
+    // ── Computed capacity ──────────────────────────────────────────────────
+    get totalAgents() {
+      return (this.config.max_eng_vps + this.config.max_qa_vps) * this.config.pool_size_per_vp;
+    },
+    get engSlots() { return this.config.max_eng_vps * this.config.pool_size_per_vp; },
+    get qaSlots()  { return this.config.max_qa_vps  * this.config.pool_size_per_vp; },
+    get engPct()   { return this.totalAgents ? Math.round(this.engSlots / this.totalAgents * 100) : 50; },
+    get qaPct()    { return this.totalAgents ? Math.round(this.qaSlots  / this.totalAgents * 100) : 50; },
+
+    // ── Lifecycle ──────────────────────────────────────────────────────────
     async init() {
+      // Hydrate from server-rendered data attribute first (zero flicker)
+      const raw = this.$el.dataset.config;
+      if (raw) {
+        try { this.config = { ...defaults, ...JSON.parse(raw) }; }
+        catch (_) { /* fall back to defaults */ }
+      }
+      // Re-fetch for freshness
       try {
         const r = await fetch('/api/config');
         if (!r.ok) throw new Error('HTTP ' + r.status);
-        this.config = await r.json();
+        this.config = { ...defaults, ...await r.json() };
       } catch (err) {
         this._showToast('Failed to load config: ' + err.message, 'err');
       }
+      this.lastSaved = JSON.parse(JSON.stringify(this.config));
     },
 
+    // ── Tab navigation ─────────────────────────────────────────────────────
+    setTab(tab) { this.activeTab = tab; },
+
+    // ── Label editor ───────────────────────────────────────────────────────
     addLabel() {
       const label = this.newLabel.trim();
       if (!label) return;
@@ -764,10 +799,52 @@ function configPanel(initialConfig) {
     },
 
     onDragEnd() {
-      document.querySelectorAll('.label-item.drag-over').forEach(el => {
+      document.querySelectorAll('.cfg-label-item.drag-over').forEach(el => {
         el.classList.remove('drag-over');
       });
       this._dragIdx = null;
+    },
+
+    // ── A/B mode ───────────────────────────────────────────────────────────
+    ensureAbMode() {
+      if (!this.config.ab_mode) {
+        this.config.ab_mode = { enabled: false, target_role: null, variant_a_file: null, variant_b_file: null };
+      }
+    },
+
+    // ── Projects ───────────────────────────────────────────────────────────
+    async switchProject(name) {
+      this.projectSaving = name;
+      try {
+        const r = await fetch('/api/config/switch-project', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ project_name: name }),
+        });
+        if (!r.ok) {
+          const detail = await r.json().then(d => d.detail || r.statusText).catch(() => r.statusText);
+          throw new Error(detail);
+        }
+        const updated = await r.json();
+        this.config.active_project = updated.active_project;
+        this.lastSaved = JSON.parse(JSON.stringify(this.config));
+        this._showToast('✅ Switched to ' + name, 'ok');
+      } catch (err) {
+        this._showToast('Switch failed: ' + err.message, 'err');
+      } finally {
+        this.projectSaving = null;
+      }
+    },
+
+    // ── Save / Cancel ──────────────────────────────────────────────────────
+    cancel() {
+      if (!this.lastSaved) return;
+      this.config = JSON.parse(JSON.stringify(this.lastSaved));
+      this._showToast('Changes discarded.', '');
+    },
+
+    get isDirty() {
+      return JSON.stringify(this.config) !== JSON.stringify(this.lastSaved);
     },
 
     async save() {
@@ -783,7 +860,9 @@ function configPanel(initialConfig) {
           const detail = await r.json().then(d => d.detail || r.statusText).catch(() => r.statusText);
           throw new Error(detail);
         }
-        this.config = await r.json();
+        this.config = { ...defaults, ...await r.json() };
+        this.lastSaved = JSON.parse(JSON.stringify(this.config));
+        this.savedAt = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
         this._showToast('✅ Config saved.', 'ok');
       } catch (err) {
         this._showToast('Save failed: ' + err.message, 'err');
@@ -792,6 +871,7 @@ function configPanel(initialConfig) {
       }
     },
 
+    // ── Helpers ────────────────────────────────────────────────────────────
     _showToast(msg, cls) { this.toast = { msg, cls }; },
   };
 }

--- a/agentception/static/scss/app.scss
+++ b/agentception/static/scss/app.scss
@@ -25,6 +25,7 @@
 //     _brain-dump.scss  Brain Dump page
 //     _roles.scss       Cognitive Architecture Studio
 //     _agents.scss      Agents list page
+//     _config.scss      Pipeline Config page
 //
 // Compilation
 // ───────────
@@ -51,3 +52,4 @@
 @use 'pages/brain-dump';
 @use 'pages/roles';
 @use 'pages/agents';
+@use 'pages/config';

--- a/agentception/static/scss/pages/_config.scss
+++ b/agentception/static/scss/pages/_config.scss
@@ -1,0 +1,774 @@
+/* ═══ Pipeline Config Page ═══════════════════════════════════════════════════ */
+
+/* ── Page header ─────────────────────────────────────────────────────────── */
+
+.cfg-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.cfg-page-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.2rem;
+}
+
+.cfg-page-subtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.cfg-save-stamp {
+  font-size: 0.75rem;
+  color: var(--text-faint);
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Two-column layout ───────────────────────────────────────────────────── */
+
+.cfg-layout {
+  display: grid;
+  grid-template-columns: 188px 1fr;
+  grid-template-rows: 1fr auto;
+  gap: 0;
+  height: calc(100vh - 9rem);
+  min-height: 400px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+}
+
+/* ── Sidebar tab navigation ──────────────────────────────────────────────── */
+
+.cfg-sidebar {
+  grid-column: 1;
+  grid-row: 1 / 3;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated);
+  border-right: 1px solid var(--border-default);
+  padding: 0.75rem 0;
+  gap: 0.125rem;
+}
+
+.cfg-sidebar-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  padding: 0.25rem 1rem 0.5rem;
+}
+
+.cfg-tab-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  background: transparent;
+  border: none;
+  border-left: 2px solid transparent;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  text-align: left;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.cfg-tab-btn:hover {
+  background: rgba(139, 92, 246, 0.06);
+  color: var(--text-primary);
+}
+
+.cfg-tab-btn.active {
+  background: rgba(139, 92, 246, 0.1);
+  border-left-color: var(--accent);
+  color: var(--accent-bright);
+  font-weight: 600;
+}
+
+.cfg-tab-icon {
+  font-size: 0.9rem;
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
+.cfg-tab-badge {
+  margin-left: auto;
+  font-size: 0.65rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-full);
+  background: var(--accent-glow);
+  color: var(--accent-bright);
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.cfg-tab-badge.on {
+  background: var(--success-dim);
+  color: var(--success);
+}
+
+/* ── Content area ────────────────────────────────────────────────────────── */
+
+.cfg-content {
+  grid-column: 2;
+  grid-row: 1;
+  overflow-y: auto;
+  padding: 1.5rem 2rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-default) transparent;
+}
+
+.cfg-content::-webkit-scrollbar { width: 5px; }
+.cfg-content::-webkit-scrollbar-track { background: transparent; }
+.cfg-content::-webkit-scrollbar-thumb {
+  background: var(--border-default);
+  border-radius: var(--radius-full);
+}
+
+/* ── Panel sections ──────────────────────────────────────────────────────── */
+
+.cfg-panel-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin: 0 0 1.25rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.cfg-section {
+  margin-bottom: 2rem;
+}
+
+.cfg-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ── Allocation sliders ──────────────────────────────────────────────────── */
+
+.cfg-slider-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.cfg-slider-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem 1rem;
+  align-items: center;
+}
+
+.cfg-slider-label {
+  font-size: 0.84rem;
+  color: var(--text-primary);
+  font-weight: 500;
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.cfg-slider-hint {
+  font-size: 0.73rem;
+  color: var(--text-faint);
+  grid-column: 1;
+  grid-row: 2;
+  margin-top: -0.25rem;
+}
+
+.cfg-slider-value {
+  grid-column: 2;
+  grid-row: 1 / 3;
+  width: 2.5rem;
+  text-align: center;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  background: var(--accent-glow);
+  border-radius: var(--radius-sm);
+  padding: 0.15rem 0;
+  transition: transform 0.1s;
+}
+
+.cfg-slider-value.pulse {
+  transform: scale(1.15);
+}
+
+.cfg-slider-input {
+  grid-column: 1;
+  grid-row: 3;
+  width: 100%;
+  accent-color: var(--accent);
+  cursor: pointer;
+  height: 4px;
+  margin-top: 0.35rem;
+}
+
+/* ── Capacity meter ──────────────────────────────────────────────────────── */
+
+.cfg-capacity-card {
+  margin-top: 1.75rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+}
+
+.cfg-capacity-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.75rem;
+}
+
+.cfg-capacity-label {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.cfg-capacity-total {
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+
+.cfg-capacity-total span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-weight: 500;
+  font-family: var(--font-sans);
+  margin-left: 0.3rem;
+}
+
+.cfg-capacity-bar {
+  height: 10px;
+  border-radius: var(--radius-full);
+  background: var(--bg-overlay);
+  overflow: hidden;
+  display: flex;
+  gap: 2px;
+}
+
+.cfg-capacity-bar-eng {
+  height: 100%;
+  background: var(--grad-accent);
+  border-radius: var(--radius-full) 0 0 var(--radius-full);
+  transition: width 0.3s ease;
+  min-width: 0;
+}
+
+.cfg-capacity-bar-qa {
+  height: 100%;
+  background: var(--grad-warm);
+  border-radius: 0 var(--radius-full) var(--radius-full) 0;
+  transition: width 0.3s ease;
+  min-width: 0;
+}
+
+.cfg-capacity-legend {
+  display: flex;
+  gap: 1.25rem;
+  margin-top: 0.6rem;
+}
+
+.cfg-capacity-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.cfg-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.cfg-legend-dot.eng { background: var(--accent); }
+.cfg-legend-dot.qa  { background: var(--warning); }
+
+/* ── Labels panel ────────────────────────────────────────────────────────── */
+
+.cfg-label-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+  min-height: 2rem;
+}
+
+.cfg-label-empty {
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--text-faint);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.cfg-label-item {
+  display: grid;
+  grid-template-columns: 1.75rem 1.5rem 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 0.45rem 0.6rem;
+  cursor: grab;
+  user-select: none;
+  transition: background 0.12s, border-color 0.12s, box-shadow 0.12s;
+
+  &:active { cursor: grabbing; }
+
+  &.drag-over {
+    border-color: var(--accent);
+    background: var(--accent-glow);
+    box-shadow: 0 0 0 1px var(--accent-dim);
+  }
+}
+
+.cfg-label-position {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  text-align: center;
+  background: var(--bg-overlay);
+  border-radius: var(--radius-xs);
+  padding: 0.1rem 0.3rem;
+}
+
+.cfg-drag-handle {
+  font-size: 0.85rem;
+  color: var(--text-faint);
+  text-align: center;
+  line-height: 1;
+  opacity: 0.6;
+  transition: opacity 0.1s;
+
+  .cfg-label-item:hover & { opacity: 1; }
+}
+
+.cfg-label-text {
+  font-size: 0.8rem;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  word-break: break-all;
+  min-width: 0;
+}
+
+.cfg-btn-remove {
+  background: transparent;
+  border: none;
+  color: var(--text-faint);
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 0.15rem 0.35rem;
+  border-radius: var(--radius-xs);
+  line-height: 1;
+  transition: color 0.12s, background 0.12s;
+  flex-shrink: 0;
+
+  &:hover {
+    color: var(--danger);
+    background: var(--danger-dim);
+  }
+}
+
+.cfg-label-add-row {
+  display: flex;
+  gap: 0.5rem;
+
+  input[type="text"] {
+    flex: 1;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-size: 0.82rem;
+    font-family: var(--font-mono);
+    padding: 0.4rem 0.7rem;
+    outline: none;
+    transition: border-color 0.15s, box-shadow 0.15s;
+
+    &::placeholder { color: var(--text-faint); }
+
+    &:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px var(--accent-glow);
+    }
+  }
+}
+
+/* ── A/B Testing panel ───────────────────────────────────────────────────── */
+
+.cfg-ab-callout {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  background: var(--info-dim);
+  border: 1px solid var(--info-border);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.cfg-ab-callout-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+  margin-top: 0.05rem;
+}
+
+.cfg-ab-callout-text {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.cfg-ab-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding: 1rem 1.25rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  transition: border-color 0.2s;
+
+  &.ab-active {
+    border-color: var(--success-border);
+    background: var(--success-dim);
+  }
+}
+
+.cfg-ab-toggle-label {
+  flex: 1;
+}
+
+.cfg-ab-toggle-title {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 0.15rem;
+}
+
+.cfg-ab-toggle-desc {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* Accessible pill toggle */
+.cfg-toggle-switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  flex-shrink: 0;
+
+  input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+}
+
+.cfg-toggle-track {
+  width: 44px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-default);
+  transition: background 0.2s, border-color 0.2s;
+  position: relative;
+
+  .cfg-toggle-switch input:checked + & {
+    background: var(--success);
+    border-color: var(--success);
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--text-muted);
+    transition: transform 0.2s, background 0.2s;
+  }
+
+  .cfg-toggle-switch input:checked + &::after {
+    transform: translateX(20px);
+    background: #fff;
+  }
+}
+
+.cfg-ab-status {
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+
+  &.on  { background: var(--success-dim); color: var(--success); border: 1px solid var(--success-border); }
+  &.off { background: var(--bg-overlay); color: var(--text-faint); border: 1px solid var(--border-subtle); }
+}
+
+.cfg-ab-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cfg-ab-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.cfg-field-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.03em;
+}
+
+.cfg-field-hint {
+  font-size: 0.7rem;
+  color: var(--text-faint);
+}
+
+.cfg-text-input {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-family: var(--font-mono);
+  padding: 0.45rem 0.75rem;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  width: 100%;
+  box-sizing: border-box;
+
+  &::placeholder { color: var(--text-faint); }
+
+  &:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--accent-glow);
+  }
+}
+
+/* ── Projects panel ──────────────────────────────────────────────────────── */
+
+.cfg-projects-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cfg-project-empty {
+  padding: 2rem;
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--text-faint);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius);
+}
+
+.cfg-project-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid transparent;
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+
+  &.active {
+    border-left-color: var(--accent);
+    box-shadow: var(--shadow-glow);
+    background: rgba(139, 92, 246, 0.04);
+  }
+}
+
+.cfg-project-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.cfg-project-name {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  flex: 1;
+}
+
+.cfg-active-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: var(--radius-full);
+  background: var(--accent-glow);
+  color: var(--accent-bright);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.cfg-project-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.cfg-project-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xs);
+  padding: 0.18rem 0.5rem;
+
+  .chip-icon {
+    font-size: 0.7rem;
+    opacity: 0.7;
+  }
+}
+
+.cfg-project-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.cfg-project-cursor-id {
+  font-size: 0.7rem;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+}
+
+.cfg-switch-toast {
+  font-size: 0.78rem;
+  color: var(--success);
+  min-height: 1em;
+}
+
+/* ── Sticky save footer ──────────────────────────────────────────────────── */
+
+.cfg-footer {
+  grid-column: 2;
+  grid-row: 2;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.875rem 2rem;
+  background: var(--bg-glass);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-top: 1px solid var(--border-default);
+}
+
+.cfg-toast {
+  font-size: 0.82rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius-sm);
+  min-height: 1.6rem;
+  display: flex;
+  align-items: center;
+
+  &.ok  { background: var(--success-dim); color: var(--success); border: 1px solid var(--success-border); }
+  &.err { background: var(--danger-dim);  color: var(--danger);  border: 1px solid var(--danger-border); }
+}
+
+.cfg-footer-spacer { flex: 1; }
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+
+@media (max-width: 680px) {
+  .cfg-layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+    height: auto;
+    min-height: unset;
+  }
+
+  .cfg-sidebar {
+    grid-column: 1;
+    grid-row: 1;
+    flex-direction: row;
+    border-right: none;
+    border-bottom: 1px solid var(--border-default);
+    padding: 0.5rem;
+    overflow-x: auto;
+  }
+
+  .cfg-sidebar-label { display: none; }
+
+  .cfg-tab-btn {
+    border-left: none;
+    border-bottom: 2px solid transparent;
+    padding: 0.4rem 0.75rem;
+    white-space: nowrap;
+    font-size: 0.78rem;
+
+    &.active { border-left-color: transparent; border-bottom-color: var(--accent); }
+  }
+
+  .cfg-content {
+    grid-column: 1;
+    grid-row: 2;
+    padding: 1rem;
+  }
+
+  .cfg-footer {
+    grid-column: 1;
+    grid-row: 3;
+  }
+}

--- a/agentception/templates/config.html
+++ b/agentception/templates/config.html
@@ -2,313 +2,385 @@
 
 {% block title %}Pipeline Config — AgentCeption{% endblock %}
 
-{% block head %}
-<style>
-  .config-layout {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    max-width: 720px;
-  }
-
-  .config-section {
-    background: var(--bg-secondary);
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    padding: 1.25rem 1.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .config-section h2 {
-    font-size: 0.9rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--text-muted);
-    margin: 0 0 0.25rem 0;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid var(--border);
-  }
-
-  .slider-row {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-  }
-
-  .slider-row label {
-    flex: 0 0 200px;
-    font-size: 0.88rem;
-    color: var(--text-primary);
-  }
-
-  .slider-row input[type="range"] {
-    flex: 1;
-    accent-color: var(--accent);
-    cursor: pointer;
-  }
-
-  .slider-row .slider-value {
-    flex: 0 0 2rem;
-    text-align: right;
-    font-size: 0.88rem;
-    font-weight: 600;
-    color: var(--accent);
-    font-family: monospace;
-  }
-
-  /* ── Label order editor ─────────────────────────────────────────────────── */
-
-  .label-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  .label-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    background: var(--bg-tertiary);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    padding: 0.4rem 0.6rem;
-    cursor: grab;
-    user-select: none;
-    transition: background 0.1s, border-color 0.1s;
-  }
-
-  .label-item:active {
-    cursor: grabbing;
-  }
-
-  .label-item.drag-over {
-    border-color: var(--accent);
-    background: var(--bg-tertiary);
-  }
-
-  .drag-handle {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    flex-shrink: 0;
-  }
-
-  .label-item__text {
-    flex: 1;
-    font-size: 0.85rem;
-    font-family: monospace;
-    color: var(--text-primary);
-    word-break: break-all;
-  }
-
-  .btn-remove {
-    background: transparent;
-    border: none;
-    color: var(--text-muted);
-    cursor: pointer;
-    font-size: 0.8rem;
-    padding: 0.1rem 0.3rem;
-    border-radius: 3px;
-    line-height: 1;
-    transition: color 0.1s, background 0.1s;
-    flex-shrink: 0;
-  }
-
-  .btn-remove:hover {
-    color: var(--danger);
-    background: rgba(248, 81, 73, 0.12);
-  }
-
-  .label-add-row {
-    display: flex;
-    gap: 0.5rem;
-    margin-top: 0.25rem;
-  }
-
-  .label-add-row input[type="text"] {
-    flex: 1;
-    background: var(--bg-tertiary);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    color: var(--text-primary);
-    font-size: 0.85rem;
-    font-family: monospace;
-    padding: 0.35rem 0.6rem;
-    outline: none;
-    transition: border-color 0.1s;
-  }
-
-  .label-add-row input[type="text"]:focus {
-    border-color: var(--accent);
-  }
-
-  .btn-add-label {
-    background: var(--bg-secondary);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    color: var(--text-primary);
-    cursor: pointer;
-    font-size: 0.82rem;
-    padding: 0.35rem 0.75rem;
-    white-space: nowrap;
-    transition: background 0.1s, border-color 0.1s;
-  }
-
-  .btn-add-label:hover {
-    background: var(--bg-tertiary);
-    border-color: var(--accent);
-  }
-
-  /* ── Save button and toast ───────────────────────────────────────────────── */
-
-  .config-footer {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-  }
-
-  .btn-save-config {
-    background: var(--accent);
-    border: 1px solid var(--accent);
-    border-radius: 4px;
-    color: #fff;
-    cursor: pointer;
-    font-size: 0.9rem;
-    font-weight: 600;
-    padding: 0.5rem 1.25rem;
-    transition: opacity 0.1s;
-  }
-
-  .btn-save-config:hover {
-    opacity: 0.85;
-  }
-
-  .btn-save-config:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-
-  .config-toast {
-    font-size: 0.85rem;
-    padding: 0.35rem 0.75rem;
-    border-radius: 4px;
-    display: none;
-  }
-
-  .config-toast.ok {
-    display: inline-block;
-    background: rgba(76, 175, 80, 0.15);
-    color: #81c784;
-    border: 1px solid rgba(76, 175, 80, 0.35);
-  }
-
-  .config-toast.err {
-    display: inline-block;
-    background: rgba(244, 67, 54, 0.15);
-    color: #e57373;
-    border: 1px solid rgba(244, 67, 54, 0.35);
-  }
-</style>
-{% endblock %}
-
 {% block content %}
-<div class="config-layout"
-     x-data='configPanel({{ config.model_dump() | tojson if config else "null" }})'
+
+{# ── Page header ──────────────────────────────────────────────────────────── #}
+<div class="cfg-page-header">
+  <div>
+    <h1 class="cfg-page-title">Pipeline Config</h1>
+    <p class="cfg-page-subtitle">Tune allocation, label queue, A/B testing, and project targeting.</p>
+  </div>
+  <span class="cfg-save-stamp"
+        x-text="savedAt ? 'Saved at ' + savedAt : ''"
+        x-show="savedAt"
+        style="display:none"></span>
+</div>
+
+{# ── Main layout: sidebar tabs + content + sticky footer ─────────────────── #}
+<div class="cfg-layout"
+     x-data="configPanel()"
+     data-config='{{ config.model_dump() | tojson if config else "{}" }}'
      x-init="init()">
 
-  <!-- ── Allocation sliders ────────────────────────────────────────────────── -->
-  <div class="config-section">
-    <h2>Allocation</h2>
+  {# ── Sidebar tab navigation ─────────────────────────────────────────────── #}
+  <nav class="cfg-sidebar" aria-label="Config sections">
+    <span class="cfg-sidebar-label">Settings</span>
 
-    <div class="slider-row">
-      <label for="slider-eng-vps">Max Engineering VPs</label>
-      <input id="slider-eng-vps"
-             type="range" min="1" max="4" step="1"
-             x-model.number="config.max_eng_vps"
-             aria-label="Max Engineering VPs" />
-      <span class="slider-value" x-text="config.max_eng_vps"></span>
-    </div>
+    <button class="cfg-tab-btn"
+            :class="{ active: activeTab === 'allocation' }"
+            @click="setTab('allocation')"
+            type="button"
+            aria-controls="panel-allocation">
+      <span class="cfg-tab-icon">⚡</span>
+      Allocation
+    </button>
 
-    <div class="slider-row">
-      <label for="slider-qa-vps">Max QA VPs</label>
-      <input id="slider-qa-vps"
-             type="range" min="1" max="4" step="1"
-             x-model.number="config.max_qa_vps"
-             aria-label="Max QA VPs" />
-      <span class="slider-value" x-text="config.max_qa_vps"></span>
-    </div>
+    <button class="cfg-tab-btn"
+            :class="{ active: activeTab === 'labels' }"
+            @click="setTab('labels')"
+            type="button"
+            aria-controls="panel-labels">
+      <span class="cfg-tab-icon">🏷</span>
+      Labels
+      <span class="cfg-tab-badge"
+            x-text="config.active_labels_order.length"
+            x-show="config.active_labels_order.length > 0"></span>
+    </button>
 
-    <div class="slider-row">
-      <label for="slider-pool-size">Pool size per VP</label>
-      <input id="slider-pool-size"
-             type="range" min="1" max="8" step="1"
-             x-model.number="config.pool_size_per_vp"
-             aria-label="Pool size per VP" />
-      <span class="slider-value" x-text="config.pool_size_per_vp"></span>
-    </div>
-  </div>
+    <button class="cfg-tab-btn"
+            :class="{ active: activeTab === 'ab' }"
+            @click="setTab('ab')"
+            type="button"
+            aria-controls="panel-ab">
+      <span class="cfg-tab-icon">🔬</span>
+      A/B Testing
+      <span class="cfg-tab-badge on"
+            x-show="config.ab_mode && config.ab_mode.enabled">ON</span>
+    </button>
 
-  <!-- ── Label order editor ────────────────────────────────────────────────── -->
-  <div class="config-section">
-    <h2>Label order</h2>
+    <button class="cfg-tab-btn"
+            :class="{ active: activeTab === 'projects' }"
+            @click="setTab('projects')"
+            type="button"
+            aria-controls="panel-projects">
+      <span class="cfg-tab-icon">📂</span>
+      Projects
+      <span class="cfg-tab-badge"
+            x-text="config.projects.length"
+            x-show="config.projects.length > 0"></span>
+    </button>
+  </nav>
 
-    <ul class="label-list"
-        id="label-list"
-        aria-label="Active labels ordered by priority">
-      <template x-for="(label, idx) in config.active_labels_order" :key="label">
-        <li class="label-item"
-            draggable="true"
-            :data-idx="idx"
-            @dragstart="onDragStart($event, idx)"
-            @dragover.prevent="onDragOver($event, idx)"
-            @dragleave="onDragLeave($event)"
-            @drop.prevent="onDrop($event, idx)"
-            @dragend="onDragEnd()">
-          <span class="drag-handle" aria-hidden="true">⠿</span>
-          <span class="label-item__text" x-text="label"></span>
-          <button class="btn-remove"
-                  type="button"
-                  :aria-label="'Remove ' + label"
-                  @click="removeLabel(idx)">✕</button>
-        </li>
-      </template>
-    </ul>
+  {# ── Content area ───────────────────────────────────────────────────────── #}
+  <div class="cfg-content">
 
-    <div class="label-add-row">
-      <input id="new-label-input"
-             type="text"
-             placeholder="e.g. agentception/7-new-phase"
-             x-model.trim="newLabel"
-             @keydown.enter="addLabel()"
-             aria-label="New label name" />
-      <button class="btn-add-label"
-              type="button"
-              @click="addLabel()">Add label</button>
-    </div>
-  </div>
+    {# ════════ Allocation Panel ════════ #}
+    <section id="panel-allocation"
+             role="tabpanel"
+             x-show="activeTab === 'allocation'"
+             x-transition:enter="transition ease-out duration-150"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100">
 
-  <!-- ── Save + toast ──────────────────────────────────────────────────────── -->
-  <div class="config-footer">
-    <button class="btn-save-config"
+      <h2 class="cfg-panel-title">Allocation</h2>
+
+      <div class="cfg-slider-group">
+
+        <div class="cfg-slider-row">
+          <label class="cfg-slider-label" for="slider-eng-vps">Engineering VPs</label>
+          <p class="cfg-slider-hint">Parallel engineering VP agents in the pipeline</p>
+          <input id="slider-eng-vps"
+                 class="cfg-slider-input"
+                 type="range" min="1" max="8" step="1"
+                 x-model.number="config.max_eng_vps"
+                 aria-label="Max Engineering VPs" />
+          <span class="cfg-slider-value" x-text="config.max_eng_vps"></span>
+        </div>
+
+        <div class="cfg-slider-row">
+          <label class="cfg-slider-label" for="slider-qa-vps">QA VPs</label>
+          <p class="cfg-slider-hint">Parallel QA VP agents in the pipeline</p>
+          <input id="slider-qa-vps"
+                 class="cfg-slider-input"
+                 type="range" min="1" max="4" step="1"
+                 x-model.number="config.max_qa_vps"
+                 aria-label="Max QA VPs" />
+          <span class="cfg-slider-value" x-text="config.max_qa_vps"></span>
+        </div>
+
+        <div class="cfg-slider-row">
+          <label class="cfg-slider-label" for="slider-pool">Pool size per VP</label>
+          <p class="cfg-slider-hint">Worker agents assigned to each VP</p>
+          <input id="slider-pool"
+                 class="cfg-slider-input"
+                 type="range" min="1" max="20" step="1"
+                 x-model.number="config.pool_size_per_vp"
+                 aria-label="Pool size per VP" />
+          <span class="cfg-slider-value" x-text="config.pool_size_per_vp"></span>
+        </div>
+
+      </div>
+
+      {# ── Capacity meter card ─────────────────────────────────────────────── #}
+      <div class="cfg-capacity-card">
+        <div class="cfg-capacity-header">
+          <span class="cfg-capacity-label">Total agent slots</span>
+          <span class="cfg-capacity-total">
+            <span x-text="totalAgents"></span>
+            <span>agents</span>
+          </span>
+        </div>
+
+        <div class="cfg-capacity-bar" role="meter"
+             :aria-valuenow="totalAgents"
+             aria-valuemin="0"
+             :aria-valuemax="totalAgents"
+             aria-label="Agent slot allocation">
+          <div class="cfg-capacity-bar-eng"
+               :style="'width:' + engPct + '%'"
+               :title="engSlots + ' engineering slots'"></div>
+          <div class="cfg-capacity-bar-qa"
+               :style="'width:' + qaPct + '%'"
+               :title="qaSlots + ' QA slots'"></div>
+        </div>
+
+        <div class="cfg-capacity-legend">
+          <span class="cfg-capacity-legend-item">
+            <span class="cfg-legend-dot eng"></span>
+            <span x-text="engSlots + ' engineering'"></span>
+          </span>
+          <span class="cfg-capacity-legend-item">
+            <span class="cfg-legend-dot qa"></span>
+            <span x-text="qaSlots + ' QA'"></span>
+          </span>
+        </div>
+      </div>
+    </section>
+
+    {# ════════ Labels Panel ════════ #}
+    <section id="panel-labels"
+             role="tabpanel"
+             x-show="activeTab === 'labels'"
+             x-transition:enter="transition ease-out duration-150"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100">
+
+      <h2 class="cfg-panel-title">Label Queue</h2>
+
+      <ul class="cfg-label-list"
+          id="cfg-label-list"
+          aria-label="Active labels in priority order">
+
+        <template x-if="config.active_labels_order.length === 0">
+          <li class="cfg-label-empty">
+            No labels configured — add one below.
+          </li>
+        </template>
+
+        <template x-for="(label, idx) in config.active_labels_order" :key="label">
+          <li class="cfg-label-item"
+              draggable="true"
+              :data-idx="idx"
+              @dragstart="onDragStart($event, idx)"
+              @dragover.prevent="onDragOver($event)"
+              @dragleave="onDragLeave($event)"
+              @drop.prevent="onDrop($event, idx)"
+              @dragend="onDragEnd()">
+            <span class="cfg-label-position" x-text="idx + 1" aria-hidden="true"></span>
+            <span class="cfg-drag-handle" aria-hidden="true">⠿</span>
+            <span class="cfg-label-text" x-text="label"></span>
+            <button class="cfg-btn-remove"
+                    type="button"
+                    :aria-label="'Remove label ' + label"
+                    @click="removeLabel(idx)">✕</button>
+          </li>
+        </template>
+      </ul>
+
+      <div class="cfg-label-add-row">
+        <input id="cfg-new-label"
+               type="text"
+               placeholder="e.g. agentception/7-new-phase"
+               x-model.trim="newLabel"
+               @keydown.enter="addLabel()"
+               aria-label="New label name" />
+        <button class="btn btn-secondary"
+                type="button"
+                @click="addLabel()">Add label</button>
+      </div>
+    </section>
+
+    {# ════════ A/B Testing Panel ════════ #}
+    <section id="panel-ab"
+             role="tabpanel"
+             x-show="activeTab === 'ab'"
+             x-transition:enter="transition ease-out duration-150"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100">
+
+      <h2 class="cfg-panel-title">A/B Testing</h2>
+
+      <div class="cfg-ab-callout">
+        <span class="cfg-ab-callout-icon">ℹ️</span>
+        <p class="cfg-ab-callout-text">
+          When enabled, the Engineering VP alternates between two role files for the
+          target role — Variant A on even batch seconds, Variant B on odd — so successive
+          batches see different prompts while everything else stays constant.
+        </p>
+      </div>
+
+      {# ── Enable/disable toggle ─────────────────────────────────────────── #}
+      <div class="cfg-ab-toggle-row" :class="{ 'ab-active': config.ab_mode && config.ab_mode.enabled }">
+        <div class="cfg-ab-toggle-label">
+          <p class="cfg-ab-toggle-title">A/B mode</p>
+          <p class="cfg-ab-toggle-desc">Alternate role files across consecutive batches</p>
+        </div>
+
+        <span class="cfg-ab-status"
+              :class="config.ab_mode && config.ab_mode.enabled ? 'on' : 'off'"
+              x-text="config.ab_mode && config.ab_mode.enabled ? 'Active' : 'Inactive'"></span>
+
+        <label class="cfg-toggle-switch" :aria-label="'A/B mode ' + (config.ab_mode && config.ab_mode.enabled ? 'on' : 'off')">
+          <input type="checkbox"
+                 x-model="config.ab_mode.enabled"
+                 @change="ensureAbMode()"
+                 role="switch"
+                 :aria-checked="config.ab_mode && config.ab_mode.enabled" />
+          <span class="cfg-toggle-track"></span>
+        </label>
+      </div>
+
+      {# ── Conditional fields ────────────────────────────────────────────── #}
+      <div class="cfg-ab-fields"
+           x-show="config.ab_mode && config.ab_mode.enabled"
+           x-transition>
+
+        <div class="cfg-ab-field">
+          <label class="cfg-field-label" for="ab-target-role">Target Role</label>
+          <p class="cfg-field-hint">The role slug that will be split (e.g. <code>python-developer</code>)</p>
+          <input id="ab-target-role"
+                 class="cfg-text-input"
+                 type="text"
+                 placeholder="e.g. python-developer"
+                 x-model.trim="config.ab_mode.target_role"
+                 aria-label="A/B target role" />
+        </div>
+
+        <div class="cfg-ab-field">
+          <label class="cfg-field-label" for="ab-variant-a">Variant A File</label>
+          <p class="cfg-field-hint">Path relative to repo root (e.g. <code>.cursor/roles/python-developer.md</code>)</p>
+          <input id="ab-variant-a"
+                 class="cfg-text-input"
+                 type="text"
+                 placeholder=".cursor/roles/python-developer.md"
+                 x-model.trim="config.ab_mode.variant_a_file"
+                 aria-label="Variant A file path" />
+        </div>
+
+        <div class="cfg-ab-field">
+          <label class="cfg-field-label" for="ab-variant-b">Variant B File</label>
+          <p class="cfg-field-hint">Alternate role file shown on odd-second batches</p>
+          <input id="ab-variant-b"
+                 class="cfg-text-input"
+                 type="text"
+                 placeholder=".cursor/roles/python-developer-v2.md"
+                 x-model.trim="config.ab_mode.variant_b_file"
+                 aria-label="Variant B file path" />
+        </div>
+      </div>
+    </section>
+
+    {# ════════ Projects Panel ════════ #}
+    <section id="panel-projects"
+             role="tabpanel"
+             x-show="activeTab === 'projects'"
+             x-transition:enter="transition ease-out duration-150"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100">
+
+      <h2 class="cfg-panel-title">Projects</h2>
+
+      <div id="project-toast"
+           class="cfg-switch-toast"
+           aria-live="polite"></div>
+
+      <div class="cfg-projects-list">
+
+        <template x-if="config.projects.length === 0">
+          <div class="cfg-project-empty">
+            No projects configured in <code>pipeline-config.json</code>.
+          </div>
+        </template>
+
+        <template x-for="project in config.projects" :key="project.name">
+          <div class="cfg-project-card"
+               :class="{ active: config.active_project === project.name }">
+
+            <div class="cfg-project-header">
+              <span class="cfg-project-name" x-text="project.name"></span>
+              <span class="cfg-active-badge"
+                    x-show="config.active_project === project.name">Active</span>
+            </div>
+
+            <div class="cfg-project-chips">
+              <span class="cfg-project-chip">
+                <span class="chip-icon">🐙</span>
+                <span x-text="project.gh_repo"></span>
+              </span>
+              <span class="cfg-project-chip" x-show="project.repo_dir">
+                <span class="chip-icon">📁</span>
+                <span x-text="project.repo_dir"></span>
+              </span>
+              <span class="cfg-project-chip" x-show="project.worktrees_dir">
+                <span class="chip-icon">🌳</span>
+                <span x-text="project.worktrees_dir"></span>
+              </span>
+            </div>
+
+            <div class="cfg-project-footer">
+              <span class="cfg-project-cursor-id"
+                    x-show="project.cursor_project_id"
+                    x-text="'cursor: ' + project.cursor_project_id"></span>
+              <button class="btn btn-secondary btn-sm"
+                      type="button"
+                      :disabled="config.active_project === project.name || projectSaving === project.name"
+                      @click="switchProject(project.name)"
+                      x-text="projectSaving === project.name ? 'Switching…' : config.active_project === project.name ? 'Active' : 'Switch to'">
+              </button>
+            </div>
+
+          </div>
+        </template>
+      </div>
+    </section>
+
+  </div>{# end .cfg-content #}
+
+  {# ── Sticky footer ──────────────────────────────────────────────────────── #}
+  <footer class="cfg-footer" role="contentinfo">
+    <button class="btn btn-secondary"
+            type="button"
+            :disabled="!isDirty || saving"
+            @click="cancel()">Discard</button>
+
+    <button class="btn btn-primary"
             type="button"
             :disabled="saving"
             @click="save()"
-            x-text="saving ? 'Saving…' : 'Save'">Save</button>
+            x-text="saving ? 'Saving…' : 'Save changes'">Save changes</button>
 
-    <span class="config-toast"
+    <span class="cfg-footer-spacer"></span>
+
+    <span class="cfg-toast"
           :class="toast.cls"
+          x-show="toast.msg"
           x-text="toast.msg"
-          id="config-toast"
           role="status"
-          aria-live="polite"></span>
-  </div>
+          aria-live="polite"
+          style="display:none"></span>
+  </footer>
 
-</div>
+</div>{# end .cfg-layout #}
 
 {# configPanel() lives in /static/app.js #}
 {% endblock %}


### PR DESCRIPTION
## Summary

Replaces the monolithic config page (inline CSS, 2 sections, no A/B or Projects) with a fully separated Jinja → HTMX → Alpine architecture covering all four config sections.

## What Changed

### `agentception/templates/config.html` — Full rebuild
- Removed all `<style>` from `{% block head %}`
- Two-column grid layout: 188px sidebar tab rail + flex-1 scrollable content area
- Config hydrated via `data-config` attribute (avoids quote collision with Jinja `tojson`)
- **4 panels**: Allocation, Labels, A/B Testing, Projects
- Sticky footer with Discard + Save + aria-live toast
- Accessible: `role=tabpanel`, `aria-live`, `aria-label`, `role=meter`

### `agentception/static/scss/pages/_config.scss` — New file
- All tokens from foundation (`--bg-surface/elevated/overlay`, `--accent`, `--success/danger/warning`)
- `cfg-tab-btn`: left-rail tabs with accent border-left indicator on active
- Capacity bar: split accent/warm gradient meter reacting live to slider changes
- `cfg-toggle-track`: CSS-only pill toggle with smooth transition
- `cfg-project-card`: accent left-border + glow on active project
- `cfg-footer`: `backdrop-filter: blur` sticky bar
- Responsive: collapses sidebar to top tab row on ≤680px

### `agentception/static/app.js` — Expanded `configPanel()`
- Data hydration from `this.$el.dataset.config` (zero-flicker, no quote collision)
- Computed getters: `totalAgents`, `engSlots`, `qaSlots`, `engPct`, `qaPct`
- Tab navigation: `activeTab`, `setTab()`
- `isDirty` getter: enables Discard only when there are unsaved changes
- `cancel()`: restores `lastSaved` snapshot
- `ensureAbMode()`: guard for A/B mode object initialization
- `switchProject(name)`: POST `/api/config/switch-project` + inline toast
- `savedAt`: timestamp shown in page header after successful save

## Taxonomy: What's Now Shown

| Section | Before | After |
|---|---|---|
| Allocation | 3 basic sliders | Sliders + live capacity bar with eng/QA split |
| Labels | Drag-and-drop | Same, improved visuals with position numbers |
| A/B Testing | **Absent** | Toggle + conditional file path inputs + info callout |
| Projects | **Absent** | Cards with chips, active badge, Switch To button |

## Validation
- Sass compiled clean (`--no-source-map`)
- mypy `maestro/ tests/` clean (740 files, 0 issues)
- HTML parsed OK (386 lines)
- No linter errors