### PR TITLE
fix(agentception): uniform fingerprint timestamps and safe branch delete

### DIFF
--- a/.cursor/parallel-issue-to-pr.md
+++ b/.cursor/parallel-issue-to-pr.md
@@ -545,13 +545,15 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
 
   # Leave an audit trail: which cognitive identity claimed this issue.
   AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
+  CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
   CLAIM_FINGERPRINT=$(python3 "$REPO/scripts/gen_prompts/resolve_arch.py" "${COGNITIVE_ARCH:-unset}" \
     --fingerprint \
     --role "${ROLE:-python-developer}" \
     --session "$AGENT_SESSION" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" 2>/dev/null)
+    --vp "${VP_FINGERPRINT:-unset}" \
+    --started-at "$CLAIMED_AT" 2>/dev/null)
   # Fallback: if resolve_arch.py is unavailable or returned nothing, build the table in shell.
   # This ensures a consistent <details> table appears even when Python/PyYAML is absent.
   # ⚠️  Row labels MUST match render_fingerprint() exactly — this is the single source of truth.
@@ -1011,16 +1013,35 @@ STEP 5 — PUSH & CREATE PR:
 
   # Post fingerprint comment on the issue so it's traceable even if the claim
   # step was skipped (e.g. issue opened manually rather than claimed from pool).
-  gh issue comment <N> --repo "$GH_REPO" \
-    --body "🤖 **Implemented by agent** — PR #${MY_PR_NUM:-?}
-
-$(python3 "$REPO/scripts/gen_prompts/resolve_arch.py" "${COGNITIVE_ARCH:-unset}" \
+  # Reuse $PR_CREATED_AT so "Implemented" timestamp matches the PR creation moment.
+  IMPL_FINGERPRINT=$(python3 "$REPO/scripts/gen_prompts/resolve_arch.py" "${COGNITIVE_ARCH:-unset}" \
     --fingerprint \
     --role "${ROLE:-python-developer}" \
     --session "${AGENT_SESSION:-unset}" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}")" 2>/dev/null || true
+    --vp "${VP_FINGERPRINT:-unset}" \
+    --started-at "${PR_CREATED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}" 2>/dev/null)
+  if [ -z "$IMPL_FINGERPRINT" ]; then
+    IMPL_FINGERPRINT="<details>
+<summary>🤖 Agent Fingerprint</summary>
+
+| | |
+|---|---|
+| **Role** | \`${ROLE:-python-developer}\` |
+| **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
+| **Session** | \`${AGENT_SESSION:-unset}\` |
+| **CTO Wave** | \`${WAVE:-unset}\` |
+| **VP Batch** | \`${BATCH_ID:-none}\` |
+| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Timestamp** | \`${PR_CREATED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}\` |
+
+</details>"
+  fi
+  gh issue comment <N> --repo "$GH_REPO" \
+    --body "🤖 **Implemented by agent** — PR #${MY_PR_NUM:-?}
+
+$IMPL_FINGERPRINT" 2>/dev/null || true
 
   # Transition status label: in-progress → pr-open
   gh issue edit <N> --repo "$GH_REPO" \

--- a/.cursor/parallel-pr-review.md
+++ b/.cursor/parallel-pr-review.md
@@ -981,19 +981,18 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   # 6. Clear agent:wip now that the PR is merged — it must not persist on closed PRs.
        gh pr edit <N> --repo "$GH_REPO" --remove-label "agent:wip" 2>/dev/null || true
 
-  # 7. Delete the remote branch manually (now safe — merge is done):
-  # NOTE: GitHub auto-delete-head-branches is ENABLED on this repo.
-  # The explicit push --delete here is belt-and-suspenders: it handles the
-  # case where auto-delete races with a local delete or the setting is toggled off.
-       git push origin --delete "$BRANCH" 2>&1 || echo "⚠️  Remote branch delete failed or already deleted — continuing"
-
-  # Verify remote branch is gone:
+  # 7. Delete the remote branch — CHECK EXISTENCE FIRST.
+  # GitHub auto-delete-head-branches is ENABLED on this repo, so the branch is
+  # usually already gone by the time we reach this step. Attempting push --delete
+  # on a non-existent branch always produces an error even with || true, which is
+  # noisy and confusing. Check with ls-remote first; only delete if still present.
+       git fetch --prune 2>/dev/null || true
        STILL_EXISTS=$(git ls-remote --heads origin "$BRANCH" | wc -l | tr -d ' ')
        if [ "$STILL_EXISTS" -gt 0 ]; then
-         echo "⚠️  Remote branch $BRANCH still exists — retrying deletion"
-         git push origin --delete "$BRANCH" 2>&1 || echo "⚠️  Branch delete failed or already deleted"
+         echo "🗑️  Remote branch $BRANCH still exists — deleting..."
+         git push origin --delete "$BRANCH" 2>&1 || echo "⚠️  Branch delete failed — may need manual cleanup"
        else
-         echo "✅ Remote branch $BRANCH deleted"
+         echo "✅ Remote branch $BRANCH already removed (GitHub auto-delete)."
        fi
 
   # 8. Post a fingerprint comment on the PR so every merge is permanently traceable:

--- a/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
+++ b/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
@@ -544,13 +544,15 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
 
   # Leave an audit trail: which cognitive identity claimed this issue.
   AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
+  CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
   CLAIM_FINGERPRINT=$(python3 "$REPO/scripts/gen_prompts/resolve_arch.py" "${COGNITIVE_ARCH:-unset}" \
     --fingerprint \
     --role "${ROLE:-python-developer}" \
     --session "$AGENT_SESSION" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" 2>/dev/null)
+    --vp "${VP_FINGERPRINT:-unset}" \
+    --started-at "$CLAIMED_AT" 2>/dev/null)
   # Fallback: if resolve_arch.py is unavailable or returned nothing, build the table in shell.
   # This ensures a consistent <details> table appears even when Python/PyYAML is absent.
   # ⚠️  Row labels MUST match render_fingerprint() exactly — this is the single source of truth.
@@ -1010,16 +1012,35 @@ STEP 5 — PUSH & CREATE PR:
 
   # Post fingerprint comment on the issue so it's traceable even if the claim
   # step was skipped (e.g. issue opened manually rather than claimed from pool).
-  gh issue comment <N> --repo "$GH_REPO" \
-    --body "🤖 **Implemented by agent** — PR #${MY_PR_NUM:-?}
-
-$(python3 "$REPO/scripts/gen_prompts/resolve_arch.py" "${COGNITIVE_ARCH:-unset}" \
+  # Reuse $PR_CREATED_AT so "Implemented" timestamp matches the PR creation moment.
+  IMPL_FINGERPRINT=$(python3 "$REPO/scripts/gen_prompts/resolve_arch.py" "${COGNITIVE_ARCH:-unset}" \
     --fingerprint \
     --role "${ROLE:-python-developer}" \
     --session "${AGENT_SESSION:-unset}" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}")" 2>/dev/null || true
+    --vp "${VP_FINGERPRINT:-unset}" \
+    --started-at "${PR_CREATED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}" 2>/dev/null)
+  if [ -z "$IMPL_FINGERPRINT" ]; then
+    IMPL_FINGERPRINT="<details>
+<summary>🤖 Agent Fingerprint</summary>
+
+| | |
+|---|---|
+| **Role** | \`${ROLE:-python-developer}\` |
+| **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
+| **Session** | \`${AGENT_SESSION:-unset}\` |
+| **CTO Wave** | \`${WAVE:-unset}\` |
+| **VP Batch** | \`${BATCH_ID:-none}\` |
+| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Timestamp** | \`${PR_CREATED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}\` |
+
+</details>"
+  fi
+  gh issue comment <N> --repo "$GH_REPO" \
+    --body "🤖 **Implemented by agent** — PR #${MY_PR_NUM:-?}
+
+$IMPL_FINGERPRINT" 2>/dev/null || true
 
   # Transition status label: in-progress → pr-open
   gh issue edit <N> --repo "$GH_REPO" \

--- a/scripts/gen_prompts/templates/parallel-pr-review.md.j2
+++ b/scripts/gen_prompts/templates/parallel-pr-review.md.j2
@@ -980,19 +980,18 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   # 6. Clear agent:wip now that the PR is merged — it must not persist on closed PRs.
        gh pr edit <N> --repo "$GH_REPO" --remove-label "agent:wip" 2>/dev/null || true
 
-  # 7. Delete the remote branch manually (now safe — merge is done):
-  # NOTE: GitHub auto-delete-head-branches is ENABLED on this repo.
-  # The explicit push --delete here is belt-and-suspenders: it handles the
-  # case where auto-delete races with a local delete or the setting is toggled off.
-       git push origin --delete "$BRANCH" 2>&1 || echo "⚠️  Remote branch delete failed or already deleted — continuing"
-
-  # Verify remote branch is gone:
+  # 7. Delete the remote branch — CHECK EXISTENCE FIRST.
+  # GitHub auto-delete-head-branches is ENABLED on this repo, so the branch is
+  # usually already gone by the time we reach this step. Attempting push --delete
+  # on a non-existent branch always produces an error even with || true, which is
+  # noisy and confusing. Check with ls-remote first; only delete if still present.
+       git fetch --prune 2>/dev/null || true
        STILL_EXISTS=$(git ls-remote --heads origin "$BRANCH" | wc -l | tr -d ' ')
        if [ "$STILL_EXISTS" -gt 0 ]; then
-         echo "⚠️  Remote branch $BRANCH still exists — retrying deletion"
-         git push origin --delete "$BRANCH" 2>&1 || echo "⚠️  Branch delete failed or already deleted"
+         echo "🗑️  Remote branch $BRANCH still exists — deleting..."
+         git push origin --delete "$BRANCH" 2>&1 || echo "⚠️  Branch delete failed — may need manual cleanup"
        else
-         echo "✅ Remote branch $BRANCH deleted"
+         echo "✅ Remote branch $BRANCH already removed (GitHub auto-delete)."
        fi
 
   # 8. Post a fingerprint comment on the PR so every merge is permanently traceable:


### PR DESCRIPTION
## Summary

- All six fingerprint call sites now pass an explicit `--started-at` timestamp — no fingerprint ever auto-defaults silently
- Branch delete step in pr-review checks existence with `git ls-remote` **before** attempting `git push origin --delete`, eliminating the error that appeared on every single PR merge

## Fingerprint fix

The implementer's three fingerprints (claim, PR body, "implemented" comment) were inconsistent:

| Fingerprint | Before | After |
|---|---|---|
| 🔖 Claimed by agent | no `--started-at` (defaulted at runtime) | `--started-at $CLAIMED_AT` (explicit) |
| PR body | `--started-at $PR_CREATED_AT` ✅ | unchanged |
| 🤖 Implemented by agent | no `--started-at`, no fallback | `--started-at $PR_CREATED_AT`, with fallback |

The "Implemented" comment now reuses `$PR_CREATED_AT` so all three implementer fingerprints carry the same moment — the PR creation instant.

## Branch delete fix

**Root cause:** GitHub auto-deletes the head branch when a PR is merged. Step 7 of the reviewer was running `git push origin --delete $BRANCH` unconditionally *first*, which always errored, then checking existence with `git ls-remote` after.

**Fix:** Check with `git fetch --prune && git ls-remote --heads origin "$BRANCH"` first:
- Branch already gone → `✅ Remote branch already removed (GitHub auto-delete).` — no error
- Branch still present → delete it normally

## Files changed
- `scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2`
- `scripts/gen_prompts/templates/parallel-pr-review.md.j2`
- `.cursor/parallel-issue-to-pr.md` (regenerated)
- `.cursor/parallel-pr-review.md` (regenerated)