### PR TITLE
feat(devops): bind-mount agentception/ into maestro container

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -26,6 +26,7 @@ services:
     volumes:
       - maestro_data:/data
       - ./maestro:/app/maestro
+      - ./agentception:/app/agentception
       - ./tests:/app/tests
       - ./scripts:/app/scripts
       - ./tools:/app/tools


### PR DESCRIPTION
## Summary

Closes #646

Adds `./agentception:/app/agentception` bind mount to the `maestro` service in `docker-compose.override.yml`.

This allows agentception tests to run directly in the maestro container:

```bash
docker compose exec maestro pytest tests/test_agentception_scaffold.py tests/test_agentception_worktrees.py -v
```

without requiring `PYTHONPATH=/worktrees/...` as a workaround.

## Files Changed

- `docker-compose.override.yml` — add `./agentception:/app/agentception` to maestro volumes

## Verification

- Infrastructure-only change; no mypy or pytest needed
- Bind mount follows exact same pattern as existing `./maestro:/app/maestro` mount

---
Agent: hopper:devops
Issue: #646