### PR TITLE
feat: brain dump — add visible step indicator (Dump → Preview → Running → Done)

### DIFF
--- a/agentception/static/scss/pages/_brain-dump.scss
+++ b/agentception/static/scss/pages/_brain-dump.scss
@@ -16,6 +16,97 @@
 /* ── Left column ─────────────────────────────────────────────────────────── */
 .bd-main { display: flex; flex-direction: column; gap: 1rem; min-width: 0; }
 
+/* ── Step indicator ─────────────────────────────────────────────────────── */
+
+/* The stepper sits at the top of .bd-main, above all step panels. */
+.bd-stepper { margin-bottom: 0.25rem; }
+
+.bd-stepper-list {
+  display: flex;
+  align-items: flex-start;  /* bubble + label align to top; connector offset by margin */
+  gap: 0;
+}
+
+.bd-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+  flex-shrink: 0;
+}
+
+.bd-step-bubble {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-full);
+  border: 2px solid var(--border-default);
+  background: var(--bg-surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  transition: background 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s;
+  flex-shrink: 0;
+}
+
+.bd-step-check,
+.bd-step-num { line-height: 1; }
+
+.bd-step-label {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  white-space: nowrap;
+  transition: color 0.2s, font-weight 0.2s, opacity 0.2s;
+}
+
+/* ── Active step ── */
+.bd-step--active .bd-step-bubble {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.bd-step--active .bd-step-label {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+/* ── Completed step ── */
+.bd-step--done .bd-step-bubble {
+  background: var(--success-dim);
+  border-color: var(--success-border);
+  color: var(--success);
+}
+
+.bd-step--done .bd-step-label {
+  color: var(--text-muted);
+  opacity: 0.65;
+}
+
+/* ── Future step ── */
+.bd-step--future .bd-step-bubble { opacity: 0.3; }
+.bd-step--future .bd-step-label  { opacity: 0.3; }
+
+/* ── Connector line between steps ── */
+.bd-step-conn {
+  flex: 1;
+  height: 1.5px;
+  /* Visually centre the line with the 28px bubble (14px = half the height) */
+  margin-top: 13px;
+  background: var(--border-default);
+  border-radius: 1px;
+  transition: background 0.3s;
+}
+
+.bd-step-conn--lit {
+  background: var(--accent);
+  opacity: 0.5;
+}
+
 .bd-title {
   font-size: 1.6rem;
   font-weight: 700;
@@ -495,5 +586,12 @@
   .bd-sidebar { position: static; }
   .bd-funnel { display: flex; flex-direction: row; flex-wrap: wrap; gap: 0; }
   .bd-funnel-connector { display: none; }
+}
+
+/* Responsive: collapse step labels to bubbles-only on narrow viewports */
+@media (max-width: 480px) {
+  .bd-step-label  { display: none; }
+  .bd-step-bubble { width: 24px; height: 24px; font-size: 0.62rem; }
+  .bd-step-conn   { margin-top: 11px; } /* re-centre for smaller bubble */
 }
 

--- a/agentception/static/scss/pages/_brain-dump.scss
+++ b/agentception/static/scss/pages/_brain-dump.scss
@@ -66,7 +66,7 @@
 .bd-step--active .bd-step-bubble {
   background: var(--accent);
   border-color: var(--accent);
-  color: #fff;
+  color: var(--text-primary);
   box-shadow: 0 0 0 3px var(--accent-glow);
 }
 

--- a/agentception/templates/brain_dump.html
+++ b/agentception/templates/brain_dump.html
@@ -24,6 +24,72 @@
      ══════════════════════════════════════════════════════════════════════ #}
   <div class="bd-main">
 
+    {# ── Step indicator: 1 Dump → 2 Preview → 3 Running → 4 Done ─────── #}
+    <nav class="bd-stepper" aria-label="Progress">
+      <div class="bd-stepper-list">
+
+        {# Step 1: Dump — active while user is writing #}
+        <div class="bd-step"
+             :class="step === 'input' ? 'bd-step--active' : 'bd-step--done'"
+             :aria-current='step === "input" ? "step" : "false"'>
+          <span class="bd-step-bubble">
+            <span class="bd-step-check" x-show="step !== 'input'" aria-hidden="true">✓</span>
+            <span class="bd-step-num"   x-show="step === 'input'"  aria-hidden="true">1</span>
+          </span>
+          <span class="bd-step-label">Dump</span>
+        </div>
+
+        <div class="bd-step-conn"
+             :class="{'bd-step-conn--lit': step !== 'input'}"
+             aria-hidden="true"></div>
+
+        {# Step 2: Preview — planned step (wired in Phase 4 / #835) #}
+        <div class="bd-step"
+             :class="step === 'preview' ? 'bd-step--active'
+                   : (step === 'loading' || step === 'done' ? 'bd-step--done'
+                   : 'bd-step--future')"
+             :aria-current='step === "preview" ? "step" : "false"'>
+          <span class="bd-step-bubble">
+            <span class="bd-step-check" x-show="step === 'loading' || step === 'done'" aria-hidden="true">✓</span>
+            <span class="bd-step-num"   x-show="step !== 'loading' && step !== 'done'" aria-hidden="true">2</span>
+          </span>
+          <span class="bd-step-label">Preview</span>
+        </div>
+
+        <div class="bd-step-conn"
+             :class="{'bd-step-conn--lit': step === 'loading' || step === 'done'}"
+             aria-hidden="true"></div>
+
+        {# Step 3: Running — active while the coordinator is running #}
+        <div class="bd-step"
+             :class="step === 'loading' ? 'bd-step--active'
+                   : (step === 'done'   ? 'bd-step--done'
+                   : 'bd-step--future')"
+             :aria-current='step === "loading" ? "step" : "false"'>
+          <span class="bd-step-bubble">
+            <span class="bd-step-check" x-show="step === 'done'"    aria-hidden="true">✓</span>
+            <span class="bd-step-num"   x-show="step !== 'done'"    aria-hidden="true">3</span>
+          </span>
+          <span class="bd-step-label">Running</span>
+        </div>
+
+        <div class="bd-step-conn"
+             :class="{'bd-step-conn--lit': step === 'done'}"
+             aria-hidden="true"></div>
+
+        {# Step 4: Done — active once the coordinator has been queued #}
+        <div class="bd-step"
+             :class="step === 'done' ? 'bd-step--active' : 'bd-step--future'"
+             :aria-current='step === "done" ? "step" : "false"'>
+          <span class="bd-step-bubble">
+            <span class="bd-step-num" aria-hidden="true">4</span>
+          </span>
+          <span class="bd-step-label">Done</span>
+        </div>
+
+      </div>
+    </nav>
+
     {# ── Step: INPUT ──────────────────────────────────────────────────── #}
     <div x-show="step === 'input'" x-transition.opacity>
 

--- a/agentception/tests/test_a11y.py
+++ b/agentception/tests/test_a11y.py
@@ -158,3 +158,47 @@ def test_config_panels_have_aria_labelledby() -> None:
     assert 'aria-labelledby="tab-btn-labels"' in content
     assert 'aria-labelledby="tab-btn-ab"' in content
     assert 'aria-labelledby="tab-btn-projects"' in content
+
+
+# ---------------------------------------------------------------------------
+# Brain Dump — horizontal step indicator (issue #827)
+# ---------------------------------------------------------------------------
+
+
+def test_brain_dump_stepper_present() -> None:
+    """brain_dump.html must include the horizontal step indicator nav element."""
+    content = _read("brain_dump.html")
+    assert 'class="bd-stepper"' in content, (
+        "brain_dump.html is missing the .bd-stepper nav element"
+    )
+
+
+def test_brain_dump_stepper_has_aria_label() -> None:
+    """The stepper nav must carry aria-label='Progress' for screen readers."""
+    content = _read("brain_dump.html")
+    assert 'aria-label="Progress"' in content, (
+        "brain_dump.html stepper is missing aria-label='Progress'"
+    )
+
+
+def test_brain_dump_stepper_has_four_steps() -> None:
+    """The stepper must render exactly four step labels: Dump, Preview, Running, Done."""
+    content = _read("brain_dump.html")
+    for label in ("Dump", "Preview", "Running", "Done"):
+        assert f">{label}<" in content, (
+            f"brain_dump.html stepper is missing step label '{label}'"
+        )
+
+
+def test_brain_dump_stepper_driven_by_step_var() -> None:
+    """Stepper classes must reference the existing Alpine 'step' variable, not new state."""
+    content = _read("brain_dump.html")
+    assert "step === 'input'" in content, (
+        "brain_dump.html stepper must use the existing Alpine 'step' variable"
+    )
+    assert "step === 'loading'" in content, (
+        "brain_dump.html stepper must reference 'loading' state"
+    )
+    assert "step === 'done'" in content, (
+        "brain_dump.html stepper must reference 'done' state"
+    )


### PR DESCRIPTION
## Summary
Closes #827 — adds a horizontal 4-step progress indicator to the brain dump page.

## Root Cause / Motivation
The brain dump flow had three implicit states (input → loading → done) with no visible progress cue.
Users had no way to know where they were in the process or what steps remained.

## Solution

### HTML (`agentception/templates/brain_dump.html`)
- Added `<nav class="bd-stepper" aria-label="Progress">` at the top of `.bd-main`, above all step panels
- Four steps rendered in sequence: **1 Dump → 2 Preview → 3 Running → 4 Done**
- Step state derived entirely from the existing Alpine `step` variable (`'input'`, `'loading'`, `'done'`); `'preview'` is reserved for Phase 4 (#835)
- Completed steps show a ✓ checkmark with success-dim styling; future steps are dimmed to 30% opacity
- Connector lines between steps light up with accent colour as steps complete
- Proper `aria-current="step"` on the active step for screen-reader support

### SCSS (`agentception/static/scss/pages/_brain-dump.scss`)
- All styles use existing design tokens (`--accent`, `--accent-glow`, `--success-dim`, `--success-border`, `--border-default`, `--radius-full`, etc.)
- No new colours or font sizes introduced
- Connector lines align visually to the centre of the 28 px bubble via `margin-top: 13px`
- Responsive: below 480 px, step labels collapse to bubble-icons-only (`.bd-step-label { display: none }`)

### Tests (`agentception/tests/test_a11y.py`)
- 4 new targeted tests: stepper present, aria-label set, all four step labels present, state driven by existing `step` var

## Verification
- [x] mypy clean (`Success: no issues found in 97 source files`)
- [x] 20/20 tests pass (`test_a11y.py` incl. 4 new stepper tests)
- [x] No new state introduced — stepper reads from existing Alpine `step` variable
- [x] Uses only existing SCSS design tokens

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Role** | `python-developer` |
| **Architecture** | `don_norman:alpine:javascript` |
| **Session** | `eng-20260303T164050Z-0827` |
| **CTO Wave** | `cto-20260303T163909Z` |
| **VP Batch** | `vp-eng-ac-phase1-20260303T163909Z` |
| **VP** | `vp-eng-ac-phase1-20260303T163909Z` |
| **Timestamp** | `2026-03-03T16:48:05Z` |

</details>