### PR TITLE
feat: sync VALID_ROLES with role-taxonomy.yaml

### DIFF
--- a/agentception/models.py
+++ b/agentception/models.py
@@ -6,32 +6,59 @@ models that reference external services.
 """
 from __future__ import annotations
 
+import logging
 from enum import Enum
+from pathlib import Path
 
+import yaml
 from pydantic import BaseModel, Field, field_validator
 
+logger = logging.getLogger(__name__)
+
+# Path to the canonical role taxonomy — two directories up from this file (repo root).
+_TAXONOMY_PATH: Path = (
+    Path(__file__).parent.parent / "scripts" / "gen_prompts" / "role-taxonomy.yaml"
+)
+
+
+def _load_valid_roles() -> frozenset[str]:
+    """Load spawnable role slugs from role-taxonomy.yaml at import time.
+
+    Extracts every entry with ``spawnable: true`` from the three-tier org
+    hierarchy and returns their slugs as an immutable set. This keeps
+    ``VALID_ROLES`` automatically in sync with the taxonomy without manual
+    list maintenance.
+
+    Logs a warning and returns an empty frozenset when the taxonomy file is
+    absent (e.g. during tests that run against an isolated module).
+    """
+    if not _TAXONOMY_PATH.exists():
+        logger.warning(
+            "⚠️ role-taxonomy.yaml not found at %s — VALID_ROLES will be empty",
+            _TAXONOMY_PATH,
+        )
+        return frozenset()
+    raw: object = yaml.safe_load(_TAXONOMY_PATH.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        logger.warning("⚠️ role-taxonomy.yaml has unexpected structure — VALID_ROLES will be empty")
+        return frozenset()
+    roles: set[str] = set()
+    for level in raw.get("levels", []):
+        if not isinstance(level, dict):
+            continue
+        for role in level.get("roles", []):
+            if isinstance(role, dict) and role.get("spawnable") is True:
+                slug = role.get("slug")
+                if isinstance(slug, str):
+                    roles.add(slug)
+    return frozenset(roles)
+
+
 #: Roles that can be assigned to a spawned leaf agent via POST /api/control/spawn.
+#: Derived dynamically from ``scripts/gen_prompts/role-taxonomy.yaml`` (spawnable: true entries).
 #: Orchestration roles (cto, engineering-manager, qa-manager, coordinator) are
-#: spawnable only through the CTO pipeline, not directly via the control plane.
-VALID_ROLES: frozenset[str] = frozenset({
-    # Original leaf roles
-    "python-developer",
-    "database-architect",
-    "pr-reviewer",
-    # New worker / leaf roles
-    "frontend-developer",
-    "full-stack-developer",
-    "mobile-developer",
-    "systems-programmer",
-    "ml-engineer",
-    "data-engineer",
-    "devops-engineer",
-    "security-engineer",
-    "test-engineer",
-    "architect",
-    "api-developer",
-    "technical-writer",
-})
+#: spawnable only through the CTO pipeline — their taxonomy entries have spawnable: false.
+VALID_ROLES: frozenset[str] = _load_valid_roles()
 
 
 class AgentStatus(str, Enum):

--- a/agentception/routes/ui/_shared.py
+++ b/agentception/routes/ui/_shared.py
@@ -24,26 +24,47 @@ _TEMPLATES = Jinja2Templates(directory=str(_HERE.parent.parent / "templates"))
 
 # Ordered category map for the spawn Mission Control role picker.
 # Each entry: slug → (category_name, sort_position_within_category)
+# Roles not listed here fall into the "Other" catch-all category, which
+# appears last so newly-added taxonomy roles are always visible in the form.
 _ROLE_CATEGORY_MAP: dict[str, tuple[str, int]] = {
-    "python-developer":     ("Backend", 0),
-    "api-developer":        ("Backend", 1),
-    "database-architect":   ("Backend", 2),
-    "systems-programmer":   ("Backend", 3),
-    "frontend-developer":   ("Frontend", 0),
-    "mobile-developer":     ("Frontend", 1),
-    "full-stack-developer": ("Frontend", 2),
-    "test-engineer":        ("Quality", 0),
-    "pr-reviewer":          ("Quality", 1),
-    "technical-writer":     ("Quality", 2),
-    "devops-engineer":      ("Infrastructure", 0),
-    "security-engineer":    ("Infrastructure", 1),
-    "ml-engineer":          ("Data / AI", 0),
-    "data-engineer":        ("Data / AI", 1),
-    "architect":            ("Architecture", 0),
+    # Backend
+    "python-developer":         ("Backend", 0),
+    "api-developer":            ("Backend", 1),
+    "database-architect":       ("Backend", 2),
+    "systems-programmer":       ("Backend", 3),
+    "go-developer":             ("Backend", 4),
+    "rails-developer":          ("Backend", 5),
+    # Frontend
+    "frontend-developer":       ("Frontend", 0),
+    "mobile-developer":         ("Frontend", 1),
+    "full-stack-developer":     ("Frontend", 2),
+    "typescript-developer":     ("Frontend", 3),
+    "react-developer":          ("Frontend", 4),
+    # Mobile
+    "ios-developer":            ("Mobile", 0),
+    "android-developer":        ("Mobile", 1),
+    # Quality
+    "test-engineer":            ("Quality", 0),
+    "pr-reviewer":              ("Quality", 1),
+    "technical-writer":         ("Quality", 2),
+    # Infrastructure
+    "devops-engineer":          ("Infrastructure", 0),
+    "security-engineer":        ("Infrastructure", 1),
+    "site-reliability-engineer": ("Infrastructure", 2),
+    # Data / AI
+    "ml-engineer":              ("Data / AI", 0),
+    "data-engineer":            ("Data / AI", 1),
+    "ml-researcher":            ("Data / AI", 2),
+    "data-scientist":           ("Data / AI", 3),
+    # Systems
+    "rust-developer":           ("Systems", 0),
+    # Architecture
+    "architect":                ("Architecture", 0),
 }
 
 _CATEGORY_ORDER: list[str] = [
-    "Backend", "Frontend", "Quality", "Infrastructure", "Data / AI", "Architecture",
+    "Backend", "Frontend", "Mobile", "Quality", "Infrastructure",
+    "Data / AI", "Systems", "Architecture", "Other",
 ]
 
 

--- a/agentception/tests/test_agentception_models.py
+++ b/agentception/tests/test_agentception_models.py
@@ -1,0 +1,104 @@
+"""Tests for agentception/models.py — VALID_ROLES taxonomy sync (issue #822).
+
+Verifies that ``VALID_ROLES`` is derived from the role taxonomy rather than a
+hand-maintained frozenset, and that the set stays in sync with the YAML file.
+
+Run targeted:
+    pytest agentception/tests/test_agentception_models.py -v
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from agentception.models import VALID_ROLES
+
+# Derive taxonomy path the same way models.py does — two levels up from agentception/.
+# This avoids importing the private _TAXONOMY_PATH symbol while still testing
+# that the path resolution logic is correct.
+_HERE = Path(__file__).parent  # agentception/tests/
+_TAXONOMY_PATH = _HERE.parent.parent / "scripts" / "gen_prompts" / "role-taxonomy.yaml"
+
+
+def _spawnable_slugs_from_taxonomy() -> frozenset[str]:
+    """Re-read the taxonomy YAML independently and return spawnable slugs.
+
+    Used as a ground-truth reference in tests so any regression — e.g.
+    someone accidentally re-introducing a hardcoded frozenset — is caught.
+    """
+    raw: object = yaml.safe_load(_TAXONOMY_PATH.read_text(encoding="utf-8"))
+    assert isinstance(raw, dict), "role-taxonomy.yaml must be a YAML mapping"
+    slugs: set[str] = set()
+    for level in raw.get("levels", []):
+        if not isinstance(level, dict):
+            continue
+        for role in level.get("roles", []):
+            if isinstance(role, dict) and role.get("spawnable") is True:
+                slug = role.get("slug")
+                if isinstance(slug, str):
+                    slugs.add(slug)
+    return frozenset(slugs)
+
+
+def test_valid_roles_matches_taxonomy() -> None:
+    """VALID_ROLES must equal the set of spawnable slugs in role-taxonomy.yaml.
+
+    This is the regression guard for issue #822: if a new role is added to
+    the taxonomy with spawnable: true, VALID_ROLES must automatically include
+    it without any manual list update in models.py.
+    """
+    expected = _spawnable_slugs_from_taxonomy()
+    assert VALID_ROLES == expected, (
+        f"VALID_ROLES is out of sync with role-taxonomy.yaml.\n"
+        f"  Missing from VALID_ROLES: {expected - VALID_ROLES}\n"
+        f"  Extra in VALID_ROLES:     {VALID_ROLES - expected}"
+    )
+
+
+def test_valid_roles_taxonomy_file_exists() -> None:
+    """role-taxonomy.yaml must exist at the resolved path."""
+    assert _TAXONOMY_PATH.exists(), (
+        f"Taxonomy file not found: {_TAXONOMY_PATH}. "
+        "Did the file move? Update _TAXONOMY_PATH in models.py."
+    )
+
+
+def test_valid_roles_is_nonempty() -> None:
+    """VALID_ROLES must contain at least the original leaf agent roles."""
+    core_roles = {
+        "python-developer",
+        "database-architect",
+        "pr-reviewer",
+    }
+    assert core_roles.issubset(VALID_ROLES), (
+        f"Core roles missing from VALID_ROLES: {core_roles - VALID_ROLES}"
+    )
+
+
+def test_valid_roles_excludes_non_spawnable() -> None:
+    """Orchestration roles (spawnable: false) must not appear in VALID_ROLES."""
+    orchestration_roles = {"cto", "engineering-manager", "qa-manager", "ceo"}
+    overlap = orchestration_roles & VALID_ROLES
+    assert not overlap, (
+        f"Non-spawnable orchestration roles found in VALID_ROLES: {overlap}"
+    )
+
+
+def test_valid_roles_contains_new_taxonomy_roles() -> None:
+    """VALID_ROLES must include roles added in the extended taxonomy (issue #822)."""
+    new_roles = {
+        "rust-developer",
+        "go-developer",
+        "typescript-developer",
+        "ios-developer",
+        "android-developer",
+        "rails-developer",
+        "react-developer",
+        "site-reliability-engineer",
+        "ml-researcher",
+        "data-scientist",
+    }
+    assert new_roles.issubset(VALID_ROLES), (
+        f"New taxonomy roles missing from VALID_ROLES: {new_roles - VALID_ROLES}"
+    )


### PR DESCRIPTION
## Summary

Closes #822 — Replace the hardcoded `VALID_ROLES` frozenset in `agentception/models.py` with a dynamic load from `scripts/gen_prompts/role-taxonomy.yaml` at import time.

## Root Cause / Motivation

`VALID_ROLES` was a manually-maintained frozenset of 15 roles. When new roles were added to `role-taxonomy.yaml` (rust-developer, go-developer, typescript-developer, ios-developer, android-developer, rails-developer, react-developer, site-reliability-engineer, ml-researcher, data-scientist), they needed to be manually copied to the frozenset. This caused `POST /api/control/spawn` to reject valid taxonomy roles with a 422 error.

## Solution

- **`agentception/models.py`**: Added `_load_valid_roles()` that reads `role-taxonomy.yaml` at import time, extracts every entry with `spawnable: true`, and builds `VALID_ROLES` as a `frozenset[str]`. The taxonomy file is found via `Path(__file__).parent.parent / "scripts/gen_prompts/role-taxonomy.yaml"` — robust under Docker bind-mount layout.

- **`agentception/routes/ui/_shared.py`**: Updated `_ROLE_CATEGORY_MAP` to properly categorize the 10 new taxonomy roles in the Mission Control spawn form. Added an `"Other"` catch-all category to `_CATEGORY_ORDER` so future taxonomy additions are always visible in the UI without needing a map update.

- **`agentception/tests/test_agentception_models.py`** (new): Five tests covering the sync contract — `test_valid_roles_matches_taxonomy` is the primary regression guard that will fail whenever the two sources diverge.

## Verification

- [x] mypy clean (95 source files, 0 errors)
- [x] All 20 tests pass (5 new + 15 existing spawn tests)
- [x] No rebuild needed — code change only

---

<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Architecture** | `hopper:python` |
| **Session** | `eng-20260303T155209Z-2475` |
| **Batch** | `13972510-4daf-46f7-a9c8-22ab4e4d5c16` |
| **Wave (CTO)** | `0` |

</details>