### PR TITLE
fix: mount scripts/ into agentception container (#841)

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -79,6 +79,9 @@ services:
     volumes:
       # Live code — host edits are instantly visible; no rebuild needed
       - ./agentception:/app/agentception
+      # scripts/ — required so models.py can resolve _TAXONOMY_PATH at /app/scripts/
+      # (Path(__file__).parent.parent / "scripts" / ...) when __file__=/app/agentception/models.py
+      - ./scripts:/app/scripts
       # .cursor/ — mounted so pipeline-config.json and role files are readable
       # by get_active_label(), read_pipeline_config(), and the spawn endpoint.
       - ./.cursor:/app/.cursor:ro


### PR DESCRIPTION
## Summary
Closes #841 — VALID_ROLES was resolving to an empty frozenset() in the live agentception container after PR #837.

## Root Cause / Motivation
PR #837 added code to load `VALID_ROLES` from `scripts/gen_prompts/role-taxonomy.yaml` using a path relative to `__file__`:

```python
_TAXONOMY_PATH = Path(__file__).parent.parent / "scripts" / "gen_prompts" / "role-taxonomy.yaml"
```

In the live container `__file__ = /app/agentception/models.py`, so the resolved path is `/app/scripts/gen_prompts/role-taxonomy.yaml`. However, the agentception service only had `./agentception:/app/agentception` mounted — `scripts/` was not mounted, so the YAML file was missing and `VALID_ROLES` silently fell back to `frozenset()`. All spawn calls with any role then returned 422.

## Solution
Add `./scripts:/app/scripts` volume mount to the agentception service in `docker-compose.override.yml`. This is a one-line compose config change with no code modifications required. No rebuild needed — `docker compose up -d agentception` applies the new mount.

## Verification
- [x] mypy clean: `Success: no issues found in 97 source files`
- [x] All 5 model tests pass: `test_valid_roles_matches_taxonomy`, `test_valid_roles_taxonomy_file_exists`, `test_valid_roles_is_nonempty`, `test_valid_roles_excludes_non_spawnable`, `test_valid_roles_contains_new_taxonomy_roles`
- [x] Live container regression test: `✅ 25 roles loaded` (was `frozenset()` before fix)

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Role** | `python-developer` |
| **Architecture** | `dijkstra:python` |
| **Session** | `eng-20260303T162437Z-0464` |
| **CTO Wave** | `unset` |
| **VP Batch** | `13972510-4daf-46f7-a9c8-22ab4e4d5c16` |
| **VP** | `unset` |
| **Timestamp** | `2026-03-03T16:27:03Z` |

</details>