### PR TITLE
feat: polish recent-runs sidebar with re-run and DAG link

### DIFF
--- a/agentception/routes/ui/brain_dump.py
+++ b/agentception/routes/ui/brain_dump.py
@@ -1,10 +1,17 @@
-"""UI routes: Brain Dump page and recent-runs partial."""
+"""UI routes: Brain Dump page and recent-runs partial.
+
+Endpoints
+---------
+GET /brain-dump                              — full page
+GET /brain-dump/recent-runs                  — HTMX partial (sidebar refresh)
+GET /api/brain-dump/{run_id}/dump-text       — return original dump text for re-run
+"""
 from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import HTMLResponse, JSONResponse
 from starlette.requests import Request
 
 from ._shared import _TEMPLATES
@@ -74,8 +81,35 @@ _BD_LOADING_MSGS: list[str] = [
 ]
 
 
+def _parse_task_fields(content: str) -> dict[str, str]:
+    """Parse key=value lines from the structured header of a ``.agent-task`` file.
+
+    Only processes lines before the first blank line or ``BRAIN_DUMP:`` marker so
+    that multi-line dump text is never misinterpreted as a key=value pair.
+    """
+    fields: dict[str, str] = {}
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped == "BRAIN_DUMP:":
+            break
+        if "=" in stripped:
+            key, _, val = stripped.partition("=")
+            fields[key.strip()] = val.strip()
+    return fields
+
+
+def _count_dump_items(dump_text: str) -> int:
+    """Count non-empty lines in a BRAIN_DUMP block as a proxy for item count."""
+    return sum(1 for ln in dump_text.splitlines() if ln.strip())
+
+
 async def _build_recent_dumps() -> list[dict[str, str]]:
-    """Scan the worktrees directory and return metadata for the 6 most recent brain-dump runs."""
+    """Scan the worktrees directory and return metadata for the 6 most recent brain-dump runs.
+
+    Each entry contains: slug, label_prefix, preview, ts, batch_id, item_count.
+    ``item_count`` is a line-count heuristic over the BRAIN_DUMP block (not a live
+    GitHub issue count) so no network call is needed on the hot render path.
+    """
     from agentception.config import settings as _cfg
 
     recent_dumps: list[dict[str, str]] = []
@@ -90,17 +124,21 @@ async def _build_recent_dumps() -> list[dict[str, str]]:
             for d in candidates[:6]:
                 label_prefix = ""
                 preview = ""
+                batch_id = d.name
+                item_count = "—"
                 task_file = d / ".agent-task"
                 if task_file.exists():
                     try:
                         content = task_file.read_text(encoding="utf-8")
-                        for raw_line in content.splitlines():
-                            if raw_line.startswith("LABEL_PREFIX="):
-                                label_prefix = raw_line.split("=", 1)[1].strip()
+                        fields = _parse_task_fields(content)
+                        label_prefix = fields.get("LABEL_PREFIX", "")
+                        batch_id = fields.get("BATCH_ID", d.name)
                         if "BRAIN_DUMP:" in content:
                             dump_part = content.split("BRAIN_DUMP:", 1)[1].strip()
                             first = next((ln.strip() for ln in dump_part.splitlines() if ln.strip()), "")
                             preview = first[:90]
+                            count = _count_dump_items(dump_part)
+                            item_count = str(count) if count else "—"
                     except OSError:
                         pass
                 ts_raw = d.name[len("brain-dump-"):]
@@ -108,7 +146,14 @@ async def _build_recent_dumps() -> list[dict[str, str]]:
                     ts_fmt = f"{ts_raw[:4]}-{ts_raw[4:6]}-{ts_raw[6:8]} {ts_raw[9:11]}:{ts_raw[11:13]}"
                 except Exception:
                     ts_fmt = ts_raw
-                recent_dumps.append({"slug": d.name, "label_prefix": label_prefix, "preview": preview, "ts": ts_fmt})
+                recent_dumps.append({
+                    "slug": d.name,
+                    "label_prefix": label_prefix,
+                    "preview": preview,
+                    "ts": ts_fmt,
+                    "batch_id": batch_id,
+                    "item_count": item_count,
+                })
     except OSError:
         pass
     return recent_dumps
@@ -148,3 +193,48 @@ async def brain_dump_recent_runs(request: Request) -> HTMLResponse:
         "_bd_recent_runs.html",
         {"recent_dumps": recent_dumps, "gh_repo": _cfg.gh_repo},
     )
+
+
+@router.get("/api/brain-dump/{run_id}/dump-text")
+async def brain_dump_run_dump_text(run_id: str) -> JSONResponse:
+    """Return the original BRAIN_DUMP text for a given run slug.
+
+    Used by the "Re-run →" button in the sidebar: the JS handler fetches this,
+    populates the main textarea, and switches Alpine to the ``input`` step so
+    the user can edit and resubmit without copy-pasting.
+
+    Parameters
+    ----------
+    run_id:
+        The directory slug, e.g. ``brain-dump-20260303-164033``.  Must start
+        with ``brain-dump-`` and must not contain path traversal characters.
+
+    Raises
+    ------
+    HTTP 400
+        When ``run_id`` contains illegal characters or does not start with
+        ``brain-dump-``.
+    HTTP 404
+        When the worktree directory or ``.agent-task`` file does not exist, or
+        the file contains no ``BRAIN_DUMP:`` section.
+    """
+    from agentception.config import settings as _cfg
+
+    if not run_id.startswith("brain-dump-") or "/" in run_id or ".." in run_id:
+        raise HTTPException(status_code=400, detail="Invalid run_id format.")
+
+    task_file = _cfg.worktrees_dir / run_id / ".agent-task"
+    if not task_file.exists():
+        raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found.")
+
+    try:
+        content = task_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("⚠️ Could not read .agent-task for run %s: %s", run_id, exc)
+        raise HTTPException(status_code=404, detail="Could not read task file.") from exc
+
+    if "BRAIN_DUMP:" not in content:
+        raise HTTPException(status_code=404, detail="No BRAIN_DUMP section in task file.")
+
+    dump_text = content.split("BRAIN_DUMP:", 1)[1].strip()
+    return JSONResponse({"dump_text": dump_text})

--- a/agentception/static/js/brain_dump.js
+++ b/agentception/static/js/brain_dump.js
@@ -121,5 +121,32 @@ export function brainDump() {
       this.errorMsg = '';
       this.result = {};
     },
+
+    /**
+     * Load a previous run's dump text into the editor and switch to input step.
+     *
+     * Called from the "Re-run →" button rendered in _bd_recent_runs.html:
+     *   @click='reRun({{ run.slug | tojson }})'
+     *
+     * Fetches GET /api/brain-dump/{runId}/dump-text, populates the textarea,
+     * then resets to the input step so the user can review and resubmit.
+     */
+    async reRun(runId) {
+      try {
+        const resp = await fetch(`/api/brain-dump/${encodeURIComponent(runId)}/dump-text`);
+        if (!resp.ok) {
+          const body = await resp.json().catch(() => ({}));
+          this.errorMsg = body.detail || `Could not load run (HTTP ${resp.status})`;
+          return;
+        }
+        const data = await resp.json();
+        this.reset();
+        this.text = data.dump_text ?? '';
+        await this.$nextTick();
+        if (this.$refs.textarea) this.autoGrow(this.$refs.textarea);
+      } catch (err) {
+        this.errorMsg = err.message || 'Failed to load previous run.';
+      }
+    },
   };
 }

--- a/agentception/templates/_bd_recent_runs.html
+++ b/agentception/templates/_bd_recent_runs.html
@@ -1,8 +1,27 @@
 {#
   HTMX partial — Brain Dump recent runs sidebar section.
-  Included inline on first load (brain_dump.html {% include %}).
-  HTMX swaps outerHTML of #bd-recent-runs after a successful submit.
+
+  This template owns the #bd-recent-runs wrapper div, including HTMX attributes,
+  so that outerHTML swaps after a successful submit keep re-triggering functional.
+
+  Included inline on first load via brain_dump.html {% include %}.
+  The /brain-dump/recent-runs endpoint returns this same template so HTMX
+  replaces the entire div (outerHTML) and the refreshed version is identical
+  in structure, preserving Alpine bindings on the parent scope.
+
+  Each card shows:
+    - Run timestamp and optional initiative label
+    - Item count (lines parsed from BRAIN_DUMP block)
+    - Preview of the first dump line
+    - "View DAG" link to /dag?batch=<batch_id>
+    - "Re-run →" button — calls reRun(slug) on the parent Alpine component
 #}
+<div
+  id="bd-recent-runs"
+  hx-get="/brain-dump/recent-runs"
+  hx-trigger="refresh"
+  hx-swap="outerHTML"
+>
 {% if recent_dumps %}
 <p class="bd-funnel-heading">Recent runs</p>
 <div class="bd-history">
@@ -13,13 +32,31 @@
       {% if run.label_prefix %}
       <span class="bd-history-prefix">{{ run.label_prefix }}</span>
       {% endif %}
+      {% if run.item_count and run.item_count != "—" %}
+      <span class="bd-history-count" title="Items in dump">{{ run.item_count }} items</span>
+      {% endif %}
     </div>
     <p class="bd-history-preview">{{ run.preview or '(no preview)' }}</p>
     <div class="bd-history-links">
-      <a href="https://github.com/{{ gh_repo }}/issues" target="_blank" rel="noopener noreferrer" class="bd-history-link">Issues ↗</a>
-      <a href="/agents" class="bd-history-link">Agents →</a>
+      <a
+        href="/dag?batch={{ run.batch_id | urlencode }}"
+        class="bd-history-link"
+        title="View execution DAG for this run"
+      >View DAG ↗</a>
+      <a
+        href="https://github.com/{{ gh_repo }}/issues"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="bd-history-link"
+      >Issues ↗</a>
+      <button
+        class="bd-rerun-btn"
+        @click='reRun({{ run.slug | tojson }})'
+        title="Load this dump into the editor"
+      >Re-run →</button>
     </div>
   </div>
   {% endfor %}
 </div>
 {% endif %}
+</div>

--- a/agentception/templates/brain_dump.html
+++ b/agentception/templates/brain_dump.html
@@ -174,14 +174,8 @@
     </div>
 
     {# Recent runs — server-rendered initially, HTMX-refreshed after submit ── #}
-    <div
-      id="bd-recent-runs"
-      hx-get="/brain-dump/recent-runs"
-      hx-trigger="refresh"
-      hx-swap="outerHTML"
-    >
-      {% include "_bd_recent_runs.html" %}
-    </div>
+    {# The partial owns the #bd-recent-runs div with HTMX attrs so outerHTML swap works. #}
+    {% include "_bd_recent_runs.html" %}
 
   </aside>
 

--- a/agentception/tests/test_agentception_ui_brain_dump.py
+++ b/agentception/tests/test_agentception_ui_brain_dump.py
@@ -1,0 +1,173 @@
+"""Tests for the Brain Dump UI routes (issue #826 — sidebar polish).
+
+Covers:
+- GET /brain-dump page renders correctly
+- GET /brain-dump/recent-runs HTMX partial
+- GET /api/brain-dump/{run_id}/dump-text endpoint
+- _parse_task_fields helper
+- _count_dump_items helper
+
+Run targeted:
+    pytest agentception/tests/test_agentception_ui_brain_dump.py -v
+"""
+from __future__ import annotations
+
+import textwrap
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+from agentception.config import AgentCeptionSettings
+from agentception.routes.ui.brain_dump import _count_dump_items, _parse_task_fields
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    """Synchronous test client."""
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_task_fields_extracts_key_value_pairs() -> None:
+    """_parse_task_fields must parse structured key=value lines correctly."""
+    content = textwrap.dedent("""\
+        WORKFLOW=bugs-to-issues
+        GH_REPO=cgcardona/maestro
+        BATCH_ID=brain-dump-20260303-164033
+        LABEL_PREFIX=q2-rewrite
+
+        BRAIN_DUMP:
+        - Some item
+    """)
+    fields = _parse_task_fields(content)
+    assert fields["WORKFLOW"] == "bugs-to-issues"
+    assert fields["BATCH_ID"] == "brain-dump-20260303-164033"
+    assert fields["LABEL_PREFIX"] == "q2-rewrite"
+
+
+def test_parse_task_fields_stops_at_brain_dump_marker() -> None:
+    """_parse_task_fields must not parse lines after BRAIN_DUMP:."""
+    content = "KEY=value\nBRAIN_DUMP:\nFAKE_KEY=should_not_appear\n"
+    fields = _parse_task_fields(content)
+    assert "KEY" in fields
+    assert "FAKE_KEY" not in fields
+
+
+def test_parse_task_fields_stops_at_blank_line() -> None:
+    """_parse_task_fields must stop at the first blank line (before BRAIN_DUMP section)."""
+    content = "A=1\nB=2\n\nC=3\n"
+    fields = _parse_task_fields(content)
+    assert fields["A"] == "1"
+    assert fields["B"] == "2"
+    assert "C" not in fields
+
+
+def test_parse_task_fields_empty_content() -> None:
+    """_parse_task_fields must return an empty dict for empty content."""
+    assert _parse_task_fields("") == {}
+
+
+def test_count_dump_items_counts_non_empty_lines() -> None:
+    """_count_dump_items must count only lines that have non-whitespace content."""
+    dump = "- Fix login\n- Add dark mode\n\n- Rate limiter\n"
+    assert _count_dump_items(dump) == 3
+
+
+def test_count_dump_items_empty_returns_zero() -> None:
+    """_count_dump_items must return 0 for blank/empty input."""
+    assert _count_dump_items("") == 0
+    assert _count_dump_items("   \n\n  ") == 0
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint tests
+# ---------------------------------------------------------------------------
+
+
+def test_brain_dump_page_renders(client: TestClient) -> None:
+    """GET /brain-dump must return 200 with the page title."""
+    resp = client.get("/brain-dump")
+    assert resp.status_code == 200
+    assert "Brain Dump" in resp.text or "brain-dump" in resp.text.lower()
+
+
+def test_brain_dump_recent_runs_partial_empty(client: TestClient, tmp_path: Path) -> None:
+    """GET /brain-dump/recent-runs returns 200 even when the worktrees dir is empty."""
+    with patch("agentception.routes.ui.brain_dump._build_recent_dumps", return_value=[]):
+        resp = client.get("/brain-dump/recent-runs")
+    assert resp.status_code == 200
+    assert "bd-recent-runs" in resp.text
+
+
+def test_brain_dump_recent_runs_shows_cards(client: TestClient) -> None:
+    """GET /brain-dump/recent-runs renders a card for each recent dump."""
+    fake_runs = [
+        {
+            "slug": "brain-dump-20260303-164033",
+            "label_prefix": "q2-rewrite",
+            "preview": "- Fix login bug",
+            "ts": "2026-03-03 16:40",
+            "batch_id": "brain-dump-20260303-164033",
+            "item_count": "3",
+        }
+    ]
+    with patch("agentception.routes.ui.brain_dump._build_recent_dumps", return_value=fake_runs):
+        resp = client.get("/brain-dump/recent-runs")
+    assert resp.status_code == 200
+    assert "2026-03-03 16:40" in resp.text
+    assert "q2-rewrite" in resp.text
+    assert "Fix login bug" in resp.text
+    assert "View DAG" in resp.text
+    assert "Re-run" in resp.text
+
+
+def test_brain_dump_dump_text_returns_dump(client: TestClient, tmp_path: Path) -> None:
+    """GET /api/brain-dump/{run_id}/dump-text returns the BRAIN_DUMP section as JSON."""
+    run_id = "brain-dump-20260303-164033"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+    task_file = run_dir / ".agent-task"
+    task_file.write_text(
+        "WORKFLOW=bugs-to-issues\nBATCH_ID=brain-dump-20260303-164033\n\nBRAIN_DUMP:\n- Fix login\n- Add dark mode\n",
+        encoding="utf-8",
+    )
+
+    from agentception.config import AgentCeptionSettings
+    fake_settings = AgentCeptionSettings.model_construct(worktrees_dir=tmp_path)
+    with patch("agentception.config.settings", fake_settings):
+        resp = client.get(f"/api/brain-dump/{run_id}/dump-text")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "dump_text" in data
+    assert "Fix login" in data["dump_text"]
+    assert "Add dark mode" in data["dump_text"]
+
+
+def test_brain_dump_dump_text_invalid_run_id(client: TestClient) -> None:
+    """GET /api/brain-dump/{run_id}/dump-text returns 400 for invalid run_id format."""
+    resp = client.get("/api/brain-dump/../../etc-passwd/dump-text")
+    assert resp.status_code in (400, 404)
+
+
+def test_brain_dump_dump_text_wrong_prefix(client: TestClient) -> None:
+    """GET /api/brain-dump/{run_id}/dump-text returns 400 when run_id doesn't start with brain-dump-."""
+    resp = client.get("/api/brain-dump/issue-826/dump-text")
+    assert resp.status_code == 400
+
+
+def test_brain_dump_dump_text_not_found(client: TestClient, tmp_path: Path) -> None:
+    """GET /api/brain-dump/{run_id}/dump-text returns 404 when the worktree doesn't exist."""
+    fake_settings = AgentCeptionSettings.model_construct(worktrees_dir=tmp_path)
+    with patch("agentception.config.settings", fake_settings):
+        resp = client.get("/api/brain-dump/brain-dump-99991231-999999/dump-text")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Closes #826 — Polishes the brain-dump recent-runs sidebar with item count badges, View DAG links, and a Re-run → button that repopulates the editor without a page reload.

## Root Cause / Motivation
The sidebar cards showed only a timestamp and a preview line. Users had no way to re-submit a previous dump or navigate to the execution DAG for a past run.

## Solution

### Backend
- **`_parse_task_fields()`** — extracts the structured `key=value` header from any `.agent-task` file, stopping before the `BRAIN_DUMP:` block.
- **`_count_dump_items()`** — line-count heuristic over the `BRAIN_DUMP` block (no GitHub API call on the hot render path).
- **`GET /api/brain-dump/{run_id}/dump-text`** — returns the original `BRAIN_DUMP` text as `{"dump_text": "..."}` JSON; validates the run_id format and guards against path traversal.
- **`_build_recent_dumps()`** extended to include `batch_id` and `item_count` in each entry.

### Templates
- **`_bd_recent_runs.html`** now owns the `#bd-recent-runs` wrapper div including HTMX attributes (`hx-get`, `hx-trigger`, `hx-swap="outerHTML"`), so `brain_dump.html` only needs a bare `{% include %}`. This is the correct pattern for HTMX outerHTML swap — the swapped-in response carries its own re-trigger metadata.
- Single-quoted `@click='reRun({{ run.slug | tojson }})'` follows the Jinja2+Alpine rule (no double-quoted tojson).
- "View DAG ↗" links to `/dag?batch=<batch_id>`.

### JavaScript
- **`reRun(runId)`** in `brain_dump.js` — fetches `/api/brain-dump/{runId}/dump-text`, calls `reset()`, sets `this.text`, then waits for `$nextTick` to auto-grow the textarea.

## Verification
- [x] mypy clean (98 source files, 0 errors)
- [x] 13 new tests pass (`test_agentception_ui_brain_dump.py`)
- [x] HTMX outerHTML swap pattern verified: partial owns its own wrapper

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Role** | `python-developer` |
| **Architecture** | `dhh:htmx:jinja2:fastapi` |
| **Session** | `eng-20260303T164033Z-0826` |
| **CTO Wave** | `cto-20260303T163909Z` |
| **VP Batch** | `vp-eng-ac-phase1-20260303T163909Z` |
| **VP** | `vp-eng-ac-phase1-20260303T163909Z` |
| **Timestamp** | `2026-03-03T16:46:41Z` |

</details>