### PR TITLE
feat: add /org-chart page with preset org picker (#828)

### DIFF
--- a/agentception/routes/ui/__init__.py
+++ b/agentception/routes/ui/__init__.py
@@ -21,6 +21,7 @@ from .config import router as _config
 from .dag import router as _dag
 from .docs import router as _docs
 from .github_ui import router as _github
+from .org_chart import router as _org_chart
 from .overview import router as _overview
 from .roles_ui import router as _roles_ui
 from .telemetry import router as _telemetry
@@ -43,6 +44,7 @@ router.include_router(_config)
 router.include_router(_ab)
 router.include_router(_brain_dump)
 router.include_router(_roles_ui)
+router.include_router(_org_chart)
 router.include_router(_github)
 router.include_router(_transcripts)
 router.include_router(_worktrees)

--- a/agentception/routes/ui/org_chart.py
+++ b/agentception/routes/ui/org_chart.py
@@ -1,0 +1,144 @@
+"""UI routes: Org Chart page with preset org picker.
+
+Provides:
+- ``GET /org-chart`` — full-page render of the org chart with a left-panel
+  preset picker and a right-panel shell (``#org-right-panel``) reserved for
+  the interactive builder (#829) and D3 tree (#830).
+- ``POST /api/org/select-preset`` — HTMX endpoint that persists the chosen
+  preset to ``pipeline-config.json`` under the ``active_org`` key and returns
+  a refreshed left-panel partial so the active card updates in-place.
+
+Preset definitions are loaded from ``org-presets.yaml`` at the repo root.
+The file is read once per request (fast — ~1 KB) so hot-editing the YAML
+during development takes effect without a service restart.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+from fastapi import APIRouter, Form, HTTPException
+from fastapi.responses import HTMLResponse
+from starlette.requests import Request
+
+from agentception.config import settings
+from ._shared import _TEMPLATES
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Path to the org-presets YAML, resolved relative to the repo root so it works
+# both on the host and inside Docker (where the repo is mounted at /repo).
+_PRESETS_PATH = Path(__file__).parent.parent.parent.parent / "org-presets.yaml"
+
+
+def _load_presets() -> list[dict[str, Any]]:
+    """Read and parse org-presets.yaml, returning the ``presets`` list.
+
+    Returns an empty list if the file is missing or malformed so the UI
+    degrades gracefully rather than raising a 500.
+    """
+    try:
+        raw: object = yaml.safe_load(_PRESETS_PATH.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return []
+        presets: object = raw.get("presets", [])
+        if not isinstance(presets, list):
+            return []
+        return [p for p in presets if isinstance(p, dict)]
+    except Exception as exc:
+        logger.warning("⚠️ Could not load org-presets.yaml: %s", exc)
+        return []
+
+
+def _pipeline_config_path() -> Path:
+    """Return the canonical path to pipeline-config.json for the active repo."""
+    return settings.repo_dir / ".cursor" / "pipeline-config.json"
+
+
+def _read_pipeline_config() -> dict[str, Any]:
+    """Read pipeline-config.json, returning an empty dict on any error."""
+    path = _pipeline_config_path()
+    if not path.exists():
+        return {}
+    try:
+        raw: object = json.loads(path.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except Exception as exc:
+        logger.warning("⚠️ Could not read pipeline-config.json: %s", exc)
+        return {}
+
+
+def _write_pipeline_config(data: dict[str, Any]) -> None:
+    """Persist *data* back to pipeline-config.json atomically via a rename."""
+    path = _pipeline_config_path()
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    tmp.rename(path)
+
+
+@router.get("/org-chart", response_class=HTMLResponse)
+async def org_chart_page(request: Request) -> HTMLResponse:
+    """Org Chart page — preset picker (left) + builder shell (right).
+
+    Renders the full org-chart layout.  The right panel (``#org-right-panel``)
+    is an empty shell that issues #829 and #830 will populate with the
+    interactive builder and D3 tree respectively.
+    """
+    presets = _load_presets()
+    config = _read_pipeline_config()
+    active_org: object = config.get("active_org")
+    active_org_id: str | None = active_org if isinstance(active_org, str) else None
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "org_chart.html",
+        {
+            "presets": presets,
+            "active_org_id": active_org_id,
+        },
+    )
+
+
+@router.post("/api/org/select-preset", response_class=HTMLResponse)
+async def select_preset(
+    request: Request,
+    preset_id: str = Form(...),
+) -> HTMLResponse:
+    """Persist the chosen preset to pipeline-config.json and return a refreshed partial.
+
+    Called by HTMX when the user clicks a preset card.  Writes ``active_org``
+    to ``pipeline-config.json`` and swaps the left panel so the selected card
+    gets the ``active`` CSS class without a full-page reload.
+
+    Returns HTTP 422 when *preset_id* does not match any known preset so HTMX
+    can surface the error in the toast system.
+    """
+    presets = _load_presets()
+    preset_ids = {p["id"] for p in presets if "id" in p}
+
+    if preset_id not in preset_ids:
+        logger.warning("⚠️ Unknown preset_id requested: %s", preset_id)
+        raise HTTPException(status_code=422, detail=f"Unknown preset: {preset_id!r}")
+
+    config = _read_pipeline_config()
+    config["active_org"] = preset_id
+    try:
+        _write_pipeline_config(config)
+        logger.info("✅ Active org set to %r", preset_id)
+    except Exception as exc:
+        logger.error("❌ Failed to write pipeline-config.json: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to persist preset selection") from exc
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "_org_preset_list.html",
+        {
+            "presets": presets,
+            "active_org_id": preset_id,
+        },
+    )

--- a/agentception/templates/_org_preset_list.html
+++ b/agentception/templates/_org_preset_list.html
@@ -1,0 +1,63 @@
+{#
+  Partial: Org preset card list — rendered by both the full page (included via
+  `{% include %}`) and the `POST /api/org/select-preset` HTMX swap so the
+  active card updates without a full-page reload.
+
+  Context:
+    presets      — list[dict] from org-presets.yaml
+    active_org_id — str | None — the currently active preset id
+#}
+<div class="org-preset-list" id="org-preset-list">
+  {% for preset in presets %}
+  <form
+    class="org-preset-card {% if preset.id == active_org_id %}org-preset-card--active{% endif %}"
+    hx-post="/api/org/select-preset"
+    hx-target="#org-preset-list"
+    hx-swap="outerHTML"
+    hx-vals='{"preset_id": {{ preset.id | tojson }}}'
+    aria-label="Select {{ preset.name }} preset"
+  >
+    <div class="org-preset-card__header">
+      <span class="org-preset-card__name">{{ preset.name }}</span>
+      {% if preset.id == active_org_id %}
+      <span class="badge badge--success org-preset-card__badge">Active</span>
+      {% endif %}
+    </div>
+    <p class="org-preset-card__desc text-muted">{{ preset.description }}</p>
+
+    {% if preset.tiers %}
+    <div class="org-preset-card__tiers">
+      {% if preset.tiers.leadership %}
+      <div class="org-preset-card__tier">
+        <span class="org-preset-card__tier-label">Leadership</span>
+        <div class="org-preset-card__roles">
+          {% for role in preset.tiers.leadership %}
+          <span class="tag">{{ role }}</span>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+      {% if preset.tiers.workers %}
+      <div class="org-preset-card__tier">
+        <span class="org-preset-card__tier-label">Workers</span>
+        <div class="org-preset-card__roles">
+          {% for role in preset.tiers.workers %}
+          <span class="tag">{{ role }}</span>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+    </div>
+    {% endif %}
+
+    <button
+      type="submit"
+      class="btn {% if preset.id == active_org_id %}btn--secondary{% else %}btn--primary{% endif %} org-preset-card__btn"
+    >
+      {% if preset.id == active_org_id %}Selected{% else %}Select{% endif %}
+    </button>
+  </form>
+  {% else %}
+  <p class="text-muted">No presets defined in <code>org-presets.yaml</code>.</p>
+  {% endfor %}
+</div>

--- a/agentception/templates/base.html
+++ b/agentception/templates/base.html
@@ -34,6 +34,7 @@
     <a href="/agents"   class="{% if request.url.path.startswith('/agents') %}active{% endif %}">Agents</a>
     <a href="/telemetry" class="{% if request.url.path.startswith('/telemetry') %}active{% endif %}">Telemetry</a>
     <a href="/roles"    class="{% if request.url.path.startswith('/roles') %}active{% endif %}">Roles</a>
+    <a href="/org-chart" class="{% if request.url.path.startswith('/org-chart') %}active{% endif %}">Org Chart</a>
     <a href="/cognitive-arch" class="{% if request.url.path.startswith('/cognitive-arch') %}active{% endif %}">Cog Arch</a>
     <a href="/config"   class="{% if request.url.path.startswith('/config') %}active{% endif %}">Config</a>
     <a href="/dag"      class="{% if request.url.path.startswith('/dag') %}active{% endif %}">DAG</a>

--- a/agentception/templates/org_chart.html
+++ b/agentception/templates/org_chart.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block title %}Org Chart — Agentception{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <h1 class="page-title">Org Chart</h1>
+  <p class="page-subtitle text-muted">
+    Choose a preset org topology. The active org governs which agent roles the
+    pipeline spawns.  Issues #829 and #830 will add an interactive builder and
+    D3 tree to the right panel.
+  </p>
+</div>
+
+<div class="org-chart-layout">
+
+  {# ── Left panel: preset org picker ──────────────────────────────────────── #}
+  <section class="org-chart-left" aria-label="Preset org configurations">
+    <h2 class="panel-title">Preset Configurations</h2>
+    {% include "_org_preset_list.html" %}
+  </section>
+
+  {# ── Right panel: builder shell — reserved for #829 (builder) and #830 (D3) #}
+  <section class="org-chart-right" aria-label="Org chart builder">
+    <div id="org-right-panel" class="org-right-panel">
+      <div class="org-right-panel__placeholder">
+        <span class="org-right-panel__icon" aria-hidden="true">🌳</span>
+        <p class="org-right-panel__message text-muted">
+          Interactive builder coming in <strong>#829</strong>.
+          D3 org tree coming in <strong>#830</strong>.
+        </p>
+        {% if active_org_id %}
+        <p class="text-muted">
+          Active preset: <code>{{ active_org_id }}</code>
+        </p>
+        {% endif %}
+      </div>
+    </div>
+  </section>
+
+</div>
+{% endblock %}

--- a/agentception/tests/test_agentception_org_chart.py
+++ b/agentception/tests/test_agentception_org_chart.py
@@ -1,0 +1,217 @@
+"""Tests for the /org-chart page and POST /api/org/select-preset endpoint.
+
+Covers:
+- GET /org-chart renders the page with preset cards
+- POST /api/org/select-preset persists the selection and returns a refreshed partial
+- POST /api/org/select-preset rejects unknown preset IDs with HTTP 422
+
+Run targeted:
+    docker compose exec agentception pytest agentception/tests/test_agentception_org_chart.py -v
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    """Synchronous test client wrapping the full FastAPI app."""
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def tmp_pipeline_config(tmp_path: Path) -> Generator[Path, None, None]:
+    """Write a minimal pipeline-config.json to a temp dir and patch settings.repo_dir."""
+    config = {"active_org": None}
+    config_dir = tmp_path / ".cursor"
+    config_dir.mkdir(parents=True)
+    config_file = config_dir / "pipeline-config.json"
+    config_file.write_text(json.dumps(config), encoding="utf-8")
+
+    with patch("agentception.routes.ui.org_chart.settings") as mock_settings:
+        mock_settings.repo_dir = tmp_path
+        yield config_file
+
+
+@pytest.fixture()
+def sample_presets() -> list[dict[str, object]]:
+    """Minimal preset list for mocking _load_presets."""
+    return [
+        {
+            "id": "solo-cto",
+            "name": "Solo CTO",
+            "description": "Minimal setup.",
+            "tiers": {
+                "leadership": ["cto"],
+                "workers": ["python-developer", "pr-reviewer"],
+            },
+        },
+        {
+            "id": "small-team",
+            "name": "Small Team",
+            "description": "A focused squad.",
+            "tiers": {
+                "leadership": ["cto", "vp-engineering"],
+                "workers": ["python-developer", "frontend-developer", "test-engineer"],
+            },
+        },
+        {
+            "id": "full",
+            "name": "Full Org",
+            "description": "Complete ten-slot org.",
+            "tiers": {
+                "leadership": ["cto", "vp-engineering", "vp-qa"],
+                "workers": ["python-developer", "frontend-developer", "typescript-developer"],
+            },
+        },
+    ]
+
+
+class TestOrgChartPage:
+    """GET /org-chart — full-page render."""
+
+    def test_org_chart_returns_200(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """GET /org-chart should return HTTP 200 with a valid HTML body."""
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets),
+            patch("agentception.routes.ui.org_chart._read_pipeline_config", return_value={}),
+        ):
+            resp = client.get("/org-chart")
+
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+
+    def test_org_chart_contains_preset_names(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """Preset card names should appear in the rendered HTML."""
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets),
+            patch("agentception.routes.ui.org_chart._read_pipeline_config", return_value={}),
+        ):
+            resp = client.get("/org-chart")
+
+        body = resp.text
+        assert "Solo CTO" in body
+        assert "Small Team" in body
+        assert "Full Org" in body
+
+    def test_org_chart_contains_right_panel_shell(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """The right panel shell div must exist for future issues #829 and #830."""
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets),
+            patch("agentception.routes.ui.org_chart._read_pipeline_config", return_value={}),
+        ):
+            resp = client.get("/org-chart")
+
+        assert 'id="org-right-panel"' in resp.text
+
+    def test_org_chart_marks_active_preset(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """When active_org is set in config, the matching card should have the active class."""
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets),
+            patch(
+                "agentception.routes.ui.org_chart._read_pipeline_config",
+                return_value={"active_org": "small-team"},
+            ),
+        ):
+            resp = client.get("/org-chart")
+
+        assert "org-preset-card--active" in resp.text
+
+    def test_org_chart_empty_presets_degrades_gracefully(
+        self,
+        client: TestClient,
+    ) -> None:
+        """If no presets are found, the page should still return 200 without crashing."""
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=[]),
+            patch("agentception.routes.ui.org_chart._read_pipeline_config", return_value={}),
+        ):
+            resp = client.get("/org-chart")
+
+        assert resp.status_code == 200
+
+
+class TestSelectPreset:
+    """POST /api/org/select-preset — preset persistence."""
+
+    def test_select_preset_persists_active_org(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """Selecting a valid preset should write active_org to pipeline-config.json."""
+        with patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets):
+            resp = client.post("/api/org/select-preset", data={"preset_id": "solo-cto"})
+
+        assert resp.status_code == 200
+        written = json.loads(tmp_pipeline_config.read_text(encoding="utf-8"))
+        assert written.get("active_org") == "solo-cto"
+
+    def test_select_preset_returns_refreshed_partial(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """The response should contain the preset list partial with the new active card."""
+        with patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets):
+            resp = client.post("/api/org/select-preset", data={"preset_id": "full"})
+
+        assert resp.status_code == 200
+        body = resp.text
+        assert "org-preset-list" in body
+        assert "Full Org" in body
+
+    def test_select_preset_rejects_unknown_id(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """An unknown preset_id should return HTTP 422."""
+        with patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets):
+            resp = client.post(
+                "/api/org/select-preset",
+                data={"preset_id": "does-not-exist"},
+            )
+
+        assert resp.status_code == 422
+
+    def test_select_preset_active_card_marked(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """After selection, the returned partial should mark the chosen card as active."""
+        with patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets):
+            resp = client.post("/api/org/select-preset", data={"preset_id": "small-team"})
+
+        assert resp.status_code == 200
+        assert "org-preset-card--active" in resp.text

--- a/org-presets.yaml
+++ b/org-presets.yaml
@@ -1,0 +1,60 @@
+# Org Chart Presets — preset org configurations for the AgentCeption pipeline.
+#
+# Each preset defines a named org topology that can be selected from the
+# /org-chart page.  Selecting a preset writes the ``active_org`` key to
+# pipeline-config.json so the poller and spawn logic pick it up immediately.
+#
+# Fields:
+#   id          — machine-readable slug (used as the POST body value)
+#   name        — human-readable display name shown on the card
+#   description — one-sentence summary of when to use this preset
+#   roles       — ordered list of role slugs that make up this org
+#                 (slug must match entries in the role taxonomy YAML)
+#   tiers:
+#     leadership — CTO, VP-level agents; drive strategy and reviews
+#     workers    — hands-on implementers and QA agents
+
+presets:
+  - id: solo-cto
+    name: "Solo CTO"
+    description: "Minimal setup: a CTO directing a single python developer with a PR reviewer."
+    tiers:
+      leadership:
+        - cto
+      workers:
+        - python-developer
+        - pr-reviewer
+
+  - id: small-team
+    name: "Small Team"
+    description: "A focused squad: CTO + VP Engineering + VP QA managing three workers."
+    tiers:
+      leadership:
+        - cto
+        - vp-engineering
+        - vp-qa
+      workers:
+        - python-developer
+        - frontend-developer
+        - test-engineer
+
+  - id: full
+    name: "Full Org"
+    description: "Complete ten-slot org: full leadership tier with diverse specialist workers."
+    tiers:
+      leadership:
+        - cto
+        - vp-engineering
+        - vp-qa
+        - vp-product
+      workers:
+        - python-developer
+        - frontend-developer
+        - typescript-developer
+        - test-engineer
+        - pr-reviewer
+        - devops-engineer
+        - ml-engineer
+        - database-architect
+        - api-developer
+        - mobile-developer


### PR DESCRIPTION
## Summary
Closes #828 — new `/org-chart` page with a left-panel preset picker and an empty right-panel shell (`#org-right-panel`) for future issues #829 and #830.

## Root Cause / Motivation
The pipeline lacked a dedicated org topology UI.  Agents had no way to select or persist an org preset; the right-panel shell needed to exist before the interactive builder (#829) and D3 tree (#830) could be added.

## Solution
- **`GET /org-chart`** — full-page render via `agentception/routes/ui/org_chart.py` and `agentception/templates/org_chart.html`.  Two-panel layout: preset cards on the left, empty shell (`id=\"org-right-panel\"`) on the right.
- **`POST /api/org/select-preset`** — HTMX endpoint that writes `active_org` to `pipeline-config.json` and returns a refreshed `_org_preset_list.html` partial so the active card updates without a full reload.
- **`org-presets.yaml`** — defines three presets at the repo root:
  - `solo-cto`: CTO + python-developer + pr-reviewer
  - `small-team`: CTO + VP Eng + VP QA + 3 workers
  - `full`: full leadership tier + 10 worker slots
- **Nav link** added to `base.html` between Roles and Cog Arch.
- **9 tests** in `agentception/tests/test_agentception_org_chart.py` covering page render, HTMX partial swap, persistence to JSON, and 422 on unknown preset.

## Verification
- [x] mypy clean (0 errors, 102 source files)
- [x] 9 tests pass
- [x] Right panel is an empty shell — no builder or D3 code

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Role** | `python-developer` |
| **Architecture** | `martin_fowler:fastapi:htmx:jinja2` |
| **Session** | `eng-20260303T170140Z-00d7` |
| **CTO Wave** | `cto-20260303T170027Z` |
| **VP Batch** | `vp-eng-ac-phase2-20260303T170027Z` |
| **Timestamp** | `2026-03-03T17:05:15Z` |

</details>