### PR TITLE
feat: Org chart D3 tree visualization (#830)

### DIFF
--- a/agentception/models.py
+++ b/agentception/models.py
@@ -698,3 +698,37 @@ class TemplateListEntry(BaseModel):
     created_at: str
     gh_repo: str
     size_bytes: int
+
+
+class OrgTreeRole(BaseModel):
+    """A single role entry in the org tree returned by ``GET /api/org/tree``.
+
+    ``figures`` holds the first two compatible figures from the taxonomy so the
+    D3 tree can render avatar chips without a second round-trip.
+    ``assigned_phases`` is reserved for future phase-assignment features and
+    is always an empty list in the current implementation.
+    """
+
+    slug: str
+    name: str
+    tier: str
+    assigned_phases: list[str]
+    figures: list[str]
+
+
+class OrgTreeNode(BaseModel):
+    """One node in the org hierarchy tree returned by ``GET /api/org/tree``.
+
+    The root node represents the active preset; its children are the
+    leadership and workers tiers; each tier's ``roles`` list holds the
+    individual role cards rendered by the D3 tree.
+    """
+
+    name: str
+    id: str
+    tier: str
+    roles: list[OrgTreeRole]
+    children: list["OrgTreeNode"]
+
+
+OrgTreeNode.model_rebuild()

--- a/agentception/routes/ui/org_chart.py
+++ b/agentception/routes/ui/org_chart.py
@@ -1,4 +1,4 @@
-"""UI routes: Org Chart page with preset org picker.
+"""UI routes: Org Chart page with preset org picker and D3 tree endpoint.
 
 Provides:
 - ``GET /org-chart`` — full-page render of the org chart with a left-panel
@@ -7,6 +7,8 @@ Provides:
 - ``POST /api/org/select-preset`` — HTMX endpoint that persists the chosen
   preset to ``pipeline-config.json`` under the ``active_org`` key and returns
   a refreshed left-panel partial so the active card updates in-place.
+- ``GET /api/org/tree`` — returns the active preset as a hierarchical JSON
+  tree consumed by the D3 tree visualization in ``org_chart_tree.js``.
 
 Preset definitions are loaded from ``org-presets.yaml`` at the repo root.
 The file is read once per request (fast — ~1 KB) so hot-editing the YAML
@@ -21,10 +23,11 @@ from typing import Any
 
 import yaml  # type: ignore[import-untyped]
 from fastapi import APIRouter, Form, HTTPException
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from starlette.requests import Request
 
 from agentception.config import settings
+from agentception.models import OrgTreeNode, OrgTreeRole
 from ._shared import _TEMPLATES
 
 logger = logging.getLogger(__name__)
@@ -102,6 +105,120 @@ async def org_chart_page(request: Request) -> HTMLResponse:
             "active_org_id": active_org_id,
         },
     )
+
+
+# Path to role-taxonomy.yaml — used by /api/org/tree to enrich role nodes.
+_TAXONOMY_PATH = Path(__file__).parent.parent.parent.parent / "scripts" / "gen_prompts" / "role-taxonomy.yaml"
+
+# Tier label mapping from taxonomy level ids to display strings.
+_TIER_LABELS: dict[str, str] = {
+    "c_suite": "C-Suite",
+    "vp_level": "VP",
+    "workers": "Worker",
+}
+
+
+def _load_taxonomy_role_index() -> dict[str, dict[str, Any]]:
+    """Build a flat slug → role-metadata dict from role-taxonomy.yaml.
+
+    Returns an empty dict if the taxonomy file is missing or malformed so the
+    tree endpoint degrades gracefully.  Each value includes ``tier`` (display
+    string) and ``compatible_figures`` (list of strings).
+    """
+    try:
+        raw: object = yaml.safe_load(_TAXONOMY_PATH.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return {}
+        index: dict[str, dict[str, Any]] = {}
+        for level in raw.get("levels", []):
+            if not isinstance(level, dict):
+                continue
+            level_id = str(level.get("id", ""))
+            tier_label = _TIER_LABELS.get(level_id, level_id)
+            for role in level.get("roles", []):
+                if not isinstance(role, dict):
+                    continue
+                slug = str(role.get("slug", ""))
+                if slug:
+                    figures: object = role.get("compatible_figures", [])
+                    index[slug] = {
+                        "tier": tier_label,
+                        "compatible_figures": [str(f) for f in figures] if isinstance(figures, list) else [],
+                        "label": str(role.get("label", slug)),
+                        "title": str(role.get("title", slug)),
+                    }
+        return index
+    except Exception as exc:
+        logger.warning("⚠️ Could not load role-taxonomy.yaml: %s", exc)
+        return {}
+
+
+@router.get("/api/org/tree", response_class=JSONResponse)
+async def org_tree() -> JSONResponse:
+    """Return the active preset org as a hierarchical JSON tree for the D3 visualization.
+
+    Reads the active preset from pipeline-config.json, enriches each role with
+    tier and compatible-figure data from role-taxonomy.yaml, and returns a nested
+    ``OrgTreeNode`` tree.  The root node is the preset itself; children are the
+    tier groups (leadership / workers); each tier's ``roles`` list holds the role
+    cards rendered by ``org_chart_tree.js``.
+
+    Returns HTTP 404 when no preset is selected or the active preset id is unknown.
+    """
+    config = _read_pipeline_config()
+    active_org: object = config.get("active_org")
+    if not isinstance(active_org, str) or not active_org:
+        raise HTTPException(status_code=404, detail="No active org selected. Choose a preset first.")
+
+    presets = _load_presets()
+    preset: dict[str, Any] | None = next((p for p in presets if p.get("id") == active_org), None)
+    if preset is None:
+        raise HTTPException(status_code=404, detail=f"Active preset {active_org!r} not found in org-presets.yaml")
+
+    role_index = _load_taxonomy_role_index()
+
+    def _make_role(slug: str) -> OrgTreeRole:
+        meta = role_index.get(slug, {})
+        figures: list[str] = meta.get("compatible_figures", [])
+        return OrgTreeRole(
+            slug=slug,
+            name=meta.get("label", slug),
+            tier=meta.get("tier", "Worker"),
+            assigned_phases=[],
+            figures=figures[:2],
+        )
+
+    tiers_raw: object = preset.get("tiers", {})
+    if not isinstance(tiers_raw, dict):
+        tiers_raw = {}
+
+    tier_children: list[OrgTreeNode] = []
+    tier_display = {"leadership": "Leadership", "workers": "Workers"}
+    for tier_key in ("leadership", "workers"):
+        slugs: object = tiers_raw.get(tier_key, [])
+        if not isinstance(slugs, list):
+            continue
+        roles = [_make_role(str(s)) for s in slugs]
+        tier_children.append(
+            OrgTreeNode(
+                name=tier_display.get(tier_key, tier_key.title()),
+                id=tier_key,
+                tier=tier_key,
+                roles=roles,
+                children=[],
+            )
+        )
+
+    root = OrgTreeNode(
+        name=str(preset.get("name", active_org)),
+        id=active_org,
+        tier="org",
+        roles=[],
+        children=tier_children,
+    )
+
+    logger.info("✅ /api/org/tree built for preset %r (%d tiers)", active_org, len(tier_children))
+    return JSONResponse(content=root.model_dump())
 
 
 @router.post("/api/org/select-preset", response_class=HTMLResponse)

--- a/agentception/routes/ui/org_chart.py
+++ b/agentception/routes/ui/org_chart.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 import yaml  # type: ignore[import-untyped]
 from fastapi import APIRouter, Form, HTTPException
@@ -118,7 +118,17 @@ _TIER_LABELS: dict[str, str] = {
 }
 
 
-def _load_taxonomy_role_index() -> dict[str, dict[str, Any]]:
+class _RoleIndexEntry(TypedDict):
+    """Enriched metadata for a single role slug from role-taxonomy.yaml."""
+
+    tier: str
+    compatible_figures: list[str]
+    label: str
+    title: str
+
+
+
+def _load_taxonomy_role_index() -> dict[str, _RoleIndexEntry]:
     """Build a flat slug → role-metadata dict from role-taxonomy.yaml.
 
     Returns an empty dict if the taxonomy file is missing or malformed so the
@@ -129,7 +139,7 @@ def _load_taxonomy_role_index() -> dict[str, dict[str, Any]]:
         raw: object = yaml.safe_load(_TAXONOMY_PATH.read_text(encoding="utf-8"))
         if not isinstance(raw, dict):
             return {}
-        index: dict[str, dict[str, Any]] = {}
+        index: dict[str, _RoleIndexEntry] = {}
         for level in raw.get("levels", []):
             if not isinstance(level, dict):
                 continue
@@ -171,14 +181,14 @@ async def org_tree() -> JSONResponse:
         raise HTTPException(status_code=404, detail="No active org selected. Choose a preset first.")
 
     presets = _load_presets()
-    preset: dict[str, Any] | None = next((p for p in presets if p.get("id") == active_org), None)
+    preset = next((p for p in presets if p.get("id") == active_org), None)
     if preset is None:
         raise HTTPException(status_code=404, detail=f"Active preset {active_org!r} not found in org-presets.yaml")
 
     role_index = _load_taxonomy_role_index()
 
     def _make_role(slug: str) -> OrgTreeRole:
-        meta = role_index.get(slug, {})
+        meta: _RoleIndexEntry = role_index.get(slug, _RoleIndexEntry(tier="Worker", compatible_figures=[], label=slug, title=slug))
         figures: list[str] = meta.get("compatible_figures", [])
         return OrgTreeRole(
             slug=slug,

--- a/agentception/static/app.css
+++ b/agentception/static/app.css
@@ -1,4 +1,9910 @@
-﻿@import"https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,300..800;1,14..32,300..800&family=JetBrains+Mono:wght@400;500&display=swap";[x-cloak]{display:none !important}:root{--bg-void: #040710;--bg-base: #070b14;--bg-surface: #0c1220;--bg-elevated: #111b2e;--bg-overlay: #172038;--bg-glass: rgba(10, 16, 32, 0.72);--border-subtle: #15223a;--border-default: #1f3050;--border-strong: #3a5478;--border: var(--border-default);--text-primary: #eef5ff;--text-secondary: #a8c4e0;--text-muted: #6a8aaa;--text-faint: #3a5570;--accent: #8b5cf6;--accent-bright: #a78bfa;--accent-dim: #5b21b6;--accent-hover: #9461fb;--accent-glow: rgba(139, 92, 246, 0.22);--accent-glow-strong: rgba(139, 92, 246, 0.45);--success: #10d9a0;--success-dim: rgba(16, 217, 160, 0.12);--success-border: rgba(16, 217, 160, 0.3);--success-glow: rgba(16, 217, 160, 0.2);--warning: #fbbf24;--warning-dim: rgba(251, 191, 36, 0.12);--warning-border: rgba(251, 191, 36, 0.3);--warning-glow: rgba(251, 191, 36, 0.2);--danger: #f43f5e;--danger-dim: rgba(244, 63, 94, 0.12);--danger-border: rgba(244, 63, 94, 0.3);--danger-glow: rgba(244, 63, 94, 0.2);--info: #38bdf8;--info-dim: rgba(56, 189, 248, 0.12);--info-border: rgba(56, 189, 248, 0.3);--grad-brand: linear-gradient(135deg, #c084fc 0%, #818cf8 50%, #38bdf8 100%);--grad-accent: linear-gradient(135deg, #7c3aed 0%, #8b5cf6 100%);--grad-success: linear-gradient(135deg, #10d9a0 0%, #3b82f6 100%);--grad-warm: linear-gradient(135deg, #f59e0b 0%, #ef4444 100%);--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;--font-mono: 'JetBrains Mono', 'SF Mono', ui-monospace, SFMono-Regular, monospace;--radius-xs: 3px;--radius-sm: 5px;--radius: 8px;--radius-lg: 12px;--radius-xl: 16px;--radius-full: 9999px;--shadow-sm: 0 1px 4px rgba(0, 0, 0, 0.6);--shadow-md: 0 4px 20px rgba(0, 0, 0, 0.7);--shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.8);--shadow-glow: 0 0 24px var(--accent-glow);--shadow-glow-strong: 0 0 36px var(--accent-glow-strong);--ease-out: cubic-bezier(0.22, 1, 0.36, 1);--ease-in-out: cubic-bezier(0.4, 0, 0.2, 1)}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}html{overflow-y:scroll;scrollbar-gutter:stable}html,body{background:var(--bg-void);color:var(--text-primary);font-family:var(--font-sans);font-size:15px;line-height:1.55;min-height:100vh;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-feature-settings:"cv02","cv03","cv04","cv11"}a{color:var(--accent-bright);text-decoration:none;transition:color .15s}a:hover{color:#fff;text-decoration:none}code{font-family:var(--font-mono);font-size:.85em;background:var(--bg-elevated);border:1px solid var(--border-subtle);border-radius:var(--radius-xs);padding:.1em .35em;color:var(--accent-bright)}.layout{display:grid;grid-template-rows:auto 1fr;min-height:100vh}nav.topnav{position:sticky;top:0;z-index:100;background:var(--bg-glass);backdrop-filter:blur(16px) saturate(1.4);-webkit-backdrop-filter:blur(16px) saturate(1.4);border-bottom:1px solid var(--border-subtle);padding:0 1.5rem;display:flex;align-items:center;gap:.25rem;height:52px;box-shadow:0 1px 0 hsla(0,0%,100%,.03),var(--shadow-sm)}a.brand,nav.topnav .brand{font-size:.9375rem;font-weight:700;letter-spacing:-0.01em;background:var(--grad-brand);-webkit-background-clip:text;-webkit-text-fill-color:rgba(0,0,0,0);background-clip:text;color:rgba(0,0,0,0);white-space:nowrap;padding:.25rem .75rem .25rem 0;margin-right:.5rem;flex-shrink:0;text-decoration:none}a.brand:hover,nav.topnav .brand:hover{opacity:.85;-webkit-text-fill-color:rgba(0,0,0,0)}nav.topnav a{color:var(--text-muted);font-size:.8125rem;font-weight:450;padding:.3rem .6rem;border-radius:var(--radius-sm);transition:color .15s,background .15s;white-space:nowrap}nav.topnav a:not(.brand):hover{color:var(--text-primary);background:hsla(0,0%,100%,.06);text-decoration:none}nav.topnav a.active{color:var(--accent-bright);background:rgba(139,92,246,.12);font-weight:500}.project-switcher{margin-left:auto;display:flex;align-items:center;gap:.5rem;flex-shrink:0}.project-switcher__label{font-size:.75rem;color:var(--text-muted);font-weight:500}.project-switcher__select{background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius-sm);color:var(--text-primary);font-size:.8125rem;font-family:var(--font-sans);padding:.25rem .5rem;cursor:pointer;transition:border-color .15s}.project-switcher__select:focus{outline:none;border-color:var(--accent)}main{padding:1.5rem 1.75rem;width:100%;max-width:1440px;margin:0 auto;animation:fade-in .25s var(--ease-out)}@keyframes fade-in{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}.card{background:var(--bg-surface);border:1px solid var(--border-default);border-radius:var(--radius);padding:1rem 1.25rem;transition:border-color .2s,box-shadow .2s}.card:hover{border-color:var(--border-strong)}.skip-link{position:absolute;top:-100%;left:1rem;z-index:9999;padding:.5rem 1rem;background:var(--accent);color:#fff;font-size:.875rem;font-weight:600;border-radius:0 0 var(--radius) var(--radius);text-decoration:none;transition:top .15s ease}.skip-link:focus{top:0;outline:3px solid var(--accent-bright);outline-offset:2px}.alert-banner{display:flex;align-items:center;gap:.625rem;background:var(--danger-dim);border:1px solid var(--danger-border);border-radius:var(--radius-sm);color:var(--danger);font-size:.8125rem;font-weight:500;padding:.5rem .875rem;margin-bottom:.5rem}.alert-banner--info{background:var(--info-dim);border-color:var(--info-border);color:var(--info)}.alert-banner--violation{background:var(--warning-dim);border-color:var(--warning-border);color:var(--warning)}.section-title{font-size:.625rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--text-muted);margin-bottom:.75rem;display:flex;align-items:center;gap:.5rem}.section-subtitle{font-size:.6rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--text-muted);margin-bottom:.5rem;display:flex;align-items:center;gap:.4rem}.overview-columns{display:grid;grid-template-columns:60fr 40fr;gap:1.5rem;align-items:start}@media(max-width: 1000px){.overview-columns{grid-template-columns:1fr}}#tree{display:flex;flex-direction:column;gap:.5rem}.agent-row{background:var(--bg-surface);border:1px solid var(--border-default);border-left:3px solid var(--border-strong);border-radius:var(--radius);overflow:hidden;transition:border-color .2s,box-shadow .2s,transform .15s;animation:slide-in .2s var(--ease-out)}@keyframes slide-in{from{opacity:0;transform:translateX(-8px)}to{opacity:1;transform:translateX(0)}}.agent-row:hover{transform:translateX(2px);box-shadow:var(--shadow-md)}.agent-row--status-implementing{border-left-color:#3b82f6;box-shadow:-1px 0 0 0 rgba(59,130,246,.3) inset}.agent-row--status-implementing:hover{border-left-color:#60a5fa;box-shadow:-2px 0 12px rgba(59,130,246,.2)}.agent-row--status-reviewing{border-left-color:var(--warning);box-shadow:-1px 0 0 0 var(--warning-glow) inset}.agent-row--status-reviewing:hover{box-shadow:-2px 0 12px var(--warning-glow)}.agent-row--status-done{border-left-color:var(--success);box-shadow:-1px 0 0 0 var(--success-glow) inset}.agent-row--status-done:hover{box-shadow:-2px 0 12px var(--success-glow)}.agent-row--status-stale{border-left-color:var(--danger);box-shadow:-1px 0 0 0 var(--danger-glow) inset}.agent-row--status-stale:hover{box-shadow:-2px 0 12px var(--danger-glow)}.agent-row--child{margin-left:1.5rem;background:var(--bg-elevated);border-left-width:2px}.agent-row-header{display:flex;align-items:center;flex-wrap:wrap;gap:.5rem;padding:.625rem 1rem}.agent-children{padding:0 1rem .625rem;display:flex;flex-direction:column;gap:.375rem}.agent-role{font-weight:500;font-size:.875rem;color:var(--text-primary);transition:color .15s}.agent-role:hover{color:var(--accent-bright)}.agent-meta{font-size:.6875rem;color:var(--text-muted);font-variant-numeric:tabular-nums}.empty-state{padding:3rem 1rem;text-align:center;font-size:.875rem;color:var(--text-muted);border:1px dashed var(--border-subtle);border-radius:var(--radius)}.status-badge{display:inline-flex;align-items:center;font-size:.575rem;font-weight:700;padding:.2rem .55rem;border-radius:var(--radius-full);text-transform:uppercase;letter-spacing:.07em;white-space:nowrap}.status-badge--implementing{background:rgba(59,130,246,.15);color:#60a5fa;border:1px solid rgba(59,130,246,.3)}.status-badge--reviewing{background:var(--warning-dim);color:var(--warning);border:1px solid var(--warning-border)}.status-badge--done{background:var(--success-dim);color:var(--success);border:1px solid var(--success-border)}.status-badge--stale{background:var(--danger-dim);color:var(--danger);border:1px solid var(--danger-border)}.status-badge--unknown{background:var(--bg-elevated);color:var(--text-muted);border:1px solid var(--border-subtle)}.btn{display:inline-flex;align-items:center;justify-content:center;gap:.375rem;padding:.4rem .875rem;border-radius:var(--radius-sm);font-size:.8125rem;font-weight:500;font-family:var(--font-sans);cursor:pointer;border:1px solid rgba(0,0,0,0);text-decoration:none;transition:background .15s,color .15s,border-color .15s,box-shadow .15s,transform .1s;white-space:nowrap;letter-spacing:.01em}.btn:disabled{opacity:.4;cursor:not-allowed}.btn:hover:not(:disabled){text-decoration:none}.btn:active:not(:disabled){transform:scale(0.97)}.btn-primary{background:var(--grad-accent);color:#fff;border:none;box-shadow:0 2px 8px var(--accent-glow)}.btn-primary:hover:not(:disabled){box-shadow:0 4px 16px var(--accent-glow-strong);filter:brightness(1.1)}.btn-primary:disabled{background:var(--bg-elevated);color:var(--text-muted);box-shadow:none;filter:none}.btn-secondary{background:var(--bg-elevated);border-color:var(--border-default);color:var(--text-secondary)}.btn-secondary:hover:not(:disabled){background:var(--bg-overlay);border-color:var(--border-strong);color:var(--text-primary)}.btn-danger{background:var(--danger-dim);border-color:var(--danger-border);color:var(--danger)}.btn-danger:hover:not(:disabled){background:var(--danger);border-color:var(--danger);color:#fff;box-shadow:0 2px 12px var(--danger-glow)}.btn-warning{background:var(--warning-dim);border-color:var(--warning-border);color:var(--warning)}.btn-warning:hover:not(:disabled){background:var(--warning);border-color:var(--warning);color:#000}.btn-sm{padding:.2rem .55rem;font-size:.75rem}.btn-kill-inline{margin-left:auto;padding:.15rem .45rem;background:none;border:1px solid var(--danger-border);border-radius:var(--radius-xs);color:var(--text-muted);font-size:.6875rem;cursor:pointer;line-height:1;transition:background .15s,color .15s,border-color .15s;flex-shrink:0;opacity:0;transition:opacity .15s,background .15s,color .15s}.agent-row:hover .btn-kill-inline,.agent-row--child:hover .btn-kill-inline{opacity:1}.btn-kill-inline:hover{background:var(--danger);border-color:var(--danger);color:#fff}.agent-card__header{display:flex;align-items:center;flex-wrap:wrap;gap:.5rem;padding:.625rem 1rem;cursor:pointer;user-select:none;transition:background .15s}.agent-card__header:hover{background:hsla(0,0%,100%,.025)}.agent-card__chevron{margin-left:auto;font-size:.8rem;color:var(--text-muted);transition:transform .2s var(--ease-out);flex-shrink:0;line-height:1}.agent-card__chevron--open{transform:rotate(90deg)}.agent-card__body{border-top:1px solid var(--border-subtle)}.transcript-feed{max-height:380px;overflow-y:auto;padding:.75rem 1rem;display:flex;flex-direction:column;gap:.375rem;scrollbar-width:thin;scrollbar-color:var(--border-strong) rgba(0,0,0,0)}.transcript-msg{display:flex;gap:.5rem;font-size:.8125rem;line-height:1.5;align-items:flex-start}.transcript-msg--assistant{background:rgba(139,92,246,.05);border-left:2px solid rgba(139,92,246,.25);border-radius:0 var(--radius-sm, 4px) var(--radius-sm, 4px) 0;padding:.375rem .5rem .375rem .5rem}.transcript-msg--user{padding:.25rem 0}.transcript-msg__icon{font-size:.875rem;flex-shrink:0;width:1.25rem;text-align:center;line-height:1.5}.transcript-msg__body{flex:1;min-width:0}.transcript-msg__role{font-size:.6rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.1rem}.transcript-msg__text{color:var(--text-primary);white-space:pre-wrap;word-break:break-word;overflow:hidden;display:-webkit-box;-webkit-line-clamp:6;-webkit-box-orient:vertical}.transcript-loading,.transcript-empty{padding:.5rem 0;font-size:.8125rem;color:var(--text-muted);text-align:center}.transcript-error{padding:.5rem 0;font-size:.8125rem;color:var(--danger);text-align:center}.transcript-thinking{display:flex;align-items:center;gap:.5rem;padding:.25rem 0;font-size:.8125rem;color:var(--text-muted)}.transcript-thinking__dot{width:.5rem;height:.5rem;border-radius:50%;background:#3b82f6;flex-shrink:0;animation:pulse-dot 1.4s ease-in-out infinite}@keyframes pulse-dot{0%,100%{opacity:.3;transform:scale(0.75)}50%{opacity:1;transform:scale(1.15)}}.agent-task-details{border-top:1px solid var(--border-subtle);padding:.625rem 1rem}.agent-task-details__title{font-size:.6rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--text-muted);margin-bottom:.4rem}.agent-task-grid{display:grid;grid-template-columns:max-content 1fr;gap:.2rem .75rem;font-size:.75rem}.agent-task-grid__key{color:var(--text-muted);font-weight:500;white-space:nowrap;line-height:1.5}.agent-task-grid__value{font-family:var(--font-mono);color:var(--text-secondary, var(--text-primary));word-break:break-all;overflow:hidden;text-overflow:ellipsis;line-height:1.5}.agent-card-actions{display:flex;gap:.4rem;padding:.5rem 1rem;border-top:1px solid var(--border-subtle);flex-wrap:wrap;background:hsla(0,0%,100%,.01)}.agent-pulse{display:inline-block;width:.45rem;height:.45rem;border-radius:50%;flex-shrink:0;animation:pulse-ring 1.8s ease-out infinite}.agent-pulse--implementing{background:#3b82f6}.agent-pulse--reviewing{background:var(--warning, #f59e0b)}@keyframes pulse-ring{0%{box-shadow:0 0 0 0 rgba(59,130,246,.7)}60%{box-shadow:0 0 0 5px rgba(59,130,246,0)}100%{box-shadow:0 0 0 0 rgba(59,130,246,0)}}.agent-role-name{font-weight:600;font-size:.875rem;color:var(--text-primary)}.agent-meta-chip{display:inline-flex;align-items:center;padding:.1rem .4rem;border-radius:4px;font-size:.6875rem;font-weight:700;text-decoration:none;font-variant-numeric:tabular-nums;line-height:1.4;transition:background .12s,color .12s}.agent-meta-chip--issue{background:rgba(139,92,246,.1);color:var(--accent-bright);border:1px solid rgba(139,92,246,.25)}.agent-meta-chip--issue:hover{background:rgba(139,92,246,.22);color:#fff}.agent-meta-chip--pr{background:rgba(34,197,94,.09);color:var(--success);border:1px solid rgba(34,197,94,.25)}.agent-meta-chip--pr:hover{background:rgba(34,197,94,.2);color:#fff}.agent-branch-chip{font-size:.6875rem;font-family:var(--font-mono);color:var(--text-muted);max-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.issue-card-status{margin:.3rem 0}.issue-status-badge{display:inline-flex;align-items:center;gap:.2rem;padding:.1rem .45rem;border-radius:99px;font-size:.6875rem;font-weight:600;letter-spacing:.03em;text-decoration:none;transition:background .12s,color .12s}.issue-status-badge--available{background:hsla(0,0%,100%,.04);color:var(--text-muted);border:1px solid var(--border-subtle)}.issue-status-badge--implementing{background:rgba(59,130,246,.1);color:#60a5fa;border:1px solid rgba(59,130,246,.28)}.issue-status-badge--pr{background:rgba(34,197,94,.1);color:var(--success);border:1px solid rgba(34,197,94,.28)}.issue-status-badge--pr:hover{background:rgba(34,197,94,.2);color:#fff}.wave-branch{font-size:.6875rem;color:var(--accent-bright);font-family:var(--font-mono)}.badge{display:inline-flex;align-items:center;font-size:.6rem;font-weight:700;padding:.15rem .55rem;border-radius:var(--radius-full);text-transform:uppercase;letter-spacing:.06em}.badge-count{background:var(--bg-overlay);color:var(--text-secondary);border:1px solid var(--border-default)}.badge--green{background:var(--success-dim);color:var(--success);border:1px solid var(--success-border)}.badge--blue{background:var(--info-dim);color:var(--info);border:1px solid var(--info-border)}.badge--yellow{background:var(--warning-dim);color:var(--warning);border:1px solid var(--warning-border)}.badge--red{background:var(--danger-dim);color:var(--danger);border:1px solid var(--danger-border)}.badge--grey{background:var(--bg-elevated);color:var(--text-muted);border:1px solid var(--border-subtle)}.badge--purple{background:var(--accent-glow);color:var(--accent-bright);border:1px solid rgba(139,92,246,.3)}.modal-backdrop{position:fixed;inset:0;background:rgba(4,7,16,.75);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);display:flex;align-items:center;justify-content:center;z-index:300;animation:fade-in .15s var(--ease-out)}.modal-box{background:var(--bg-elevated);border:1px solid var(--border-strong);border-radius:var(--radius-lg);padding:1.5rem;max-width:28rem;width:90%;box-shadow:var(--shadow-lg),0 0 0 1px rgba(139,92,246,.08);animation:modal-in .2s var(--ease-out)}@keyframes modal-in{from{opacity:0;transform:scale(0.96) translateY(-8px)}to{opacity:1;transform:scale(1) translateY(0)}}.modal-title{font-size:1rem;font-weight:600;margin:0 0 .75rem;color:var(--text-primary)}.modal-body{font-size:.875rem;color:var(--text-secondary);margin:0 0 1.25rem;line-height:1.6}.modal-actions{display:flex;gap:.5rem;justify-content:flex-end}.text-muted{color:var(--text-muted)}.text-secondary{color:var(--text-secondary)}.text-success{color:var(--success)}.text-warning{color:var(--warning)}.text-danger{color:var(--danger)}.text-accent{color:var(--accent-bright)}.text-sm{font-size:.8125rem}.text-xs{font-size:.6875rem}.mt-1{margin-top:.5rem}.mt-2{margin-top:1rem}.mt-3{margin-top:1.5rem}.mb-1{margin-bottom:.5rem}.mb-2{margin-bottom:1rem}.breadcrumb{display:flex;align-items:center;gap:.375rem;font-size:.8125rem;color:var(--text-muted);margin-bottom:1.25rem}.breadcrumb a{color:var(--accent-bright)}.breadcrumb a:hover{color:#fff}.breadcrumb-sep{color:var(--border-strong)}.breadcrumb-current{color:var(--text-primary);font-weight:500}.pipeline-summary-bar{display:flex;flex-wrap:nowrap;align-items:center;gap:0;background:var(--bg-surface);border:1px solid var(--border-default);border-radius:var(--radius);padding:0 0 0 1rem;margin-bottom:1rem;height:44px;box-shadow:var(--shadow-sm)}.summary-item{display:flex;flex-direction:column;justify-content:center;gap:0;padding:0 .85rem;position:relative;height:100%;flex-shrink:0}.summary-item+.summary-item::before{content:"";position:absolute;left:0;top:20%;height:60%;width:1px;background:var(--border-subtle)}.phase-switcher+.summary-item::before{display:none}.summary-item--dim{opacity:.4}.summary-item--warn{opacity:1}.summary-item--warn .summary-label{color:var(--warning)}.summary-item--warn .summary-value{color:var(--warning)}.summary-item--clickable{cursor:pointer;border-radius:4px;transition:background .12s}.summary-item--clickable:hover{background:rgba(251,191,36,.1)}.summary-label{font-size:.575rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--text-muted);white-space:nowrap;line-height:1}.summary-value{font-size:1.05rem;font-weight:700;color:var(--text-primary);line-height:1.15;letter-spacing:-0.02em;font-variant-numeric:tabular-nums;white-space:nowrap}.summary-value--active{color:var(--success)}.summary-value--accent{color:var(--accent-bright)}.summary-value--mono{font-size:.8rem;font-weight:500;letter-spacing:0}.summary-value--phase{font-weight:700;color:var(--accent-bright);font-size:1.05rem;letter-spacing:-0.02em}.phase-switcher{position:relative;flex-shrink:0;margin-right:.5rem;display:flex;align-items:center}.phase-switcher__trigger{display:flex;align-items:center;gap:.3rem;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius-sm);padding:.25rem .6rem;font-size:.78rem;font-weight:500;font-family:var(--font-sans);color:var(--text-primary);cursor:pointer;white-space:nowrap;transition:border-color .15s,background .15s,box-shadow .15s;max-width:220px}.phase-switcher__trigger:hover{border-color:var(--accent);background:rgba(139,92,246,.1);box-shadow:0 0 0 3px var(--accent-glow)}.phase-switcher__icon{color:var(--accent-bright);font-size:.875rem}.phase-switcher__current{overflow:hidden;text-overflow:ellipsis}.phase-switcher__pin{font-size:.65rem}.phase-switcher__caret{color:var(--text-muted);font-size:.65rem;margin-left:.1rem}.phase-switcher__dropdown{position:absolute;top:calc(100% + 8px);left:0;z-index:200;min-width:240px;background:var(--bg-elevated);border:1px solid var(--border-strong);border-radius:var(--radius);box-shadow:var(--shadow-lg),0 0 0 1px rgba(139,92,246,.08);overflow:hidden}.phase-switcher__header{padding:.5rem .875rem .375rem;font-size:.625rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--text-muted)}.phase-switcher__divider{height:1px;background:var(--border-subtle);margin:.25rem 0}.phase-switcher__option{display:flex;align-items:center;gap:.5rem;width:100%;text-align:left;padding:.5rem .875rem;font-size:.8125rem;font-family:var(--font-sans);color:var(--text-secondary);background:rgba(0,0,0,0);border:none;cursor:pointer;transition:background .1s,color .1s}.phase-switcher__option:hover{background:rgba(139,92,246,.1);color:var(--text-primary)}.phase-switcher__option--active{color:var(--accent-bright);font-weight:500}.phase-switcher__option-check{width:1rem;flex-shrink:0;color:var(--accent-bright);font-size:.75rem}.phase-switcher__auto-hint{color:var(--text-muted);font-size:.75rem}.poller-right{display:flex;align-items:center;gap:0;margin-left:auto;flex-shrink:0;height:100%;border-left:1px solid var(--border-subtle)}.poller-polled{display:flex;flex-direction:column;align-items:flex-end;gap:0;padding:0 .75rem;cursor:default}.poller-polled__label{font-size:.575rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--text-muted);line-height:1}.poller-polled__value{font-size:.8rem;font-weight:500;color:var(--text-primary);white-space:nowrap;line-height:1.2}.poller-btn{display:flex;align-items:center;justify-content:center;gap:.35rem;width:80px;height:100%;padding:0 1rem 0 .75rem;border-left:1px solid var(--border-subtle);border-right:none;border-top:none;border-bottom:none;background:none;cursor:pointer;font-family:var(--font-sans);border-radius:0 8px 8px 0;transition:background .12s;box-sizing:border-box}.poller-btn:hover{background:hsla(0,0%,100%,.06)}.poller-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}.poller-dot--live{background:#22c55e;box-shadow:0 0 6px rgba(34,197,94,.6);animation:pulse-dot 2.5s ease-in-out infinite}.poller-dot--warn{background:var(--warning)}.poller-dot--paused{background:#ef4444;box-shadow:0 0 6px rgba(239,68,68,.4)}@keyframes pulse-dot{0%,100%{opacity:1;box-shadow:0 0 6px rgba(34,197,94,.6)}50%{opacity:.5;box-shadow:0 0 2px rgba(34,197,94,.3)}}.poller-btn__label{font-size:.7rem;font-weight:600;letter-spacing:.03em;color:var(--text-muted);white-space:nowrap}.overview-columns{display:grid;grid-template-columns:60fr 40fr;gap:1.5rem;align-items:start}@media(max-width: 1000px){.overview-columns{grid-template-columns:1fr}}#tree{display:flex;flex-direction:column;gap:.5rem}.agent-row{background:var(--bg-surface);border:1px solid var(--border-default);border-left:3px solid var(--border-strong);border-radius:var(--radius);overflow:hidden;transition:border-color .2s,box-shadow .2s,transform .15s;animation:slide-in .2s var(--ease-out)}@keyframes slide-in{from{opacity:0;transform:translateX(-8px)}to{opacity:1;transform:translateX(0)}}.agent-row:hover{transform:translateX(2px);box-shadow:var(--shadow-md)}.agent-row--status-implementing{border-left-color:#3b82f6;box-shadow:-1px 0 0 0 rgba(59,130,246,.3) inset}.agent-row--status-implementing:hover{border-left-color:#60a5fa;box-shadow:-2px 0 12px rgba(59,130,246,.2)}.agent-row--status-reviewing{border-left-color:var(--warning);box-shadow:-1px 0 0 0 var(--warning-glow) inset}.agent-row--status-reviewing:hover{box-shadow:-2px 0 12px var(--warning-glow)}.agent-row--status-done{border-left-color:var(--success);box-shadow:-1px 0 0 0 var(--success-glow) inset}.agent-row--status-done:hover{box-shadow:-2px 0 12px var(--success-glow)}.agent-row--status-stale{border-left-color:var(--danger);box-shadow:-1px 0 0 0 var(--danger-glow) inset}.agent-row--status-stale:hover{box-shadow:-2px 0 12px var(--danger-glow)}.agent-row--child{margin-left:1.5rem;background:var(--bg-elevated);border-left-width:2px}.agent-row-header{display:flex;align-items:center;flex-wrap:wrap;gap:.5rem;padding:.625rem 1rem}.agent-children{padding:0 1rem .625rem;display:flex;flex-direction:column;gap:.375rem}.agent-role{font-weight:500;font-size:.875rem;color:var(--text-primary);transition:color .15s}.agent-role:hover{color:var(--accent-bright)}.agent-meta{font-size:.6875rem;color:var(--text-muted);font-variant-numeric:tabular-nums}.empty-state{padding:3rem 1rem;text-align:center;font-size:.875rem;color:var(--text-muted);border:1px dashed var(--border-subtle);border-radius:var(--radius)}.status-badge{display:inline-flex;align-items:center;font-size:.575rem;font-weight:700;padding:.2rem .55rem;border-radius:var(--radius-full);text-transform:uppercase;letter-spacing:.07em;white-space:nowrap}.status-badge--implementing{background:rgba(59,130,246,.15);color:#60a5fa;border:1px solid rgba(59,130,246,.3)}.status-badge--reviewing{background:var(--warning-dim);color:var(--warning);border:1px solid var(--warning-border)}.status-badge--done{background:var(--success-dim);color:var(--success);border:1px solid var(--success-border)}.status-badge--stale{background:var(--danger-dim);color:var(--danger);border:1px solid var(--danger-border)}.status-badge--unknown{background:var(--bg-elevated);color:var(--text-muted);border:1px solid var(--border-subtle)}.github-board{position:sticky;top:4rem;display:flex;flex-direction:column;gap:.75rem}.board-label-row{margin-bottom:.375rem}.label-chip{display:inline-flex;align-items:center;background:rgba(139,92,246,.12);border:1px solid rgba(139,92,246,.3);color:var(--accent-bright);border-radius:var(--radius-full);font-size:.75rem;font-weight:600;padding:.2rem .65rem}.label-chip--active{background:rgba(139,92,246,.18);border-color:var(--accent);color:var(--accent-bright);box-shadow:0 0 8px var(--accent-glow)}.label-chip--none{background:hsla(0,0%,100%,.04);border-color:var(--border-default);color:var(--text-muted)}.label-chip--small{font-size:.6rem;padding:.1rem .45rem;background:rgba(139,92,246,.08);border:1px solid rgba(139,92,246,.2);border-radius:var(--radius-full);color:var(--text-muted)}.board-stats{display:flex;align-items:center;gap:.4rem;font-size:.8125rem}.board-stats-sep{color:var(--border-strong)}.alert-item{background:var(--danger-dim);border-left:2px solid var(--danger);color:var(--danger);font-size:.8125rem;padding:.375rem .75rem;border-radius:0 var(--radius-sm) var(--radius-sm) 0;margin-bottom:.25rem}.wave-control-card{border-left:3px solid var(--accent);background:linear-gradient(135deg, rgba(139, 92, 246, 0.06) 0%, transparent 60%)}.wave-control-header{display:flex;align-items:flex-start;justify-content:space-between;gap:.75rem}.wave-phase-label{margin-bottom:.3rem}.wave-phase-stats{font-size:.8125rem}.btn-wave-start{white-space:nowrap;flex-shrink:0;background:var(--grad-accent) !important;border:none !important;box-shadow:0 2px 12px var(--accent-glow)}.btn-wave-start:hover:not(:disabled){box-shadow:0 4px 20px var(--accent-glow-strong);transform:translateY(-1px)}.board-syncing{font-size:.8125rem;color:var(--text-muted)}.wave-result{border-top:1px solid var(--border-subtle);padding-top:.75rem;margin-top:.75rem;animation:fade-in .3s var(--ease-out)}.wave-worktree-row{display:flex;align-items:baseline;gap:.5rem;margin-bottom:.375rem;font-size:.8125rem}.wave-issue-num{font-weight:700;color:var(--accent-bright);min-width:2.5rem;font-variant-numeric:tabular-nums}.wave-worktree-path{font-size:.6875rem;color:var(--text-muted);font-family:var(--font-mono);word-break:break-all}.issue-card{background:var(--bg-elevated);border:1px solid var(--border-subtle);border-radius:var(--radius);padding:.625rem .875rem;margin-bottom:.5rem;transition:border-color .15s,box-shadow .15s}.issue-card:hover{border-color:var(--border-strong);box-shadow:var(--shadow-sm)}.issue-card-header{display:flex;align-items:baseline;gap:.5rem;margin-bottom:.25rem}.issue-card-number{font-weight:700;font-size:.75rem;color:var(--accent-bright);font-variant-numeric:tabular-nums;flex-shrink:0}.issue-card-number:hover{color:#fff}.issue-card-title{font-size:.8125rem;color:var(--text-primary);line-height:1.4}.issue-card-labels{display:flex;flex-wrap:wrap;gap:.25rem;margin:.25rem 0}.issue-card-actions{margin-top:.4rem}.issue-analysis-result{margin-top:.625rem;padding-top:.625rem;border-top:1px solid var(--border-subtle);font-size:.8125rem;line-height:1.6;color:var(--text-secondary);animation:fade-in .25s var(--ease-out)}.stale-claim-card{background:var(--danger-dim);border:1px solid var(--danger-border);border-radius:var(--radius-sm);padding:.625rem .875rem;margin-bottom:.5rem}.stale-claim-header{display:flex;align-items:baseline;gap:.4rem;margin-bottom:.25rem}.stale-claim-number{font-weight:700;color:var(--danger);flex-shrink:0;font-variant-numeric:tabular-nums}.stale-claim-title{font-size:.8125rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.stale-claim-path{font-size:.6875rem;font-family:var(--font-mono);margin-bottom:.4rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-muted)}.stale-claim-actions{display:flex;align-items:center;gap:.4rem;flex-wrap:wrap}.stale-claim-confirm{display:flex;align-items:center;gap:.4rem;font-size:.8125rem}.batch-group{border:1px solid var(--border-subtle);border-radius:var(--radius);padding:.5rem .75rem .75rem;background:var(--bg-surface)}.batch-heading{display:flex;align-items:center;gap:.5rem;font-size:.6875rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted);margin:0 0 .5rem;padding-bottom:.375rem;border-bottom:1px solid var(--border-subtle)}.issue-grid{display:flex;flex-direction:column;gap:.5rem}.agent-detail-header{display:flex;flex-direction:column;gap:.75rem}.agent-detail-title{display:flex;align-items:center;gap:.75rem}.agent-detail-role{font-size:1.25rem;font-weight:700;color:var(--text-primary);letter-spacing:-0.02em}.agent-detail-meta{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center}.meta-chip{display:inline-flex;align-items:center;gap:.25rem;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius-sm);padding:.2rem .55rem;font-size:.75rem}.meta-label{color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;font-size:.6rem}.meta-value{color:var(--text-primary);font-weight:500}.meta-value a{color:var(--accent-bright)}.agent-detail-columns{display:grid;grid-template-columns:40fr 60fr;gap:1.5rem;align-items:start}@media(max-width: 900px){.agent-detail-columns{grid-template-columns:1fr}}.agent-task-panel{position:sticky;top:5rem}.task-table{width:100%;border-collapse:collapse}.task-table tr+tr{border-top:1px solid var(--border-subtle)}.task-key{font-size:.625rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted);padding:.5rem .75rem .5rem 0;vertical-align:top;width:38%;white-space:nowrap}.task-value{font-size:.8125rem;color:var(--text-primary);padding:.5rem 0;vertical-align:top;word-break:break-word}.task-value--path code{font-size:.65rem;word-break:break-all}.transcript-container{display:flex;flex-direction:column;gap:.5rem;max-height:70vh;overflow-y:auto;padding-right:.25rem}.message{border-radius:var(--radius);overflow:hidden}.message--user{background:var(--bg-surface);border:1px solid var(--border-default)}.message--assistant{background:rgba(139,92,246,.07);border:1px solid rgba(139,92,246,.2)}.message-role{font-size:.575rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;padding:.3rem .875rem;border-bottom:1px solid var(--border-subtle)}.message--user .message-role{color:var(--text-muted);background:var(--bg-elevated)}.message--assistant .message-role{color:var(--accent-bright);background:rgba(139,92,246,.1)}.message-body{cursor:pointer;padding:.5rem .875rem 0}.message-body--collapsed{max-height:5rem;overflow:hidden;-webkit-mask-image:linear-gradient(to bottom, black 60%, transparent 100%);mask-image:linear-gradient(to bottom, black 60%, transparent 100%)}.message-body--expanded{max-height:none}.message-text{font-family:var(--font-sans);font-size:.8125rem;line-height:1.6;color:var(--text-primary);white-space:pre-wrap;word-break:break-word;margin:0}.message-expand-btn{display:block;width:100%;text-align:center;background:none;border:none;border-top:1px solid var(--border-subtle);color:var(--text-muted);font-size:.625rem;padding:.3rem;cursor:pointer;margin-top:.25rem;transition:color .15s;font-family:var(--font-sans)}.message-expand-btn:hover{color:var(--accent-bright)}:root{--arch-visionary: #9b59b6;--arch-architect: #3498db;--arch-hacker: #f39c12;--arch-guardian: #27ae60;--arch-scholar: #1abc9c;--arch-mentor: #e67e22;--arch-operator: #95a5a6;--arch-pragmatist: #e74c3c;--arch-default: #6c757d}.card-persona-avatar{width:2rem;height:2rem;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:1rem;flex-shrink:0;background:var(--bg-elevated);border:1.5px solid var(--border-default);transition:transform .15s ease}.agent-card__header:hover .card-persona-avatar{transform:scale(1.08)}.card-persona-avatar--visionary{border-color:var(--arch-visionary);background:rgba(155,89,182,.15)}.card-persona-avatar--architect{border-color:var(--arch-architect);background:rgba(52,152,219,.15)}.card-persona-avatar--hacker{border-color:var(--arch-hacker);background:rgba(243,156,18,.15)}.card-persona-avatar--guardian{border-color:var(--arch-guardian);background:rgba(39,174,96,.15)}.card-persona-avatar--scholar{border-color:var(--arch-scholar);background:rgba(26,188,156,.15)}.card-persona-avatar--mentor{border-color:var(--arch-mentor);background:rgba(230,126,34,.15)}.card-persona-avatar--operator{border-color:var(--arch-operator);background:rgba(149,165,166,.12)}.card-persona-avatar--pragmatist{border-color:var(--arch-pragmatist);background:rgba(231,76,60,.15)}.card-persona-avatar--default{border-color:var(--border-default);background:var(--bg-elevated)}.agent-role-stack{display:flex;flex-direction:column;gap:.1rem;min-width:0}.agent-persona-sub{font-size:.7rem;color:var(--text-muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.card-arch-panel{background:var(--bg-elevated);border:1px solid var(--border-subtle);border-radius:6px;padding:.6rem .75rem;margin-bottom:.5rem}.card-arch-panel__header{display:flex;align-items:center;gap:.4rem;font-size:.82rem;font-weight:600;color:var(--text-primary);margin-bottom:.35rem}.card-arch-panel__archetype{font-size:.68rem;color:var(--accent-muted);background:rgba(124,106,247,.12);border-radius:4px;padding:.1rem .35rem}.card-arch-panel__skills{display:flex;flex-wrap:wrap;gap:.25rem;margin-bottom:.35rem}.card-arch-panel__link{font-size:.7rem;color:var(--accent-bright);text-decoration:none}.card-arch-panel__link:hover{text-decoration:underline}.cog-skill-tag{display:inline-flex;align-items:center;background:rgba(22,153,255,.1);border:1px solid rgba(22,153,255,.25);color:#60b4ff;border-radius:4px;padding:.15rem .5rem;font-size:.73rem;font-family:var(--font-mono)}.cog-skill-tag--sm{font-size:.65rem;padding:.1rem .35rem}.agent-hero-row{display:flex;align-items:flex-start;gap:1rem;margin-bottom:.75rem}.agent-persona-avatar{width:3.5rem;height:3.5rem;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:1.6rem;flex-shrink:0;background:var(--bg-elevated);border:2px solid var(--border-default)}.agent-persona-avatar--visionary{border-color:var(--arch-visionary);background:rgba(155,89,182,.18)}.agent-persona-avatar--architect{border-color:var(--arch-architect);background:rgba(52,152,219,.18)}.agent-persona-avatar--hacker{border-color:var(--arch-hacker);background:rgba(243,156,18,.18)}.agent-persona-avatar--guardian{border-color:var(--arch-guardian);background:rgba(39,174,96,.18)}.agent-persona-avatar--scholar{border-color:var(--arch-scholar);background:rgba(26,188,156,.18)}.agent-persona-avatar--mentor{border-color:var(--arch-mentor);background:rgba(230,126,34,.18)}.agent-persona-avatar--operator{border-color:var(--arch-operator);background:rgba(149,165,166,.15)}.agent-persona-avatar--pragmatist{border-color:var(--arch-pragmatist);background:rgba(231,76,60,.18)}.agent-persona-avatar--default{border-color:var(--border-default);background:var(--bg-elevated)}.agent-hero-body{flex:1;min-width:0}.agent-persona-line{display:flex;align-items:center;gap:.5rem;margin:.2rem 0 .5rem;flex-wrap:wrap}.agent-persona-name{font-weight:600;color:var(--text-primary);font-size:.9rem}.agent-persona-archetype{font-size:.72rem;color:var(--accent-muted);background:rgba(124,106,247,.12);border-radius:4px;padding:.1rem .4rem}.agent-persona-link{font-size:.72rem;color:var(--accent-bright);text-decoration:none;margin-left:auto}.agent-persona-link:hover{text-decoration:underline}.cog-panel{padding:1rem 1.25rem}.cog-panel__header{display:flex;align-items:center;gap:.5rem;font-size:1rem;margin-bottom:.5rem}.cog-panel__title{font-weight:700;color:var(--text-primary);font-size:1rem}.cog-panel__sub{font-size:.72rem;color:var(--accent-muted);background:rgba(124,106,247,.12);border-radius:4px;padding:.1rem .4rem}.cog-panel__detail-link{margin-left:auto;font-size:.75rem;color:var(--accent-bright);text-decoration:none}.cog-panel__detail-link:hover{text-decoration:underline}.cog-panel__desc{font-size:.82rem;color:var(--text-secondary);line-height:1.55;margin:0 0 .75rem}.cog-panel__body{display:flex;gap:1rem;flex-wrap:wrap}.cog-panel__section-label{font-size:.68rem;font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--text-muted);margin-bottom:.35rem}.cog-atoms-row{display:flex;flex-wrap:wrap;gap:.3rem}.cog-atom-pill{display:flex;flex-direction:column;background:var(--bg-elevated);border:1px solid var(--border-subtle);border-radius:5px;padding:.2rem .5rem;font-size:.7rem}.cog-atom-pill__key{color:var(--text-muted);font-size:.62rem}.cog-atom-pill__val{color:var(--text-primary);font-weight:600}.cog-skills-row{display:flex;flex-wrap:wrap;gap:.25rem}.cog-hero{display:flex;gap:1.5rem;align-items:flex-start;padding:1.5rem}.cog-hero__avatar-wrap{display:flex;flex-direction:column;align-items:center;gap:.4rem;flex-shrink:0}.cog-hero__avatar{width:6rem;height:6rem;border-radius:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;background:var(--bg-elevated);border:3px solid var(--border-default);position:relative}.cog-hero__avatar--visionary{border-color:var(--arch-visionary);background:rgba(155,89,182,.22)}.cog-hero__avatar--architect{border-color:var(--arch-architect);background:rgba(52,152,219,.22)}.cog-hero__avatar--hacker{border-color:var(--arch-hacker);background:rgba(243,156,18,.22)}.cog-hero__avatar--guardian{border-color:var(--arch-guardian);background:rgba(39,174,96,.22)}.cog-hero__avatar--scholar{border-color:var(--arch-scholar);background:rgba(26,188,156,.22)}.cog-hero__avatar--mentor{border-color:var(--arch-mentor);background:rgba(230,126,34,.22)}.cog-hero__avatar--operator{border-color:var(--arch-operator);background:rgba(149,165,166,.2)}.cog-hero__avatar--pragmatist{border-color:var(--arch-pragmatist);background:rgba(231,76,60,.22)}.cog-hero__avatar--default{border-color:var(--border-strong);background:var(--bg-elevated)}.cog-hero__emoji{font-size:2.5rem;line-height:1}.cog-hero__initials{font-size:.65rem;color:var(--text-muted);font-weight:700;margin-top:-0.2rem}.cog-hero__named-badge{font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.07em;background:rgba(124,106,247,.18);color:var(--accent-bright);border-radius:4px;padding:.15rem .5rem}.cog-hero__named-badge--custom{background:rgba(26,188,156,.14);color:#4ecdc4}.cog-hero__info{flex:1;min-width:0}.cog-hero__name-row{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:.4rem}.cog-hero__name{font-size:1.7rem;font-weight:800;color:var(--text-primary);margin:0}.cog-hero__archetype-chip{font-size:.75rem;color:var(--accent-muted);background:rgba(124,106,247,.12);border-radius:5px;padding:.15rem .5rem;white-space:nowrap}.cog-hero__desc{font-size:.88rem;color:var(--text-secondary);line-height:1.6;margin:0 0 .75rem;max-width:60ch}.cog-hero__raw-row{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap}.cog-hero__raw-label{font-size:.68rem;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--text-muted)}.cog-hero__raw-value{font-family:var(--font-mono);font-size:.78rem;color:var(--text-secondary);background:var(--bg-elevated);border:1px solid var(--border-subtle);border-radius:4px;padding:.1rem .4rem}.cog-columns{display:grid;grid-template-columns:1fr 1.5fr;gap:1rem}@media(max-width: 800px){.cog-columns{grid-template-columns:1fr}}.cog-atoms-grid{display:grid;grid-template-columns:repeat(auto-fill, minmax(140px, 1fr));gap:.5rem;padding:.75rem}.cog-atom{background:var(--bg-elevated);border:1px solid var(--border-subtle);border-radius:6px;padding:.45rem .6rem}.cog-atom__label{font-size:.65rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted);margin-bottom:.2rem}.cog-atom__value{font-size:.78rem;font-weight:700;color:var(--text-primary)}.cog-prompt__preview{max-height:8rem;overflow:hidden;transition:max-height .3s ease;position:relative}.cog-prompt__preview--expanded{max-height:60rem}.cog-prompt__text{font-family:var(--font-mono);font-size:.75rem;color:var(--text-secondary);white-space:pre-wrap;word-break:break-word;margin:0;line-height:1.6}.cog-prompt__toggle{background:none;border:none;cursor:pointer;color:var(--accent-bright);font-size:.75rem;padding:.4rem 0;display:block;margin-top:.25rem}.cog-prompt__toggle:hover{text-decoration:underline}.cog-skills{display:flex;flex-wrap:wrap;gap:.375rem;padding:.5rem}.cog-footer{display:flex;gap:.5rem;flex-wrap:wrap}.spawn-page{display:flex;flex-direction:column;gap:1.25rem}.spawn-status-bar{display:flex;align-items:center;gap:.625rem;flex-wrap:wrap}.spawn-status-pill{display:inline-flex;align-items:center;gap:.35rem;font-size:.72rem;font-weight:600;letter-spacing:.04em;text-transform:uppercase;padding:.3rem .65rem;border-radius:999px;border:1px solid var(--border-subtle);background:var(--bg-elevated);color:var(--text-secondary)}.spawn-status-pill--phase{color:var(--accent);border-color:var(--accent-glow);background:rgba(124,106,247,.08)}.spawn-status-pill--unclaimed{color:var(--success);border-color:rgba(74,222,128,.25);background:rgba(74,222,128,.07)}.spawn-status-pill--claimed{color:var(--warning);border-color:var(--warning-border);background:var(--warning-dim)}.spawn-status-dot{width:6px;height:6px;border-radius:50%;background:currentColor;flex-shrink:0}.spawn-tabs{display:flex;gap:0;border:1px solid var(--border-default);border-radius:var(--radius);overflow:hidden;background:var(--bg-elevated);width:fit-content}.spawn-tab{padding:.5rem 1.1rem;font-size:.8rem;font-weight:600;color:var(--text-muted);background:rgba(0,0,0,0);border:none;border-right:1px solid var(--border-default);cursor:pointer;transition:background .15s,color .15s;white-space:nowrap}.spawn-tab:last-child{border-right:none}.spawn-tab:hover{background:var(--bg-hover);color:var(--text-secondary)}.spawn-tab--active{background:var(--accent);color:#fff}.spawn-tab--active:hover{background:var(--accent);color:#fff}.spawn-panel{display:flex;flex-direction:column;gap:1rem}.spawn-single-layout{display:grid;grid-template-columns:1fr 280px;gap:1rem;align-items:start}@media(max-width: 820px){.spawn-single-layout{grid-template-columns:1fr}}.spawn-issue-board{display:flex;flex-direction:column;gap:0;border:1px solid var(--border-default);border-radius:var(--radius);background:var(--bg-elevated);overflow:hidden}.spawn-issue-toolbar{display:flex;align-items:center;gap:.5rem;padding:.625rem .75rem;border-bottom:1px solid var(--border-subtle);background:var(--bg-void)}.spawn-issue-search{flex:1;background:var(--bg-elevated);border:1px solid var(--border-subtle);border-radius:var(--radius-sm);color:var(--text-primary);font-size:.8rem;font-family:var(--font-sans);padding:.35rem .6rem;transition:border-color .15s}.spawn-issue-search:focus{outline:none;border-color:var(--accent)}.spawn-issue-search::placeholder{color:var(--text-muted)}.spawn-issue-refresh{padding:.35rem .6rem;font-size:.75rem;color:var(--text-muted);background:rgba(0,0,0,0);border:1px solid var(--border-subtle);border-radius:var(--radius-sm);cursor:pointer;transition:color .15s,border-color .15s;line-height:1}.spawn-issue-refresh:hover{color:var(--text-secondary);border-color:var(--border-default)}.spawn-issue-list{display:flex;flex-direction:column;gap:0;max-height:340px;overflow-y:auto}.spawn-issue-card{display:flex;align-items:flex-start;gap:.6rem;padding:.6rem .75rem;border-bottom:1px solid var(--border-subtle);cursor:pointer;transition:background .12s;user-select:none}.spawn-issue-card:last-child{border-bottom:none}.spawn-issue-card:hover:not(.spawn-issue-card--claimed){background:var(--bg-hover)}.spawn-issue-card--selected{background:rgba(124,106,247,.1);border-left:3px solid var(--accent)}.spawn-issue-card--claimed{opacity:.45;cursor:not-allowed}.spawn-issue-num{font-size:.72rem;font-weight:700;color:var(--text-muted);font-family:var(--font-mono);white-space:nowrap;padding-top:.1rem;min-width:2.8rem}.spawn-issue-body{flex:1;min-width:0}.spawn-issue-title{font-size:.82rem;color:var(--text-primary);line-height:1.35;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.spawn-issue-meta{display:flex;align-items:center;gap:.4rem;margin-top:.2rem}.spawn-issue-phase{font-size:.67rem;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--accent);background:rgba(124,106,247,.1);border:1px solid rgba(124,106,247,.2);border-radius:999px;padding:.1rem .45rem}.spawn-issue-wip{font-size:.67rem;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--warning);background:var(--warning-dim);border:1px solid var(--warning-border);border-radius:999px;padding:.1rem .45rem}.spawn-issue-empty{padding:1.5rem 1rem;text-align:center;color:var(--text-muted);font-size:.82rem}.spawn-role-picker{border:1px solid var(--border-default);border-radius:var(--radius);background:var(--bg-elevated);overflow:hidden}.spawn-role-section{border-bottom:1px solid var(--border-subtle)}.spawn-role-section:last-child{border-bottom:none}.spawn-role-section-label{font-size:.67rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);padding:.45rem .75rem .3rem;background:var(--bg-void);border-bottom:1px solid var(--border-subtle)}.spawn-role-option{display:flex;align-items:center;gap:.5rem;padding:.45rem .75rem;cursor:pointer;transition:background .12s;border-bottom:1px solid var(--border-subtle)}.spawn-role-option:last-child{border-bottom:none}.spawn-role-option:hover{background:var(--bg-hover)}.spawn-role-option--selected{background:rgba(124,106,247,.1)}.spawn-role-radio{width:13px;height:13px;border-radius:50%;border:2px solid var(--border-default);flex-shrink:0;transition:border-color .12s,background .12s}.spawn-role-option--selected .spawn-role-radio{border-color:var(--accent);background:var(--accent);box-shadow:0 0 0 2px var(--accent-glow)}.spawn-role-body{display:flex;flex-direction:column;gap:.15rem;min-width:0}.spawn-role-name{font-size:.8rem;color:var(--text-secondary);line-height:1.2}.spawn-role-option--selected .spawn-role-name{color:var(--text-primary);font-weight:600}.spawn-role-desc{font-size:.68rem;color:var(--text-muted);line-height:1.3;white-space:normal;display:block}.spawn-wave-layout{display:flex;flex-direction:column;gap:1rem}.spawn-wave-info{display:flex;align-items:center;gap:.75rem;padding:.875rem 1rem;background:rgba(124,106,247,.06);border:1px solid rgba(124,106,247,.15);border-radius:var(--radius)}.spawn-wave-count{font-size:2rem;font-weight:800;color:var(--accent);line-height:1;font-variant-numeric:tabular-nums}.spawn-wave-label{font-size:.82rem;color:var(--text-secondary)}.spawn-wave-label strong{color:var(--text-primary);font-weight:700}.spawn-coordinator-layout{display:flex;flex-direction:column;gap:1rem}.spawn-coordinator-desc{font-size:.82rem;color:var(--text-secondary);line-height:1.5;padding:.75rem 1rem;background:var(--bg-elevated);border:1px solid var(--border-subtle);border-radius:var(--radius)}.spawn-brain-dump{width:100%;min-height:120px;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius);color:var(--text-primary);font-size:.875rem;font-family:var(--font-sans);padding:.75rem 1rem;resize:vertical;transition:border-color .15s;line-height:1.55}.spawn-brain-dump:focus{outline:none;border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-glow)}.spawn-brain-dump::placeholder{color:var(--text-muted)}.spawn-actions{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap}.spawn-selection-summary{font-size:.78rem;color:var(--text-muted)}.spawn-selection-summary strong{color:var(--text-secondary)}.spawn-result{border-left:3px solid var(--success)}.spawn-result--wave{border-left:3px solid var(--accent)}.spawn-result--error{border-left:3px solid var(--danger, #f87171)}.spawn-result-grid{display:grid;grid-template-columns:auto 1fr;gap:.3rem 1rem;font-size:.82rem}.spawn-result-key{color:var(--text-muted);white-space:nowrap;font-weight:600}.spawn-result-val{color:var(--text-secondary);font-family:var(--font-mono);font-size:.77rem;word-break:break-all}.spawn-wave-results{display:flex;flex-direction:column;gap:.4rem;margin-top:.5rem}.spawn-wave-result-item{display:flex;align-items:center;gap:.5rem;font-size:.8rem;color:var(--text-secondary)}.spawn-wave-result-skip{color:var(--text-muted);font-size:.78rem}.form-group{display:flex;flex-direction:column;gap:.375rem}.form-label{font-size:.75rem;font-weight:600;color:var(--text-secondary);text-transform:uppercase;letter-spacing:.06em}.form-select{width:100%;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius);color:var(--text-primary);font-size:.875rem;font-family:var(--font-sans);padding:.5rem .75rem;appearance:none;cursor:pointer;transition:border-color .15s,box-shadow .15s}.form-select:focus{outline:none;border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-glow)}.form-actions{display:flex;align-items:center;gap:.75rem}.agent-task-pre{background:var(--bg-void);border:1px solid var(--border-subtle);border-radius:var(--radius);padding:.875rem 1rem;font-size:.75rem;font-family:var(--font-mono);line-height:1.65;color:var(--text-secondary);white-space:pre;overflow-x:auto;margin:0}.quick-actions{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center}.spawn-success{display:flex;flex-direction:column;gap:1.25rem;border-left:3px solid var(--success)}.spawn-success-header{display:flex;align-items:center;gap:.75rem}.spawn-success-icon{font-size:1.5rem;line-height:1}.spawn-success-actions{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap}.spawn-success-task{border-top:1px solid var(--border-subtle);padding-top:.875rem;margin-top:.25rem}.spawn-success-task-toggle{font-size:.78rem;color:var(--text-muted);cursor:pointer;user-select:none;list-style:none}.spawn-success-task-toggle::-webkit-details-marker{display:none}.spawn-success-task-toggle::before{content:"▶ ";font-size:.65rem}details[open] .spawn-success-task-toggle::before{content:"▼ "}.telemetry-tab-strip{display:flex;gap:0;border:1px solid var(--border-default);border-radius:var(--radius);overflow:hidden;background:var(--bg-elevated);width:fit-content}.telemetry-tab{padding:.5rem 1rem;font-size:.8rem;font-weight:600;color:var(--text-muted);background:rgba(0,0,0,0);border:none;border-right:1px solid var(--border-default);cursor:pointer;transition:background .15s,color .15s;white-space:nowrap}.telemetry-tab:last-child{border-right:none}.telemetry-tab:hover{background:var(--bg-hover);color:var(--text-secondary)}.telemetry-tab--active{background:var(--accent);color:#fff}.telemetry-tab--active:hover{background:var(--accent);color:#fff}.telemetry-layout{display:grid;grid-template-columns:1fr 300px;gap:1rem;align-items:start}@media(max-width: 900px){.telemetry-layout{grid-template-columns:1fr}}.telemetry-chart-main{background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius);height:380px;position:relative;overflow:hidden}.telemetry-chart-main svg{display:block}.telemetry-sidebar{display:flex;flex-direction:column;gap:.75rem}.telemetry-sidebar-chart{background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius);padding:.75rem;overflow:hidden}.telemetry-sidebar-chart svg{display:block}.telemetry-chart-label{font-size:.67rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);margin-bottom:.5rem}.telemetry-empty{display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:.82rem}.d3-tooltip{position:absolute;pointer-events:none;background:var(--bg-void);border:1px solid var(--border-default);border-radius:var(--radius-sm);padding:.45rem .65rem;font-size:.75rem;color:var(--text-primary);line-height:1.45;white-space:nowrap;z-index:100;opacity:0;transition:opacity .1s}.d3-tooltip.visible{opacity:1}.d3-tooltip-key{color:var(--text-muted);margin-right:.3rem}.d3-axis text{fill:var(--text-muted);font-size:.7rem;font-family:var(--font-sans)}.d3-axis path,.d3-axis line{stroke:var(--border-subtle)}.d3-grid line{stroke:var(--border-subtle);stroke-dasharray:3 3;opacity:.6}.d3-crosshair{stroke:var(--text-muted);stroke-dasharray:4 3;stroke-width:1;pointer-events:none}.telemetry-table-wrap{overflow-x:auto}.telemetry-table{width:100%;border-collapse:collapse;font-size:.8125rem}.telemetry-th{font-size:.6rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted);padding:.5rem .875rem;text-align:left;border-bottom:1px solid var(--border-subtle);white-space:nowrap}.telemetry-td{padding:.5rem .875rem;vertical-align:middle;border-bottom:1px solid var(--border-subtle)}.telemetry-row:last-child .telemetry-td{border-bottom:none}.telemetry-td--batch{max-width:220px;overflow:hidden;text-overflow:ellipsis}.telemetry-batch-id{font-size:.6875rem;font-family:var(--font-mono);color:var(--accent-bright)}.telemetry-expand-btn{font-size:.75rem;padding:.2rem .5rem;white-space:nowrap}.telemetry-agents-row{background:var(--bg-elevated)}.telemetry-agents-cell{padding:.625rem .875rem .625rem 2rem;border-bottom:1px solid var(--border-subtle)}.telemetry-agents-list{display:flex;flex-direction:column;gap:.375rem}.telemetry-agent-item{display:flex;align-items:center;flex-wrap:wrap;gap:.4rem}.telemetry-agent-role{font-size:.8125rem;font-weight:500;color:var(--text-primary)}.telemetry-controls{display:flex;align-items:center;justify-content:space-between;gap:.75rem;margin-bottom:.625rem;flex-wrap:wrap}.telemetry-controls__filters{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap}.telemetry-filter-label{display:flex;align-items:center;gap:.375rem;font-size:.72rem;font-weight:600;color:var(--text-muted);white-space:nowrap}.telemetry-date-input{padding:.2rem .45rem;font-size:.72rem;font-family:var(--font-mono);background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius-sm);color:var(--text-primary);cursor:pointer}.telemetry-date-input:focus{outline:none;border-color:var(--accent)}.telemetry-clear-btn{font-size:.72rem;padding:.2rem .5rem}.telemetry-export-btn{font-size:.72rem;padding:.25rem .65rem;white-space:nowrap;flex-shrink:0}.telemetry-th--sortable{cursor:pointer;user-select:none}.telemetry-th--sortable:hover{color:var(--text-secondary);background:var(--bg-hover)}.telemetry-sort-icon{font-size:.65rem;opacity:.6;margin-left:.15rem}.telemetry-refresh{font-size:.72rem;color:var(--text-muted);background:rgba(0,0,0,0);border:1px solid var(--border-subtle);border-radius:var(--radius-sm);padding:.25rem .5rem;cursor:pointer;transition:color .15s,border-color .15s}.telemetry-refresh:hover{color:var(--text-secondary);border-color:var(--border-default)}.run-history-table{width:100%;border-collapse:collapse;font-size:.8125rem}.run-history-table th{text-align:left;padding:.4rem .6rem;color:var(--text-muted);border-bottom:1px solid var(--border-subtle);font-weight:700;font-size:.6rem;text-transform:uppercase;letter-spacing:.08em}.run-history-table td{padding:.45rem .6rem;border-bottom:1px solid hsla(0,0%,100%,.03);color:var(--text-secondary);vertical-align:top}.run-history-table tr:hover td{background:hsla(0,0%,100%,.015)}.run-status-badge{display:inline-block;padding:.1rem .45rem;border-radius:var(--radius-full);font-size:.6rem;font-weight:700;text-transform:uppercase;letter-spacing:.05em}.run-status-badge--running{background:var(--success-dim);color:var(--success);border:1px solid var(--success-border)}.run-status-badge--done{background:rgba(139,92,246,.12);color:var(--accent-bright);border:1px solid rgba(139,92,246,.25)}.run-status-badge--failed{background:var(--danger-dim);color:var(--danger);border:1px solid var(--danger-border)}.run-status-badge--spawned{background:var(--warning-dim);color:var(--warning);border:1px solid var(--warning-border)}.run-status-badge--unknown{background:var(--bg-elevated);color:var(--text-muted);border:1px solid var(--border-subtle)}@keyframes spin{to{transform:rotate(360deg)}}.board-spinner{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:.75rem;padding:2.5rem 1rem;color:var(--text-muted);font-size:.8125rem}.board-spinner__ring{width:2rem;height:2rem;border:2px solid var(--border-default);border-top-color:var(--accent);border-radius:50%;animation:spin .65s linear infinite}.issues-list,.prs-list{display:flex;flex-direction:column;gap:.5rem}.issue-row,.pr-row{display:flex;align-items:baseline;gap:.75rem;padding:.75rem 1rem;background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:var(--radius);transition:border-color .15s,background .15s;text-decoration:none}.issue-row:hover,.pr-row:hover{border-color:var(--border-strong);background:var(--bg-elevated);text-decoration:none}.issue-row-number,.pr-row-number{font-weight:700;color:var(--accent-bright);font-size:.8125rem;font-variant-numeric:tabular-nums;flex-shrink:0;min-width:3rem}.issue-row-title,.pr-row-title{flex:1;font-size:.875rem;color:var(--text-primary);min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.issue-row-state,.pr-row-state{flex-shrink:0}.issue-row-date,.pr-row-date{font-size:.6875rem;color:var(--text-muted);flex-shrink:0;font-variant-numeric:tabular-nums}.env-page-header{display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:2rem;gap:1rem}.env-page-title{font-size:1.35rem;font-weight:700;color:var(--text-primary);margin:0 0 .375rem}.env-page-subtitle{font-size:.8125rem;color:var(--text-muted);margin:0;max-width:58ch}.env-page-meta{display:flex;flex-direction:column;align-items:flex-end;flex-shrink:0}.env-page-count{font-size:2rem;font-weight:700;color:var(--accent);line-height:1}.env-page-count-label{font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted)}.env-tree{position:relative;padding-left:1.5rem}.env-tree::before{content:"";position:absolute;left:.5rem;top:1.5rem;bottom:1.75rem;width:2px;background:linear-gradient(to bottom, var(--accent) 0%, rgba(124, 58, 237, 0.3) 70%, transparent 100%);border-radius:1px}.env-trunk-node{display:flex;align-items:center;gap:.75rem;margin-bottom:1.25rem;position:relative;z-index:1}.env-trunk-dot{width:14px;height:14px;border-radius:50%;background:var(--accent);border:3px solid var(--bg-base);box-shadow:0 0 0 2px var(--accent);flex-shrink:0;margin-left:-0.125rem}.env-trunk-info{display:flex;align-items:center;gap:.625rem;flex-wrap:wrap}.env-trunk-branch{font-family:var(--font-mono, monospace);font-size:.875rem;font-weight:700;color:var(--text-primary)}.env-trunk-label{font-size:.72rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted);background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:4px;padding:.15em .5em}.env-trunk-sha{font-family:var(--font-mono, monospace);font-size:.72rem;color:var(--text-muted)}.env-trunk-commit{font-size:.8rem;color:var(--text-muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:40ch}.env-branch{position:relative;margin-bottom:.875rem;transition:opacity .25s,transform .25s}.env-branch::before{content:"";position:absolute;left:-1rem;top:1.125rem;width:1rem;height:2px;background:rgba(124,58,237,.5)}.env-branch--last::after{content:"";position:absolute;left:-1.0625rem;top:1.0625rem;width:8px;height:8px;border-left:2px solid rgba(124,58,237,.5);border-bottom:2px solid rgba(124,58,237,.5);border-radius:0 0 0 3px}.env-branch-origin-dot{position:absolute;left:-1.3125rem;top:.8125rem;width:10px;height:10px;border-radius:50%;background:var(--bg-base);border:2px solid var(--accent);z-index:1}.env-branch--open .env-branch-origin-dot{background:var(--accent)}.env-branch-head{display:flex;align-items:flex-start;gap:.75rem;padding:.75rem 1rem;background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:var(--radius);cursor:pointer;user-select:none;transition:border-color .15s,background .15s}.env-branch-head:hover{border-color:var(--border-strong);background:var(--bg-hover, var(--bg-surface))}.env-branch--open .env-branch-head{border-color:var(--accent);border-bottom-left-radius:0;border-bottom-right-radius:0;background:rgba(124,58,237,.04)}.env-branch-content{flex:1;min-width:0}.env-branch-top{display:flex;align-items:center;gap:.5rem;flex-wrap:wrap}.env-badge{display:inline-flex;align-items:center;font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.06em;padding:.2em .55em;border-radius:4px;flex-shrink:0}.env-badge--issue{background:rgba(124,58,237,.15);color:var(--accent)}.env-badge--custom{background:rgba(59,130,246,.15);color:#60a5fa}.env-lock{font-size:.7rem;opacity:.55;flex-shrink:0}.env-branch-name{font-family:var(--font-mono, monospace);font-size:.8125rem;font-weight:600;color:var(--text-primary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}.env-branch-actions{display:flex;align-items:center;gap:.5rem;margin-left:auto;flex-shrink:0}.env-age{font-size:.75rem;color:var(--text-muted)}.env-gh-link{font-size:.75rem;font-weight:600;color:var(--accent);text-decoration:none;padding:.15em .5em;border:1px solid rgba(124,58,237,.3);border-radius:4px;transition:background .12s;flex-shrink:0}.env-gh-link:hover{background:rgba(124,58,237,.12)}.env-delete{opacity:0;transition:opacity .15s}.env-branch-head:hover .env-delete{opacity:1}.env-chevron{font-size:.7rem;color:var(--text-muted);transition:transform .2s;display:inline-block}.env-chevron--open{transform:rotate(180deg)}.env-branch-commit-preview{display:flex;align-items:center;gap:.5rem;margin-top:.375rem;font-size:.775rem;color:var(--text-muted)}.env-sha{font-family:var(--font-mono, monospace);font-size:.7rem;color:var(--accent);flex-shrink:0}.env-commit-msg{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.env-branch-body{background:var(--bg-base);border:1px solid var(--accent);border-top:none;border-bottom-left-radius:var(--radius);border-bottom-right-radius:var(--radius);overflow:hidden}.env-detail{padding:1.25rem 1.5rem}.env-detail-loading{display:flex;align-items:center;gap:.5rem;font-size:.8125rem;color:var(--text-muted);padding:.5rem 0}@keyframes env-spin{to{transform:rotate(360deg)}}.env-spinner{display:inline-block;width:12px;height:12px;border:2px solid var(--border-subtle);border-top-color:var(--accent);border-radius:50%;animation:env-spin .7s linear infinite;flex-shrink:0}.env-commit-section,.env-diff-section,.env-task-section{margin-bottom:1.5rem}.env-commit-section:last-child,.env-diff-section:last-child,.env-task-section:last-child{margin-bottom:0}.env-detail-heading{display:flex;align-items:center;gap:.625rem;font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted);margin:0 0 .75rem}.env-detail-meta{font-weight:400;text-transform:none;letter-spacing:0;font-size:.75rem}.env-detail-empty{font-size:.8125rem;color:var(--text-muted);font-style:italic;margin:0}.env-commit-chain{display:flex;flex-direction:column}.env-commit-node{display:flex;align-items:flex-start;gap:.75rem}.env-commit-spine{display:flex;flex-direction:column;align-items:center;flex-shrink:0;width:14px}.env-commit-dot{width:10px;height:10px;border-radius:50%;background:var(--bg-base);border:2px solid rgba(124,58,237,.5);flex-shrink:0;margin-top:.2rem}.env-commit-dot--head{background:var(--accent);border-color:var(--accent);box-shadow:0 0 0 3px rgba(124,58,237,.2)}.env-commit-line{width:2px;flex:1;min-height:1.25rem;background:rgba(124,58,237,.25);margin:.15rem 0}.env-commit-body{display:flex;align-items:baseline;gap:.625rem;padding:.05rem 0 .875rem;flex:1;min-width:0}.env-commit-sha{font-family:var(--font-mono, monospace);font-size:.7rem;color:var(--accent);flex-shrink:0}.env-head-tag{font-size:.62rem;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--accent);background:rgba(124,58,237,.12);border:1px solid rgba(124,58,237,.3);border-radius:3px;padding:.1em .4em;flex-shrink:0}.env-diff-stat,.env-task-file{font-family:var(--font-mono, monospace);font-size:.78rem;line-height:1.65;color:var(--text-secondary);background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:var(--radius);padding:.75rem 1rem;overflow-x:auto;margin:0;white-space:pre}.env-task-file{max-height:280px;overflow-y:auto;white-space:pre-wrap;word-break:break-word}.env-empty{padding:2.5rem 1.5rem;color:var(--text-muted);font-size:.875rem;text-align:center}.env-empty p{margin:.25rem 0}.env-empty a{color:var(--accent)}.docs-layout{display:grid;grid-template-columns:220px 1fr;gap:1.5rem;margin-top:1rem;align-items:start}.docs-sidebar{position:sticky;top:1rem;padding:.875rem}.docs-sidebar-heading{font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted);margin:0 0 .625rem}.docs-sidebar-list{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:.125rem}.docs-sidebar-link{display:block;padding:.3rem .625rem;border-radius:5px;font-size:.8125rem;color:var(--text-secondary);text-decoration:none;transition:background .12s,color .12s}.docs-sidebar-link:hover{background:var(--bg-hover);color:var(--text-primary)}.docs-sidebar-link--active{background:rgba(124,58,237,.12);color:var(--accent);font-weight:600}.docs-content{padding:1.5rem 2rem;min-width:0}.docs-content-header{display:flex;align-items:baseline;justify-content:space-between;gap:1rem;margin-bottom:1.5rem;padding-bottom:.875rem;border-bottom:1px solid var(--border-subtle)}.docs-content-title{font-size:1.125rem;font-weight:700;color:var(--text-primary);margin:0}.docs-content-slug{font-size:.75rem;font-family:var(--font-mono, monospace);color:var(--text-muted);flex-shrink:0}.docs-error{color:var(--danger);font-size:.875rem}.docs-empty{color:var(--text-muted);font-size:.875rem;font-style:italic}.docs-prose{font-size:.9rem;line-height:1.8;color:var(--text-secondary);overflow-wrap:break-word;word-break:break-word}.docs-prose h1,.docs-prose h2,.docs-prose h3,.docs-prose h4{color:var(--text-primary);font-weight:700;letter-spacing:-0.02em;margin:2rem 0 .625rem;line-height:1.3}.docs-prose h1{font-size:1.5rem;margin-top:0}.docs-prose h2{font-size:1.175rem;padding-bottom:.4rem;border-bottom:1px solid var(--border-subtle)}.docs-prose h3{font-size:1rem}.docs-prose h4{font-size:.9rem;color:var(--text-muted);font-weight:600}.docs-prose p{margin:.875rem 0}.docs-prose hr{border:none;border-top:1px solid var(--border-subtle);margin:2rem 0}.docs-prose ul,.docs-prose ol{padding-left:1.75rem;margin:.75rem 0}.docs-prose li{margin:.375rem 0}.docs-prose li>p{margin:0}.docs-prose ul ul,.docs-prose ol ol{margin:.25rem 0}.docs-prose code{font-family:var(--font-mono, monospace);font-size:.825em;background:rgba(124,58,237,.08);color:var(--accent);border:1px solid rgba(124,58,237,.18);border-radius:4px;padding:.1em .4em}.docs-prose pre{background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:var(--radius);padding:1rem 1.25rem;overflow-x:auto;margin:1.25rem 0;font-size:.8125rem;line-height:1.65}.docs-prose pre code{background:none;border:none;padding:0;color:var(--text-primary);font-size:inherit}.docs-prose blockquote{border-left:3px solid var(--accent);padding:.5rem 1rem;margin:1.25rem 0;color:var(--text-muted);font-style:italic;background:rgba(124,58,237,.04);border-radius:0 var(--radius) var(--radius) 0}.docs-prose blockquote p{margin:0}.docs-prose table{width:100%;border-collapse:collapse;font-size:.85rem;margin:1.25rem 0}.docs-prose th,.docs-prose td{padding:.5rem .875rem;border:1px solid var(--border-subtle);text-align:left}.docs-prose th{background:var(--bg-surface);color:var(--text-primary);font-weight:600;font-size:.78rem;text-transform:uppercase;letter-spacing:.04em}.docs-prose td{color:var(--text-secondary)}.docs-prose tr:nth-child(even) td{background:hsla(0,0%,100%,.02)}.docs-prose strong{color:var(--text-primary);font-weight:700}.docs-prose em{color:var(--text-secondary)}.docs-prose a{color:var(--accent);text-decoration:underline;text-underline-offset:2px}.docs-prose a:hover{color:var(--accent-hover, var(--accent));opacity:.85}.transcript-row{cursor:pointer}.transcript-row td{transition:background .1s}.transcript-row:hover td{background:var(--bg-elevated)}.transcript-uuid{font-family:var(--font-mono);font-size:.6875rem;color:var(--text-muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}.transcript-meta{font-size:.6875rem;color:var(--text-muted);flex-shrink:0}::-webkit-scrollbar{width:6px;height:6px}::-webkit-scrollbar-track{background:var(--bg-void)}::-webkit-scrollbar-thumb{background:var(--border-default);border-radius:var(--radius-full)}::-webkit-scrollbar-thumb:hover{background:var(--border-strong)}@media(max-width: 900px){nav.topnav{gap:.125rem;padding:0 1rem}main{padding:1rem}.pipeline-summary-bar{gap:.75rem 1.25rem}.summary-value{font-size:1.25rem}.agent-detail-columns{grid-template-columns:1fr}}.telemetry-table tbody tr{transition:background .12s}.telemetry-table tbody tr:hover{background:rgba(139,92,246,.04)}.telemetry-table td a{color:var(--text-primary);font-weight:500}.telemetry-table td a:first-child{color:var(--accent-bright);font-family:var(--font-mono);font-size:.8125rem}.page-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:1.25rem;gap:1rem}.page-title{font-size:1.125rem;font-weight:700;color:var(--text-primary);letter-spacing:-0.02em;margin:0}.page-subtitle{font-size:.8125rem;color:var(--text-muted);margin:.2rem 0 0}.page-subtitle a{color:var(--accent-bright)}.filter-group{display:flex;flex-direction:column;gap:1rem}.filter-bar{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap}.filter-input{background:var(--bg-elevated);border:1px solid var(--border-default);color:var(--text-primary);border-radius:6px;padding:.4rem .65rem;font-size:.83rem;outline:none;transition:border-color .15s;min-width:130px}.filter-input:focus{border-color:var(--accent)}.filter-input option{background:var(--bg-elevated)}.filter-input--wide{min-width:160px}.filter-input--search{width:100%;padding-left:2rem;flex:1;min-width:200px}.search-wrapper{position:relative;flex:1;min-width:200px}.search-icon{position:absolute;left:.6rem;top:50%;transform:translateY(-50%);color:var(--text-muted);pointer-events:none}.filter-clear{white-space:nowrap}.alert-card--danger{border-left:3px solid var(--danger);margin-bottom:1rem}.alert-text--danger{color:var(--danger-dim)}.btn--top{margin-top:.75rem}.table-card{padding:0;overflow:hidden}.transcript-table{width:100%;margin:0;table-layout:fixed}.transcript-table col:nth-child(1){width:7rem}.transcript-table col:nth-child(2){width:10rem}.transcript-table col:nth-child(3){width:7rem}.transcript-table col:nth-child(5){width:5rem}.transcript-table col:nth-child(6){width:5.5rem}.transcript-table col:nth-child(7){width:7rem}.transcript-table col:nth-child(8){width:6.5rem}.text-right{text-align:right}.text-faint{color:var(--text-faint)}.mono-badge{font-family:var(--font-mono);font-size:.72rem;color:var(--text-muted);background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:4px;padding:.15rem .35rem}.badge--sm{font-size:.65rem}.badge--xs{font-size:.68rem}.badge--coord{margin-left:.25rem}.issue-link{color:var(--accent-bright);font-size:.75rem;text-decoration:none}.issue-link:hover{text-decoration:underline}.dir-badge{font-size:.78rem;color:var(--text-muted)}.transcript-preview-cell{max-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:.82rem;color:var(--text-primary)}.transcript-count-cell{text-align:right;font-variant-numeric:tabular-nums;font-size:.82rem}.transcript-subagent-cell{text-align:right}.transcript-issues-cell{font-size:.78rem}.transcript-date-cell{text-align:right;font-size:.75rem;color:var(--text-muted)}.badge--teal{background:rgba(20,184,166,.15);color:#5eead4;border-color:rgba(20,184,166,.3)}.badge--pink{background:rgba(236,72,153,.15);color:#f9a8d4;border-color:rgba(236,72,153,.3)}.badge--yellow{background:rgba(234,179,8,.15);color:#fde047;border-color:rgba(234,179,8,.3)}.badge--orange{background:rgba(249,115,22,.15);color:#fdba74;border-color:rgba(249,115,22,.3)}.detail-layout{display:grid;grid-template-columns:1fr 260px;gap:1.25rem;align-items:start}@media(max-width: 900px){.detail-layout{grid-template-columns:1fr}.detail-sidebar{order:-1}}.detail-header-content{flex:1;min-width:0}.detail-breadcrumb{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:.4rem}.detail-back-link{color:var(--text-muted);font-size:.82rem;text-decoration:none}.detail-back-link:hover{color:var(--text-primary)}.page-title--mono{font-family:var(--font-mono);font-size:1.1rem;letter-spacing:0}.stats-strip{display:flex;flex-wrap:wrap;gap:.75rem;margin-bottom:1.25rem}.stat-chip{background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:8px;padding:.5rem 1rem;display:flex;flex-direction:column;align-items:center;min-width:80px}.stat-chip__value{font-size:1.4rem;font-weight:700;font-variant-numeric:tabular-nums;color:var(--text-primary);line-height:1}.stat-chip__label{font-size:.68rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin-top:.2rem}.truncated-notice{background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:8px;padding:.75rem 1rem;margin-bottom:1rem;font-size:.82rem;color:var(--text-muted)}.truncated-notice a{color:var(--accent-bright)}.thread-search{display:flex;align-items:center;gap:.5rem;margin-bottom:1rem}.thread-search__field{position:relative;flex:1}.thread-search__icon{position:absolute;left:.6rem;top:50%;transform:translateY(-50%);color:var(--text-muted);pointer-events:none;font-size:.85rem}.thread-search__input{width:100%;padding:.4rem .65rem .4rem 2rem;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:6px;color:var(--text-primary);font-size:.82rem;outline:none}.thread-search__input:focus{border-color:var(--accent)}.chat-thread{display:flex;flex-direction:column;gap:.75rem}.chat-msg{border-radius:10px;padding:.85rem 1rem;max-width:100%}.chat-msg--user{background:var(--bg-surface);border:1px solid var(--border-subtle);margin-right:2rem}.chat-msg--assistant{background:linear-gradient(135deg, rgba(139, 92, 246, 0.08) 0%, rgba(99, 102, 241, 0.06) 100%);border:1px solid rgba(139,92,246,.2);margin-left:2rem}.chat-msg__header{margin-bottom:.4rem}.chat-msg__role{font-size:.7rem;font-weight:700;letter-spacing:.07em;text-transform:uppercase}.chat-msg__role--user{color:var(--text-muted)}.chat-msg__role--assistant{color:var(--accent-bright)}.chat-msg__text{margin:0;font-family:var(--font-sans, inherit);font-size:.83rem;line-height:1.6;color:var(--text-primary);white-space:pre-wrap;word-break:break-word;max-height:400px;overflow-y:auto}.chat-msg__text.collapsed{max-height:160px;overflow:hidden}mark.hl{background:rgba(251,191,36,.35);color:inherit;border-radius:2px;padding:0 2px}.detail-sidebar{display:flex;flex-direction:column;gap:.85rem}.sidebar-card{background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:10px;overflow:hidden}.sidebar-card__title{font-size:.72rem;font-weight:700;letter-spacing:.07em;text-transform:uppercase;color:var(--text-muted);padding:.65rem .85rem;border-bottom:1px solid var(--border-subtle);margin:0}.sidebar-card__body{padding:.75rem .85rem;display:flex;flex-direction:column}.sidebar-card__body--subagents{gap:.5rem}.sidebar-issue-link{display:inline-block;color:var(--accent-bright);font-size:.82rem;font-weight:600;text-decoration:none;margin-right:.4rem;margin-bottom:.25rem}.sidebar-issue-link:hover{text-decoration:underline}.sidebar-pr-link{display:block;color:var(--success);font-size:.8rem;text-decoration:none;margin-bottom:.25rem;word-break:break-all}.sidebar-pr-link:hover{text-decoration:underline}.subagent-card{background:var(--bg-elevated);border:1px solid var(--border-subtle);border-radius:8px;padding:.6rem .75rem}.subagent-card__header{display:flex;justify-content:space-between;align-items:center;margin-bottom:.35rem}.subagent-card__uuid{font-family:var(--font-mono);font-size:.68rem;color:var(--text-muted);margin:0 0 .25rem}.subagent-card__preview{font-size:.72rem;color:var(--text-secondary);margin:0;overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}.subagent-card__count{font-size:.7rem;color:var(--text-faint);margin:.3rem 0 0}.meta-dl{margin:0;display:grid;grid-template-columns:auto 1fr;gap:.3rem .75rem;font-size:.78rem}.meta-dl dt{color:var(--text-muted);white-space:nowrap}.meta-dl dd{color:var(--text-primary);margin:0}.meta-dd--mono{font-family:var(--font-mono);font-size:.72rem;word-break:break-all}.bd-page{display:grid;grid-template-columns:1fr 296px;gap:2rem;max-width:1100px;margin:0 auto;padding:1.5rem 1.25rem 3rem;align-items:start}.bd-main{display:flex;flex-direction:column;gap:1rem;min-width:0}.bd-title{font-size:1.6rem;font-weight:700;letter-spacing:-0.02em;margin:0 0 .2rem}.bd-sub{color:var(--text-muted);font-size:.875rem;line-height:1.5;margin:0}.bd-textarea-wrap{border:1.5px solid var(--border);border-radius:10px;overflow:hidden;background:var(--bg);transition:border-color .15s,box-shadow .15s}.bd-textarea-wrap--focused{border-color:var(--accent, #6366f1);box-shadow:0 0 0 3px rgba(99,102,241,.12)}.bd-textarea{width:100%;box-sizing:border-box;font-family:var(--font-mono, "JetBrains Mono", monospace);font-size:.82rem;line-height:1.7;padding:.9rem 1rem .5rem;border:none;outline:none;background:rgba(0,0,0,0);color:var(--text);resize:none;display:block;min-height:max(480px,100vh - 260px)}.bd-textarea:disabled{opacity:.5}.bd-textarea-toolbar{display:flex;align-items:center;gap:.5rem;padding:.4rem .75rem .55rem;border-top:1px solid var(--border);background:hsla(0,0%,100%,.02)}.bd-toolbar-btn{background:none;border:1px solid var(--border);border-radius:5px;color:var(--text-muted);font-size:.72rem;padding:.18rem .48rem;cursor:pointer;transition:background .12s,color .12s;white-space:nowrap}.bd-toolbar-btn:hover:not(:disabled){background:var(--border);color:var(--text)}.bd-toolbar-btn:disabled{opacity:.35;cursor:default}.bd-char-count{margin-left:auto;font-size:.7rem;color:var(--text-muted);opacity:.55;font-variant-numeric:tabular-nums;white-space:nowrap}.bd-seeds{display:flex;align-items:center;flex-wrap:wrap;gap:.35rem}.bd-seeds-label{font-size:.75rem;color:var(--text-muted);margin-right:.15rem;flex-shrink:0}.bd-seed-chip{font-size:.73rem;padding:.22rem .58rem;border:1px solid var(--border);border-radius:20px;background:none;color:var(--text-muted);cursor:pointer;transition:background .12s,color .12s,border-color .12s;white-space:nowrap}.bd-seed-chip:hover:not(:disabled){background:rgba(99,102,241,.1);color:var(--accent, #6366f1);border-color:var(--accent, #6366f1)}.bd-seed-chip:disabled{opacity:.35;cursor:default}.bd-options-row{display:flex;flex-direction:column;gap:.5rem}.bd-options-btn{background:none;border:none;color:var(--text-muted);font-size:.8rem;cursor:pointer;padding:0;display:flex;align-items:center;gap:.35rem;width:fit-content;transition:color .12s}.bd-options-btn:hover{color:var(--text)}.bd-options-badge{font-size:.68rem;font-weight:600;padding:.08rem .38rem;border-radius:10px;background:rgba(99,102,241,.15);color:var(--accent, #6366f1)}.bd-options-fields{padding:.75rem;background:hsla(0,0%,100%,.02);border:1px solid var(--border);border-radius:8px;display:flex;flex-direction:column;gap:.4rem}.bd-prefix-row{display:flex;align-items:center;gap:.6rem;flex-wrap:wrap}.bd-label-sm{font-size:.75rem;font-weight:600;color:var(--text-muted);letter-spacing:.03em}.bd-optional{font-weight:400;opacity:.65}.bd-input{padding:.38rem .6rem;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--text);font-size:.85rem;max-width:220px;transition:border-color .12s}.bd-input:focus{outline:none;border-color:var(--accent, #6366f1)}.bd-hint{font-size:.72rem;color:var(--text-muted);opacity:.7}.bd-submit-row{display:flex;align-items:center;gap:.65rem}.bd-submit-btn{font-size:.9rem;padding:.65rem 1.4rem}.bd-kbd{font-size:.7rem;color:var(--text-muted);background:hsla(0,0%,100%,.04);border:1px solid var(--border);border-radius:4px;padding:.18rem .42rem;font-family:var(--font-mono, monospace)}.bd-error{padding:.55rem .8rem;background:rgba(239,68,68,.08);border:1px solid rgba(239,68,68,.3);border-radius:8px;color:#ef4444;font-size:.83rem}.bd-loading-panel{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:1.25rem;min-height:320px;text-align:center}.bd-spinner{width:40px;height:40px;border:3px solid var(--border);border-top-color:var(--accent, #6366f1);border-radius:50%;animation:bdSpin .75s linear infinite}@keyframes bdSpin{to{transform:rotate(360deg)}}.bd-loading-text{color:var(--text-muted);font-size:.9rem;margin:0;min-height:1.4em}.bd-done-panel{display:flex;flex-direction:column;align-items:flex-start;gap:1.1rem;padding:1rem 0}.bd-done-badge{font-size:2.5rem;line-height:1}.bd-done-title{font-size:1.5rem;font-weight:700;margin:0}.bd-done-sub{color:var(--text-muted);font-size:.88rem;line-height:1.55;margin:0;max-width:480px}.bd-done-actions{display:flex;gap:.65rem;flex-wrap:wrap}.bd-task-details{width:100%}.bd-task-summary{cursor:pointer;font-size:.77rem;color:var(--text-muted);user-select:none;padding:.2rem 0;transition:color .12s}.bd-task-summary:hover{color:var(--text)}.bd-task-pre{margin:.5rem 0 0;padding:.7rem;background:hsla(0,0%,100%,.03);border:1px solid var(--border);border-radius:8px;font-size:.7rem;overflow-x:auto;white-space:pre-wrap;word-break:break-all;color:var(--text-muted);line-height:1.5}.bd-restart-btn{background:none;border:none;color:var(--text-muted);font-size:.82rem;cursor:pointer;padding:0;margin-top:.25rem;transition:color .12s}.bd-restart-btn:hover{color:var(--text)}.bd-sidebar{display:flex;flex-direction:column;gap:0;border:1px solid var(--border);border-radius:10px;overflow:hidden}.bd-funnel-heading{font-size:.72rem;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);margin:0;padding:.7rem 1rem;border-bottom:1px solid var(--border);background:hsla(0,0%,100%,.025)}.bd-funnel{padding:.75rem 1rem 1rem;border-bottom:1px solid var(--border)}.bd-funnel-stage{display:flex;align-items:center;gap:.65rem;padding:.45rem .5rem;border-radius:8px;opacity:.3;transition:opacity .3s,background .3s}.bd-funnel-stage--active{opacity:1;background:rgba(99,102,241,.08)}.bd-funnel-stage--done{opacity:.85;background:rgba(99,102,241,.04)}.bd-funnel-stage--pulse .bd-funnel-icon{animation:bdPulse .65s ease-in-out infinite alternate}@keyframes bdPulse{from{transform:scale(1)}to{transform:scale(1.3)}}.bd-funnel-icon{font-size:1.15rem;line-height:1;flex-shrink:0}.bd-funnel-info{display:flex;flex-direction:column;gap:.05rem;min-width:0}.bd-funnel-label{font-size:.8rem;font-weight:600;color:var(--text);line-height:1.2}.bd-funnel-stage--active .bd-funnel-label{color:var(--accent, #6366f1)}.bd-funnel-desc{font-size:.67rem;color:var(--text-muted);opacity:.7;line-height:1.2}.bd-funnel-connector{width:2px;height:14px;background:var(--border);margin-left:1.05rem;border-radius:1px;transition:background .3s}.bd-funnel-connector--lit{background:var(--accent, #6366f1);opacity:.5}.bd-history{display:flex;flex-direction:column;gap:0}.bd-history-card{padding:.65rem 1rem;border-bottom:1px solid var(--border);background:rgba(0,0,0,0);display:flex;flex-direction:column;gap:.25rem;min-width:0;transition:background .12s}.bd-history-card:last-child{border-bottom:none}.bd-history-card:hover{background:hsla(0,0%,100%,.03)}.bd-history-meta{display:flex;align-items:center;gap:.4rem;flex-wrap:wrap}.bd-history-ts{font-size:.68rem;color:var(--text-muted);font-variant-numeric:tabular-nums;opacity:.7}.bd-history-prefix{font-size:.62rem;font-weight:600;padding:.08rem .35rem;border-radius:8px;background:rgba(99,102,241,.12);color:var(--accent, #6366f1)}.bd-history-preview{font-size:.75rem;color:var(--text);margin:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;opacity:.75}.bd-history-links{display:flex;gap:.6rem}.bd-history-link{font-size:.68rem;color:var(--text-muted);text-decoration:none;transition:color .12s;opacity:.65}.bd-history-link:hover{color:var(--accent, #6366f1);opacity:1}.topnav .nav-cta{font-weight:600;color:var(--accent, #6366f1) !important}.topnav .nav-cta:hover,.topnav .nav-cta.active{background:rgba(99,102,241,.1) !important}@media(max-width: 680px){.bd-page{grid-template-columns:1fr}.bd-sidebar{position:static}.bd-funnel{display:flex;flex-direction:row;flex-wrap:wrap;gap:0}.bd-funnel-connector{display:none}}.cas-page-header{display:flex;align-items:flex-start;justify-content:space-between;gap:1rem;margin-bottom:.75rem;flex-wrap:wrap}.cas-page-title{font-size:1.15rem;font-weight:700;color:var(--color-text, #e0e0e0);margin:0 0 .2rem}.cas-page-subtitle{font-size:.8rem;color:var(--color-muted, #888);margin:0}.cas-page-stats{display:flex;gap:1rem;align-items:center;flex-shrink:0}.cas-stat{font-size:.78rem;color:var(--color-muted, #888)}.cas-stat strong{color:var(--color-text, #e0e0e0)}.cas-layout{display:grid;grid-template-columns:220px 1fr 1fr;gap:.75rem;height:calc(100vh - 8.5rem);min-height:400px;position:relative}.cas-panel{display:flex;flex-direction:column;background:var(--color-card, #1e1e2e);border:1px solid var(--color-border, #333);border-radius:6px;overflow:hidden;min-height:0}.cas-panel__header{display:flex;align-items:center;justify-content:space-between;padding:.55rem .85rem;border-bottom:1px solid var(--color-border, #333);font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-muted, #888);flex-shrink:0}.cas-panel__count{background:var(--color-border, #333);border-radius:10px;padding:.1rem .45rem;font-size:.68rem;color:var(--color-muted, #888)}.cas-panel__body{flex:1 1 0;overflow-y:auto;padding:.5rem;overscroll-behavior:contain}.cas-panel__legend{display:flex;gap:.75rem;padding:.45rem .75rem;border-top:1px solid var(--color-border, #333);flex-shrink:0;flex-wrap:wrap}.cas-org-search-wrap{padding:.4rem .5rem;border-bottom:1px solid var(--color-border, #333);flex-shrink:0}.cas-org-search{width:100%;box-sizing:border-box;padding:.3rem .6rem;font-size:.78rem;background:var(--color-bg, #13131f);border:1px solid var(--color-border, #444);border-radius:4px;color:var(--color-text, #e0e0e0);outline:none}.cas-org-search:focus{border-color:var(--color-accent, #7c6af7)}.cas-org-level{margin-bottom:.5rem}.cas-org-level__title{font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-muted, #888);padding:.2rem .3rem;margin-bottom:.2rem;border-bottom:1px solid var(--color-border, #333)}.cas-org-role{display:flex;align-items:center;gap:.4rem;width:100%;padding:.32rem .5rem;border-radius:4px;cursor:pointer;border:1px solid rgba(0,0,0,0);background:rgba(0,0,0,0);color:var(--color-text, #e0e0e0);text-align:left;transition:background .1s,border-color .1s;user-select:none}.cas-org-role:hover{background:var(--color-card-hover, #2a2a3e);border-color:var(--color-border, #444)}.cas-org-role--active{background:var(--color-card-active, #252540);border-color:var(--color-accent, #7c6af7)}.cas-org-role__dot{width:7px;height:7px;border-radius:50%;flex-shrink:0;background:var(--color-border, #555)}.cas-org-role--exists .cas-org-role__dot{background:#4caf50}.cas-org-role--spawnable .cas-org-role__dot{background:var(--color-accent, #7c6af7)}.cas-org-role__label{font-size:.8rem;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}.cas-org-role__badge{font-size:.58rem;padding:.08rem .3rem;border-radius:3px;background:rgba(124,106,247,.2);color:var(--color-accent, #7c6af7);flex-shrink:0}.cas-legend-item{display:flex;align-items:center;gap:.3rem;font-size:.68rem;color:var(--color-muted, #888)}.cas-legend-dot{width:7px;height:7px;border-radius:50%;flex-shrink:0}.cas-legend-dot--spawnable{background:var(--color-accent, #7c6af7)}.cas-legend-dot--exists{background:#4caf50}.cas-legend-dot--draft{background:var(--color-border, #555)}.cas-placeholder{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:.6rem;height:100%;padding:2rem;text-align:center}.cas-placeholder__icon{font-size:2rem;opacity:.3}.cas-placeholder__text{font-size:.83rem;color:var(--color-muted, #888);max-width:240px;line-height:1.5}.cas-loading{display:none;position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);background:var(--color-card, #1e1e2e);border:1px solid var(--color-border, #444);border-radius:6px;padding:.5rem 1rem;font-size:.8rem;color:var(--color-muted, #888);z-index:10;pointer-events:none}.cas-loading.htmx-request{display:block}.cas-empty{font-size:.8rem;color:var(--color-muted, #888);padding:.75rem}.cas-detail{display:flex;flex-direction:column;height:100%;overflow:hidden}.cas-detail__header{padding:.85rem 1rem .65rem;border-bottom:1px solid var(--color-border, #333);flex-shrink:0}.cas-detail__title-row{display:flex;align-items:flex-start;gap:.6rem;flex-wrap:wrap;margin-bottom:.35rem}.cas-detail__title{font-size:1rem;font-weight:700;color:var(--color-text, #e0e0e0);margin:0}.cas-detail__chips{display:flex;gap:.4rem;flex-wrap:wrap;align-items:center}.cas-chip{font-size:.65rem;padding:.15rem .5rem;border-radius:10px;background:var(--color-border, #333);color:var(--color-muted, #888);white-space:nowrap}.cas-chip--spawnable{background:rgba(124,106,247,.2);color:var(--color-accent, #7c6af7)}.cas-chip--exists{background:rgba(76,175,80,.15);color:#81c784}.cas-chip--missing{background:rgba(244,67,54,.15);color:#ef9a9a}.cas-chip--draft{background:var(--color-border, #333);color:var(--color-muted, #888)}.cas-detail__desc{font-size:.8rem;color:var(--color-muted, #888);margin:0 0 .6rem;line-height:1.5}.cas-edit-btn{font-size:.75rem;padding:.28rem .75rem}.cas-tabs{display:flex;border-bottom:1px solid var(--color-border, #333);flex-shrink:0}.cas-tab{display:flex;align-items:center;gap:.4rem;padding:.5rem 1rem;font-size:.8rem;font-weight:500;color:var(--color-muted, #888);cursor:pointer;border:none;border-bottom:2px solid rgba(0,0,0,0);background:rgba(0,0,0,0);transition:color .15s,border-color .15s;margin-bottom:-1px}.cas-tab:hover{color:var(--color-text, #e0e0e0)}.cas-tab--active{color:var(--color-accent, #7c6af7);border-bottom-color:var(--color-accent, #7c6af7)}.cas-tab__count{font-size:.65rem;background:var(--color-border, #333);border-radius:8px;padding:.08rem .35rem;color:var(--color-muted, #888)}.cas-tab-panel{flex:1 1 0;overflow-y:auto;padding:.75rem;overscroll-behavior:contain}.cas-persona-grid{display:grid;grid-template-columns:repeat(auto-fill, minmax(180px, 1fr));gap:.6rem}.cas-persona-card{background:var(--color-bg, #13131f);border:1px solid var(--color-border, #333);border-radius:6px;padding:.65rem .75rem;cursor:pointer;transition:border-color .15s,background .15s;display:flex;flex-direction:column;gap:.25rem}.cas-persona-card:hover{background:var(--color-card-hover, #2a2a3e);border-color:#555}.cas-persona-card--selected{border-color:var(--color-accent, #7c6af7);background:rgba(124,106,247,.06)}.cas-persona-card__name{font-size:.82rem;font-weight:700;color:var(--color-text, #e0e0e0)}.cas-persona-card__archetype{font-size:.7rem;color:var(--color-accent, #7c6af7);text-transform:capitalize}.cas-persona-card__desc{font-size:.72rem;color:var(--color-muted, #888);line-height:1.4;flex:1;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden}.cas-persona-card__apply{font-size:.7rem;padding:.22rem .6rem;border-radius:4px;border:1px solid var(--color-accent, #7c6af7);background:rgba(0,0,0,0);color:var(--color-accent, #7c6af7);cursor:pointer;margin-top:.35rem;transition:background .1s;align-self:flex-start}.cas-persona-card__apply:hover{background:rgba(124,106,247,.15)}.cas-composer__section{margin-bottom:1rem}.cas-composer__section-title{font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-muted, #888);margin-bottom:.5rem;padding-bottom:.3rem;border-bottom:1px solid var(--color-border, #333)}.cas-composer__hint{font-weight:400;text-transform:none;letter-spacing:0}.cas-composer__row{display:flex;align-items:center;gap:.5rem;margin-bottom:.35rem}.cas-composer__label{font-size:.75rem;color:var(--color-muted, #888);width:130px;flex-shrink:0;text-transform:capitalize}.cas-composer__select{flex:1;padding:.25rem .5rem;font-size:.75rem;background:var(--color-bg, #13131f);border:1px solid var(--color-border, #444);border-radius:4px;color:var(--color-text, #e0e0e0);outline:none}.cas-composer__select:focus{border-color:var(--color-accent, #7c6af7)}.cas-skill-grid{display:flex;flex-wrap:wrap;gap:.4rem}.cas-skill-chip{display:flex;align-items:center;gap:.3rem;font-size:.72rem;padding:.22rem .6rem;border-radius:12px;background:var(--color-bg, #13131f);border:1px solid var(--color-border, #444);color:var(--color-muted, #888);cursor:pointer;transition:background .1s,border-color .1s}.cas-skill-chip:hover{background:var(--color-card-hover, #2a2a3e);border-color:#555}.cas-skill-chip input[type=checkbox]{accent-color:var(--color-accent, #7c6af7)}.cas-arch-preview{font-size:.75rem;font-family:var(--font-mono, monospace);background:var(--color-bg, #13131f);border:1px solid var(--color-border, #444);border-radius:4px;padding:.5rem .75rem;color:#81c784;word-break:break-all;margin-bottom:.5rem}.cas-composer__actions{display:flex;gap:.5rem}.cas-panel--editor{position:relative}.cas-editor-header{display:flex;align-items:center;gap:.5rem;padding:.45rem .75rem;background:var(--color-card, #1e1e2e);border-bottom:1px solid var(--color-border, #333);min-height:2.4rem;flex-shrink:0}.cas-editor-breadcrumb{flex:1;font-size:.72rem;color:var(--color-muted, #888);font-family:var(--font-mono, monospace);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.cas-editor-body{flex:1 1 0;overflow:hidden;position:relative}.cas-editor-placeholder{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:.6rem;text-align:center;padding:2rem;pointer-events:none}.cas-editor-status{font-size:.7rem;padding:.2rem .75rem;min-height:1.35rem;color:var(--color-muted, #888);background:var(--color-card, #1e1e2e);border-top:1px solid var(--color-border, #333);flex-shrink:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.cas-editor-status.ok{color:#4caf50}.cas-editor-status.err{color:#f44336}.cas-diff-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.65);z-index:200;align-items:center;justify-content:center}.cas-diff-overlay--visible{display:flex}.cas-diff-modal{background:var(--color-card, #1e1e2e);border:1px solid var(--color-border, #444);border-radius:8px;width:min(880px,92vw);max-height:82vh;display:flex;flex-direction:column;overflow:hidden;box-shadow:0 8px 32px rgba(0,0,0,.5)}.cas-diff-modal__header{display:flex;align-items:center;padding:.75rem 1rem;border-bottom:1px solid var(--color-border, #333);font-size:.88rem;font-weight:600;color:var(--color-text, #e0e0e0);gap:.75rem}.cas-diff-modal__header span{flex:1}.cas-diff-modal__header button{background:none;border:none;color:var(--color-muted, #888);cursor:pointer;font-size:1rem;line-height:1;padding:.2rem}.cas-diff-modal__body{flex:1;overflow-y:auto;padding:.75rem 1rem;font-family:var(--font-mono, monospace);font-size:.76rem;line-height:1.55}.cas-diff-empty{color:var(--color-muted, #888);font-style:italic}.cas-diff-line{white-space:pre-wrap;word-break:break-all;padding:0 .25rem;border-radius:2px}.cas-diff-line--added{background:rgba(76,175,80,.18);color:#81c784}.cas-diff-line--removed{background:rgba(244,67,54,.18);color:#e57373}.cas-diff-line--hunk{color:#90caf9;margin-top:.5rem}.cas-diff-modal__footer{display:flex;justify-content:flex-end;gap:.5rem;padding:.65rem 1rem;border-top:1px solid var(--color-border, #333)}@media(max-width: 900px){.cas-layout{grid-template-columns:1fr;height:auto}.cas-panel{min-height:250px}.cas-panel--editor{min-height:350px}}.agents-page{display:flex;flex-direction:column;gap:1.5rem}.agents-page-header{display:flex;align-items:flex-start;justify-content:space-between;gap:1rem}.agents-page-subtitle{margin-top:.25rem;font-size:.82rem}.agents-stats-bar{display:grid;grid-template-columns:repeat(7, minmax(0, 1fr));gap:.5rem}@media(max-width: 900px){.agents-stats-bar{grid-template-columns:repeat(4, 1fr)}}@media(max-width: 500px){.agents-stats-bar{grid-template-columns:repeat(2, 1fr)}}.agents-stat{background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:var(--radius);padding:.65rem .5rem;display:flex;flex-direction:column;gap:.2rem;text-align:center;min-width:0}.agents-stat__value{font-size:1.25rem;font-weight:800;color:var(--text-primary);font-variant-numeric:tabular-nums;line-height:1;white-space:nowrap}.agents-stat__value--live{color:var(--accent-bright)}.agents-stat__value--done{color:var(--success)}.agents-stat__value--failed{color:var(--danger)}.agents-stat__label{font-size:.68rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted)}.agents-toolbar{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:var(--radius);padding:.6rem .875rem}.agents-filter-chips{display:flex;gap:.35rem;flex-wrap:wrap;flex:1}.filter-chip{background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:20px;padding:.2rem .65rem;font-size:.72rem;font-weight:500;color:var(--text-secondary);cursor:pointer;display:inline-flex;align-items:center;gap:.3rem;transition:background .12s,border-color .12s,color .12s}.filter-chip:hover{border-color:var(--accent);color:var(--text-primary)}.filter-chip--active{background:rgba(124,106,247,.18);border-color:var(--accent);color:var(--accent-bright)}.filter-chip--implementing{--chip-c: #3b82f6}.filter-chip--reviewing{--chip-c: var(--warning)}.filter-chip--done{--chip-c: var(--success)}.filter-chip--stale{--chip-c: var(--danger)}.filter-chip--unknown{--chip-c: var(--text-muted)}.filter-chip.filter-chip--active.filter-chip--implementing{border-color:#3b82f6;color:#3b82f6;background:rgba(59,130,246,.12)}.filter-chip.filter-chip--active.filter-chip--reviewing{border-color:var(--warning);color:var(--warning);background:rgba(234,179,8,.1)}.filter-chip.filter-chip--active.filter-chip--done{border-color:var(--success);color:var(--success);background:rgba(34,197,94,.1)}.filter-chip.filter-chip--active.filter-chip--stale{border-color:var(--danger);color:var(--danger);background:rgba(239,68,68,.1)}.filter-chip__count{background:var(--bg-overlay);border-radius:8px;padding:.05rem .35rem;font-size:.65rem}.agents-toolbar-right{display:flex;align-items:center;gap:.5rem;flex-shrink:0}.agents-select{background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:5px;color:var(--text-secondary);font-size:.75rem;padding:.25rem .5rem;cursor:pointer}.agents-select:focus{border-color:var(--accent);outline:none}.agents-search-wrap{position:relative;display:flex;align-items:center}.agents-search-icon{position:absolute;left:.5rem;font-size:.75rem;pointer-events:none}.agents-search{background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:5px;color:var(--text-primary);font-size:.75rem;padding:.25rem .5rem .25rem 1.75rem;width:200px;transition:border-color .12s}.agents-search:focus{border-color:var(--accent);outline:none}.view-toggle{display:flex;border:1px solid var(--border-default);border-radius:5px;overflow:hidden}.view-toggle__btn{background:var(--bg-elevated);border:none;padding:.25rem .55rem;font-size:.85rem;color:var(--text-muted);cursor:pointer;transition:background .12s,color .12s}.view-toggle__btn:hover{background:var(--bg-overlay);color:var(--text-primary)}.view-toggle__btn--active{background:rgba(124,106,247,.2);color:var(--accent-bright)}.agents-section{display:flex;flex-direction:column;gap:.75rem}.agents-section-title{font-size:.875rem;font-weight:600;display:flex;align-items:center;gap:.5rem;border-bottom:1px solid var(--border-subtle);padding-bottom:.4rem;color:var(--text-secondary)}.section-title-icon{font-size:1rem}.agents-section-subtitle{color:var(--text-muted);font-weight:400;font-size:.75rem}.badge-count--live{background:rgba(22,153,255,.2);color:var(--accent-bright)}.agents-empty{display:flex;flex-direction:column;align-items:center;gap:.4rem;padding:2.5rem 2rem;text-align:center}.agents-empty__icon{font-size:2.5rem}.agents-empty__title{font-size:1rem;font-weight:700;color:var(--text-primary)}.agents-empty__body{font-size:.82rem;color:var(--text-muted);max-width:36ch}.agents-live-grid{display:grid;grid-template-columns:repeat(auto-fill, minmax(220px, 1fr));gap:.75rem}.agent-live-card{display:flex;gap:.75rem;background:var(--bg-surface);border:1px solid var(--border-default);border-left:3px solid var(--border-strong);border-radius:var(--radius);padding:.875rem;text-decoration:none;color:inherit;transition:border-color .15s,box-shadow .15s,transform .12s}.agent-live-card:hover{border-color:var(--accent);box-shadow:var(--shadow-md);transform:translateY(-1px);text-decoration:none;color:inherit}.agent-live-card--implementing{border-left-color:#3b82f6}.agent-live-card--reviewing{border-left-color:var(--warning)}.agent-live-card--done{border-left-color:var(--success)}.agent-live-card--stale{border-left-color:var(--danger)}.agent-live-card--unknown{border-left-color:var(--border-strong)}.agent-live-card--stale-idle{border-left-color:var(--warning);background:rgba(234,179,8,.04)}.agent-live-avatar{width:2.5rem;height:2.5rem;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:1.2rem;flex-shrink:0;background:var(--bg-elevated);border:1.5px solid var(--border-default)}.agent-live-avatar--visionary{border-color:var(--arch-visionary);background:rgba(155,89,182,.18)}.agent-live-avatar--architect{border-color:var(--arch-architect);background:rgba(52,152,219,.18)}.agent-live-avatar--hacker{border-color:var(--arch-hacker);background:rgba(243,156,18,.18)}.agent-live-avatar--guardian{border-color:var(--arch-guardian);background:rgba(39,174,96,.18)}.agent-live-avatar--scholar{border-color:var(--arch-scholar);background:rgba(26,188,156,.18)}.agent-live-avatar--mentor{border-color:var(--arch-mentor);background:rgba(230,126,34,.18)}.agent-live-avatar--operator{border-color:var(--arch-operator);background:rgba(149,165,166,.15)}.agent-live-avatar--pragmatist{border-color:var(--arch-pragmatist);background:rgba(231,76,60,.18)}.agent-live-avatar--default{border-color:var(--border-default);background:var(--bg-elevated)}.agent-live-body{flex:1;min-width:0;display:flex;flex-direction:column;gap:.2rem}.agent-live-top{display:flex;align-items:center;gap:.4rem}.agent-live-role{font-size:.85rem;font-weight:700;color:var(--text-primary)}.agent-live-persona{font-size:.72rem;color:var(--text-muted)}.agent-live-chips{display:flex;flex-wrap:wrap;gap:.25rem;margin-top:.2rem}.agent-live-branch{font-size:.65rem;color:var(--text-muted);font-family:var(--font-mono);background:var(--bg-elevated);border-radius:3px;padding:.05rem .3rem}.agent-live-footer{display:flex;align-items:center;gap:.5rem;margin-top:.3rem}.agent-live-elapsed{font-size:.68rem;font-family:var(--font-mono);color:var(--text-muted);font-variant-numeric:tabular-nums}.agent-live-stale-badge{font-size:.62rem;font-weight:600;color:var(--warning);background:rgba(234,179,8,.12);border:1px solid rgba(234,179,8,.3);border-radius:4px;padding:.05rem .3rem;letter-spacing:.03em}.agent-sandbox-link{margin-left:auto;font-size:.65rem;color:var(--text-muted);text-decoration:none;opacity:.65;transition:opacity .15s,color .15s}.agent-sandbox-link:hover{opacity:1;color:var(--accent-bright)}.agent-arch-link{margin-left:auto;text-decoration:none;opacity:.6;transition:opacity .15s}.agent-arch-link:hover{opacity:1}.agents-batches{display:flex;flex-direction:column;gap:.75rem}.batch-group{background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:var(--radius);overflow:hidden}.batch-header{display:flex;align-items:center;gap:.5rem;padding:.6rem .875rem;cursor:pointer;background:var(--bg-surface);border-bottom:1px solid rgba(0,0,0,0);transition:background .12s;flex-wrap:wrap}.batch-header:hover{background:var(--bg-elevated)}.batch-chevron{font-size:1.2rem;color:var(--text-muted);transition:transform .18s;flex-shrink:0}.batch-chevron--open{transform:rotate(90deg)}.batch-icon{font-size:.9rem}.batch-id{font-size:.8rem;color:var(--text-primary);font-family:var(--font-mono)}.batch-meta{font-size:.7rem}.batch-count{font-size:.65rem}.batch-phase{font-size:.65rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--accent-bright);background:rgba(124,106,247,.12);border-radius:4px;padding:.1rem .4rem}.batch-success-rate{font-size:.68rem;font-weight:600;color:var(--success);margin-left:auto;flex-shrink:0}.batch-status-pills{display:flex;gap:.25rem;flex-wrap:wrap}.batch-body{padding:.75rem;border-top:1px solid var(--border-subtle)}.agents-history-grid{display:grid;grid-template-columns:repeat(auto-fill, minmax(200px, 1fr));gap:.5rem}.history-card{display:flex;flex-direction:column;gap:.3rem;background:var(--bg-elevated);border:1px solid var(--border-subtle);border-left:3px solid var(--border-strong);border-radius:5px;padding:.6rem .75rem;text-decoration:none;color:inherit;transition:border-color .12s,background .12s}.history-card:hover{border-color:var(--accent);background:var(--bg-overlay);text-decoration:none;color:inherit}.history-card--implementing{border-left-color:#3b82f6}.history-card--reviewing{border-left-color:var(--warning)}.history-card--done{border-left-color:var(--success)}.history-card--stale{border-left-color:var(--danger)}.history-card--unknown{border-left-color:var(--border-strong)}.history-card__top{display:flex;align-items:center;justify-content:space-between;gap:.3rem}.history-card__duration{font-size:.65rem;font-variant-numeric:tabular-nums}.history-card__role{font-size:.8rem;font-weight:600;color:var(--text-primary)}.history-card__chips{display:flex;flex-wrap:wrap;gap:.2rem}.history-card__branch{font-size:.62rem;font-family:var(--font-mono);color:var(--text-muted)}.history-card__date{font-size:.62rem}.history-card__meta{display:flex;flex-wrap:wrap;gap:.3rem;align-items:center;margin-top:.1rem}.run-attempt-badge{font-size:.6rem;font-weight:700;color:var(--warning);background:rgba(234,179,8,.12);border:1px solid rgba(234,179,8,.25);border-radius:4px;padding:.05rem .3rem;letter-spacing:.02em}.run-spawn-mode{font-size:.6rem;font-weight:600;border-radius:4px;padding:.05rem .3rem;text-transform:uppercase;letter-spacing:.04em}.run-spawn-mode--wave{color:var(--accent-bright);background:rgba(124,106,247,.12);border:1px solid rgba(124,106,247,.2)}.run-spawn-mode--chain{color:#3b82f6;background:rgba(59,130,246,.1);border:1px solid rgba(59,130,246,.2)}.run-spawn-mode--manual{color:var(--text-muted);background:var(--bg-elevated);border:1px solid var(--border-subtle)}.btn-copy{display:inline-flex;align-items:center;justify-content:center;margin-left:.35rem;padding:.15rem .35rem;font-size:.75rem;line-height:1;color:var(--text-muted);background:rgba(0,0,0,0);border:1px solid var(--border-subtle);border-radius:4px;cursor:pointer;vertical-align:middle;transition:color .15s,border-color .15s,background .15s}.btn-copy:hover{color:var(--text-primary);border-color:var(--border-strong);background:var(--bg-elevated)}.btn-copy:active{color:var(--success);border-color:var(--success);background:rgba(34,197,94,.08)}.run-row:hover td{background:var(--bg-elevated)}.run-row--implementing td:first-child{border-left:2px solid #3b82f6}.run-row--reviewing td:first-child{border-left:2px solid var(--warning)}.run-row--done td:first-child{border-left:2px solid var(--success)}.run-row--stale td:first-child{border-left:2px solid var(--danger)}.run-row--unknown td:first-child{border-left:2px solid var(--border-strong)}.run-status-badge{font-size:.65rem}.run-branch{font-size:.68rem}.run-date{font-size:.7rem;white-space:nowrap}.run-duration{font-size:.7rem;white-space:nowrap;font-variant-numeric:tabular-nums}.cfg-page-header{display:flex;align-items:flex-start;justify-content:space-between;gap:1rem;margin-bottom:1.25rem;flex-wrap:wrap}.cfg-page-title{font-size:1.15rem;font-weight:700;color:var(--text-primary);margin:0 0 .2rem}.cfg-page-subtitle{font-size:.8rem;color:var(--text-muted);margin:0}.cfg-save-stamp{font-size:.75rem;color:var(--text-faint);align-self:flex-start;margin-top:.25rem;font-variant-numeric:tabular-nums}.cfg-layout{display:grid;grid-template-columns:188px 1fr;grid-template-rows:1fr auto;gap:0;height:calc(100vh - 9rem);min-height:400px;background:var(--bg-surface);border:1px solid var(--border-default);border-radius:var(--radius);overflow:hidden;box-shadow:var(--shadow-md)}.cfg-sidebar{grid-column:1;grid-row:1/3;display:flex;flex-direction:column;background:var(--bg-elevated);border-right:1px solid var(--border-default);padding:.75rem 0;gap:.125rem}.cfg-sidebar-label{font-size:.65rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--text-faint);padding:.25rem 1rem .5rem}.cfg-tab-btn{display:flex;align-items:center;gap:.6rem;width:100%;padding:.6rem 1rem;background:rgba(0,0,0,0);border:none;border-left:2px solid rgba(0,0,0,0);color:var(--text-secondary);font-size:.82rem;font-weight:500;font-family:var(--font-sans);cursor:pointer;text-align:left;transition:color .15s,background .15s,border-color .15s}.cfg-tab-btn:hover{background:rgba(139,92,246,.06);color:var(--text-primary)}.cfg-tab-btn.active{background:rgba(139,92,246,.1);border-left-color:var(--accent);color:var(--accent-bright);font-weight:600}.cfg-tab-icon{font-size:.9rem;flex-shrink:0;opacity:.85}.cfg-tab-badge{margin-left:auto;font-size:.65rem;padding:.1rem .4rem;border-radius:var(--radius-full);background:var(--accent-glow);color:var(--accent-bright);font-weight:700;line-height:1.4}.cfg-tab-badge.on{background:var(--success-dim);color:var(--success)}.cfg-content{grid-column:2;grid-row:1;overflow-y:auto;padding:1.5rem 2rem;scrollbar-width:thin;scrollbar-color:var(--border-default) rgba(0,0,0,0)}.cfg-content::-webkit-scrollbar{width:5px}.cfg-content::-webkit-scrollbar-track{background:rgba(0,0,0,0)}.cfg-content::-webkit-scrollbar-thumb{background:var(--border-default);border-radius:var(--radius-full)}.cfg-panel-title{font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted);margin:0 0 1.25rem;padding-bottom:.6rem;border-bottom:1px solid var(--border-subtle)}.cfg-section{margin-bottom:2rem}.cfg-section-title{font-size:.75rem;font-weight:600;color:var(--text-secondary);margin:0 0 .75rem;text-transform:uppercase;letter-spacing:.06em}.cfg-slider-group{display:flex;flex-direction:column;gap:1.25rem}.cfg-slider-row{display:grid;grid-template-columns:1fr auto;gap:.5rem 1rem;align-items:center}.cfg-slider-label{font-size:.84rem;color:var(--text-primary);font-weight:500;grid-column:1;grid-row:1}.cfg-slider-hint{font-size:.73rem;color:var(--text-faint);grid-column:1;grid-row:2;margin-top:-0.25rem}.cfg-slider-value{grid-column:2;grid-row:1/3;width:2.5rem;text-align:center;font-size:1.1rem;font-weight:700;color:var(--accent-bright);font-family:var(--font-mono);background:var(--accent-glow);border-radius:var(--radius-sm);padding:.15rem 0;transition:transform .1s}.cfg-slider-value.pulse{transform:scale(1.15)}.cfg-slider-input{grid-column:1;grid-row:3;width:100%;accent-color:var(--accent);cursor:pointer;height:4px;margin-top:.35rem}.cfg-capacity-card{margin-top:1.75rem;background:var(--bg-elevated);border:1px solid var(--border-subtle);border-radius:var(--radius);padding:1rem 1.25rem}.cfg-capacity-header{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:.75rem}.cfg-capacity-label{font-size:.78rem;color:var(--text-muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em}.cfg-capacity-total{font-size:1.35rem;font-weight:800;color:var(--text-primary);font-family:var(--font-mono)}.cfg-capacity-total span{font-size:.78rem;color:var(--text-muted);font-weight:500;font-family:var(--font-sans);margin-left:.3rem}.cfg-capacity-bar{height:10px;border-radius:var(--radius-full);background:var(--bg-overlay);overflow:hidden;display:flex;gap:2px}.cfg-capacity-bar-eng{height:100%;background:var(--grad-accent);border-radius:var(--radius-full) 0 0 var(--radius-full);transition:width .3s ease;min-width:0}.cfg-capacity-bar-qa{height:100%;background:var(--grad-warm);border-radius:0 var(--radius-full) var(--radius-full) 0;transition:width .3s ease;min-width:0}.cfg-capacity-legend{display:flex;gap:1.25rem;margin-top:.6rem}.cfg-capacity-legend-item{display:flex;align-items:center;gap:.4rem;font-size:.75rem;color:var(--text-secondary)}.cfg-legend-dot{width:8px;height:8px;border-radius:var(--radius-full);flex-shrink:0}.cfg-legend-dot.eng{background:var(--accent)}.cfg-legend-dot.qa{background:var(--warning)}.cfg-label-list{display:flex;flex-direction:column;gap:.3rem;list-style:none;margin:0 0 1rem;padding:0;min-height:2rem}.cfg-label-empty{padding:1.5rem;text-align:center;font-size:.82rem;color:var(--text-faint);border:1px dashed var(--border-subtle);border-radius:var(--radius-sm)}.cfg-label-item{display:grid;grid-template-columns:1.75rem 1.5rem 1fr auto;align-items:center;gap:.5rem;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius-sm);padding:.45rem .6rem;cursor:grab;user-select:none;transition:background .12s,border-color .12s,box-shadow .12s}.cfg-label-item:active{cursor:grabbing}.cfg-label-item.drag-over{border-color:var(--accent);background:var(--accent-glow);box-shadow:0 0 0 1px var(--accent-dim)}.cfg-label-position{font-size:.68rem;font-weight:700;color:var(--text-faint);font-family:var(--font-mono);text-align:center;background:var(--bg-overlay);border-radius:var(--radius-xs);padding:.1rem .3rem}.cfg-drag-handle{font-size:.85rem;color:var(--text-faint);text-align:center;line-height:1;opacity:.6;transition:opacity .1s}.cfg-label-item:hover .cfg-drag-handle{opacity:1}.cfg-label-text{font-size:.8rem;font-family:var(--font-mono);color:var(--text-primary);word-break:break-all;min-width:0}.cfg-btn-remove{background:rgba(0,0,0,0);border:none;color:var(--text-faint);cursor:pointer;font-size:.75rem;padding:.15rem .35rem;border-radius:var(--radius-xs);line-height:1;transition:color .12s,background .12s;flex-shrink:0}.cfg-btn-remove:hover{color:var(--danger);background:var(--danger-dim)}.cfg-label-add-row{display:flex;gap:.5rem}.cfg-label-add-row input[type=text]{flex:1;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius-sm);color:var(--text-primary);font-size:.82rem;font-family:var(--font-mono);padding:.4rem .7rem;outline:none;transition:border-color .15s,box-shadow .15s}.cfg-label-add-row input[type=text]::placeholder{color:var(--text-faint)}.cfg-label-add-row input[type=text]:focus{border-color:var(--accent);box-shadow:0 0 0 2px var(--accent-glow)}.cfg-ab-callout{display:flex;gap:.75rem;align-items:flex-start;background:var(--info-dim);border:1px solid var(--info-border);border-radius:var(--radius-sm);padding:.75rem 1rem;margin-bottom:1.5rem}.cfg-ab-callout-icon{font-size:1rem;flex-shrink:0;margin-top:.05rem}.cfg-ab-callout-text{font-size:.8rem;color:var(--text-secondary);line-height:1.5;margin:0}.cfg-ab-toggle-row{display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem;padding:1rem 1.25rem;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius);transition:border-color .2s}.cfg-ab-toggle-row.ab-active{border-color:var(--success-border);background:var(--success-dim)}.cfg-ab-toggle-label{flex:1}.cfg-ab-toggle-title{font-size:.88rem;font-weight:600;color:var(--text-primary);margin:0 0 .15rem}.cfg-ab-toggle-desc{font-size:.75rem;color:var(--text-muted);margin:0}.cfg-toggle-switch{position:relative;display:inline-flex;align-items:center;cursor:pointer;flex-shrink:0}.cfg-toggle-switch input[type=checkbox]{position:absolute;opacity:0;width:0;height:0}.cfg-toggle-track{width:44px;height:24px;border-radius:var(--radius-full);background:var(--bg-overlay);border:1px solid var(--border-default);transition:background .2s,border-color .2s;position:relative}.cfg-toggle-switch input:checked+.cfg-toggle-track{background:var(--success);border-color:var(--success)}.cfg-toggle-track::after{content:"";position:absolute;top:3px;left:3px;width:16px;height:16px;border-radius:50%;background:var(--text-muted);transition:transform .2s,background .2s}.cfg-toggle-switch input:checked+.cfg-toggle-track::after{transform:translateX(20px);background:#fff}.cfg-ab-status{font-size:.72rem;font-weight:700;padding:.2rem .55rem;border-radius:var(--radius-full);flex-shrink:0}.cfg-ab-status.on{background:var(--success-dim);color:var(--success);border:1px solid var(--success-border)}.cfg-ab-status.off{background:var(--bg-overlay);color:var(--text-faint);border:1px solid var(--border-subtle)}.cfg-ab-fields{display:flex;flex-direction:column;gap:1rem}.cfg-ab-field{display:flex;flex-direction:column;gap:.35rem}.cfg-field-label{font-size:.75rem;font-weight:600;color:var(--text-secondary);letter-spacing:.03em}.cfg-field-hint{font-size:.7rem;color:var(--text-faint)}.cfg-text-input{background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius-sm);color:var(--text-primary);font-size:.82rem;font-family:var(--font-mono);padding:.45rem .75rem;outline:none;transition:border-color .15s,box-shadow .15s;width:100%;box-sizing:border-box}.cfg-text-input::placeholder{color:var(--text-faint)}.cfg-text-input:focus{border-color:var(--accent);box-shadow:0 0 0 2px var(--accent-glow)}.cfg-projects-list{display:flex;flex-direction:column;gap:.75rem}.cfg-project-empty{padding:2rem;text-align:center;font-size:.82rem;color:var(--text-faint);border:1px dashed var(--border-subtle);border-radius:var(--radius)}.cfg-project-card{background:var(--bg-elevated);border:1px solid var(--border-default);border-left:3px solid rgba(0,0,0,0);border-radius:var(--radius);padding:1rem 1.25rem;transition:border-color .2s,box-shadow .2s;display:flex;flex-direction:column;gap:.6rem}.cfg-project-card.active{border-left-color:var(--accent);box-shadow:var(--shadow-glow);background:rgba(139,92,246,.04)}.cfg-project-header{display:flex;align-items:center;gap:.75rem}.cfg-project-name{font-size:.9rem;font-weight:700;color:var(--text-primary);flex:1}.cfg-active-badge{font-size:.65rem;font-weight:700;padding:.15rem .5rem;border-radius:var(--radius-full);background:var(--accent-glow);color:var(--accent-bright);border:1px solid rgba(139,92,246,.3);text-transform:uppercase;letter-spacing:.06em}.cfg-project-chips{display:flex;flex-wrap:wrap;gap:.4rem}.cfg-project-chip{display:flex;align-items:center;gap:.3rem;font-size:.72rem;font-family:var(--font-mono);color:var(--text-secondary);background:var(--bg-overlay);border:1px solid var(--border-subtle);border-radius:var(--radius-xs);padding:.18rem .5rem}.cfg-project-chip .chip-icon{font-size:.7rem;opacity:.7}.cfg-project-footer{display:flex;align-items:center;justify-content:space-between;gap:.5rem;padding-top:.5rem;border-top:1px solid var(--border-subtle)}.cfg-project-cursor-id{font-size:.7rem;color:var(--text-faint);font-family:var(--font-mono)}.cfg-switch-toast{font-size:.78rem;color:var(--success);min-height:1em}.cfg-footer{grid-column:2;grid-row:2;display:flex;align-items:center;gap:1rem;padding:.875rem 2rem;background:var(--bg-glass);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);border-top:1px solid var(--border-default)}.cfg-toast{font-size:.82rem;padding:.3rem .7rem;border-radius:var(--radius-sm);min-height:1.6rem;display:flex;align-items:center}.cfg-toast.ok{background:var(--success-dim);color:var(--success);border:1px solid var(--success-border)}.cfg-toast.err{background:var(--danger-dim);color:var(--danger);border:1px solid var(--danger-border)}.cfg-footer-spacer{flex:1}@media(max-width: 680px){.cfg-layout{grid-template-columns:1fr;grid-template-rows:auto 1fr auto;height:auto;min-height:unset}.cfg-sidebar{grid-column:1;grid-row:1;flex-direction:row;border-right:none;border-bottom:1px solid var(--border-default);padding:.5rem;overflow-x:auto}.cfg-sidebar-label{display:none}.cfg-tab-btn{border-left:none;border-bottom:2px solid rgba(0,0,0,0);padding:.4rem .75rem;white-space:nowrap;font-size:.78rem}.cfg-tab-btn.active{border-left-color:rgba(0,0,0,0);border-bottom-color:var(--accent)}.cfg-content{grid-column:1;grid-row:2;padding:1rem}.cfg-footer{grid-column:1;grid-row:3}}.dag-layout{display:grid;grid-template-rows:auto auto auto 1fr auto;gap:var(--space-3);height:calc(100vh - 80px);min-height:600px}.dag-page-header{display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.dag-page-title{font-size:1.15rem;font-weight:700;color:var(--text-primary);margin:0 0 .2rem}.dag-page-subtitle{font-size:.8rem;color:var(--text-muted);margin:0}.dag-stats-bar{display:flex;flex-wrap:wrap;gap:var(--space-2)}.dag-stat-chip{display:flex;align-items:center;gap:6px;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:6px;padding:6px 12px;font-size:.8rem;color:var(--text-secondary);white-space:nowrap}.dag-stat-chip-value{font-weight:700;font-size:.95rem;color:var(--text-primary);font-variant-numeric:tabular-nums}.dag-stat-chip-icon{font-size:.9rem}.dag-stat-chip.wip .dag-stat-chip-value{color:#22c55e}.dag-stat-chip.depth .dag-stat-chip-value{color:var(--accent-glow)}.dag-controls{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap}.dag-controls-label{font-size:.8rem;color:var(--text-muted);white-space:nowrap}.dag-filter-select{background:var(--bg-elevated);color:var(--text-primary);border:1px solid var(--border-default);border-radius:5px;padding:5px 8px;font-size:.82rem;cursor:pointer;transition:border-color .15s}.dag-filter-select:focus{outline:none;border-color:var(--accent-glow);box-shadow:0 0 0 2px color-mix(in srgb, var(--accent-glow) 25%, transparent)}.dag-search-input{background:var(--bg-elevated);color:var(--text-primary);border:1px solid var(--border-default);border-radius:5px;padding:5px 10px;font-size:.82rem;width:180px;transition:border-color .15s,width .2s}.dag-search-input::placeholder{color:var(--text-muted)}.dag-search-input:focus{outline:none;border-color:var(--accent-glow);width:240px;box-shadow:0 0 0 2px color-mix(in srgb, var(--accent-glow) 25%, transparent)}.dag-ctrl-btn{background:var(--bg-elevated);color:var(--text-secondary);border:1px solid var(--border-default);border-radius:5px;padding:5px 10px;font-size:.82rem;cursor:pointer;transition:background .15s,color .15s,border-color .15s;white-space:nowrap}.dag-ctrl-btn:hover{background:var(--bg-overlay);color:var(--text-primary);border-color:var(--border-strong)}.dag-ctrl-btn:active{background:color-mix(in srgb, var(--accent-glow) 15%, var(--bg-overlay))}.dag-ctrl-btn-icon{margin-right:4px}.dag-body{display:grid;grid-template-columns:1fr;gap:var(--space-2);min-height:0}.dag-body.sidebar-open{grid-template-columns:1fr 300px}.dag-canvas-wrapper{position:relative;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:8px;overflow:hidden;min-height:480px}.dag-canvas-empty{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:var(--space-2);color:var(--text-muted);font-size:.85rem}.dag-canvas-empty .dag-canvas-empty-icon{font-size:2.5rem;opacity:.4}#dag-svg{width:100%;height:100%;min-height:480px;display:block}#dag-tooltip{position:absolute;pointer-events:none;background:var(--bg-overlay);border:1px solid var(--border-strong);border-radius:5px;padding:6px 10px;font-size:.78rem;color:var(--text-primary);max-width:280px;display:none;z-index:100;box-shadow:0 4px 12px rgba(0,0,0,.3);line-height:1.5}.dag-tooltip-num{font-weight:700;color:var(--accent-glow);font-family:var(--font-mono, monospace)}.dag-tooltip-title{display:block}.dag-tooltip-meta{display:flex;gap:6px;margin-top:3px;flex-wrap:wrap}.dag-tooltip-badge{font-size:.7rem;padding:1px 5px;border-radius:3px;background:var(--bg-surface);border:1px solid var(--border-subtle);color:var(--text-muted)}.dag-tooltip-badge.wip{background:color-mix(in srgb, #22c55e 15%, transparent);border-color:#22c55e;color:#22c55e}.dag-tooltip-badge.blocking{background:color-mix(in srgb, var(--accent-glow) 15%, transparent);border-color:var(--accent-glow);color:var(--accent-glow)}.dag-sidebar{background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:8px;padding:var(--space-3);overflow-y:auto;display:flex;flex-direction:column;gap:var(--space-2)}.dag-sidebar-header{display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-1)}.dag-sidebar-num{font-family:var(--font-mono, monospace);font-size:.85rem;font-weight:700;color:var(--accent-glow)}.dag-sidebar-close{background:none;border:none;color:var(--text-muted);cursor:pointer;font-size:1rem;line-height:1;padding:2px 4px;border-radius:3px;transition:color .15s,background .15s}.dag-sidebar-close:hover{color:var(--text-primary);background:var(--bg-overlay)}.dag-sidebar-title{font-size:.9rem;font-weight:600;color:var(--text-primary);line-height:1.4;word-break:break-word}.dag-sidebar-state{display:inline-flex;align-items:center;gap:5px;font-size:.75rem;font-weight:600;padding:2px 8px;border-radius:10px;width:fit-content}.dag-sidebar-state.open{background:color-mix(in srgb, #22c55e 15%, transparent);color:#22c55e;border:1px solid #22c55e}.dag-sidebar-state.closed{background:color-mix(in srgb, #6b7280 20%, transparent);color:#9ca3af;border:1px solid #4b5563}.dag-sidebar-section-title{font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-muted);margin-bottom:4px}.dag-sidebar-labels{display:flex;flex-wrap:wrap;gap:4px}.dag-sidebar-label-chip{font-size:.7rem;padding:2px 7px;border-radius:10px;background:color-mix(in srgb, var(--accent-glow) 12%, transparent);border:1px solid color-mix(in srgb, var(--accent-glow) 35%, transparent);color:var(--text-secondary)}.dag-sidebar-dep-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:3px}.dag-sidebar-dep-item{display:flex;align-items:center;gap:6px;font-size:.78rem;color:var(--text-secondary);padding:3px 0;border-bottom:1px solid var(--border-subtle)}.dag-sidebar-dep-item:last-child{border-bottom:none}.dag-sidebar-dep-num{font-family:var(--font-mono, monospace);color:var(--accent-glow);font-weight:600;flex-shrink:0;cursor:pointer;text-decoration:underline;text-decoration-color:rgba(0,0,0,0);transition:text-decoration-color .15s}.dag-sidebar-dep-num:hover{text-decoration-color:var(--accent-glow)}.dag-sidebar-dep-title{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.dag-sidebar-metrics{display:grid;grid-template-columns:1fr 1fr;gap:6px}.dag-sidebar-metric{background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:5px;padding:6px 8px;text-align:center}.dag-sidebar-metric-val{font-size:1.15rem;font-weight:700;color:var(--text-primary);font-variant-numeric:tabular-nums}.dag-sidebar-metric-lbl{font-size:.68rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.04em}.dag-sidebar-gh-link{display:flex;align-items:center;justify-content:center;gap:6px;padding:7px;border-radius:6px;background:var(--bg-surface);border:1px solid var(--border-default);color:var(--text-secondary);font-size:.8rem;text-decoration:none;transition:background .15s,color .15s,border-color .15s}.dag-sidebar-gh-link:hover{background:var(--bg-overlay);color:var(--text-primary);border-color:var(--accent-glow)}.dag-legend{display:flex;flex-wrap:wrap;gap:var(--space-2);align-items:center}.dag-legend-item{display:flex;align-items:center;gap:6px;font-size:.78rem;color:var(--text-muted)}.dag-legend-swatch{width:11px;height:11px;border-radius:50%;flex-shrink:0}.dag-legend-sep{width:1px;height:14px;background:var(--border-default);margin:0 4px}.dag-legend-edge-indicator{width:28px;height:1.5px;background:#6b7280;position:relative;flex-shrink:0;align-self:center}.dag-legend-edge-indicator::after{content:"";position:absolute;right:-1px;top:50%;transform:translateY(-50%);width:0;height:0;border-top:3.5px solid rgba(0,0,0,0);border-bottom:3.5px solid rgba(0,0,0,0);border-left:5px solid #6b7280}@media(max-width: 700px){.dag-body.sidebar-open{grid-template-columns:1fr;grid-template-rows:1fr auto}.dag-search-input{width:140px}.dag-search-input:focus{width:180px}.dag-stats-bar{gap:var(--space-1)}}.tpl-page-header{margin-bottom:1.5rem}.tpl-page-title{font-size:1.15rem;font-weight:700;color:var(--text-primary);margin:0 0 .2rem}.tpl-page-subtitle{font-size:.8rem;color:var(--text-muted);margin:0}.tpl-layout{display:flex;flex-direction:column;gap:1.5rem;max-width:780px}.tpl-section{background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius);padding:1.25rem 1.5rem;display:flex;flex-direction:column;gap:1rem;box-shadow:var(--shadow-sm)}.tpl-section-title{font-size:.78rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--text-muted);margin:0 0 .25rem;padding-bottom:.5rem;border-bottom:1px solid var(--border-default)}.tpl-form-row{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap}.tpl-form-label{flex:0 0 90px;font-size:.82rem;color:var(--text-muted);font-weight:500}.tpl-input{flex:1;min-width:180px;background:var(--bg-surface);border:1px solid var(--border-default);border-radius:var(--radius-sm);color:var(--text-primary);font-size:.85rem;padding:.4rem .65rem;outline:none;transition:border-color .15s,box-shadow .15s;font-family:var(--font-sans)}.tpl-input:focus{border-color:var(--accent);box-shadow:0 0 0 2px var(--accent-glow)}.tpl-input::placeholder{color:var(--text-faint)}input[type=file].tpl-input{cursor:pointer;padding:.35rem .55rem;font-size:.82rem}input[type=file].tpl-input::file-selector-button{background:var(--bg-overlay);border:1px solid var(--border-default);border-radius:var(--radius-xs);color:var(--text-secondary);font-size:.8rem;padding:.2rem .55rem;cursor:pointer;margin-right:.5rem;transition:background .15s}input[type=file].tpl-input::file-selector-button:hover{background:var(--border-default)}.tpl-btn-primary{background:var(--accent);border:1px solid var(--accent);border-radius:var(--radius-sm);color:#fff;cursor:pointer;font-size:.85rem;font-weight:600;padding:.45rem 1.1rem;transition:opacity .15s,background .15s;white-space:nowrap;font-family:var(--font-sans)}.tpl-btn-primary:hover{opacity:.85}.tpl-btn-primary:disabled{opacity:.35;cursor:not-allowed}.tpl-toast{font-size:.82rem;padding:.35rem .75rem;border-radius:var(--radius-sm);display:none}.tpl-toast.ok{display:inline-block;background:var(--success-dim);color:var(--success);border:1px solid var(--success-border)}.tpl-toast.err{display:inline-block;background:var(--danger-dim);color:var(--danger);border:1px solid var(--danger-border)}.tpl-table{width:100%;border-collapse:collapse;font-size:.84rem}.tpl-table th{text-align:left;padding:.4rem .6rem;color:var(--text-muted);font-weight:600;font-size:.72rem;text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border-default)}.tpl-table td{padding:.5rem .6rem;border-bottom:1px solid var(--border-subtle);color:var(--text-primary);vertical-align:middle}.tpl-table tr:last-child td{border-bottom:none}.tpl-table tr:hover td{background:rgba(139,92,246,.04)}.tpl-cell-name{font-weight:600}.tpl-cell-version{font-family:var(--font-mono);color:var(--accent-bright);font-size:.82rem}.tpl-cell-repo{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.tpl-cell-date{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);white-space:nowrap}.tpl-cell-size{font-family:var(--font-mono);font-size:.78rem;color:var(--text-muted);text-align:right;white-space:nowrap}.tpl-cell-action{text-align:right;white-space:nowrap}.tpl-btn-download{background:rgba(0,0,0,0);border:1px solid var(--border-default);border-radius:var(--radius-sm);color:var(--accent-bright);cursor:pointer;font-size:.78rem;padding:.25rem .6rem;text-decoration:none;display:inline-block;transition:background .15s,border-color .15s;white-space:nowrap}.tpl-btn-download:hover{background:var(--accent-glow);border-color:var(--accent);color:var(--accent-bright)}.tpl-conflict-warning{font-size:.82rem;color:var(--warning);margin:0 0 .35rem}.tpl-conflict-list{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:.2rem}.tpl-conflict-item{font-family:var(--font-mono);font-size:.78rem;color:var(--danger);padding:.2rem .5rem;background:var(--danger-dim);border:1px solid var(--danger-border);border-radius:var(--radius-xs)}.tpl-empty{color:var(--text-muted);font-size:.85rem;padding:.5rem 0}.ab-page-header{margin-bottom:1.5rem}.ab-page-title{font-size:1.15rem;font-weight:700;color:var(--text-primary);margin:0 0 .35rem}.ab-page-subtitle{font-size:.85rem;color:var(--text-muted);margin:0;line-height:1.55}.ab-error-banner{border-left:3px solid var(--danger);background:var(--danger-dim);border-radius:var(--radius-sm);padding:.75rem 1rem;margin-bottom:1rem}.ab-error-banner p{margin:0;color:var(--text-secondary);font-size:.875rem}.ab-comparison-grid{display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-top:1rem}@media(max-width: 640px){.ab-comparison-grid{grid-template-columns:1fr}}.ab-variant-card{position:relative;background:var(--bg-surface);border:1px solid var(--border-default);border-radius:var(--radius);padding:1.25rem;transition:border-color .2s}.ab-variant-card--winner{border-color:var(--success-border);background:linear-gradient(160deg, var(--bg-surface) 70%, rgba(16, 217, 160, 0.04) 100%);box-shadow:0 0 0 1px var(--success-border),var(--shadow-sm)}.ab-winner-badge{position:absolute;top:.75rem;right:.75rem;background:var(--success-dim);border:1px solid var(--success-border);color:var(--success);font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;padding:.2rem .6rem;border-radius:var(--radius-full)}.ab-variant-title{font-size:1rem;font-weight:700;color:var(--text-primary);margin:0 0 .75rem;padding-right:5rem;display:flex;align-items:center;gap:.4rem}.ab-variant-title-check{color:var(--success);font-size:.9em}.ab-variant-sha{font-family:var(--font-mono);font-size:.775rem;color:var(--text-muted);margin:0 0 .75rem}.ab-metrics-table{width:100%;border-collapse:collapse;font-size:.875rem}.ab-metrics-table td{padding:.45rem 0;vertical-align:middle}.ab-metrics-table td:first-child{color:var(--text-muted);padding-right:1rem;width:50%}.ab-metrics-table td:last-child{color:var(--text-primary);font-weight:600}.ab-metrics-table tr+tr td{border-top:1px solid var(--border-subtle)}.ab-tie-note{text-align:center;font-style:italic;color:var(--text-muted);font-size:.85rem;margin-top:1rem}.ab-winner-banner{display:flex;align-items:center;gap:.6rem;background:var(--success-dim);border:1px solid var(--success-border);border-radius:var(--radius);padding:.65rem 1rem;margin-top:1rem;font-size:.875rem;color:var(--success);font-weight:600}.ab-winner-banner-label{color:var(--text-secondary);font-weight:400}.ab-batch-section{margin-top:1.5rem}.ab-batch-section-title{font-size:.95rem;font-weight:700;color:var(--text-primary);margin:0 0 .75rem}.ab-batch-table-wrapper{background:var(--bg-surface);border:1px solid var(--border-default);border-radius:var(--radius);overflow:hidden}.ab-batch-table{width:100%;margin:0;border-collapse:collapse;font-size:.875rem}.ab-batch-table th{background:var(--bg-elevated);color:var(--text-muted);font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;padding:.5rem .875rem;text-align:left;border-bottom:1px solid var(--border-default)}.ab-batch-table td{padding:.45rem .875rem;color:var(--text-secondary);vertical-align:middle;border-bottom:1px solid var(--border-subtle)}.ab-batch-table tbody tr:last-child td{border-bottom:none}.ab-batch-table tbody tr:hover td{background:var(--bg-elevated)}.ab-batch-id{font-family:var(--font-mono);font-size:.8rem;color:var(--text-secondary)}.ab-empty-state{background:var(--bg-surface);border:1px solid var(--border-default);border-radius:var(--radius);padding:2.5rem 2rem;text-align:center;margin-top:1rem}.ab-empty-icon{font-size:2rem;margin-bottom:.75rem;display:block;opacity:.5}.ab-empty-title{font-size:.95rem;font-weight:600;color:var(--text-secondary);margin:0 0 .4rem}.ab-empty-body{font-size:.825rem;color:var(--text-muted);max-width:36ch;margin:0 auto 1rem;line-height:1.6}.ab-empty-link{display:inline-flex;align-items:center;gap:.3rem;font-size:.8rem;color:var(--accent-bright);border:1px solid var(--border-default);border-radius:var(--radius-sm);padding:.3rem .7rem;transition:border-color .15s,color .15s}.ab-empty-link:hover{border-color:var(--accent);color:#fff}.ab-config-callout{display:flex;align-items:center;justify-content:space-between;gap:1rem;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius);padding:.75rem 1rem;margin-top:1.25rem;font-size:.825rem;color:var(--text-muted);flex-wrap:wrap}.ab-config-callout a{color:var(--accent-bright);font-weight:500;white-space:nowrap}.ab-config-callout a:hover{color:#fff}.controls-page-header{display:flex;align-items:flex-start;justify-content:space-between;gap:1rem;margin-bottom:1.5rem}.controls-page-title{font-size:1.5rem;font-weight:700;color:var(--text-primary);margin:0}.controls-page-subtitle{margin-top:.25rem;font-size:.82rem;color:var(--text-muted)}.controls-status-pill{display:inline-flex;align-items:center;gap:.4rem;padding:.3rem .75rem;border-radius:var(--radius-full);font-size:.75rem;font-weight:600;letter-spacing:.04em;text-transform:uppercase;white-space:nowrap;flex-shrink:0;border:1px solid}.controls-status-pill--running{background:var(--success-dim);border-color:var(--success-border);color:var(--success)}.controls-status-pill--paused{background:var(--warning-dim);border-color:var(--warning-border);color:var(--warning)}.controls-status-dot{display:inline-block;width:7px;height:7px;border-radius:50%;background:currentColor;flex-shrink:0}.controls-grid{display:grid;grid-template-columns:repeat(2, 1fr);gap:1rem;margin-bottom:2rem}@media(max-width: 800px){.controls-grid{grid-template-columns:1fr}}.controls-card{background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:var(--radius-lg);padding:1.25rem 1.5rem;display:flex;flex-direction:column;gap:.75rem}.controls-card-icon{font-size:1.75rem;line-height:1}.controls-card-title{font-size:1rem;font-weight:700;color:var(--text-primary);margin:0}.controls-card-desc{font-size:.8125rem;color:var(--text-muted);line-height:1.55;margin:0}.controls-card-actions{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap}.controls-card-state{font-size:.8rem;color:var(--text-muted);margin:0}.controls-spinner{font-size:1rem;opacity:0;transition:opacity .2s}.htmx-request .controls-spinner,.controls-spinner.htmx-indicator{opacity:1}.controls-kill-form{display:flex;flex-direction:column;gap:.5rem}.controls-kill-row{display:flex;align-items:center;gap:.5rem}.controls-select{flex:1;min-width:0;padding:.35rem .6rem;background:var(--bg-elevated);border:1px solid var(--border-default);border-radius:var(--radius-sm);color:var(--text-primary);font-size:.8125rem;font-family:var(--font-sans);cursor:pointer;appearance:none}.controls-select:focus{outline:2px solid var(--accent);outline-offset:2px;border-color:var(--accent)}.controls-kill-result,.controls-poll-result{font-size:.8rem;color:var(--text-muted);min-height:1.2em}.controls-history{margin-top:1rem}.controls-history-title{font-size:.9rem;font-weight:600;color:var(--text-secondary);text-transform:uppercase;letter-spacing:.06em;margin:0 0 .75rem}.controls-history-table{width:100%;border-collapse:collapse;font-size:.8125rem;color:var(--text-secondary)}.controls-history-table th{text-align:left;font-weight:600;font-size:.72rem;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted);padding:.3rem .75rem;border-bottom:1px solid var(--border-subtle)}.controls-history-table td{padding:.45rem .75rem;border-bottom:1px solid var(--border-subtle);vertical-align:middle}.controls-history-table tr:last-child td{border-bottom:none}.controls-history-table tr:hover td{background:var(--bg-elevated)}.controls-history-link{color:var(--accent-bright);text-decoration:none}.controls-history-link:hover{text-decoration:underline}.toast-container{position:fixed;bottom:1.5rem;right:1.5rem;z-index:9999;display:flex;flex-direction:column;gap:.5rem;max-width:360px;pointer-events:none}.toast{padding:.75rem 1rem;border-radius:var(--radius, 0.375rem);box-shadow:0 4px 6px -1px rgba(0,0,0,.1);cursor:pointer;font-size:.875rem;pointer-events:all}.toast--success{background:#dcfce7;color:#15803d;border-left:3px solid #16a34a}.toast--error{background:#fee2e2;color:#b91c1c;border-left:3px solid #dc2626}.toast--warning{background:#fef9c3;color:#a16207;border-left:3px solid #ca8a04}.toast--info{background:#dbeafe;color:#1d4ed8;border-left:3px solid #2563eb}
+@charset "UTF-8";
+/* ══════════════════════════════════════════════════════════════
+   AgentCeption — Mission Control Design System
+   Deep dark. Electric violet. Precision UI.
+   ══════════════════════════════════════════════════════════════ */
+@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,300..800;1,14..32,300..800&family=JetBrains+Mono:wght@400;500&display=swap");
+/* FOUC guard — Alpine removes x-cloak once it initialises */
+[x-cloak] {
+  display: none !important;
+}
 
-/* ── Brain Dump: Phase Preview styles (issue-825) ─────────────────────── */
-.bd-preview-panel{display:flex;flex-direction:column;gap:1.25rem;padding:.5rem 0}.bd-preview-title{font-size:1.5rem;font-weight:700;margin:0}.bd-preview-sub{color:var(--text-muted);font-size:.875rem;line-height:1.55;margin:0;max-width:520px}.bd-phase-cards{display:flex;flex-direction:column;gap:.75rem}.bd-phase-card{border:1.5px solid var(--border);border-radius:10px;padding:.85rem 1.1rem;background:rgba(255,255,255,.02);display:flex;flex-direction:column;gap:.4rem;transition:border-color .15s}.bd-phase-card:hover{border-color:var(--border-strong)}.bd-phase-card-header{display:flex;align-items:center;justify-content:space-between;gap:.5rem}.bd-phase-label{font-size:.72rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--accent,#6366f1);background:rgba(99,102,241,.12);padding:.15rem .5rem;border-radius:6px}.bd-phase-issue-count{font-size:.75rem;color:var(--text-muted);font-variant-numeric:tabular-nums}.bd-phase-description{font-size:.875rem;font-weight:600;color:var(--text);margin:0;line-height:1.35}.bd-phase-deps{display:flex;align-items:center;flex-wrap:wrap;gap:.35rem;margin-top:.15rem}.bd-phase-deps-label{font-size:.7rem;color:var(--text-muted);opacity:.7}.bd-phase-dep-chip{font-size:.67rem;font-weight:600;padding:.08rem .4rem;border-radius:8px;background:rgba(16,217,160,.08);border:1px solid rgba(16,217,160,.25);color:var(--success,#10d9a0)}.bd-preview-actions{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;padding-top:.25rem}.bd-back-btn,.bd-confirm-btn{font-size:.87rem}
+/* ── Design Tokens ────────────────────────────────────────────── */
+:root {
+  /* Backgrounds — layered depth */
+  --bg-void: #040710;
+  --bg-base: #070b14;
+  --bg-surface: #0c1220;
+  --bg-elevated: #111b2e;
+  --bg-overlay: #172038;
+  --bg-glass: rgba(10, 16, 32, 0.72);
+  /* Borders */
+  --border-subtle: #15223a;
+  --border-default: #1f3050;
+  --border-strong: #3a5478;
+  --border: var(--border-default);
+  /* Text */
+  --text-primary: #eef5ff;
+  --text-secondary: #a8c4e0;
+  --text-muted: #6a8aaa;
+  --text-faint: #3a5570;
+  /* Accent — Electric Violet */
+  --accent: #8b5cf6;
+  --accent-bright: #a78bfa;
+  --accent-dim: #5b21b6;
+  --accent-hover: #9461fb;
+  --accent-glow: rgba(139, 92, 246, 0.22);
+  --accent-glow-strong: rgba(139, 92, 246, 0.45);
+  /* Semantic colors */
+  --success: #10d9a0;
+  --success-dim: rgba(16, 217, 160, 0.12);
+  --success-border: rgba(16, 217, 160, 0.3);
+  --success-glow: rgba(16, 217, 160, 0.2);
+  --warning: #fbbf24;
+  --warning-dim: rgba(251, 191, 36, 0.12);
+  --warning-border: rgba(251, 191, 36, 0.3);
+  --warning-glow: rgba(251, 191, 36, 0.2);
+  --danger: #f43f5e;
+  --danger-dim: rgba(244, 63, 94, 0.12);
+  --danger-border: rgba(244, 63, 94, 0.3);
+  --danger-glow: rgba(244, 63, 94, 0.2);
+  --info: #38bdf8;
+  --info-dim: rgba(56, 189, 248, 0.12);
+  --info-border: rgba(56, 189, 248, 0.3);
+  /* Gradients */
+  --grad-brand: linear-gradient(135deg, #c084fc 0%, #818cf8 50%, #38bdf8 100%);
+  --grad-accent: linear-gradient(135deg, #7c3aed 0%, #8b5cf6 100%);
+  --grad-success: linear-gradient(135deg, #10d9a0 0%, #3b82f6 100%);
+  --grad-warm: linear-gradient(135deg, #f59e0b 0%, #ef4444 100%);
+  /* Typography */
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'SF Mono', ui-monospace, SFMono-Regular, monospace;
+  /* Shape */
+  --radius-xs: 3px;
+  --radius-sm: 5px;
+  --radius: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-full: 9999px;
+  /* Shadows */
+  --shadow-sm: 0 1px 4px rgba(0, 0, 0, 0.6);
+  --shadow-md: 0 4px 20px rgba(0, 0, 0, 0.7);
+  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.8);
+  --shadow-glow: 0 0 24px var(--accent-glow);
+  --shadow-glow-strong: 0 0 36px var(--accent-glow-strong);
+  /* Transitions */
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ── Reset ────────────────────────────────────────────────────── */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+/* ── Base ─────────────────────────────────────────────────────── */
+html {
+  /* Always reserve scrollbar gutter so layout never shifts when content loads */
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
+}
+
+html, body {
+  background: var(--bg-void);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.55;
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+}
+
+a {
+  color: var(--accent-bright);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+a:hover {
+  color: #fff;
+  text-decoration: none;
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xs);
+  padding: 0.1em 0.35em;
+  color: var(--accent-bright);
+}
+
+/* ── Layout ───────────────────────────────────────────────────── */
+.layout {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+}
+
+/* ── Navigation ───────────────────────────────────────────────── */
+nav.topnav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--bg-glass);
+  backdrop-filter: blur(16px) saturate(1.4);
+  -webkit-backdrop-filter: blur(16px) saturate(1.4);
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 0 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  height: 52px;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03), var(--shadow-sm);
+}
+
+/* Brand */
+a.brand, nav.topnav .brand {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  background: var(--grad-brand);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  color: transparent;
+  white-space: nowrap;
+  padding: 0.25rem 0.75rem 0.25rem 0;
+  margin-right: 0.5rem;
+  flex-shrink: 0;
+  text-decoration: none;
+}
+
+a.brand:hover, nav.topnav .brand:hover {
+  opacity: 0.85;
+  -webkit-text-fill-color: transparent;
+}
+
+nav.topnav a {
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  font-weight: 450;
+  padding: 0.3rem 0.6rem;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s, background 0.15s;
+  white-space: nowrap;
+}
+
+nav.topnav a:not(.brand):hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.06);
+  text-decoration: none;
+}
+
+nav.topnav a.active {
+  color: var(--accent-bright);
+  background: rgba(139, 92, 246, 0.12);
+  font-weight: 500;
+}
+
+/* Project switcher in nav */
+.project-switcher {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.project-switcher__label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.project-switcher__select {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.8125rem;
+  font-family: var(--font-sans);
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.project-switcher__select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* ── Main content ─────────────────────────────────────────────── */
+main {
+  padding: 1.5rem 1.75rem;
+  width: 100%;
+  max-width: 1440px;
+  margin: 0 auto;
+  animation: fade-in 0.25s var(--ease-out);
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+/* ── Cards ────────────────────────────────────────────────────── */
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.card:hover {
+  border-color: var(--border-strong);
+}
+
+/* ── Skip-to-content link (a11y) ──────────────────────────────── */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 1rem;
+  z-index: 9999;
+  padding: 0.5rem 1rem;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 0 0 var(--radius) var(--radius);
+  text-decoration: none;
+  transition: top 0.15s ease;
+}
+.skip-link:focus {
+  top: 0;
+  outline: 3px solid var(--accent-bright);
+  outline-offset: 2px;
+}
+
+/* ── Alert banners ────────────────────────────────────────────── */
+.alert-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  background: var(--danger-dim);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--radius-sm);
+  color: var(--danger);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  padding: 0.5rem 0.875rem;
+  margin-bottom: 0.5rem;
+}
+
+.alert-banner--info {
+  background: var(--info-dim);
+  border-color: var(--info-border);
+  color: var(--info);
+}
+
+.alert-banner--violation {
+  background: var(--warning-dim);
+  border-color: var(--warning-border);
+  color: var(--warning);
+}
+
+/* ── Section headings ─────────────────────────────────────────── */
+.section-title {
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.section-subtitle {
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+/* ── Overview layout ──────────────────────────────────────────── */
+.overview-columns {
+  display: grid;
+  grid-template-columns: 60fr 40fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media (max-width: 1000px) {
+  .overview-columns {
+    grid-template-columns: 1fr;
+  }
+}
+/* ── Agent tree ───────────────────────────────────────────────── */
+.agent-tree-container {
+  /* container */
+}
+
+#tree {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.agent-row {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid var(--border-strong);
+  border-radius: var(--radius);
+  overflow: hidden;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.15s;
+  animation: slide-in 0.2s var(--ease-out);
+}
+
+@keyframes slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+.agent-row:hover {
+  transform: translateX(2px);
+  box-shadow: var(--shadow-md);
+}
+
+/* Status-colored left borders */
+.agent-row--status-implementing {
+  border-left-color: #3b82f6;
+  box-shadow: -1px 0 0 0 rgba(59, 130, 246, 0.3) inset;
+}
+
+.agent-row--status-implementing:hover {
+  border-left-color: #60a5fa;
+  box-shadow: -2px 0 12px rgba(59, 130, 246, 0.2);
+}
+
+.agent-row--status-reviewing {
+  border-left-color: var(--warning);
+  box-shadow: -1px 0 0 0 var(--warning-glow) inset;
+}
+
+.agent-row--status-reviewing:hover {
+  box-shadow: -2px 0 12px var(--warning-glow);
+}
+
+.agent-row--status-done {
+  border-left-color: var(--success);
+  box-shadow: -1px 0 0 0 var(--success-glow) inset;
+}
+
+.agent-row--status-done:hover {
+  box-shadow: -2px 0 12px var(--success-glow);
+}
+
+.agent-row--status-stale {
+  border-left-color: var(--danger);
+  box-shadow: -1px 0 0 0 var(--danger-glow) inset;
+}
+
+.agent-row--status-stale:hover {
+  box-shadow: -2px 0 12px var(--danger-glow);
+}
+
+.agent-row--child {
+  margin-left: 1.5rem;
+  background: var(--bg-elevated);
+  border-left-width: 2px;
+}
+
+.agent-row-header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+}
+
+.agent-children {
+  padding: 0 1rem 0.625rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.agent-role {
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  transition: color 0.15s;
+}
+
+.agent-role:hover {
+  color: var(--accent-bright);
+}
+
+.agent-meta {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.empty-state {
+  padding: 3rem 1rem;
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius);
+}
+
+/* ── Status badges ────────────────────────────────────────────── */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.575rem;
+  font-weight: 700;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-full);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  white-space: nowrap;
+}
+
+.status-badge--implementing {
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+  border: 1px solid rgba(59, 130, 246, 0.3);
+}
+
+.status-badge--reviewing {
+  background: var(--warning-dim);
+  color: var(--warning);
+  border: 1px solid var(--warning-border);
+}
+
+.status-badge--done {
+  background: var(--success-dim);
+  color: var(--success);
+  border: 1px solid var(--success-border);
+}
+
+.status-badge--stale {
+  background: var(--danger-dim);
+  color: var(--danger);
+  border: 1px solid var(--danger-border);
+}
+
+.status-badge--unknown {
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+}
+
+/* ── Buttons ──────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 0.4rem 0.875rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  border: 1px solid transparent;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s, border-color 0.15s, box-shadow 0.15s, transform 0.1s;
+  white-space: nowrap;
+  letter-spacing: 0.01em;
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.btn:hover:not(:disabled) {
+  text-decoration: none;
+}
+
+.btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.btn-primary {
+  background: var(--grad-accent);
+  color: #fff;
+  border: none;
+  box-shadow: 0 2px 8px var(--accent-glow);
+}
+
+.btn-primary:hover:not(:disabled) {
+  box-shadow: 0 4px 16px var(--accent-glow-strong);
+  filter: brightness(1.1);
+}
+
+.btn-primary:disabled {
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  box-shadow: none;
+  filter: none;
+}
+
+.btn-secondary {
+  background: var(--bg-elevated);
+  border-color: var(--border-default);
+  color: var(--text-secondary);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: var(--bg-overlay);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.btn-danger {
+  background: var(--danger-dim);
+  border-color: var(--danger-border);
+  color: var(--danger);
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: var(--danger);
+  border-color: var(--danger);
+  color: #fff;
+  box-shadow: 0 2px 12px var(--danger-glow);
+}
+
+.btn-warning {
+  background: var(--warning-dim);
+  border-color: var(--warning-border);
+  color: var(--warning);
+}
+
+.btn-warning:hover:not(:disabled) {
+  background: var(--warning);
+  border-color: var(--warning);
+  color: #000;
+}
+
+.btn-sm {
+  padding: 0.2rem 0.55rem;
+  font-size: 0.75rem;
+}
+
+/* Kill button — subtle, revealed on hover of agent row */
+.btn-kill-inline {
+  margin-left: auto;
+  padding: 0.15rem 0.45rem;
+  background: none;
+  border: 1px solid var(--danger-border);
+  border-radius: var(--radius-xs);
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  cursor: pointer;
+  line-height: 1;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+
+.agent-row:hover .btn-kill-inline,
+.agent-row--child:hover .btn-kill-inline {
+  opacity: 1;
+}
+
+.btn-kill-inline:hover {
+  background: var(--danger);
+  border-color: var(--danger);
+  color: #fff;
+}
+
+/* ── Agent card: expandable header + body ────────────────────────── */
+.agent-card__header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s;
+}
+
+.agent-card__header:hover {
+  background: rgba(255, 255, 255, 0.025);
+}
+
+/* Rotate chevron when card is open */
+.agent-card__chevron {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  transition: transform 0.2s var(--ease-out);
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.agent-card__chevron--open {
+  transform: rotate(90deg);
+}
+
+/* Expandable body panel */
+.agent-card__body {
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* ── Transcript feed ─────────────────────────────────────────────── */
+.transcript-feed {
+  max-height: 380px;
+  overflow-y: auto;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+
+.transcript-msg {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  align-items: flex-start;
+}
+
+.transcript-msg--assistant {
+  background: rgba(139, 92, 246, 0.05);
+  border-left: 2px solid rgba(139, 92, 246, 0.25);
+  border-radius: 0 var(--radius-sm, 4px) var(--radius-sm, 4px) 0;
+  padding: 0.375rem 0.5rem 0.375rem 0.5rem;
+}
+
+.transcript-msg--user {
+  padding: 0.25rem 0;
+}
+
+.transcript-msg__icon {
+  font-size: 0.875rem;
+  flex-shrink: 0;
+  width: 1.25rem;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.transcript-msg__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.transcript-msg__role {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.1rem;
+}
+
+.transcript-msg__text {
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+}
+
+.transcript-loading,
+.transcript-empty {
+  padding: 0.5rem 0;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.transcript-error {
+  padding: 0.5rem 0;
+  font-size: 0.8125rem;
+  color: var(--danger);
+  text-align: center;
+}
+
+/* "Agent is working…" thinking indicator */
+.transcript-thinking {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+.transcript-thinking__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #3b82f6;
+  flex-shrink: 0;
+  animation: pulse-dot 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+  0%, 100% {
+    opacity: 0.3;
+    transform: scale(0.75);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+}
+/* ── Task details grid in expanded card ──────────────────────────── */
+.agent-task-details {
+  border-top: 1px solid var(--border-subtle);
+  padding: 0.625rem 1rem;
+}
+
+.agent-task-details__title {
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 0.4rem;
+}
+
+.agent-task-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.2rem 0.75rem;
+  font-size: 0.75rem;
+}
+
+.agent-task-grid__key {
+  color: var(--text-muted);
+  font-weight: 500;
+  white-space: nowrap;
+  line-height: 1.5;
+}
+
+.agent-task-grid__value {
+  font-family: var(--font-mono);
+  color: var(--text-secondary, var(--text-primary));
+  word-break: break-all;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.5;
+}
+
+/* ── Quick action bar at bottom of expanded card ─────────────────── */
+.agent-card-actions {
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--border-subtle);
+  flex-wrap: wrap;
+  background: rgba(255, 255, 255, 0.01);
+}
+
+/* ── Animated pulse dot for active agent statuses ────────────────── */
+.agent-pulse {
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: pulse-ring 1.8s ease-out infinite;
+}
+
+.agent-pulse--implementing {
+  background: #3b82f6;
+}
+
+.agent-pulse--reviewing {
+  background: var(--warning, #f59e0b);
+}
+
+@keyframes pulse-ring {
+  0% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7);
+  }
+  60% {
+    box-shadow: 0 0 0 5px rgba(59, 130, 246, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+  }
+}
+/* ── Role name + meta chips inside agent header ───────────────────── */
+.agent-role-name {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+}
+
+.agent-meta-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-decoration: none;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.4;
+  transition: background 0.12s, color 0.12s;
+}
+
+.agent-meta-chip--issue {
+  background: rgba(139, 92, 246, 0.1);
+  color: var(--accent-bright);
+  border: 1px solid rgba(139, 92, 246, 0.25);
+}
+
+.agent-meta-chip--issue:hover {
+  background: rgba(139, 92, 246, 0.22);
+  color: #fff;
+}
+
+.agent-meta-chip--pr {
+  background: rgba(34, 197, 94, 0.09);
+  color: var(--success);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+}
+
+.agent-meta-chip--pr:hover {
+  background: rgba(34, 197, 94, 0.2);
+  color: #fff;
+}
+
+.agent-branch-chip {
+  font-size: 0.6875rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Board issue status badges ───────────────────────────────────── */
+.issue-card-status {
+  margin: 0.3rem 0;
+}
+
+.issue-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 99px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-decoration: none;
+  transition: background 0.12s, color 0.12s;
+}
+
+.issue-status-badge--available {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+}
+
+.issue-status-badge--implementing {
+  background: rgba(59, 130, 246, 0.1);
+  color: #60a5fa;
+  border: 1px solid rgba(59, 130, 246, 0.28);
+}
+
+.issue-status-badge--pr {
+  background: rgba(34, 197, 94, 0.1);
+  color: var(--success);
+  border: 1px solid rgba(34, 197, 94, 0.28);
+}
+
+.issue-status-badge--pr:hover {
+  background: rgba(34, 197, 94, 0.2);
+  color: #fff;
+}
+
+/* Wave result: branch name */
+.wave-branch {
+  font-size: 0.6875rem;
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+}
+
+/* ── Badges ──────────────────────────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.6rem;
+  font-weight: 700;
+  padding: 0.15rem 0.55rem;
+  border-radius: var(--radius-full);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.badge-count {
+  background: var(--bg-overlay);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
+}
+
+/* Semantic variants */
+.badge--green {
+  background: var(--success-dim);
+  color: var(--success);
+  border: 1px solid var(--success-border);
+}
+
+.badge--blue {
+  background: var(--info-dim);
+  color: var(--info);
+  border: 1px solid var(--info-border);
+}
+
+.badge--yellow {
+  background: var(--warning-dim);
+  color: var(--warning);
+  border: 1px solid var(--warning-border);
+}
+
+.badge--red {
+  background: var(--danger-dim);
+  color: var(--danger);
+  border: 1px solid var(--danger-border);
+}
+
+.badge--grey {
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+}
+
+.badge--purple {
+  background: var(--accent-glow);
+  color: var(--accent-bright);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+}
+
+/* ── Confirmation modal ───────────────────────────────────────── */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 7, 16, 0.75);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 300;
+  animation: fade-in 0.15s var(--ease-out);
+}
+
+.modal-box {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  max-width: 28rem;
+  width: 90%;
+  box-shadow: var(--shadow-lg), 0 0 0 1px rgba(139, 92, 246, 0.08);
+  animation: modal-in 0.2s var(--ease-out);
+}
+
+@keyframes modal-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+.modal-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+  color: var(--text-primary);
+}
+
+.modal-body {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin: 0 0 1.25rem;
+  line-height: 1.6;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+/* ── Utilities ────────────────────────────────────────────────── */
+.text-muted {
+  color: var(--text-muted);
+}
+
+.text-secondary {
+  color: var(--text-secondary);
+}
+
+.text-success {
+  color: var(--success);
+}
+
+.text-warning {
+  color: var(--warning);
+}
+
+.text-danger {
+  color: var(--danger);
+}
+
+.text-accent {
+  color: var(--accent-bright);
+}
+
+.text-sm {
+  font-size: 0.8125rem;
+}
+
+.text-xs {
+  font-size: 0.6875rem;
+}
+
+.mt-1 {
+  margin-top: 0.5rem;
+}
+
+.mt-2 {
+  margin-top: 1rem;
+}
+
+.mt-3 {
+  margin-top: 1.5rem;
+}
+
+.mb-1 {
+  margin-bottom: 0.5rem;
+}
+
+.mb-2 {
+  margin-bottom: 1rem;
+}
+
+/* ── Breadcrumb ───────────────────────────────────────────────── */
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin-bottom: 1.25rem;
+}
+
+.breadcrumb a {
+  color: var(--accent-bright);
+}
+
+.breadcrumb a:hover {
+  color: #fff;
+}
+
+.breadcrumb-sep {
+  color: var(--border-strong);
+}
+
+.breadcrumb-current {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+/* ── Pipeline summary / KPI bar ───────────────────────────────── */
+.pipeline-summary-bar {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 0;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 0 0 0 1rem; /* no right padding — poller pill owns the right edge */
+  margin-bottom: 1rem;
+  height: 44px;
+  box-shadow: var(--shadow-sm);
+}
+
+.summary-item {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0;
+  padding: 0 0.85rem;
+  position: relative;
+  height: 100%;
+  flex-shrink: 0;
+}
+
+/* Vertical dividers */
+.summary-item + .summary-item::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 20%;
+  height: 60%;
+  width: 1px;
+  background: var(--border-subtle);
+}
+
+.phase-switcher + .summary-item::before {
+  display: none;
+}
+
+.summary-item--dim {
+  opacity: 0.4;
+}
+
+.summary-item--warn {
+  opacity: 1;
+}
+
+.summary-item--warn .summary-label {
+  color: var(--warning);
+}
+
+.summary-item--warn .summary-value {
+  color: var(--warning);
+}
+
+.summary-item--clickable {
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.12s;
+}
+
+.summary-item--clickable:hover {
+  background: rgba(251, 191, 36, 0.1);
+}
+
+.summary-label {
+  font-size: 0.575rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.summary-value {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.summary-value--active {
+  color: var(--success);
+}
+
+.summary-value--accent {
+  color: var(--accent-bright);
+}
+
+.summary-value--mono {
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.summary-value--phase {
+  font-weight: 700;
+  color: var(--accent-bright);
+  font-size: 1.05rem;
+  letter-spacing: -0.02em;
+}
+
+/* ── Phase switcher (GitHub branch-style) ─────────────────────── */
+.phase-switcher {
+  position: relative;
+  flex-shrink: 0;
+  margin-right: 0.5rem;
+  display: flex;
+  align-items: center;
+}
+
+.phase-switcher__trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.6rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+  max-width: 220px;
+}
+
+.phase-switcher__trigger:hover {
+  border-color: var(--accent);
+  background: rgba(139, 92, 246, 0.1);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.phase-switcher__icon {
+  color: var(--accent-bright);
+  font-size: 0.875rem;
+}
+
+.phase-switcher__current {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.phase-switcher__pin {
+  font-size: 0.65rem;
+}
+
+.phase-switcher__caret {
+  color: var(--text-muted);
+  font-size: 0.65rem;
+  margin-left: 0.1rem;
+}
+
+.phase-switcher__dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 200;
+  min-width: 240px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg), 0 0 0 1px rgba(139, 92, 246, 0.08);
+  overflow: hidden;
+}
+
+.phase-switcher__header {
+  padding: 0.5rem 0.875rem 0.375rem;
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+}
+
+.phase-switcher__divider {
+  height: 1px;
+  background: var(--border-subtle);
+  margin: 0.25rem 0;
+}
+
+.phase-switcher__option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.875rem;
+  font-size: 0.8125rem;
+  font-family: var(--font-sans);
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+
+.phase-switcher__option:hover {
+  background: rgba(139, 92, 246, 0.1);
+  color: var(--text-primary);
+}
+
+.phase-switcher__option--active {
+  color: var(--accent-bright);
+  font-weight: 500;
+}
+
+.phase-switcher__option-check {
+  width: 1rem;
+  flex-shrink: 0;
+  color: var(--accent-bright);
+  font-size: 0.75rem;
+}
+
+.phase-switcher__auto-hint {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+/* ── Compact poller pill ──────────────────────────────────────── */
+/* ── Poller right section ─────────────────────────────────────── */
+.poller-right {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-left: auto;
+  flex-shrink: 0;
+  height: 100%;
+  border-left: 1px solid var(--border-subtle);
+}
+
+/* Non-interactive polled timestamp */
+.poller-polled {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0;
+  padding: 0 0.75rem;
+  cursor: default;
+}
+
+.poller-polled__label {
+  font-size: 0.575rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  line-height: 1;
+}
+
+.poller-polled__value {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+/* Clickable status button */
+.poller-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  width: 80px;
+  height: 100%;
+  padding: 0 1rem 0 0.75rem;
+  border-left: 1px solid var(--border-subtle);
+  border-right: none;
+  border-top: none;
+  border-bottom: none;
+  background: none;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  border-radius: 0 8px 8px 0;
+  transition: background 0.12s;
+  box-sizing: border-box;
+}
+
+.poller-btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.poller-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.poller-dot--live {
+  background: #22c55e;
+  box-shadow: 0 0 6px rgba(34, 197, 94, 0.6);
+  animation: pulse-dot 2.5s ease-in-out infinite;
+}
+
+.poller-dot--warn {
+  background: var(--warning);
+}
+
+.poller-dot--paused {
+  background: #ef4444;
+  box-shadow: 0 0 6px rgba(239, 68, 68, 0.4);
+}
+
+@keyframes pulse-dot {
+  0%, 100% {
+    opacity: 1;
+    box-shadow: 0 0 6px rgba(34, 197, 94, 0.6);
+  }
+  50% {
+    opacity: 0.5;
+    box-shadow: 0 0 2px rgba(34, 197, 94, 0.3);
+  }
+}
+.poller-btn__label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* ── Overview layout ──────────────────────────────────────────── */
+.overview-columns {
+  display: grid;
+  grid-template-columns: 60fr 40fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media (max-width: 1000px) {
+  .overview-columns {
+    grid-template-columns: 1fr;
+  }
+}
+/* ── Agent tree ───────────────────────────────────────────────── */
+.agent-tree-container {
+  /* container */
+}
+
+#tree {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.agent-row {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid var(--border-strong);
+  border-radius: var(--radius);
+  overflow: hidden;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.15s;
+  animation: slide-in 0.2s var(--ease-out);
+}
+
+@keyframes slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+.agent-row:hover {
+  transform: translateX(2px);
+  box-shadow: var(--shadow-md);
+}
+
+/* Status-colored left borders */
+.agent-row--status-implementing {
+  border-left-color: #3b82f6;
+  box-shadow: -1px 0 0 0 rgba(59, 130, 246, 0.3) inset;
+}
+
+.agent-row--status-implementing:hover {
+  border-left-color: #60a5fa;
+  box-shadow: -2px 0 12px rgba(59, 130, 246, 0.2);
+}
+
+.agent-row--status-reviewing {
+  border-left-color: var(--warning);
+  box-shadow: -1px 0 0 0 var(--warning-glow) inset;
+}
+
+.agent-row--status-reviewing:hover {
+  box-shadow: -2px 0 12px var(--warning-glow);
+}
+
+.agent-row--status-done {
+  border-left-color: var(--success);
+  box-shadow: -1px 0 0 0 var(--success-glow) inset;
+}
+
+.agent-row--status-done:hover {
+  box-shadow: -2px 0 12px var(--success-glow);
+}
+
+.agent-row--status-stale {
+  border-left-color: var(--danger);
+  box-shadow: -1px 0 0 0 var(--danger-glow) inset;
+}
+
+.agent-row--status-stale:hover {
+  box-shadow: -2px 0 12px var(--danger-glow);
+}
+
+.agent-row--child {
+  margin-left: 1.5rem;
+  background: var(--bg-elevated);
+  border-left-width: 2px;
+}
+
+.agent-row-header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+}
+
+.agent-children {
+  padding: 0 1rem 0.625rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.agent-role {
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  transition: color 0.15s;
+}
+
+.agent-role:hover {
+  color: var(--accent-bright);
+}
+
+.agent-meta {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.empty-state {
+  padding: 3rem 1rem;
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius);
+}
+
+/* ── Status badges ────────────────────────────────────────────── */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.575rem;
+  font-weight: 700;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-full);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  white-space: nowrap;
+}
+
+.status-badge--implementing {
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+  border: 1px solid rgba(59, 130, 246, 0.3);
+}
+
+.status-badge--reviewing {
+  background: var(--warning-dim);
+  color: var(--warning);
+  border: 1px solid var(--warning-border);
+}
+
+.status-badge--done {
+  background: var(--success-dim);
+  color: var(--success);
+  border: 1px solid var(--success-border);
+}
+
+.status-badge--stale {
+  background: var(--danger-dim);
+  color: var(--danger);
+  border: 1px solid var(--danger-border);
+}
+
+.status-badge--unknown {
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+}
+
+/* ── GitHub board (sidebar) ───────────────────────────────────── */
+.github-board {
+  position: sticky;
+  top: 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.board-label-row {
+  margin-bottom: 0.375rem;
+}
+
+.label-chip {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(139, 92, 246, 0.12);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  color: var(--accent-bright);
+  border-radius: var(--radius-full);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.65rem;
+}
+
+.label-chip--active {
+  background: rgba(139, 92, 246, 0.18);
+  border-color: var(--accent);
+  color: var(--accent-bright);
+  box-shadow: 0 0 8px var(--accent-glow);
+}
+
+.label-chip--none {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: var(--border-default);
+  color: var(--text-muted);
+}
+
+.label-chip--small {
+  font-size: 0.6rem;
+  padding: 0.1rem 0.45rem;
+  background: rgba(139, 92, 246, 0.08);
+  border: 1px solid rgba(139, 92, 246, 0.2);
+  border-radius: var(--radius-full);
+  color: var(--text-muted);
+}
+
+.board-stats {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8125rem;
+}
+
+.board-stats-sep {
+  color: var(--border-strong);
+}
+
+.alert-item {
+  background: var(--danger-dim);
+  border-left: 2px solid var(--danger);
+  color: var(--danger);
+  font-size: 0.8125rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  margin-bottom: 0.25rem;
+}
+
+/* ── Wave control card ────────────────────────────────────────── */
+.wave-control-card {
+  border-left: 3px solid var(--accent);
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.06) 0%, transparent 60%);
+}
+
+.wave-control-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.wave-phase-label {
+  margin-bottom: 0.3rem;
+}
+
+.wave-phase-stats {
+  font-size: 0.8125rem;
+}
+
+.btn-wave-start {
+  white-space: nowrap;
+  flex-shrink: 0;
+  background: var(--grad-accent) !important;
+  border: none !important;
+  box-shadow: 0 2px 12px var(--accent-glow);
+}
+
+.btn-wave-start:hover:not(:disabled) {
+  box-shadow: 0 4px 20px var(--accent-glow-strong);
+  transform: translateY(-1px);
+}
+
+.board-syncing {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+.wave-result {
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 0.75rem;
+  margin-top: 0.75rem;
+  animation: fade-in 0.3s var(--ease-out);
+}
+
+.wave-worktree-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.375rem;
+  font-size: 0.8125rem;
+}
+
+.wave-issue-num {
+  font-weight: 700;
+  color: var(--accent-bright);
+  min-width: 2.5rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.wave-worktree-path {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  word-break: break-all;
+}
+
+/* ── Issue cards (GitHub board) ───────────────────────────────── */
+.issue-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 0.625rem 0.875rem;
+  margin-bottom: 0.5rem;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.issue-card:hover {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-sm);
+}
+
+.issue-card-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.issue-card-number {
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: var(--accent-bright);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.issue-card-number:hover {
+  color: #fff;
+}
+
+.issue-card-title {
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+
+.issue-card-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin: 0.25rem 0;
+}
+
+.issue-card-actions {
+  margin-top: 0.4rem;
+}
+
+.issue-analysis-result {
+  margin-top: 0.625rem;
+  padding-top: 0.625rem;
+  border-top: 1px solid var(--border-subtle);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  animation: fade-in 0.25s var(--ease-out);
+}
+
+/* ── Stale claim cards ────────────────────────────────────────── */
+.stale-claim-card {
+  background: var(--danger-dim);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--radius-sm);
+  padding: 0.625rem 0.875rem;
+  margin-bottom: 0.5rem;
+}
+
+.stale-claim-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin-bottom: 0.25rem;
+}
+
+.stale-claim-number {
+  font-weight: 700;
+  color: var(--danger);
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.stale-claim-title {
+  font-size: 0.8125rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stale-claim-path {
+  font-size: 0.6875rem;
+  font-family: var(--font-mono);
+  margin-bottom: 0.4rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+}
+
+.stale-claim-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.stale-claim-confirm {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8125rem;
+}
+
+/* ── Batch-grouped board sections ─────────────────────────────── */
+.batch-group {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 0.5rem 0.75rem 0.75rem;
+  background: var(--bg-surface);
+}
+
+.batch-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin: 0 0 0.5rem;
+  padding-bottom: 0.375rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.issue-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* ── Agent detail ─────────────────────────────────────────────── */
+.agent-detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.agent-detail-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.agent-detail-role {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+}
+
+.agent-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 0.2rem 0.55rem;
+  font-size: 0.75rem;
+}
+
+.meta-label {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.6rem;
+}
+
+.meta-value {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.meta-value a {
+  color: var(--accent-bright);
+}
+
+/* ── Agent detail two-column layout ──────────────────────────── */
+.agent-detail-columns {
+  display: grid;
+  grid-template-columns: 40fr 60fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .agent-detail-columns {
+    grid-template-columns: 1fr;
+  }
+}
+.agent-task-panel {
+  position: sticky;
+  top: 5rem;
+}
+
+/* ── Task table ───────────────────────────────────────────────── */
+.task-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.task-table tr + tr {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.task-key {
+  font-size: 0.625rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 0.5rem 0.75rem 0.5rem 0;
+  vertical-align: top;
+  width: 38%;
+  white-space: nowrap;
+}
+
+.task-value {
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  padding: 0.5rem 0;
+  vertical-align: top;
+  word-break: break-word;
+}
+
+.task-value--path code {
+  font-size: 0.65rem;
+  word-break: break-all;
+}
+
+/* ── Transcript ───────────────────────────────────────────────── */
+.transcript-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 70vh;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.message {
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.message--user {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+}
+
+.message--assistant {
+  background: rgba(139, 92, 246, 0.07);
+  border: 1px solid rgba(139, 92, 246, 0.2);
+}
+
+.message-role {
+  font-size: 0.575rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.3rem 0.875rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.message--user .message-role {
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+}
+
+.message--assistant .message-role {
+  color: var(--accent-bright);
+  background: rgba(139, 92, 246, 0.1);
+}
+
+.message-body {
+  cursor: pointer;
+  padding: 0.5rem 0.875rem 0;
+}
+
+.message-body--collapsed {
+  max-height: 5rem;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+  mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+}
+
+.message-body--expanded {
+  max-height: none;
+}
+
+.message-text {
+  font-family: var(--font-sans);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
+
+.message-expand-btn {
+  display: block;
+  width: 100%;
+  text-align: center;
+  background: none;
+  border: none;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 0.625rem;
+  padding: 0.3rem;
+  cursor: pointer;
+  margin-top: 0.25rem;
+  transition: color 0.15s;
+  font-family: var(--font-sans);
+}
+
+.message-expand-btn:hover {
+  color: var(--accent-bright);
+}
+
+/* ── Forms ────────────────────────────────────────────────────── */
+/* ══════════════════════════════════════════════════════════════
+   Cognitive Architecture — shared tokens & components
+   ══════════════════════════════════════════════════════════════ */
+/* Per-archetype accent colours used for avatars, cards, etc. */
+:root {
+  --arch-visionary: #9b59b6;
+  --arch-architect: #3498db;
+  --arch-hacker: #f39c12;
+  --arch-guardian: #27ae60;
+  --arch-scholar: #1abc9c;
+  --arch-mentor: #e67e22;
+  --arch-operator: #95a5a6;
+  --arch-pragmatist: #e74c3c;
+  --arch-default: #6c757d;
+}
+
+/* ── Agent card — persona avatar (in overview cards) ────────── */
+.card-persona-avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  flex-shrink: 0;
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-default);
+  transition: transform 0.15s ease;
+}
+
+.agent-card__header:hover .card-persona-avatar {
+  transform: scale(1.08);
+}
+
+.card-persona-avatar--visionary {
+  border-color: var(--arch-visionary);
+  background: rgba(155, 89, 182, 0.15);
+}
+
+.card-persona-avatar--architect {
+  border-color: var(--arch-architect);
+  background: rgba(52, 152, 219, 0.15);
+}
+
+.card-persona-avatar--hacker {
+  border-color: var(--arch-hacker);
+  background: rgba(243, 156, 18, 0.15);
+}
+
+.card-persona-avatar--guardian {
+  border-color: var(--arch-guardian);
+  background: rgba(39, 174, 96, 0.15);
+}
+
+.card-persona-avatar--scholar {
+  border-color: var(--arch-scholar);
+  background: rgba(26, 188, 156, 0.15);
+}
+
+.card-persona-avatar--mentor {
+  border-color: var(--arch-mentor);
+  background: rgba(230, 126, 34, 0.15);
+}
+
+.card-persona-avatar--operator {
+  border-color: var(--arch-operator);
+  background: rgba(149, 165, 166, 0.12);
+}
+
+.card-persona-avatar--pragmatist {
+  border-color: var(--arch-pragmatist);
+  background: rgba(231, 76, 60, 0.15);
+}
+
+.card-persona-avatar--default {
+  border-color: var(--border-default);
+  background: var(--bg-elevated);
+}
+
+/* Role + persona name stacked inside card header */
+.agent-role-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.agent-persona-sub {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Card cognitive-arch mini-panel (expanded body) ─────────── */
+.card-arch-panel {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 0.6rem 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.card-arch-panel__header {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.35rem;
+}
+
+.card-arch-panel__archetype {
+  font-size: 0.68rem;
+  color: var(--accent-muted);
+  background: rgba(124, 106, 247, 0.12);
+  border-radius: 4px;
+  padding: 0.1rem 0.35rem;
+}
+
+.card-arch-panel__skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-bottom: 0.35rem;
+}
+
+.card-arch-panel__link {
+  font-size: 0.7rem;
+  color: var(--accent-bright);
+  text-decoration: none;
+}
+
+.card-arch-panel__link:hover {
+  text-decoration: underline;
+}
+
+/* ── Skill tag — shared, two sizes ─────────────────────────── */
+.cog-skill-tag {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(22, 153, 255, 0.1);
+  border: 1px solid rgba(22, 153, 255, 0.25);
+  color: #60b4ff;
+  border-radius: 4px;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.73rem;
+  font-family: var(--font-mono);
+}
+
+.cog-skill-tag--sm {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.35rem;
+}
+
+/* ── Agent detail page — hero row ───────────────────────────── */
+.agent-hero-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.agent-persona-avatar {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
+  flex-shrink: 0;
+  background: var(--bg-elevated);
+  border: 2px solid var(--border-default);
+}
+
+.agent-persona-avatar--visionary {
+  border-color: var(--arch-visionary);
+  background: rgba(155, 89, 182, 0.18);
+}
+
+.agent-persona-avatar--architect {
+  border-color: var(--arch-architect);
+  background: rgba(52, 152, 219, 0.18);
+}
+
+.agent-persona-avatar--hacker {
+  border-color: var(--arch-hacker);
+  background: rgba(243, 156, 18, 0.18);
+}
+
+.agent-persona-avatar--guardian {
+  border-color: var(--arch-guardian);
+  background: rgba(39, 174, 96, 0.18);
+}
+
+.agent-persona-avatar--scholar {
+  border-color: var(--arch-scholar);
+  background: rgba(26, 188, 156, 0.18);
+}
+
+.agent-persona-avatar--mentor {
+  border-color: var(--arch-mentor);
+  background: rgba(230, 126, 34, 0.18);
+}
+
+.agent-persona-avatar--operator {
+  border-color: var(--arch-operator);
+  background: rgba(149, 165, 166, 0.15);
+}
+
+.agent-persona-avatar--pragmatist {
+  border-color: var(--arch-pragmatist);
+  background: rgba(231, 76, 60, 0.18);
+}
+
+.agent-persona-avatar--default {
+  border-color: var(--border-default);
+  background: var(--bg-elevated);
+}
+
+.agent-hero-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.agent-persona-line {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.2rem 0 0.5rem;
+  flex-wrap: wrap;
+}
+
+.agent-persona-name {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.agent-persona-archetype {
+  font-size: 0.72rem;
+  color: var(--accent-muted);
+  background: rgba(124, 106, 247, 0.12);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+}
+
+.agent-persona-link {
+  font-size: 0.72rem;
+  color: var(--accent-bright);
+  text-decoration: none;
+  margin-left: auto;
+}
+
+.agent-persona-link:hover {
+  text-decoration: underline;
+}
+
+/* ── Cognitive architecture panel (on agent detail page) ─────── */
+.cog-panel {
+  padding: 1rem 1.25rem;
+}
+
+.cog-panel__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.cog-panel__title {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+.cog-panel__sub {
+  font-size: 0.72rem;
+  color: var(--accent-muted);
+  background: rgba(124, 106, 247, 0.12);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+}
+
+.cog-panel__detail-link {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--accent-bright);
+  text-decoration: none;
+}
+
+.cog-panel__detail-link:hover {
+  text-decoration: underline;
+}
+
+.cog-panel__desc {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin: 0 0 0.75rem;
+}
+
+.cog-panel__body {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.cog-panel__section-label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+  margin-bottom: 0.35rem;
+}
+
+.cog-atoms-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.cog-atom-pill {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.7rem;
+}
+
+.cog-atom-pill__key {
+  color: var(--text-muted);
+  font-size: 0.62rem;
+}
+
+.cog-atom-pill__val {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.cog-skills-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+/* ── Cognitive architecture standalone page (/cognitive-arch/*) ─ */
+.cog-hero {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  padding: 1.5rem;
+}
+
+.cog-hero__avatar-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.cog-hero__avatar {
+  width: 6rem;
+  height: 6rem;
+  border-radius: 50%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-elevated);
+  border: 3px solid var(--border-default);
+  position: relative;
+}
+
+.cog-hero__avatar--visionary {
+  border-color: var(--arch-visionary);
+  background: rgba(155, 89, 182, 0.22);
+}
+
+.cog-hero__avatar--architect {
+  border-color: var(--arch-architect);
+  background: rgba(52, 152, 219, 0.22);
+}
+
+.cog-hero__avatar--hacker {
+  border-color: var(--arch-hacker);
+  background: rgba(243, 156, 18, 0.22);
+}
+
+.cog-hero__avatar--guardian {
+  border-color: var(--arch-guardian);
+  background: rgba(39, 174, 96, 0.22);
+}
+
+.cog-hero__avatar--scholar {
+  border-color: var(--arch-scholar);
+  background: rgba(26, 188, 156, 0.22);
+}
+
+.cog-hero__avatar--mentor {
+  border-color: var(--arch-mentor);
+  background: rgba(230, 126, 34, 0.22);
+}
+
+.cog-hero__avatar--operator {
+  border-color: var(--arch-operator);
+  background: rgba(149, 165, 166, 0.2);
+}
+
+.cog-hero__avatar--pragmatist {
+  border-color: var(--arch-pragmatist);
+  background: rgba(231, 76, 60, 0.22);
+}
+
+.cog-hero__avatar--default {
+  border-color: var(--border-strong);
+  background: var(--bg-elevated);
+}
+
+.cog-hero__emoji {
+  font-size: 2.5rem;
+  line-height: 1;
+}
+
+.cog-hero__initials {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  font-weight: 700;
+  margin-top: -0.2rem;
+}
+
+.cog-hero__named-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  background: rgba(124, 106, 247, 0.18);
+  color: var(--accent-bright);
+  border-radius: 4px;
+  padding: 0.15rem 0.5rem;
+}
+
+.cog-hero__named-badge--custom {
+  background: rgba(26, 188, 156, 0.14);
+  color: #4ecdc4;
+}
+
+.cog-hero__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.cog-hero__name-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.4rem;
+}
+
+.cog-hero__name {
+  font-size: 1.7rem;
+  font-weight: 800;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.cog-hero__archetype-chip {
+  font-size: 0.75rem;
+  color: var(--accent-muted);
+  background: rgba(124, 106, 247, 0.12);
+  border-radius: 5px;
+  padding: 0.15rem 0.5rem;
+  white-space: nowrap;
+}
+
+.cog-hero__desc {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0 0 0.75rem;
+  max-width: 60ch;
+}
+
+.cog-hero__raw-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.cog-hero__raw-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.cog-hero__raw-value {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+}
+
+/* Columns for cog-arch standalone page */
+.cog-columns {
+  display: grid;
+  grid-template-columns: 1fr 1.5fr;
+  gap: 1rem;
+}
+
+@media (max-width: 800px) {
+  .cog-columns {
+    grid-template-columns: 1fr;
+  }
+}
+/* Atoms grid on standalone page */
+.cog-atoms-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.5rem;
+  padding: 0.75rem;
+}
+
+.cog-atom {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+}
+
+.cog-atom__label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 0.2rem;
+}
+
+.cog-atom__value {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+/* Prompt panel */
+.cog-prompt__preview {
+  max-height: 8rem;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+  position: relative;
+}
+
+.cog-prompt__preview--expanded {
+  max-height: 60rem;
+}
+
+.cog-prompt__text {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.cog-prompt__toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--accent-bright);
+  font-size: 0.75rem;
+  padding: 0.4rem 0;
+  display: block;
+  margin-top: 0.25rem;
+}
+
+.cog-prompt__toggle:hover {
+  text-decoration: underline;
+}
+
+/* Skills on standalone page */
+.cog-skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  padding: 0.5rem;
+}
+
+/* Footer row on cog-arch page */
+.cog-footer {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+/* ═══ Spawn / Mission Control page ═══════════════════════════════════════ */
+.spawn-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* ── Status bar ─────────────────────────────────────────────── */
+.spawn-status-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  flex-wrap: wrap;
+}
+
+.spawn-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+}
+
+.spawn-status-pill--phase {
+  color: var(--accent);
+  border-color: var(--accent-glow);
+  background: rgba(124, 106, 247, 0.08);
+}
+
+.spawn-status-pill--unclaimed {
+  color: var(--success);
+  border-color: rgba(74, 222, 128, 0.25);
+  background: rgba(74, 222, 128, 0.07);
+}
+
+.spawn-status-pill--claimed {
+  color: var(--warning);
+  border-color: var(--warning-border);
+  background: var(--warning-dim);
+}
+
+.spawn-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+/* ── Mode tabs ──────────────────────────────────────────────── */
+.spawn-tabs {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--bg-elevated);
+  width: fit-content;
+}
+
+.spawn-tab {
+  padding: 0.5rem 1.1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--border-default);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.spawn-tab:last-child {
+  border-right: none;
+}
+
+.spawn-tab:hover {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.spawn-tab--active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.spawn-tab--active:hover {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* ── Mode panels ────────────────────────────────────────────── */
+.spawn-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Single-agent layout: issue board left, role picker right */
+.spawn-single-layout {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 1rem;
+  align-items: start;
+}
+
+@media (max-width: 820px) {
+  .spawn-single-layout {
+    grid-template-columns: 1fr;
+  }
+}
+/* ── Issue board ────────────────────────────────────────────── */
+.spawn-issue-board {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  overflow: hidden;
+}
+
+.spawn-issue-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-void);
+}
+
+.spawn-issue-search {
+  flex: 1;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  font-family: var(--font-sans);
+  padding: 0.35rem 0.6rem;
+  transition: border-color 0.15s;
+}
+
+.spawn-issue-search:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.spawn-issue-search::placeholder {
+  color: var(--text-muted);
+}
+
+.spawn-issue-refresh {
+  padding: 0.35rem 0.6rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  line-height: 1;
+}
+
+.spawn-issue-refresh:hover {
+  color: var(--text-secondary);
+  border-color: var(--border-default);
+}
+
+.spawn-issue-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.spawn-issue-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+  transition: background 0.12s;
+  user-select: none;
+}
+
+.spawn-issue-card:last-child {
+  border-bottom: none;
+}
+
+.spawn-issue-card:hover:not(.spawn-issue-card--claimed) {
+  background: var(--bg-hover);
+}
+
+.spawn-issue-card--selected {
+  background: rgba(124, 106, 247, 0.1);
+  border-left: 3px solid var(--accent);
+}
+
+.spawn-issue-card--claimed {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.spawn-issue-num {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  padding-top: 0.1rem;
+  min-width: 2.8rem;
+}
+
+.spawn-issue-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.spawn-issue-title {
+  font-size: 0.82rem;
+  color: var(--text-primary);
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.spawn-issue-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.2rem;
+}
+
+.spawn-issue-phase {
+  font-size: 0.67rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: rgba(124, 106, 247, 0.1);
+  border: 1px solid rgba(124, 106, 247, 0.2);
+  border-radius: 999px;
+  padding: 0.1rem 0.45rem;
+}
+
+.spawn-issue-wip {
+  font-size: 0.67rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--warning);
+  background: var(--warning-dim);
+  border: 1px solid var(--warning-border);
+  border-radius: 999px;
+  padding: 0.1rem 0.45rem;
+}
+
+.spawn-issue-empty {
+  padding: 1.5rem 1rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+/* ── Role picker ────────────────────────────────────────────── */
+.spawn-role-picker {
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  overflow: hidden;
+}
+
+.spawn-role-section {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.spawn-role-section:last-child {
+  border-bottom: none;
+}
+
+.spawn-role-section-label {
+  font-size: 0.67rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 0.45rem 0.75rem 0.3rem;
+  background: var(--bg-void);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.spawn-role-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+  transition: background 0.12s;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.spawn-role-option:last-child {
+  border-bottom: none;
+}
+
+.spawn-role-option:hover {
+  background: var(--bg-hover);
+}
+
+.spawn-role-option--selected {
+  background: rgba(124, 106, 247, 0.1);
+}
+
+.spawn-role-radio {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  border: 2px solid var(--border-default);
+  flex-shrink: 0;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.spawn-role-option--selected .spawn-role-radio {
+  border-color: var(--accent);
+  background: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+
+.spawn-role-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.spawn-role-name {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.2;
+}
+
+.spawn-role-option--selected .spawn-role-name {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.spawn-role-desc {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  line-height: 1.3;
+  white-space: normal;
+  display: block;
+}
+
+/* ── Wave mode panel ────────────────────────────────────────── */
+.spawn-wave-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.spawn-wave-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  background: rgba(124, 106, 247, 0.06);
+  border: 1px solid rgba(124, 106, 247, 0.15);
+  border-radius: var(--radius);
+}
+
+.spawn-wave-count {
+  font-size: 2rem;
+  font-weight: 800;
+  color: var(--accent);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.spawn-wave-label {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.spawn-wave-label strong {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+/* ── Coordinator mode panel ─────────────────────────────────── */
+.spawn-coordinator-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.spawn-coordinator-desc {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  padding: 0.75rem 1rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+}
+
+.spawn-brain-dump {
+  width: 100%;
+  min-height: 120px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  padding: 0.75rem 1rem;
+  resize: vertical;
+  transition: border-color 0.15s;
+  line-height: 1.55;
+}
+
+.spawn-brain-dump:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.spawn-brain-dump::placeholder {
+  color: var(--text-muted);
+}
+
+/* ── Actions row ────────────────────────────────────────────── */
+.spawn-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.spawn-selection-summary {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.spawn-selection-summary strong {
+  color: var(--text-secondary);
+}
+
+/* ── Result panels ──────────────────────────────────────────── */
+.spawn-result {
+  border-left: 3px solid var(--success);
+}
+
+.spawn-result--wave {
+  border-left: 3px solid var(--accent);
+}
+
+.spawn-result--error {
+  border-left: 3px solid var(--danger, #f87171);
+}
+
+.spawn-result-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.3rem 1rem;
+  font-size: 0.82rem;
+}
+
+.spawn-result-key {
+  color: var(--text-muted);
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.spawn-result-val {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.77rem;
+  word-break: break-all;
+}
+
+.spawn-wave-results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+.spawn-wave-result-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.spawn-wave-result-skip {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+/* ── Shared form utilities ──────────────────────────────────── */
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.form-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.form-select {
+  width: 100%;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  padding: 0.5rem 0.75rem;
+  appearance: none;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.form-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.agent-task-pre {
+  background: var(--bg-void);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 0.875rem 1rem;
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  line-height: 1.65;
+  color: var(--text-secondary);
+  white-space: pre;
+  overflow-x: auto;
+  margin: 0;
+}
+
+/* ── Quick actions ────────────────────────────────────────────── */
+.quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+/* ── Inline success panel (replaces #spawn-form-container) ────── */
+.spawn-success {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  border-left: 3px solid var(--success);
+}
+
+.spawn-success-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.spawn-success-icon {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.spawn-success-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.spawn-success-task {
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.spawn-success-task-toggle {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+
+.spawn-success-task-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.spawn-success-task-toggle::before {
+  content: "▶ ";
+  font-size: 0.65rem;
+}
+
+details[open] .spawn-success-task-toggle::before {
+  content: "▼ ";
+}
+
+/* ═══ Telemetry Dashboard ════════════════════════════════════════════════ */
+/* ── Tab strip ──────────────────────────────────────────────────── */
+.telemetry-tab-strip {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--bg-elevated);
+  width: fit-content;
+}
+
+.telemetry-tab {
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--border-default);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.telemetry-tab:last-child {
+  border-right: none;
+}
+
+.telemetry-tab:hover {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.telemetry-tab--active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.telemetry-tab--active:hover {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* ── 2-column dashboard layout ──────────────────────────────────── */
+.telemetry-layout {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  gap: 1rem;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .telemetry-layout {
+    grid-template-columns: 1fr;
+  }
+}
+/* ── Main chart area (left column) ─────────────────────────────── */
+.telemetry-chart-main {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  height: 380px;
+  position: relative;
+  overflow: hidden;
+}
+
+.telemetry-chart-main svg {
+  display: block;
+}
+
+/* ── Sidebar (right column) ─────────────────────────────────────── */
+.telemetry-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.telemetry-sidebar-chart {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 0.75rem;
+  overflow: hidden;
+}
+
+.telemetry-sidebar-chart svg {
+  display: block;
+}
+
+.telemetry-chart-label {
+  font-size: 0.67rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+}
+
+/* ── Empty / loading states ─────────────────────────────────────── */
+.telemetry-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+/* ── D3 shared styles ───────────────────────────────────────────── */
+.d3-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: var(--bg-void);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 0.45rem 0.65rem;
+  font-size: 0.75rem;
+  color: var(--text-primary);
+  line-height: 1.45;
+  white-space: nowrap;
+  z-index: 100;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.d3-tooltip.visible {
+  opacity: 1;
+}
+
+.d3-tooltip-key {
+  color: var(--text-muted);
+  margin-right: 0.3rem;
+}
+
+/* SVG axis + grid lines pick up theme colors automatically */
+.d3-axis text {
+  fill: var(--text-muted);
+  font-size: 0.7rem;
+  font-family: var(--font-sans);
+}
+
+.d3-axis path,
+.d3-axis line {
+  stroke: var(--border-subtle);
+}
+
+.d3-grid line {
+  stroke: var(--border-subtle);
+  stroke-dasharray: 3 3;
+  opacity: 0.6;
+}
+
+.d3-crosshair {
+  stroke: var(--text-muted);
+  stroke-dasharray: 4 3;
+  stroke-width: 1;
+  pointer-events: none;
+}
+
+/* ── Telemetry wave history table ───────────────────────────────── */
+.telemetry-table-wrap {
+  overflow-x: auto;
+}
+
+.telemetry-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.telemetry-th {
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 0.5rem 0.875rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border-subtle);
+  white-space: nowrap;
+}
+
+.telemetry-td {
+  padding: 0.5rem 0.875rem;
+  vertical-align: middle;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.telemetry-row:last-child .telemetry-td {
+  border-bottom: none;
+}
+
+.telemetry-td--batch {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.telemetry-batch-id {
+  font-size: 0.6875rem;
+  font-family: var(--font-mono);
+  color: var(--accent-bright);
+}
+
+.telemetry-expand-btn {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  white-space: nowrap;
+}
+
+.telemetry-agents-row {
+  background: var(--bg-elevated);
+}
+
+.telemetry-agents-cell {
+  padding: 0.625rem 0.875rem 0.625rem 2rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.telemetry-agents-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.telemetry-agent-item {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.telemetry-agent-role {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+/* ── Wave table controls (sort headers, date filter, CSV export) ─── */
+.telemetry-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.625rem;
+  flex-wrap: wrap;
+}
+
+.telemetry-controls__filters {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.telemetry-filter-label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.telemetry-date-input {
+  padding: 0.2rem 0.45rem;
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.telemetry-date-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.telemetry-clear-btn {
+  font-size: 0.72rem;
+  padding: 0.2rem 0.5rem;
+}
+
+.telemetry-export-btn {
+  font-size: 0.72rem;
+  padding: 0.25rem 0.65rem;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.telemetry-th--sortable {
+  cursor: pointer;
+  user-select: none;
+}
+.telemetry-th--sortable:hover {
+  color: var(--text-secondary);
+  background: var(--bg-hover);
+}
+
+.telemetry-sort-icon {
+  font-size: 0.65rem;
+  opacity: 0.6;
+  margin-left: 0.15rem;
+}
+
+/* ── Trend refresh button ───────────────────────────────────────── */
+.telemetry-refresh {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.telemetry-refresh:hover {
+  color: var(--text-secondary);
+  border-color: var(--border-default);
+}
+
+/* ── Run history table ────────────────────────────────────────── */
+.run-history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.run-history-table th {
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-subtle);
+  font-weight: 700;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.run-history-table td {
+  padding: 0.45rem 0.6rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  color: var(--text-secondary);
+  vertical-align: top;
+}
+
+.run-history-table tr:hover td {
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.run-status-badge {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: var(--radius-full);
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.run-status-badge--running {
+  background: var(--success-dim);
+  color: var(--success);
+  border: 1px solid var(--success-border);
+}
+
+.run-status-badge--done {
+  background: rgba(139, 92, 246, 0.12);
+  color: var(--accent-bright);
+  border: 1px solid rgba(139, 92, 246, 0.25);
+}
+
+.run-status-badge--failed {
+  background: var(--danger-dim);
+  color: var(--danger);
+  border: 1px solid var(--danger-border);
+}
+
+.run-status-badge--spawned {
+  background: var(--warning-dim);
+  color: var(--warning);
+  border: 1px solid var(--warning-border);
+}
+
+.run-status-badge--unknown {
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+}
+
+/* ── Board loading spinner ────────────────────────────────────── */
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.board-spinner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 2.5rem 1rem;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}
+
+.board-spinner__ring {
+  width: 2rem;
+  height: 2rem;
+  border: 2px solid var(--border-default);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.65s linear infinite;
+}
+
+/* ── Issues list page ─────────────────────────────────────────── */
+.issues-list,
+.prs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.issue-row,
+.pr-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  transition: border-color 0.15s, background 0.15s;
+  text-decoration: none;
+}
+
+.issue-row:hover,
+.pr-row:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-elevated);
+  text-decoration: none;
+}
+
+.issue-row-number,
+.pr-row-number {
+  font-weight: 700;
+  color: var(--accent-bright);
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+  min-width: 3rem;
+}
+
+.issue-row-title,
+.pr-row-title {
+  flex: 1;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.issue-row-state,
+.pr-row-state {
+  flex-shrink: 0;
+}
+
+.issue-row-date,
+.pr-row-date {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Agent Sandboxes page (worktrees) ─────────────────────────── */
+/* Page header */
+.env-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 2rem;
+  gap: 1rem;
+}
+
+.env-page-title {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.375rem;
+}
+
+.env-page-subtitle {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin: 0;
+  max-width: 58ch;
+}
+
+.env-page-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  flex-shrink: 0;
+}
+
+.env-page-count {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--accent);
+  line-height: 1;
+}
+
+.env-page-count-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+/*
+  Tree container.
+
+  Layout: the vertical trunk line is a ::before pseudo-element on .env-tree.
+  It runs from below the trunk node dot to the bottom of the last branch.
+  Each .env-branch draws an L-shaped connector to that trunk via its own
+  ::before (horizontal) and the trunk line (vertical, shared).
+*/
+.env-tree {
+  position: relative;
+  padding-left: 1.5rem; /* room for trunk line + connector arms */
+}
+
+/* Vertical trunk line */
+.env-tree::before {
+  content: "";
+  position: absolute;
+  left: 0.5rem; /* centre of the trunk dot */
+  top: 1.5rem; /* start below the trunk dot */
+  bottom: 1.75rem; /* stop above the last branch connector */
+  width: 2px;
+  background: linear-gradient(to bottom, var(--accent) 0%, rgba(124, 58, 237, 0.3) 70%, transparent 100%);
+  border-radius: 1px;
+}
+
+/* ── Trunk node (base environment) ───────────────────────────── */
+.env-trunk-node {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+  position: relative;
+  z-index: 1;
+}
+
+.env-trunk-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 3px solid var(--bg-base);
+  box-shadow: 0 0 0 2px var(--accent);
+  flex-shrink: 0;
+  margin-left: -0.125rem; /* nudge to centre on trunk line */
+}
+
+.env-trunk-info {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  flex-wrap: wrap;
+}
+
+.env-trunk-branch {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.env-trunk-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: 0.15em 0.5em;
+}
+
+.env-trunk-sha {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.env-trunk-commit {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 40ch;
+}
+
+/* ── Branch item ──────────────────────────────────────────────── */
+.env-branch {
+  position: relative;
+  margin-bottom: 0.875rem;
+  transition: opacity 0.25s, transform 0.25s;
+}
+
+/* Horizontal arm from trunk to branch origin dot */
+.env-branch::before {
+  content: "";
+  position: absolute;
+  left: -1rem; /* from trunk line */
+  top: 1.125rem; /* align with branch origin dot */
+  width: 1rem;
+  height: 2px;
+  background: rgba(124, 58, 237, 0.5);
+}
+
+/* Last branch: visually terminate trunk line here */
+.env-branch--last::after {
+  content: "";
+  position: absolute;
+  left: -1.0625rem;
+  top: 1.0625rem;
+  width: 8px;
+  height: 8px;
+  border-left: 2px solid rgba(124, 58, 237, 0.5);
+  border-bottom: 2px solid rgba(124, 58, 237, 0.5);
+  border-radius: 0 0 0 3px;
+}
+
+/* Branch origin dot — sits at the junction of trunk arm and branch content */
+.env-branch-origin-dot {
+  position: absolute;
+  left: -1.3125rem;
+  top: 0.8125rem;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--bg-base);
+  border: 2px solid var(--accent);
+  z-index: 1;
+}
+
+.env-branch--open .env-branch-origin-dot {
+  background: var(--accent);
+}
+
+/* The clickable head row */
+.env-branch-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.env-branch-head:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover, var(--bg-surface));
+}
+
+.env-branch--open .env-branch-head {
+  border-color: var(--accent);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  background: rgba(124, 58, 237, 0.04);
+}
+
+/* Right side of branch head — name + actions */
+.env-branch-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.env-branch-top {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+/* Badges */
+.env-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.2em 0.55em;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.env-badge--issue {
+  background: rgba(124, 58, 237, 0.15);
+  color: var(--accent);
+}
+
+.env-badge--custom {
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+}
+
+.env-lock {
+  font-size: 0.7rem;
+  opacity: 0.55;
+  flex-shrink: 0;
+}
+
+.env-branch-name {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+/* Actions cluster — pushed to right */
+.env-branch-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.env-age {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.env-gh-link {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+  padding: 0.15em 0.5em;
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 4px;
+  transition: background 0.12s;
+  flex-shrink: 0;
+}
+
+.env-gh-link:hover {
+  background: rgba(124, 58, 237, 0.12);
+}
+
+.env-delete {
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.env-branch-head:hover .env-delete {
+  opacity: 1;
+}
+
+.env-chevron {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  transition: transform 0.2s;
+  display: inline-block;
+}
+
+.env-chevron--open {
+  transform: rotate(180deg);
+}
+
+/* HEAD commit preview row */
+.env-branch-commit-preview {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.375rem;
+  font-size: 0.775rem;
+  color: var(--text-muted);
+}
+
+.env-sha {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.7rem;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.env-commit-msg {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Expandable body ──────────────────────────────────────────── */
+.env-branch-body {
+  background: var(--bg-base);
+  border: 1px solid var(--accent);
+  border-top: none;
+  border-bottom-left-radius: var(--radius);
+  border-bottom-right-radius: var(--radius);
+  overflow: hidden;
+}
+
+.env-detail {
+  padding: 1.25rem 1.5rem;
+}
+
+.env-detail-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  padding: 0.5rem 0;
+}
+
+@keyframes env-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.env-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--border-subtle);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: env-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+/* ── Commit chain (within expanded detail) ────────────────────── */
+.env-commit-section,
+.env-diff-section,
+.env-task-section {
+  margin-bottom: 1.5rem;
+}
+
+.env-commit-section:last-child,
+.env-diff-section:last-child,
+.env-task-section:last-child {
+  margin-bottom: 0;
+}
+
+.env-detail-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 0 0 0.75rem;
+}
+
+.env-detail-meta {
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 0.75rem;
+}
+
+.env-detail-empty {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  font-style: italic;
+  margin: 0;
+}
+
+/* Vertical dot chain of commits */
+.env-commit-chain {
+  display: flex;
+  flex-direction: column;
+}
+
+.env-commit-node {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+/* Spine: dot + connecting line below it */
+.env-commit-spine {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  width: 14px;
+}
+
+.env-commit-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--bg-base);
+  border: 2px solid rgba(124, 58, 237, 0.5);
+  flex-shrink: 0;
+  margin-top: 0.2rem;
+}
+
+.env-commit-dot--head {
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.2);
+}
+
+/* Vertical connector between dots */
+.env-commit-line {
+  width: 2px;
+  flex: 1;
+  min-height: 1.25rem;
+  background: rgba(124, 58, 237, 0.25);
+  margin: 0.15rem 0;
+}
+
+/* Commit label */
+.env-commit-body {
+  display: flex;
+  align-items: baseline;
+  gap: 0.625rem;
+  padding: 0.05rem 0 0.875rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.env-commit-sha {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.7rem;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.env-head-tag {
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  background: rgba(124, 58, 237, 0.12);
+  border: 1px solid rgba(124, 58, 237, 0.3);
+  border-radius: 3px;
+  padding: 0.1em 0.4em;
+  flex-shrink: 0;
+}
+
+/* Diff stat + task file */
+.env-diff-stat,
+.env-task-file {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.78rem;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+  margin: 0;
+  white-space: pre;
+}
+
+.env-task-file {
+  max-height: 280px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Empty state */
+.env-empty {
+  padding: 2.5rem 1.5rem;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  text-align: center;
+}
+
+.env-empty p {
+  margin: 0.25rem 0;
+}
+
+.env-empty a {
+  color: var(--accent);
+}
+
+/* ── Docs page ────────────────────────────────────────────────── */
+/* Two-column layout: fixed sidebar + fluid content */
+.docs-layout {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 1.5rem;
+  margin-top: 1rem;
+  align-items: start;
+}
+
+/* Sidebar */
+.docs-sidebar {
+  position: sticky;
+  top: 1rem;
+  padding: 0.875rem;
+}
+
+.docs-sidebar-heading {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 0 0 0.625rem;
+}
+
+.docs-sidebar-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.docs-sidebar-link {
+  display: block;
+  padding: 0.3rem 0.625rem;
+  border-radius: 5px;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: background 0.12s, color 0.12s;
+}
+
+.docs-sidebar-link:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.docs-sidebar-link--active {
+  background: rgba(124, 58, 237, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+/* Content panel (the .card) */
+.docs-content {
+  padding: 1.5rem 2rem;
+  min-width: 0; /* prevent grid blowout — critical for CSS grid */
+}
+
+/* Header row inside the content panel */
+.docs-content-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.875rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.docs-content-title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.docs-content-slug {
+  font-size: 0.75rem;
+  font-family: var(--font-mono, monospace);
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.docs-error {
+  color: var(--danger);
+  font-size: 0.875rem;
+}
+
+.docs-empty {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  font-style: italic;
+}
+
+/* ── Docs prose: full Markdown rendering ──────────────────────── */
+.docs-prose {
+  font-size: 0.9rem;
+  line-height: 1.8;
+  color: var(--text-secondary);
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+/* Headings */
+.docs-prose h1,
+.docs-prose h2,
+.docs-prose h3,
+.docs-prose h4 {
+  color: var(--text-primary);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 2rem 0 0.625rem;
+  line-height: 1.3;
+}
+
+.docs-prose h1 {
+  font-size: 1.5rem;
+  margin-top: 0;
+}
+
+.docs-prose h2 {
+  font-size: 1.175rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.docs-prose h3 {
+  font-size: 1rem;
+}
+
+.docs-prose h4 {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+/* Paragraphs & horizontal rules */
+.docs-prose p {
+  margin: 0.875rem 0;
+}
+
+.docs-prose hr {
+  border: none;
+  border-top: 1px solid var(--border-subtle);
+  margin: 2rem 0;
+}
+
+/* Lists */
+.docs-prose ul,
+.docs-prose ol {
+  padding-left: 1.75rem;
+  margin: 0.75rem 0;
+}
+
+.docs-prose li {
+  margin: 0.375rem 0;
+}
+
+.docs-prose li > p {
+  margin: 0;
+} /* tight list items — no extra spacing */
+.docs-prose ul ul,
+.docs-prose ol ol {
+  margin: 0.25rem 0;
+}
+
+/* Inline code */
+.docs-prose code {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.825em;
+  background: rgba(124, 58, 237, 0.08);
+  color: var(--accent);
+  border: 1px solid rgba(124, 58, 237, 0.18);
+  border-radius: 4px;
+  padding: 0.1em 0.4em;
+}
+
+/* Fenced code blocks */
+.docs-prose pre {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  margin: 1.25rem 0;
+  font-size: 0.8125rem;
+  line-height: 1.65;
+}
+
+.docs-prose pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--text-primary);
+  font-size: inherit;
+}
+
+/* Blockquotes */
+.docs-prose blockquote {
+  border-left: 3px solid var(--accent);
+  padding: 0.5rem 1rem;
+  margin: 1.25rem 0;
+  color: var(--text-muted);
+  font-style: italic;
+  background: rgba(124, 58, 237, 0.04);
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.docs-prose blockquote p {
+  margin: 0;
+}
+
+/* Tables */
+.docs-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  margin: 1.25rem 0;
+}
+
+.docs-prose th,
+.docs-prose td {
+  padding: 0.5rem 0.875rem;
+  border: 1px solid var(--border-subtle);
+  text-align: left;
+}
+
+.docs-prose th {
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.docs-prose td {
+  color: var(--text-secondary);
+}
+
+.docs-prose tr:nth-child(even) td {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+/* Strong & em */
+.docs-prose strong {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.docs-prose em {
+  color: var(--text-secondary);
+}
+
+/* Links */
+.docs-prose a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.docs-prose a:hover {
+  color: var(--accent-hover, var(--accent));
+  opacity: 0.85;
+}
+
+/* ── Transcripts page ─────────────────────────────────────────── */
+.transcript-row {
+  cursor: pointer;
+}
+.transcript-row td {
+  transition: background 0.1s;
+}
+.transcript-row:hover td {
+  background: var(--bg-elevated);
+}
+
+.transcript-uuid {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.transcript-meta {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+/* ── Scrollbar ────────────────────────────────────────────────── */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg-void);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border-default);
+  border-radius: var(--radius-full);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--border-strong);
+}
+
+/* ── Media queries ────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  nav.topnav {
+    gap: 0.125rem;
+    padding: 0 1rem;
+  }
+  main {
+    padding: 1rem;
+  }
+  .pipeline-summary-bar {
+    gap: 0.75rem 1.25rem;
+  }
+  .summary-value {
+    font-size: 1.25rem;
+  }
+  .agent-detail-columns {
+    grid-template-columns: 1fr;
+  }
+}
+/* ── Telemetry table element selectors (non-BEM rows inherit styles) ─── */
+.telemetry-table tbody tr {
+  transition: background 0.12s;
+}
+
+.telemetry-table tbody tr:hover {
+  background: rgba(139, 92, 246, 0.04);
+}
+
+.telemetry-table td a {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.telemetry-table td a:first-child {
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+}
+
+/* ── Page header row (title + filter buttons) ─────────────────── */
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+  gap: 1rem;
+}
+
+.page-title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+.page-subtitle {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin: 0.2rem 0 0;
+}
+
+.page-subtitle a {
+  color: var(--accent-bright);
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* ── Filter bar ───────────────────────────────────────────────── */
+.filter-bar {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.filter-input {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  border-radius: 6px;
+  padding: 0.4rem 0.65rem;
+  font-size: 0.83rem;
+  outline: none;
+  transition: border-color 0.15s;
+  min-width: 130px;
+}
+.filter-input:focus {
+  border-color: var(--accent);
+}
+.filter-input option {
+  background: var(--bg-elevated);
+}
+.filter-input--wide {
+  min-width: 160px;
+}
+.filter-input--search {
+  width: 100%;
+  padding-left: 2rem;
+  flex: 1;
+  min-width: 200px;
+}
+
+.search-wrapper {
+  position: relative;
+  flex: 1;
+  min-width: 200px;
+}
+
+.search-icon {
+  position: absolute;
+  left: 0.6rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.filter-clear {
+  white-space: nowrap;
+}
+
+/* ── Alert card ───────────────────────────────────────────────── */
+.alert-card--danger {
+  border-left: 3px solid var(--danger);
+  margin-bottom: 1rem;
+}
+
+.alert-text--danger {
+  color: var(--danger-dim);
+}
+
+.btn--top {
+  margin-top: 0.75rem;
+}
+
+/* ── Transcript list table ────────────────────────────────────── */
+.table-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.transcript-table {
+  width: 100%;
+  margin: 0;
+  table-layout: fixed;
+}
+.transcript-table col:nth-child(1) {
+  width: 7rem;
+}
+.transcript-table col:nth-child(2) {
+  width: 10rem;
+}
+.transcript-table col:nth-child(3) {
+  width: 7rem;
+}
+.transcript-table col:nth-child(5) {
+  width: 5rem;
+}
+.transcript-table col:nth-child(6) {
+  width: 5.5rem;
+}
+.transcript-table col:nth-child(7) {
+  width: 7rem;
+}
+.transcript-table col:nth-child(8) {
+  width: 6.5rem;
+}
+
+.text-right {
+  text-align: right;
+}
+
+.text-faint {
+  color: var(--text-faint);
+}
+
+.mono-badge {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: 0.15rem 0.35rem;
+}
+
+.badge--sm {
+  font-size: 0.65rem;
+}
+
+.badge--xs {
+  font-size: 0.68rem;
+}
+
+.badge--coord {
+  margin-left: 0.25rem;
+}
+
+.issue-link {
+  color: var(--accent-bright);
+  font-size: 0.75rem;
+  text-decoration: none;
+}
+.issue-link:hover {
+  text-decoration: underline;
+}
+
+.dir-badge {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* ── Transcript table cell variants ──────────────────────────── */
+.transcript-preview-cell {
+  max-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.82rem;
+  color: var(--text-primary);
+}
+
+.transcript-count-cell {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.82rem;
+}
+
+.transcript-subagent-cell {
+  text-align: right;
+}
+
+.transcript-issues-cell {
+  font-size: 0.78rem;
+}
+
+.transcript-date-cell {
+  text-align: right;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* ── Extra badge colour variants ──────────────────────────────── */
+.badge--teal {
+  background: rgba(20, 184, 166, 0.15);
+  color: #5eead4;
+  border-color: rgba(20, 184, 166, 0.3);
+}
+
+.badge--pink {
+  background: rgba(236, 72, 153, 0.15);
+  color: #f9a8d4;
+  border-color: rgba(236, 72, 153, 0.3);
+}
+
+.badge--yellow {
+  background: rgba(234, 179, 8, 0.15);
+  color: #fde047;
+  border-color: rgba(234, 179, 8, 0.3);
+}
+
+.badge--orange {
+  background: rgba(249, 115, 22, 0.15);
+  color: #fdba74;
+  border-color: rgba(249, 115, 22, 0.3);
+}
+
+/* ── Detail page layout ───────────────────────────────────────── */
+.detail-layout {
+  display: grid;
+  grid-template-columns: 1fr 260px;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .detail-layout {
+    grid-template-columns: 1fr;
+  }
+  .detail-sidebar {
+    order: -1;
+  }
+}
+/* ── Detail page header ───────────────────────────────────────── */
+.detail-header-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.detail-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.4rem;
+}
+
+.detail-back-link {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  text-decoration: none;
+}
+.detail-back-link:hover {
+  color: var(--text-primary);
+}
+
+.page-title--mono {
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  letter-spacing: 0;
+}
+
+/* ── Stats strip ──────────────────────────────────────────────── */
+.stats-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.stat-chip {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 80px;
+}
+.stat-chip__value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+  line-height: 1;
+}
+.stat-chip__label {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 0.2rem;
+}
+
+/* ── Truncated notice ─────────────────────────────────────────── */
+.truncated-notice {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+.truncated-notice a {
+  color: var(--accent-bright);
+}
+
+/* ── Thread search ────────────────────────────────────────────── */
+.thread-search {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.thread-search__field {
+  position: relative;
+  flex: 1;
+}
+.thread-search__icon {
+  position: absolute;
+  left: 0.6rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted);
+  pointer-events: none;
+  font-size: 0.85rem;
+}
+.thread-search__input {
+  width: 100%;
+  padding: 0.4rem 0.65rem 0.4rem 2rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  outline: none;
+}
+.thread-search__input:focus {
+  border-color: var(--accent);
+}
+
+/* ── Chat thread ──────────────────────────────────────────────── */
+.chat-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chat-msg {
+  border-radius: 10px;
+  padding: 0.85rem 1rem;
+  max-width: 100%;
+}
+.chat-msg--user {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  margin-right: 2rem;
+}
+.chat-msg--assistant {
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.08) 0%, rgba(99, 102, 241, 0.06) 100%);
+  border: 1px solid rgba(139, 92, 246, 0.2);
+  margin-left: 2rem;
+}
+.chat-msg__header {
+  margin-bottom: 0.4rem;
+}
+.chat-msg__role {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+.chat-msg__role--user {
+  color: var(--text-muted);
+}
+.chat-msg__role--assistant {
+  color: var(--accent-bright);
+}
+.chat-msg__text {
+  margin: 0;
+  font-family: var(--font-sans, inherit);
+  font-size: 0.83rem;
+  line-height: 1.6;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 400px;
+  overflow-y: auto;
+}
+.chat-msg__text.collapsed {
+  max-height: 160px;
+  overflow: hidden;
+}
+
+mark.hl {
+  background: rgba(251, 191, 36, 0.35);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 2px;
+}
+
+/* ── Sidebar ──────────────────────────────────────────────────── */
+.detail-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.sidebar-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.sidebar-card__title {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 0.65rem 0.85rem;
+  border-bottom: 1px solid var(--border-subtle);
+  margin: 0;
+}
+.sidebar-card__body {
+  padding: 0.75rem 0.85rem;
+  display: flex;
+  flex-direction: column;
+}
+.sidebar-card__body--subagents {
+  gap: 0.5rem;
+}
+
+.sidebar-issue-link {
+  display: inline-block;
+  color: var(--accent-bright);
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-decoration: none;
+  margin-right: 0.4rem;
+  margin-bottom: 0.25rem;
+}
+.sidebar-issue-link:hover {
+  text-decoration: underline;
+}
+
+.sidebar-pr-link {
+  display: block;
+  color: var(--success);
+  font-size: 0.8rem;
+  text-decoration: none;
+  margin-bottom: 0.25rem;
+  word-break: break-all;
+}
+.sidebar-pr-link:hover {
+  text-decoration: underline;
+}
+
+.subagent-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+}
+.subagent-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.35rem;
+}
+.subagent-card__uuid {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  margin: 0 0 0.25rem;
+}
+.subagent-card__preview {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  margin: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.subagent-card__count {
+  font-size: 0.7rem;
+  color: var(--text-faint);
+  margin: 0.3rem 0 0;
+}
+
+/* ── Metadata dl ──────────────────────────────────────────────── */
+.meta-dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.3rem 0.75rem;
+  font-size: 0.78rem;
+}
+.meta-dl dt {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.meta-dl dd {
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.meta-dd--mono {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  word-break: break-all;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   Brain Dump page
+   ═══════════════════════════════════════════════════════════════════════════ */
+/* Two-column grid: form (left) + sidebar (right) */
+.bd-page {
+  display: grid;
+  grid-template-columns: 1fr 296px;
+  gap: 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5rem 1.25rem 3rem;
+  align-items: start;
+}
+
+/* ── Left column ─────────────────────────────────────────────────────────── */
+.bd-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
+}
+
+/* ── Step indicator ─────────────────────────────────────────────────────── */
+/* The stepper sits at the top of .bd-main, above all step panels. */
+.bd-stepper {
+  margin-bottom: 0.25rem;
+}
+
+.bd-stepper-list {
+  display: flex;
+  align-items: flex-start; /* bubble + label align to top; connector offset by margin */
+  gap: 0;
+}
+
+.bd-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+  flex-shrink: 0;
+}
+
+.bd-step-bubble {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-full);
+  border: 2px solid var(--border-default);
+  background: var(--bg-surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  transition: background 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s;
+  flex-shrink: 0;
+}
+
+.bd-step-check,
+.bd-step-num {
+  line-height: 1;
+}
+
+.bd-step-label {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  white-space: nowrap;
+  transition: color 0.2s, font-weight 0.2s, opacity 0.2s;
+}
+
+/* ── Active step ── */
+.bd-step--active .bd-step-bubble {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--text-primary);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.bd-step--active .bd-step-label {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+/* ── Completed step ── */
+.bd-step--done .bd-step-bubble {
+  background: var(--success-dim);
+  border-color: var(--success-border);
+  color: var(--success);
+}
+
+.bd-step--done .bd-step-label {
+  color: var(--text-muted);
+  opacity: 0.65;
+}
+
+/* ── Future step ── */
+.bd-step--future .bd-step-bubble {
+  opacity: 0.3;
+}
+
+.bd-step--future .bd-step-label {
+  opacity: 0.3;
+}
+
+/* ── Connector line between steps ── */
+.bd-step-conn {
+  flex: 1;
+  height: 1.5px;
+  /* Visually centre the line with the 28px bubble (14px = half the height) */
+  margin-top: 13px;
+  background: var(--border-default);
+  border-radius: 1px;
+  transition: background 0.3s;
+}
+
+.bd-step-conn--lit {
+  background: var(--accent);
+  opacity: 0.5;
+}
+
+.bd-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.2rem;
+}
+
+.bd-sub {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* Textarea wrapper */
+.bd-textarea-wrap {
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--bg);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.bd-textarea-wrap--focused {
+  border-color: var(--accent, #6366f1);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+}
+
+.bd-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 0.82rem;
+  line-height: 1.7;
+  padding: 0.9rem 1rem 0.5rem;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text);
+  resize: none;
+  display: block;
+  min-height: max(480px, 100vh - 260px);
+}
+
+.bd-textarea:disabled {
+  opacity: 0.5;
+}
+
+.bd-textarea-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem 0.55rem;
+  border-top: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.bd-toolbar-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  padding: 0.18rem 0.48rem;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+  white-space: nowrap;
+}
+
+.bd-toolbar-btn:hover:not(:disabled) {
+  background: var(--border);
+  color: var(--text);
+}
+
+.bd-toolbar-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.bd-char-count {
+  margin-left: auto;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  opacity: 0.55;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* Seeds */
+.bd-seeds {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.bd-seeds-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-right: 0.15rem;
+  flex-shrink: 0;
+}
+
+.bd-seed-chip {
+  font-size: 0.73rem;
+  padding: 0.22rem 0.58rem;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+  white-space: nowrap;
+}
+
+.bd-seed-chip:hover:not(:disabled) {
+  background: rgba(99, 102, 241, 0.1);
+  color: var(--accent, #6366f1);
+  border-color: var(--accent, #6366f1);
+}
+
+.bd-seed-chip:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+/* Options */
+.bd-options-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.bd-options-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  width: fit-content;
+  transition: color 0.12s;
+}
+
+.bd-options-btn:hover {
+  color: var(--text);
+}
+
+.bd-options-badge {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.08rem 0.38rem;
+  border-radius: 10px;
+  background: rgba(99, 102, 241, 0.15);
+  color: var(--accent, #6366f1);
+}
+
+.bd-options-fields {
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.bd-prefix-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.bd-label-sm {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.03em;
+}
+
+.bd-optional {
+  font-weight: 400;
+  opacity: 0.65;
+}
+
+.bd-input {
+  padding: 0.38rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.85rem;
+  max-width: 220px;
+  transition: border-color 0.12s;
+}
+
+.bd-input:focus {
+  outline: none;
+  border-color: var(--accent, #6366f1);
+}
+
+.bd-hint {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
+/* Submit */
+.bd-submit-row {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.bd-submit-btn {
+  font-size: 0.9rem;
+  padding: 0.65rem 1.4rem;
+}
+
+.bd-kbd {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.18rem 0.42rem;
+  font-family: var(--font-mono, monospace);
+}
+
+/* Error */
+.bd-error {
+  padding: 0.55rem 0.8rem;
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 8px;
+  color: #ef4444;
+  font-size: 0.83rem;
+}
+
+/* Loading */
+.bd-loading-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  min-height: 320px;
+  text-align: center;
+}
+
+.bd-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent, #6366f1);
+  border-radius: 50%;
+  animation: bdSpin 0.75s linear infinite;
+}
+
+@keyframes bdSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.bd-loading-text {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin: 0;
+  min-height: 1.4em;
+}
+
+/* Done */
+.bd-done-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.1rem;
+  padding: 1rem 0;
+}
+
+.bd-done-badge {
+  font-size: 2.5rem;
+  line-height: 1;
+}
+
+.bd-done-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.bd-done-sub {
+  color: var(--text-muted);
+  font-size: 0.88rem;
+  line-height: 1.55;
+  margin: 0;
+  max-width: 480px;
+}
+
+.bd-done-actions {
+  display: flex;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+}
+
+.bd-task-details {
+  width: 100%;
+}
+
+.bd-task-summary {
+  cursor: pointer;
+  font-size: 0.77rem;
+  color: var(--text-muted);
+  user-select: none;
+  padding: 0.2rem 0;
+  transition: color 0.12s;
+}
+
+.bd-task-summary:hover {
+  color: var(--text);
+}
+
+.bd-task-pre {
+  margin: 0.5rem 0 0;
+  padding: 0.7rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 0.7rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.bd-restart-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  cursor: pointer;
+  padding: 0;
+  margin-top: 0.25rem;
+  transition: color 0.12s;
+}
+
+.bd-restart-btn:hover {
+  color: var(--text);
+}
+
+/* ── Phase Preview (confirming step) ────────────────────────────────────── */
+.bd-preview-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 0.5rem 0;
+}
+
+.bd-preview-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.bd-preview-sub {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  line-height: 1.55;
+  margin: 0;
+  max-width: 520px;
+}
+
+.bd-phase-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.bd-phase-card {
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 0.85rem 1.1rem;
+  background: rgba(255, 255, 255, 0.02);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  transition: border-color 0.15s;
+}
+
+.bd-phase-card:hover {
+  border-color: var(--border-strong);
+}
+
+.bd-phase-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.bd-phase-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent, #6366f1);
+  background: rgba(99, 102, 241, 0.12);
+  padding: 0.15rem 0.5rem;
+  border-radius: 6px;
+}
+
+.bd-phase-issue-count {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.bd-phase-description {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+  line-height: 1.35;
+}
+
+.bd-phase-deps {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.15rem;
+}
+
+.bd-phase-deps-label {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
+.bd-phase-dep-chip {
+  font-size: 0.67rem;
+  font-weight: 600;
+  padding: 0.08rem 0.4rem;
+  border-radius: 8px;
+  background: rgba(16, 217, 160, 0.08);
+  border: 1px solid rgba(16, 217, 160, 0.25);
+  color: var(--success, #10d9a0);
+}
+
+.bd-preview-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding-top: 0.25rem;
+}
+
+.bd-back-btn {
+  font-size: 0.87rem;
+}
+
+.bd-confirm-btn {
+  font-size: 0.87rem;
+}
+
+/* ── Right sidebar ───────────────────────────────────────────────────────── */
+.bd-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.bd-funnel-heading {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0;
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+/* Vertical funnel */
+.bd-funnel {
+  padding: 0.75rem 1rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.bd-funnel-stage {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.45rem 0.5rem;
+  border-radius: 8px;
+  opacity: 0.3;
+  transition: opacity 0.3s, background 0.3s;
+}
+
+.bd-funnel-stage--active {
+  opacity: 1;
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.bd-funnel-stage--done {
+  opacity: 0.85;
+  background: rgba(99, 102, 241, 0.04);
+}
+
+.bd-funnel-stage--pulse .bd-funnel-icon {
+  animation: bdPulse 0.65s ease-in-out infinite alternate;
+}
+
+@keyframes bdPulse {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(1.3);
+  }
+}
+.bd-funnel-icon {
+  font-size: 1.15rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.bd-funnel-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.05rem;
+  min-width: 0;
+}
+
+.bd-funnel-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.2;
+}
+
+.bd-funnel-stage--active .bd-funnel-label {
+  color: var(--accent, #6366f1);
+}
+
+.bd-funnel-desc {
+  font-size: 0.67rem;
+  color: var(--text-muted);
+  opacity: 0.7;
+  line-height: 1.2;
+}
+
+.bd-funnel-connector {
+  width: 2px;
+  height: 14px;
+  background: var(--border);
+  margin-left: 1.05rem;
+  border-radius: 1px;
+  transition: background 0.3s;
+}
+
+.bd-funnel-connector--lit {
+  background: var(--accent, #6366f1);
+  opacity: 0.5;
+}
+
+/* Recent runs in sidebar */
+.bd-history {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.bd-history-card {
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+  transition: background 0.12s;
+}
+
+.bd-history-card:last-child {
+  border-bottom: none;
+}
+
+.bd-history-card:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.bd-history-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.bd-history-ts {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  opacity: 0.7;
+}
+
+.bd-history-prefix {
+  font-size: 0.62rem;
+  font-weight: 600;
+  padding: 0.08rem 0.35rem;
+  border-radius: 8px;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--accent, #6366f1);
+}
+
+.bd-history-preview {
+  font-size: 0.75rem;
+  color: var(--text);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0.75;
+}
+
+.bd-history-links {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.bd-history-link {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color 0.12s;
+  opacity: 0.65;
+}
+
+.bd-history-link:hover {
+  color: var(--accent, #6366f1);
+  opacity: 1;
+}
+
+/* ── Nav CTA highlight ───────────────────────────────────────────────────── */
+.topnav .nav-cta {
+  font-weight: 600;
+  color: var(--accent, #6366f1) !important;
+}
+
+.topnav .nav-cta:hover,
+.topnav .nav-cta.active {
+  background: rgba(99, 102, 241, 0.1) !important;
+}
+
+/* Responsive: stack at narrow viewports */
+@media (max-width: 680px) {
+  .bd-page {
+    grid-template-columns: 1fr;
+  }
+  .bd-sidebar {
+    position: static;
+  }
+  .bd-funnel {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0;
+  }
+  .bd-funnel-connector {
+    display: none;
+  }
+}
+/* Responsive: collapse step labels to bubbles-only on narrow viewports */
+@media (max-width: 480px) {
+  .bd-step-label {
+    display: none;
+  }
+  .bd-step-bubble {
+    width: 24px;
+    height: 24px;
+    font-size: 0.62rem;
+  }
+  .bd-step-conn {
+    margin-top: 11px;
+  } /* re-centre for smaller bubble */
+}
+/* ═══ Cognitive Architecture Studio (roles page) ════════════════════════════ */
+/* ── Page header ─────────────────────────────────────────────────────────── */
+.cas-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.cas-page-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--color-text, #e0e0e0);
+  margin: 0 0 0.2rem;
+}
+
+.cas-page-subtitle {
+  font-size: 0.8rem;
+  color: var(--color-muted, #888);
+  margin: 0;
+}
+
+.cas-page-stats {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.cas-stat {
+  font-size: 0.78rem;
+  color: var(--color-muted, #888);
+}
+
+.cas-stat strong {
+  color: var(--color-text, #e0e0e0);
+}
+
+/* ── 3-column studio layout ─────────────────────────────────────────────── */
+.cas-layout {
+  display: grid;
+  grid-template-columns: 220px 1fr 1fr;
+  gap: 0.75rem;
+  height: calc(100vh - 8.5rem);
+  min-height: 400px;
+  position: relative;
+}
+
+/* ── Panel base ─────────────────────────────────────────────────────────── */
+.cas-panel {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-card, #1e1e2e);
+  border: 1px solid var(--color-border, #333);
+  border-radius: 6px;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.cas-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.55rem 0.85rem;
+  border-bottom: 1px solid var(--color-border, #333);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted, #888);
+  flex-shrink: 0;
+}
+
+.cas-panel__count {
+  background: var(--color-border, #333);
+  border-radius: 10px;
+  padding: 0.1rem 0.45rem;
+  font-size: 0.68rem;
+  color: var(--color-muted, #888);
+}
+
+.cas-panel__body {
+  flex: 1 1 0;
+  overflow-y: auto;
+  padding: 0.5rem;
+  overscroll-behavior: contain;
+}
+
+.cas-panel__legend {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.45rem 0.75rem;
+  border-top: 1px solid var(--color-border, #333);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+/* ── Org tree search ────────────────────────────────────────────────────── */
+.cas-org-search-wrap {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid var(--color-border, #333);
+  flex-shrink: 0;
+}
+
+.cas-org-search {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.78rem;
+  background: var(--color-bg, #13131f);
+  border: 1px solid var(--color-border, #444);
+  border-radius: 4px;
+  color: var(--color-text, #e0e0e0);
+  outline: none;
+}
+
+.cas-org-search:focus {
+  border-color: var(--color-accent, #7c6af7);
+}
+
+/* ── Org tree levels + roles ────────────────────────────────────────────── */
+.cas-org-level {
+  margin-bottom: 0.5rem;
+}
+
+.cas-org-level__title {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-muted, #888);
+  padding: 0.2rem 0.3rem;
+  margin-bottom: 0.2rem;
+  border-bottom: 1px solid var(--color-border, #333);
+}
+
+.cas-org-role {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0.32rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-text, #e0e0e0);
+  text-align: left;
+  transition: background 0.1s, border-color 0.1s;
+  user-select: none;
+}
+
+.cas-org-role:hover {
+  background: var(--color-card-hover, #2a2a3e);
+  border-color: var(--color-border, #444);
+}
+
+.cas-org-role--active {
+  background: var(--color-card-active, #252540);
+  border-color: var(--color-accent, #7c6af7);
+}
+
+.cas-org-role__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--color-border, #555);
+}
+
+.cas-org-role--exists .cas-org-role__dot {
+  background: #4caf50;
+}
+
+.cas-org-role--spawnable .cas-org-role__dot {
+  background: var(--color-accent, #7c6af7);
+}
+
+.cas-org-role__label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.cas-org-role__badge {
+  font-size: 0.58rem;
+  padding: 0.08rem 0.3rem;
+  border-radius: 3px;
+  background: rgba(124, 106, 247, 0.2);
+  color: var(--color-accent, #7c6af7);
+  flex-shrink: 0;
+}
+
+/* ── Legend ─────────────────────────────────────────────────────────────── */
+.cas-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.68rem;
+  color: var(--color-muted, #888);
+}
+
+.cas-legend-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.cas-legend-dot--spawnable {
+  background: var(--color-accent, #7c6af7);
+}
+
+.cas-legend-dot--exists {
+  background: #4caf50;
+}
+
+.cas-legend-dot--draft {
+  background: var(--color-border, #555);
+}
+
+/* ── Placeholder (empty center + editor panels) ─────────────────────────── */
+.cas-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  height: 100%;
+  padding: 2rem;
+  text-align: center;
+}
+
+.cas-placeholder__icon {
+  font-size: 2rem;
+  opacity: 0.3;
+}
+
+.cas-placeholder__text {
+  font-size: 0.83rem;
+  color: var(--color-muted, #888);
+  max-width: 240px;
+  line-height: 1.5;
+}
+
+/* ── HTMX loading indicator ─────────────────────────────────────────────── */
+.cas-loading {
+  display: none;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--color-card, #1e1e2e);
+  border: 1px solid var(--color-border, #444);
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  color: var(--color-muted, #888);
+  z-index: 10;
+  pointer-events: none;
+}
+
+.cas-loading.htmx-request {
+  display: block;
+}
+
+.cas-empty {
+  font-size: 0.8rem;
+  color: var(--color-muted, #888);
+  padding: 0.75rem;
+}
+
+/* ── Role detail panel ──────────────────────────────────────────────────── */
+.cas-detail {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.cas-detail__header {
+  padding: 0.85rem 1rem 0.65rem;
+  border-bottom: 1px solid var(--color-border, #333);
+  flex-shrink: 0;
+}
+
+.cas-detail__title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.35rem;
+}
+
+.cas-detail__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-text, #e0e0e0);
+  margin: 0;
+}
+
+.cas-detail__chips {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.cas-chip {
+  font-size: 0.65rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 10px;
+  background: var(--color-border, #333);
+  color: var(--color-muted, #888);
+  white-space: nowrap;
+}
+
+.cas-chip--spawnable {
+  background: rgba(124, 106, 247, 0.2);
+  color: var(--color-accent, #7c6af7);
+}
+
+.cas-chip--exists {
+  background: rgba(76, 175, 80, 0.15);
+  color: #81c784;
+}
+
+.cas-chip--missing {
+  background: rgba(244, 67, 54, 0.15);
+  color: #ef9a9a;
+}
+
+.cas-chip--draft {
+  background: var(--color-border, #333);
+  color: var(--color-muted, #888);
+}
+
+.cas-detail__desc {
+  font-size: 0.8rem;
+  color: var(--color-muted, #888);
+  margin: 0 0 0.6rem;
+  line-height: 1.5;
+}
+
+.cas-edit-btn {
+  font-size: 0.75rem;
+  padding: 0.28rem 0.75rem;
+}
+
+/* ── Tab strip ──────────────────────────────────────────────────────────── */
+.cas-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--color-border, #333);
+  flex-shrink: 0;
+}
+
+.cas-tab {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--color-muted, #888);
+  cursor: pointer;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -1px;
+}
+
+.cas-tab:hover {
+  color: var(--color-text, #e0e0e0);
+}
+
+.cas-tab--active {
+  color: var(--color-accent, #7c6af7);
+  border-bottom-color: var(--color-accent, #7c6af7);
+}
+
+.cas-tab__count {
+  font-size: 0.65rem;
+  background: var(--color-border, #333);
+  border-radius: 8px;
+  padding: 0.08rem 0.35rem;
+  color: var(--color-muted, #888);
+}
+
+/* ── Tab panels ─────────────────────────────────────────────────────────── */
+.cas-tab-panel {
+  flex: 1 1 0;
+  overflow-y: auto;
+  padding: 0.75rem;
+  overscroll-behavior: contain;
+}
+
+/* ── Persona grid ───────────────────────────────────────────────────────── */
+.cas-persona-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.6rem;
+}
+
+.cas-persona-card {
+  background: var(--color-bg, #13131f);
+  border: 1px solid var(--color-border, #333);
+  border-radius: 6px;
+  padding: 0.65rem 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.cas-persona-card:hover {
+  background: var(--color-card-hover, #2a2a3e);
+  border-color: #555;
+}
+
+.cas-persona-card--selected {
+  border-color: var(--color-accent, #7c6af7);
+  background: rgba(124, 106, 247, 0.06);
+}
+
+.cas-persona-card__name {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--color-text, #e0e0e0);
+}
+
+.cas-persona-card__archetype {
+  font-size: 0.7rem;
+  color: var(--color-accent, #7c6af7);
+  text-transform: capitalize;
+}
+
+.cas-persona-card__desc {
+  font-size: 0.72rem;
+  color: var(--color-muted, #888);
+  line-height: 1.4;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.cas-persona-card__apply {
+  font-size: 0.7rem;
+  padding: 0.22rem 0.6rem;
+  border-radius: 4px;
+  border: 1px solid var(--color-accent, #7c6af7);
+  background: transparent;
+  color: var(--color-accent, #7c6af7);
+  cursor: pointer;
+  margin-top: 0.35rem;
+  transition: background 0.1s;
+  align-self: flex-start;
+}
+
+.cas-persona-card__apply:hover {
+  background: rgba(124, 106, 247, 0.15);
+}
+
+/* ── Composer ───────────────────────────────────────────────────────────── */
+.cas-composer__section {
+  margin-bottom: 1rem;
+}
+
+.cas-composer__section-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted, #888);
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid var(--color-border, #333);
+}
+
+.cas-composer__hint {
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.cas-composer__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.cas-composer__label {
+  font-size: 0.75rem;
+  color: var(--color-muted, #888);
+  width: 130px;
+  flex-shrink: 0;
+  text-transform: capitalize;
+}
+
+.cas-composer__select {
+  flex: 1;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  background: var(--color-bg, #13131f);
+  border: 1px solid var(--color-border, #444);
+  border-radius: 4px;
+  color: var(--color-text, #e0e0e0);
+  outline: none;
+}
+
+.cas-composer__select:focus {
+  border-color: var(--color-accent, #7c6af7);
+}
+
+.cas-skill-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.cas-skill-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  padding: 0.22rem 0.6rem;
+  border-radius: 12px;
+  background: var(--color-bg, #13131f);
+  border: 1px solid var(--color-border, #444);
+  color: var(--color-muted, #888);
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.cas-skill-chip:hover {
+  background: var(--color-card-hover, #2a2a3e);
+  border-color: #555;
+}
+
+.cas-skill-chip input[type=checkbox] {
+  accent-color: var(--color-accent, #7c6af7);
+}
+
+.cas-arch-preview {
+  font-size: 0.75rem;
+  font-family: var(--font-mono, monospace);
+  background: var(--color-bg, #13131f);
+  border: 1px solid var(--color-border, #444);
+  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+  color: #81c784;
+  word-break: break-all;
+  margin-bottom: 0.5rem;
+}
+
+.cas-composer__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* ── Monaco editor panel ────────────────────────────────────────────────── */
+.cas-panel--editor {
+  position: relative;
+}
+
+.cas-editor-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  background: var(--color-card, #1e1e2e);
+  border-bottom: 1px solid var(--color-border, #333);
+  min-height: 2.4rem;
+  flex-shrink: 0;
+}
+
+.cas-editor-breadcrumb {
+  flex: 1;
+  font-size: 0.72rem;
+  color: var(--color-muted, #888);
+  font-family: var(--font-mono, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cas-editor-body {
+  flex: 1 1 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.cas-editor-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  text-align: center;
+  padding: 2rem;
+  pointer-events: none;
+}
+
+.cas-editor-status {
+  font-size: 0.7rem;
+  padding: 0.2rem 0.75rem;
+  min-height: 1.35rem;
+  color: var(--color-muted, #888);
+  background: var(--color-card, #1e1e2e);
+  border-top: 1px solid var(--color-border, #333);
+  flex-shrink: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cas-editor-status.ok {
+  color: #4caf50;
+}
+
+.cas-editor-status.err {
+  color: #f44336;
+}
+
+/* ── Diff modal ─────────────────────────────────────────────────────────── */
+.cas-diff-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  z-index: 200;
+  align-items: center;
+  justify-content: center;
+}
+
+.cas-diff-overlay--visible {
+  display: flex;
+}
+
+.cas-diff-modal {
+  background: var(--color-card, #1e1e2e);
+  border: 1px solid var(--color-border, #444);
+  border-radius: 8px;
+  width: min(880px, 92vw);
+  max-height: 82vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.cas-diff-modal__header {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-border, #333);
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--color-text, #e0e0e0);
+  gap: 0.75rem;
+}
+
+.cas-diff-modal__header span {
+  flex: 1;
+}
+
+.cas-diff-modal__header button {
+  background: none;
+  border: none;
+  color: var(--color-muted, #888);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0.2rem;
+}
+
+.cas-diff-modal__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem 1rem;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.76rem;
+  line-height: 1.55;
+}
+
+.cas-diff-empty {
+  color: var(--color-muted, #888);
+  font-style: italic;
+}
+
+.cas-diff-line {
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding: 0 0.25rem;
+  border-radius: 2px;
+}
+
+.cas-diff-line--added {
+  background: rgba(76, 175, 80, 0.18);
+  color: #81c784;
+}
+
+.cas-diff-line--removed {
+  background: rgba(244, 67, 54, 0.18);
+  color: #e57373;
+}
+
+.cas-diff-line--hunk {
+  color: #90caf9;
+  margin-top: 0.5rem;
+}
+
+.cas-diff-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  border-top: 1px solid var(--color-border, #333);
+}
+
+/* ── Responsive: stack panels on narrow screens ─────────────────────────── */
+@media (max-width: 900px) {
+  .cas-layout {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
+  .cas-panel {
+    min-height: 250px;
+  }
+  .cas-panel--editor {
+    min-height: 350px;
+  }
+}
+/* ═══════════════════════════════════════════════════════════════
+   Agents page
+   ═══════════════════════════════════════════════════════════════ */
+/* ── Layout ─────────────────────────────────────────────────── */
+.agents-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.agents-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.agents-page-subtitle {
+  margin-top: 0.25rem;
+  font-size: 0.82rem;
+}
+
+/* ── KPI stats bar ─────────────────────────────────────────── */
+.agents-stats-bar {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+@media (max-width: 900px) {
+  .agents-stats-bar {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+@media (max-width: 500px) {
+  .agents-stats-bar {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+.agents-stat {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 0.65rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  text-align: center;
+  min-width: 0;
+}
+
+.agents-stat__value {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.agents-stat__value--live {
+  color: var(--accent-bright);
+}
+
+.agents-stat__value--done {
+  color: var(--success);
+}
+
+.agents-stat__value--failed {
+  color: var(--danger);
+}
+
+.agents-stat__label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+/* ── Toolbar ───────────────────────────────────────────────── */
+.agents-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 0.6rem 0.875rem;
+}
+
+.agents-filter-chips {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  flex: 1;
+}
+
+.filter-chip {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 20px;
+  padding: 0.2rem 0.65rem;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.filter-chip:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.filter-chip--active {
+  background: rgba(124, 106, 247, 0.18);
+  border-color: var(--accent);
+  color: var(--accent-bright);
+}
+
+.filter-chip--implementing {
+  --chip-c: #3b82f6;
+}
+
+.filter-chip--reviewing {
+  --chip-c: var(--warning);
+}
+
+.filter-chip--done {
+  --chip-c: var(--success);
+}
+
+.filter-chip--stale {
+  --chip-c: var(--danger);
+}
+
+.filter-chip--unknown {
+  --chip-c: var(--text-muted);
+}
+
+.filter-chip.filter-chip--active.filter-chip--implementing {
+  border-color: #3b82f6;
+  color: #3b82f6;
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.filter-chip.filter-chip--active.filter-chip--reviewing {
+  border-color: var(--warning);
+  color: var(--warning);
+  background: rgba(234, 179, 8, 0.1);
+}
+
+.filter-chip.filter-chip--active.filter-chip--done {
+  border-color: var(--success);
+  color: var(--success);
+  background: rgba(34, 197, 94, 0.1);
+}
+
+.filter-chip.filter-chip--active.filter-chip--stale {
+  border-color: var(--danger);
+  color: var(--danger);
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.filter-chip__count {
+  background: var(--bg-overlay);
+  border-radius: 8px;
+  padding: 0.05rem 0.35rem;
+  font-size: 0.65rem;
+}
+
+.agents-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.agents-select {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 5px;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.agents-select:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.agents-search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.agents-search-icon {
+  position: absolute;
+  left: 0.5rem;
+  font-size: 0.75rem;
+  pointer-events: none;
+}
+
+.agents-search {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 5px;
+  color: var(--text-primary);
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem 0.25rem 1.75rem;
+  width: 200px;
+  transition: border-color 0.12s;
+}
+
+.agents-search:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.view-toggle {
+  display: flex;
+  border: 1px solid var(--border-default);
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.view-toggle__btn {
+  background: var(--bg-elevated);
+  border: none;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.view-toggle__btn:hover {
+  background: var(--bg-overlay);
+  color: var(--text-primary);
+}
+
+.view-toggle__btn--active {
+  background: rgba(124, 106, 247, 0.2);
+  color: var(--accent-bright);
+}
+
+/* ── Section headers ───────────────────────────────────────── */
+.agents-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.agents-section-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: 0.4rem;
+  color: var(--text-secondary);
+}
+
+.section-title-icon {
+  font-size: 1rem;
+}
+
+.agents-section-subtitle {
+  color: var(--text-muted);
+  font-weight: 400;
+  font-size: 0.75rem;
+}
+
+.badge-count--live {
+  background: rgba(22, 153, 255, 0.2);
+  color: var(--accent-bright);
+}
+
+/* ── Empty states ──────────────────────────────────────────── */
+.agents-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 2.5rem 2rem;
+  text-align: center;
+}
+
+.agents-empty__icon {
+  font-size: 2.5rem;
+}
+
+.agents-empty__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.agents-empty__body {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  max-width: 36ch;
+}
+
+/* ── Live agents grid ──────────────────────────────────────── */
+.agents-live-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.agent-live-card {
+  display: flex;
+  gap: 0.75rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid var(--border-strong);
+  border-radius: var(--radius);
+  padding: 0.875rem;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.12s;
+}
+
+.agent-live-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+  text-decoration: none;
+  color: inherit;
+}
+
+.agent-live-card--implementing {
+  border-left-color: #3b82f6;
+}
+
+.agent-live-card--reviewing {
+  border-left-color: var(--warning);
+}
+
+.agent-live-card--done {
+  border-left-color: var(--success);
+}
+
+.agent-live-card--stale {
+  border-left-color: var(--danger);
+}
+
+.agent-live-card--unknown {
+  border-left-color: var(--border-strong);
+}
+
+.agent-live-card--stale-idle {
+  border-left-color: var(--warning);
+  background: rgba(234, 179, 8, 0.04);
+}
+
+.agent-live-avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  flex-shrink: 0;
+  background: var(--bg-elevated);
+  border: 1.5px solid var(--border-default);
+}
+
+.agent-live-avatar--visionary {
+  border-color: var(--arch-visionary);
+  background: rgba(155, 89, 182, 0.18);
+}
+
+.agent-live-avatar--architect {
+  border-color: var(--arch-architect);
+  background: rgba(52, 152, 219, 0.18);
+}
+
+.agent-live-avatar--hacker {
+  border-color: var(--arch-hacker);
+  background: rgba(243, 156, 18, 0.18);
+}
+
+.agent-live-avatar--guardian {
+  border-color: var(--arch-guardian);
+  background: rgba(39, 174, 96, 0.18);
+}
+
+.agent-live-avatar--scholar {
+  border-color: var(--arch-scholar);
+  background: rgba(26, 188, 156, 0.18);
+}
+
+.agent-live-avatar--mentor {
+  border-color: var(--arch-mentor);
+  background: rgba(230, 126, 34, 0.18);
+}
+
+.agent-live-avatar--operator {
+  border-color: var(--arch-operator);
+  background: rgba(149, 165, 166, 0.15);
+}
+
+.agent-live-avatar--pragmatist {
+  border-color: var(--arch-pragmatist);
+  background: rgba(231, 76, 60, 0.18);
+}
+
+.agent-live-avatar--default {
+  border-color: var(--border-default);
+  background: var(--bg-elevated);
+}
+
+.agent-live-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.agent-live-top {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.agent-live-role {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.agent-live-persona {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.agent-live-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.2rem;
+}
+
+.agent-live-branch {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  background: var(--bg-elevated);
+  border-radius: 3px;
+  padding: 0.05rem 0.3rem;
+}
+
+.agent-live-footer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.3rem;
+}
+
+.agent-live-elapsed {
+  font-size: 0.68rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.agent-live-stale-badge {
+  font-size: 0.62rem;
+  font-weight: 600;
+  color: var(--warning);
+  background: rgba(234, 179, 8, 0.12);
+  border: 1px solid rgba(234, 179, 8, 0.3);
+  border-radius: 4px;
+  padding: 0.05rem 0.3rem;
+  letter-spacing: 0.03em;
+}
+
+.agent-sandbox-link {
+  margin-left: auto;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  opacity: 0.65;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.agent-sandbox-link:hover {
+  opacity: 1;
+  color: var(--accent-bright);
+}
+
+.agent-arch-link {
+  margin-left: auto;
+  text-decoration: none;
+  opacity: 0.6;
+  transition: opacity 0.15s;
+}
+
+.agent-arch-link:hover {
+  opacity: 1;
+}
+
+/* ── History — batch groups ────────────────────────────────── */
+.agents-batches {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.batch-group {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.batch-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.875rem;
+  cursor: pointer;
+  background: var(--bg-surface);
+  border-bottom: 1px solid transparent;
+  transition: background 0.12s;
+  flex-wrap: wrap;
+}
+
+.batch-header:hover {
+  background: var(--bg-elevated);
+}
+
+.batch-chevron {
+  font-size: 1.2rem;
+  color: var(--text-muted);
+  transition: transform 0.18s;
+  flex-shrink: 0;
+}
+
+.batch-chevron--open {
+  transform: rotate(90deg);
+}
+
+.batch-icon {
+  font-size: 0.9rem;
+}
+
+.batch-id {
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+
+.batch-meta {
+  font-size: 0.7rem;
+}
+
+.batch-count {
+  font-size: 0.65rem;
+}
+
+.batch-phase {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent-bright);
+  background: rgba(124, 106, 247, 0.12);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+}
+
+.batch-success-rate {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--success);
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.batch-status-pills {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.batch-body {
+  padding: 0.75rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* ── History cards grid ────────────────────────────────────── */
+.agents-history-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.5rem;
+}
+
+.history-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-left: 3px solid var(--border-strong);
+  border-radius: 5px;
+  padding: 0.6rem 0.75rem;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.history-card:hover {
+  border-color: var(--accent);
+  background: var(--bg-overlay);
+  text-decoration: none;
+  color: inherit;
+}
+
+.history-card--implementing {
+  border-left-color: #3b82f6;
+}
+
+.history-card--reviewing {
+  border-left-color: var(--warning);
+}
+
+.history-card--done {
+  border-left-color: var(--success);
+}
+
+.history-card--stale {
+  border-left-color: var(--danger);
+}
+
+.history-card--unknown {
+  border-left-color: var(--border-strong);
+}
+
+.history-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.3rem;
+}
+
+.history-card__duration {
+  font-size: 0.65rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.history-card__role {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.history-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.2rem;
+}
+
+.history-card__branch {
+  font-size: 0.62rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.history-card__date {
+  font-size: 0.62rem;
+}
+
+.history-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: center;
+  margin-top: 0.1rem;
+}
+
+/* ── Retry + spawn mode badges ─────────────────────────────── */
+.run-attempt-badge {
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: var(--warning);
+  background: rgba(234, 179, 8, 0.12);
+  border: 1px solid rgba(234, 179, 8, 0.25);
+  border-radius: 4px;
+  padding: 0.05rem 0.3rem;
+  letter-spacing: 0.02em;
+}
+
+.run-spawn-mode {
+  font-size: 0.6rem;
+  font-weight: 600;
+  border-radius: 4px;
+  padding: 0.05rem 0.3rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.run-spawn-mode--wave {
+  color: var(--accent-bright);
+  background: rgba(124, 106, 247, 0.12);
+  border: 1px solid rgba(124, 106, 247, 0.2);
+}
+
+.run-spawn-mode--chain {
+  color: #3b82f6;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.run-spawn-mode--manual {
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+}
+
+/* ── Copy button ───────────────────────────────────────────── */
+.btn-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.35rem;
+  padding: 0.15rem 0.35rem;
+  font-size: 0.75rem;
+  line-height: 1;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  cursor: pointer;
+  vertical-align: middle;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.btn-copy:hover {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+  background: var(--bg-elevated);
+}
+.btn-copy:active {
+  color: var(--success);
+  border-color: var(--success);
+  background: rgba(34, 197, 94, 0.08);
+}
+
+/* ── History table ─────────────────────────────────────────── */
+.run-row:hover td {
+  background: var(--bg-elevated);
+}
+
+.run-row--implementing td:first-child {
+  border-left: 2px solid #3b82f6;
+}
+
+.run-row--reviewing td:first-child {
+  border-left: 2px solid var(--warning);
+}
+
+.run-row--done td:first-child {
+  border-left: 2px solid var(--success);
+}
+
+.run-row--stale td:first-child {
+  border-left: 2px solid var(--danger);
+}
+
+.run-row--unknown td:first-child {
+  border-left: 2px solid var(--border-strong);
+}
+
+.run-status-badge {
+  font-size: 0.65rem;
+}
+
+.run-branch {
+  font-size: 0.68rem;
+}
+
+.run-date {
+  font-size: 0.7rem;
+  white-space: nowrap;
+}
+
+.run-duration {
+  font-size: 0.7rem;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ═══ Pipeline Config Page ═══════════════════════════════════════════════════ */
+/* ── Page header ─────────────────────────────────────────────────────────── */
+.cfg-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.cfg-page-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.2rem;
+}
+
+.cfg-page-subtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.cfg-save-stamp {
+  font-size: 0.75rem;
+  color: var(--text-faint);
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Two-column layout ───────────────────────────────────────────────────── */
+.cfg-layout {
+  display: grid;
+  grid-template-columns: 188px 1fr;
+  grid-template-rows: 1fr auto;
+  gap: 0;
+  height: calc(100vh - 9rem);
+  min-height: 400px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+}
+
+/* ── Sidebar tab navigation ──────────────────────────────────────────────── */
+.cfg-sidebar {
+  grid-column: 1;
+  grid-row: 1/3;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated);
+  border-right: 1px solid var(--border-default);
+  padding: 0.75rem 0;
+  gap: 0.125rem;
+}
+
+.cfg-sidebar-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  padding: 0.25rem 1rem 0.5rem;
+}
+
+.cfg-tab-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  background: transparent;
+  border: none;
+  border-left: 2px solid transparent;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  text-align: left;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.cfg-tab-btn:hover {
+  background: rgba(139, 92, 246, 0.06);
+  color: var(--text-primary);
+}
+
+.cfg-tab-btn.active {
+  background: rgba(139, 92, 246, 0.1);
+  border-left-color: var(--accent);
+  color: var(--accent-bright);
+  font-weight: 600;
+}
+
+.cfg-tab-icon {
+  font-size: 0.9rem;
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
+.cfg-tab-badge {
+  margin-left: auto;
+  font-size: 0.65rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-full);
+  background: var(--accent-glow);
+  color: var(--accent-bright);
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.cfg-tab-badge.on {
+  background: var(--success-dim);
+  color: var(--success);
+}
+
+/* ── Content area ────────────────────────────────────────────────────────── */
+.cfg-content {
+  grid-column: 2;
+  grid-row: 1;
+  overflow-y: auto;
+  padding: 1.5rem 2rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-default) transparent;
+}
+
+.cfg-content::-webkit-scrollbar {
+  width: 5px;
+}
+
+.cfg-content::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.cfg-content::-webkit-scrollbar-thumb {
+  background: var(--border-default);
+  border-radius: var(--radius-full);
+}
+
+/* ── Panel sections ──────────────────────────────────────────────────────── */
+.cfg-panel-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin: 0 0 1.25rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.cfg-section {
+  margin-bottom: 2rem;
+}
+
+.cfg-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ── Allocation sliders ──────────────────────────────────────────────────── */
+.cfg-slider-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.cfg-slider-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem 1rem;
+  align-items: center;
+}
+
+.cfg-slider-label {
+  font-size: 0.84rem;
+  color: var(--text-primary);
+  font-weight: 500;
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.cfg-slider-hint {
+  font-size: 0.73rem;
+  color: var(--text-faint);
+  grid-column: 1;
+  grid-row: 2;
+  margin-top: -0.25rem;
+}
+
+.cfg-slider-value {
+  grid-column: 2;
+  grid-row: 1/3;
+  width: 2.5rem;
+  text-align: center;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  background: var(--accent-glow);
+  border-radius: var(--radius-sm);
+  padding: 0.15rem 0;
+  transition: transform 0.1s;
+}
+
+.cfg-slider-value.pulse {
+  transform: scale(1.15);
+}
+
+.cfg-slider-input {
+  grid-column: 1;
+  grid-row: 3;
+  width: 100%;
+  accent-color: var(--accent);
+  cursor: pointer;
+  height: 4px;
+  margin-top: 0.35rem;
+}
+
+/* ── Capacity meter ──────────────────────────────────────────────────────── */
+.cfg-capacity-card {
+  margin-top: 1.75rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+}
+
+.cfg-capacity-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.75rem;
+}
+
+.cfg-capacity-label {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.cfg-capacity-total {
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+
+.cfg-capacity-total span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-weight: 500;
+  font-family: var(--font-sans);
+  margin-left: 0.3rem;
+}
+
+.cfg-capacity-bar {
+  height: 10px;
+  border-radius: var(--radius-full);
+  background: var(--bg-overlay);
+  overflow: hidden;
+  display: flex;
+  gap: 2px;
+}
+
+.cfg-capacity-bar-eng {
+  height: 100%;
+  background: var(--grad-accent);
+  border-radius: var(--radius-full) 0 0 var(--radius-full);
+  transition: width 0.3s ease;
+  min-width: 0;
+}
+
+.cfg-capacity-bar-qa {
+  height: 100%;
+  background: var(--grad-warm);
+  border-radius: 0 var(--radius-full) var(--radius-full) 0;
+  transition: width 0.3s ease;
+  min-width: 0;
+}
+
+.cfg-capacity-legend {
+  display: flex;
+  gap: 1.25rem;
+  margin-top: 0.6rem;
+}
+
+.cfg-capacity-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.cfg-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.cfg-legend-dot.eng {
+  background: var(--accent);
+}
+
+.cfg-legend-dot.qa {
+  background: var(--warning);
+}
+
+/* ── Labels panel ────────────────────────────────────────────────────────── */
+.cfg-label-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+  min-height: 2rem;
+}
+
+.cfg-label-empty {
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--text-faint);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.cfg-label-item {
+  display: grid;
+  grid-template-columns: 1.75rem 1.5rem 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 0.45rem 0.6rem;
+  cursor: grab;
+  user-select: none;
+  transition: background 0.12s, border-color 0.12s, box-shadow 0.12s;
+}
+.cfg-label-item:active {
+  cursor: grabbing;
+}
+.cfg-label-item.drag-over {
+  border-color: var(--accent);
+  background: var(--accent-glow);
+  box-shadow: 0 0 0 1px var(--accent-dim);
+}
+
+.cfg-label-position {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  text-align: center;
+  background: var(--bg-overlay);
+  border-radius: var(--radius-xs);
+  padding: 0.1rem 0.3rem;
+}
+
+.cfg-drag-handle {
+  font-size: 0.85rem;
+  color: var(--text-faint);
+  text-align: center;
+  line-height: 1;
+  opacity: 0.6;
+  transition: opacity 0.1s;
+}
+.cfg-label-item:hover .cfg-drag-handle {
+  opacity: 1;
+}
+
+.cfg-label-text {
+  font-size: 0.8rem;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  word-break: break-all;
+  min-width: 0;
+}
+
+.cfg-btn-remove {
+  background: transparent;
+  border: none;
+  color: var(--text-faint);
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 0.15rem 0.35rem;
+  border-radius: var(--radius-xs);
+  line-height: 1;
+  transition: color 0.12s, background 0.12s;
+  flex-shrink: 0;
+}
+.cfg-btn-remove:hover {
+  color: var(--danger);
+  background: var(--danger-dim);
+}
+
+.cfg-label-add-row {
+  display: flex;
+  gap: 0.5rem;
+}
+.cfg-label-add-row input[type=text] {
+  flex: 1;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-family: var(--font-mono);
+  padding: 0.4rem 0.7rem;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.cfg-label-add-row input[type=text]::placeholder {
+  color: var(--text-faint);
+}
+.cfg-label-add-row input[type=text]:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+
+/* ── A/B Testing panel ───────────────────────────────────────────────────── */
+.cfg-ab-callout {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  background: var(--info-dim);
+  border: 1px solid var(--info-border);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.cfg-ab-callout-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+  margin-top: 0.05rem;
+}
+
+.cfg-ab-callout-text {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.cfg-ab-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding: 1rem 1.25rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  transition: border-color 0.2s;
+}
+.cfg-ab-toggle-row.ab-active {
+  border-color: var(--success-border);
+  background: var(--success-dim);
+}
+
+.cfg-ab-toggle-label {
+  flex: 1;
+}
+
+.cfg-ab-toggle-title {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 0.15rem;
+}
+
+.cfg-ab-toggle-desc {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* Accessible pill toggle */
+.cfg-toggle-switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.cfg-toggle-switch input[type=checkbox] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.cfg-toggle-track {
+  width: 44px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-default);
+  transition: background 0.2s, border-color 0.2s;
+  position: relative;
+}
+.cfg-toggle-switch input:checked + .cfg-toggle-track {
+  background: var(--success);
+  border-color: var(--success);
+}
+.cfg-toggle-track::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition: transform 0.2s, background 0.2s;
+}
+.cfg-toggle-switch input:checked + .cfg-toggle-track::after {
+  transform: translateX(20px);
+  background: #fff;
+}
+
+.cfg-ab-status {
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+.cfg-ab-status.on {
+  background: var(--success-dim);
+  color: var(--success);
+  border: 1px solid var(--success-border);
+}
+.cfg-ab-status.off {
+  background: var(--bg-overlay);
+  color: var(--text-faint);
+  border: 1px solid var(--border-subtle);
+}
+
+.cfg-ab-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cfg-ab-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.cfg-field-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.03em;
+}
+
+.cfg-field-hint {
+  font-size: 0.7rem;
+  color: var(--text-faint);
+}
+
+.cfg-text-input {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-family: var(--font-mono);
+  padding: 0.45rem 0.75rem;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  width: 100%;
+  box-sizing: border-box;
+}
+.cfg-text-input::placeholder {
+  color: var(--text-faint);
+}
+.cfg-text-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+
+/* ── Projects panel ──────────────────────────────────────────────────────── */
+.cfg-projects-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cfg-project-empty {
+  padding: 2rem;
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--text-faint);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius);
+}
+
+.cfg-project-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid transparent;
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+.cfg-project-card.active {
+  border-left-color: var(--accent);
+  box-shadow: var(--shadow-glow);
+  background: rgba(139, 92, 246, 0.04);
+}
+
+.cfg-project-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.cfg-project-name {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  flex: 1;
+}
+
+.cfg-active-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: var(--radius-full);
+  background: var(--accent-glow);
+  color: var(--accent-bright);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.cfg-project-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.cfg-project-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xs);
+  padding: 0.18rem 0.5rem;
+}
+.cfg-project-chip .chip-icon {
+  font-size: 0.7rem;
+  opacity: 0.7;
+}
+
+.cfg-project-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.cfg-project-cursor-id {
+  font-size: 0.7rem;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+}
+
+.cfg-switch-toast {
+  font-size: 0.78rem;
+  color: var(--success);
+  min-height: 1em;
+}
+
+/* ── Sticky save footer ──────────────────────────────────────────────────── */
+.cfg-footer {
+  grid-column: 2;
+  grid-row: 2;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.875rem 2rem;
+  background: var(--bg-glass);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-top: 1px solid var(--border-default);
+}
+
+.cfg-toast {
+  font-size: 0.82rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius-sm);
+  min-height: 1.6rem;
+  display: flex;
+  align-items: center;
+}
+.cfg-toast.ok {
+  background: var(--success-dim);
+  color: var(--success);
+  border: 1px solid var(--success-border);
+}
+.cfg-toast.err {
+  background: var(--danger-dim);
+  color: var(--danger);
+  border: 1px solid var(--danger-border);
+}
+
+.cfg-footer-spacer {
+  flex: 1;
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 680px) {
+  .cfg-layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+    height: auto;
+    min-height: unset;
+  }
+  .cfg-sidebar {
+    grid-column: 1;
+    grid-row: 1;
+    flex-direction: row;
+    border-right: none;
+    border-bottom: 1px solid var(--border-default);
+    padding: 0.5rem;
+    overflow-x: auto;
+  }
+  .cfg-sidebar-label {
+    display: none;
+  }
+  .cfg-tab-btn {
+    border-left: none;
+    border-bottom: 2px solid transparent;
+    padding: 0.4rem 0.75rem;
+    white-space: nowrap;
+    font-size: 0.78rem;
+  }
+  .cfg-tab-btn.active {
+    border-left-color: transparent;
+    border-bottom-color: var(--accent);
+  }
+  .cfg-content {
+    grid-column: 1;
+    grid-row: 2;
+    padding: 1rem;
+  }
+  .cfg-footer {
+    grid-column: 1;
+    grid-row: 3;
+  }
+}
+/* ═══ Dependency DAG Page ════════════════════════════════════════════════════ */
+/* ── Page layout ─────────────────────────────────────────────────────────── */
+.dag-layout {
+  display: grid;
+  grid-template-rows: auto auto auto 1fr auto;
+  gap: var(--space-3);
+  height: calc(100vh - 80px);
+  min-height: 600px;
+}
+
+/* ── Page header ─────────────────────────────────────────────────────────── */
+.dag-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.dag-page-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.2rem;
+}
+
+.dag-page-subtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* ── Stats bar ───────────────────────────────────────────────────────────── */
+.dag-stats-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.dag-stat-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.dag-stat-chip-value {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.dag-stat-chip-icon {
+  font-size: 0.9rem;
+}
+
+.dag-stat-chip.wip .dag-stat-chip-value {
+  color: #22c55e;
+}
+
+.dag-stat-chip.depth .dag-stat-chip-value {
+  color: var(--accent-glow);
+}
+
+/* ── Controls bar ────────────────────────────────────────────────────────── */
+.dag-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.dag-controls-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.dag-filter-select {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 5px;
+  padding: 5px 8px;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.dag-filter-select:focus {
+  outline: none;
+  border-color: var(--accent-glow);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-glow) 25%, transparent);
+}
+
+.dag-search-input {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+  border-radius: 5px;
+  padding: 5px 10px;
+  font-size: 0.82rem;
+  width: 180px;
+  transition: border-color 0.15s, width 0.2s;
+}
+.dag-search-input::placeholder {
+  color: var(--text-muted);
+}
+.dag-search-input:focus {
+  outline: none;
+  border-color: var(--accent-glow);
+  width: 240px;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-glow) 25%, transparent);
+}
+
+.dag-ctrl-btn {
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: 5px;
+  padding: 5px 10px;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+.dag-ctrl-btn:hover {
+  background: var(--bg-overlay);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+.dag-ctrl-btn:active {
+  background: color-mix(in srgb, var(--accent-glow) 15%, var(--bg-overlay));
+}
+
+.dag-ctrl-btn-icon {
+  margin-right: 4px;
+}
+
+/* ── Main body: canvas + sidebar ─────────────────────────────────────────── */
+.dag-body {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-2);
+  min-height: 0;
+}
+.dag-body.sidebar-open {
+  grid-template-columns: 1fr 300px;
+}
+
+/* ── Canvas ──────────────────────────────────────────────────────────────── */
+.dag-canvas-wrapper {
+  position: relative;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  overflow: hidden;
+  min-height: 480px;
+}
+
+.dag-canvas-empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+.dag-canvas-empty .dag-canvas-empty-icon {
+  font-size: 2.5rem;
+  opacity: 0.4;
+}
+
+#dag-svg {
+  width: 100%;
+  height: 100%;
+  min-height: 480px;
+  display: block;
+}
+
+/* ── Tooltip ─────────────────────────────────────────────────────────────── */
+#dag-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-strong);
+  border-radius: 5px;
+  padding: 6px 10px;
+  font-size: 0.78rem;
+  color: var(--text-primary);
+  max-width: 280px;
+  display: none;
+  z-index: 100;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  line-height: 1.5;
+}
+
+.dag-tooltip-num {
+  font-weight: 700;
+  color: var(--accent-glow);
+  font-family: var(--font-mono, monospace);
+}
+
+.dag-tooltip-title {
+  display: block;
+}
+
+.dag-tooltip-meta {
+  display: flex;
+  gap: 6px;
+  margin-top: 3px;
+  flex-wrap: wrap;
+}
+
+.dag-tooltip-badge {
+  font-size: 0.7rem;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+}
+.dag-tooltip-badge.wip {
+  background: color-mix(in srgb, #22c55e 15%, transparent);
+  border-color: #22c55e;
+  color: #22c55e;
+}
+.dag-tooltip-badge.blocking {
+  background: color-mix(in srgb, var(--accent-glow) 15%, transparent);
+  border-color: var(--accent-glow);
+  color: var(--accent-glow);
+}
+
+/* ── Issue detail sidebar ────────────────────────────────────────────────── */
+.dag-sidebar {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  padding: var(--space-3);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.dag-sidebar-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-1);
+}
+
+.dag-sidebar-num {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--accent-glow);
+}
+
+.dag-sidebar-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 3px;
+  transition: color 0.15s, background 0.15s;
+}
+.dag-sidebar-close:hover {
+  color: var(--text-primary);
+  background: var(--bg-overlay);
+}
+
+.dag-sidebar-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.dag-sidebar-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  width: fit-content;
+}
+.dag-sidebar-state.open {
+  background: color-mix(in srgb, #22c55e 15%, transparent);
+  color: #22c55e;
+  border: 1px solid #22c55e;
+}
+.dag-sidebar-state.closed {
+  background: color-mix(in srgb, #6b7280 20%, transparent);
+  color: #9ca3af;
+  border: 1px solid #4b5563;
+}
+
+.dag-sidebar-section-title {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.dag-sidebar-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.dag-sidebar-label-chip {
+  font-size: 0.7rem;
+  padding: 2px 7px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent-glow) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-glow) 35%, transparent);
+  color: var(--text-secondary);
+}
+
+.dag-sidebar-dep-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.dag-sidebar-dep-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  padding: 3px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.dag-sidebar-dep-item:last-child {
+  border-bottom: none;
+}
+
+.dag-sidebar-dep-num {
+  font-family: var(--font-mono, monospace);
+  color: var(--accent-glow);
+  font-weight: 600;
+  flex-shrink: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  transition: text-decoration-color 0.15s;
+}
+.dag-sidebar-dep-num:hover {
+  text-decoration-color: var(--accent-glow);
+}
+
+.dag-sidebar-dep-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dag-sidebar-metrics {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.dag-sidebar-metric {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  padding: 6px 8px;
+  text-align: center;
+}
+
+.dag-sidebar-metric-val {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.dag-sidebar-metric-lbl {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.dag-sidebar-gh-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 7px;
+  border-radius: 6px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.dag-sidebar-gh-link:hover {
+  background: var(--bg-overlay);
+  color: var(--text-primary);
+  border-color: var(--accent-glow);
+}
+
+/* ── Legend ──────────────────────────────────────────────────────────────── */
+.dag-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.dag-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.dag-legend-swatch {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dag-legend-sep {
+  width: 1px;
+  height: 14px;
+  background: var(--border-default);
+  margin: 0 4px;
+}
+
+/* Edge-type indicator: solid line + CSS arrowhead */
+.dag-legend-edge-indicator {
+  width: 28px;
+  height: 1.5px;
+  background: #6b7280;
+  position: relative;
+  flex-shrink: 0;
+  align-self: center;
+}
+.dag-legend-edge-indicator::after {
+  content: "";
+  position: absolute;
+  right: -1px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-top: 3.5px solid transparent;
+  border-bottom: 3.5px solid transparent;
+  border-left: 5px solid #6b7280;
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+@media (max-width: 700px) {
+  .dag-body.sidebar-open {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr auto;
+  }
+  .dag-search-input {
+    width: 140px;
+  }
+  .dag-search-input:focus {
+    width: 180px;
+  }
+  .dag-stats-bar {
+    gap: var(--space-1);
+  }
+}
+/* ═══ Templates Page ══════════════════════════════════════════════════════════ */
+/* ── Page header ─────────────────────────────────────────────────────────── */
+.tpl-page-header {
+  margin-bottom: 1.5rem;
+}
+
+.tpl-page-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.2rem;
+}
+
+.tpl-page-subtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* ── Page layout ─────────────────────────────────────────────────────────── */
+.tpl-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 780px;
+}
+
+/* ── Section cards ───────────────────────────────────────────────────────── */
+.tpl-section {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.tpl-section-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin: 0 0 0.25rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border-default);
+}
+
+/* ── Form rows ───────────────────────────────────────────────────────────── */
+.tpl-form-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.tpl-form-label {
+  flex: 0 0 90px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.tpl-input {
+  flex: 1;
+  min-width: 180px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  padding: 0.4rem 0.65rem;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  font-family: var(--font-sans);
+}
+.tpl-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+.tpl-input::placeholder {
+  color: var(--text-faint);
+}
+
+input[type=file].tpl-input {
+  cursor: pointer;
+  padding: 0.35rem 0.55rem;
+  font-size: 0.82rem;
+}
+input[type=file].tpl-input::file-selector-button {
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-xs);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  padding: 0.2rem 0.55rem;
+  cursor: pointer;
+  margin-right: 0.5rem;
+  transition: background 0.15s;
+}
+input[type=file].tpl-input::file-selector-button:hover {
+  background: var(--border-default);
+}
+
+/* ── Action buttons ──────────────────────────────────────────────────────── */
+.tpl-btn-primary {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.45rem 1.1rem;
+  transition: opacity 0.15s, background 0.15s;
+  white-space: nowrap;
+  font-family: var(--font-sans);
+}
+.tpl-btn-primary:hover {
+  opacity: 0.85;
+}
+.tpl-btn-primary:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* ── Toast / status indicator ────────────────────────────────────────────── */
+.tpl-toast {
+  font-size: 0.82rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-sm);
+  display: none;
+}
+.tpl-toast.ok {
+  display: inline-block;
+  background: var(--success-dim);
+  color: var(--success);
+  border: 1px solid var(--success-border);
+}
+.tpl-toast.err {
+  display: inline-block;
+  background: var(--danger-dim);
+  color: var(--danger);
+  border: 1px solid var(--danger-border);
+}
+
+/* ── Stored templates table ─────────────────────────────────────────────── */
+.tpl-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.84rem;
+}
+
+.tpl-table th {
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  color: var(--text-muted);
+  font-weight: 600;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.tpl-table td {
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+  vertical-align: middle;
+}
+
+.tpl-table tr:last-child td {
+  border-bottom: none;
+}
+
+.tpl-table tr:hover td {
+  background: rgba(139, 92, 246, 0.04);
+}
+
+.tpl-cell-name {
+  font-weight: 600;
+}
+
+.tpl-cell-version {
+  font-family: var(--font-mono);
+  color: var(--accent-bright);
+  font-size: 0.82rem;
+}
+
+.tpl-cell-repo {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tpl-cell-date {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.tpl-cell-size {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.tpl-cell-action {
+  text-align: right;
+  white-space: nowrap;
+}
+
+/* ── Download link ───────────────────────────────────────────────────────── */
+.tpl-btn-download {
+  background: transparent;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--accent-bright);
+  cursor: pointer;
+  font-size: 0.78rem;
+  padding: 0.25rem 0.6rem;
+  text-decoration: none;
+  display: inline-block;
+  transition: background 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+.tpl-btn-download:hover {
+  background: var(--accent-glow);
+  border-color: var(--accent);
+  color: var(--accent-bright);
+}
+
+/* ── Conflict list ───────────────────────────────────────────────────────── */
+.tpl-conflict-warning {
+  font-size: 0.82rem;
+  color: var(--warning);
+  margin: 0 0 0.35rem;
+}
+
+.tpl-conflict-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.tpl-conflict-item {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--danger);
+  padding: 0.2rem 0.5rem;
+  background: var(--danger-dim);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--radius-xs);
+}
+
+/* ── Empty state ─────────────────────────────────────────────────────────── */
+.tpl-empty {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  padding: 0.5rem 0;
+}
+
+/* ═══ A/B Role Variant Comparison Page ══════════════════════════════════════ */
+/* ── Page header ─────────────────────────────────────────────────────────── */
+.ab-page-header {
+  margin-bottom: 1.5rem;
+}
+
+.ab-page-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.35rem;
+}
+
+.ab-page-subtitle {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin: 0;
+  line-height: 1.55;
+}
+
+/* ── Error banner ─────────────────────────────────────────────────────────── */
+.ab-error-banner {
+  border-left: 3px solid var(--danger);
+  background: var(--danger-dim);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+}
+.ab-error-banner p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+/* ── Comparison grid ─────────────────────────────────────────────────────── */
+.ab-comparison-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+@media (max-width: 640px) {
+  .ab-comparison-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Variant card ─────────────────────────────────────────────────────────── */
+.ab-variant-card {
+  position: relative;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  transition: border-color 0.2s;
+}
+.ab-variant-card--winner {
+  border-color: var(--success-border);
+  background: linear-gradient(160deg, var(--bg-surface) 70%, rgba(16, 217, 160, 0.04) 100%);
+  box-shadow: 0 0 0 1px var(--success-border), var(--shadow-sm);
+}
+
+/* ── Winner badge (absolute top-right) ──────────────────────────────────── */
+.ab-winner-badge {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: var(--success-dim);
+  border: 1px solid var(--success-border);
+  color: var(--success);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.6rem;
+  border-radius: var(--radius-full);
+}
+
+/* ── Card header ─────────────────────────────────────────────────────────── */
+.ab-variant-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.75rem;
+  padding-right: 5rem; /* leave room for winner badge */
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.ab-variant-title-check {
+  color: var(--success);
+  font-size: 0.9em;
+}
+
+.ab-variant-sha {
+  font-family: var(--font-mono);
+  font-size: 0.775rem;
+  color: var(--text-muted);
+  margin: 0 0 0.75rem;
+}
+
+/* ── Metrics table ───────────────────────────────────────────────────────── */
+.ab-metrics-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+.ab-metrics-table td {
+  padding: 0.45rem 0;
+  vertical-align: middle;
+}
+.ab-metrics-table td:first-child {
+  color: var(--text-muted);
+  padding-right: 1rem;
+  width: 50%;
+}
+.ab-metrics-table td:last-child {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.ab-metrics-table tr + tr td {
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* ── Tie / no-winner note ───────────────────────────────────────────────── */
+.ab-tie-note {
+  text-align: center;
+  font-style: italic;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-top: 1rem;
+}
+
+/* ── Winner banner (full-width below cards) ─────────────────────────────── */
+.ab-winner-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: var(--success-dim);
+  border: 1px solid var(--success-border);
+  border-radius: var(--radius);
+  padding: 0.65rem 1rem;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: var(--success);
+  font-weight: 600;
+}
+
+.ab-winner-banner-label {
+  color: var(--text-secondary);
+  font-weight: 400;
+}
+
+/* ── Batch breakdown section ─────────────────────────────────────────────── */
+.ab-batch-section {
+  margin-top: 1.5rem;
+}
+
+.ab-batch-section-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.75rem;
+}
+
+.ab-batch-table-wrapper {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.ab-batch-table {
+  width: 100%;
+  margin: 0;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+.ab-batch-table th {
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.5rem 0.875rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border-default);
+}
+.ab-batch-table td {
+  padding: 0.45rem 0.875rem;
+  color: var(--text-secondary);
+  vertical-align: middle;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.ab-batch-table tbody tr:last-child td {
+  border-bottom: none;
+}
+.ab-batch-table tbody tr:hover td {
+  background: var(--bg-elevated);
+}
+
+.ab-batch-id {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+/* ── Empty state ─────────────────────────────────────────────────────────── */
+.ab-empty-state {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 2.5rem 2rem;
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.ab-empty-icon {
+  font-size: 2rem;
+  margin-bottom: 0.75rem;
+  display: block;
+  opacity: 0.5;
+}
+
+.ab-empty-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin: 0 0 0.4rem;
+}
+
+.ab-empty-body {
+  font-size: 0.825rem;
+  color: var(--text-muted);
+  max-width: 36ch;
+  margin: 0 auto 1rem;
+  line-height: 1.6;
+}
+
+.ab-empty-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  color: var(--accent-bright);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 0.3rem 0.7rem;
+  transition: border-color 0.15s, color 0.15s;
+}
+.ab-empty-link:hover {
+  border-color: var(--accent);
+  color: #fff;
+}
+
+/* ── Config callout ──────────────────────────────────────────────────────── */
+.ab-config-callout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  margin-top: 1.25rem;
+  font-size: 0.825rem;
+  color: var(--text-muted);
+  flex-wrap: wrap;
+}
+.ab-config-callout a {
+  color: var(--accent-bright);
+  font-weight: 500;
+  white-space: nowrap;
+}
+.ab-config-callout a:hover {
+  color: #fff;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   Controls hub page
+   ═══════════════════════════════════════════════════════════════ */
+/* ── Page header ─────────────────────────────────────────────── */
+.controls-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.controls-page-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.controls-page-subtitle {
+  margin-top: 0.25rem;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+/* ── Pipeline status pill ─────────────────────────────────────── */
+.controls-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: var(--radius-full);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  flex-shrink: 0;
+  border: 1px solid;
+}
+
+.controls-status-pill--running {
+  background: var(--success-dim);
+  border-color: var(--success-border);
+  color: var(--success);
+}
+
+.controls-status-pill--paused {
+  background: var(--warning-dim);
+  border-color: var(--warning-border);
+  color: var(--warning);
+}
+
+.controls-status-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+/* ── Action grid ─────────────────────────────────────────────── */
+.controls-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+@media (max-width: 800px) {
+  .controls-grid {
+    grid-template-columns: 1fr;
+  }
+}
+/* ── Control card ────────────────────────────────────────────── */
+.controls-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.controls-card-icon {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.controls-card-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.controls-card-desc {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  line-height: 1.55;
+  margin: 0;
+}
+
+.controls-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.controls-card-state {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* ── HTMX loading spinner ─────────────────────────────────────── */
+.controls-spinner {
+  font-size: 1rem;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.htmx-request .controls-spinner,
+.controls-spinner.htmx-indicator {
+  opacity: 1;
+}
+
+/* ── Kill form ───────────────────────────────────────────────── */
+.controls-kill-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.controls-kill-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.controls-select {
+  flex: 1;
+  min-width: 0;
+  padding: 0.35rem 0.6rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.8125rem;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  appearance: none;
+}
+
+.controls-select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-color: var(--accent);
+}
+
+.controls-kill-result,
+.controls-poll-result {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  min-height: 1.2em;
+}
+
+/* ── Kill history table ──────────────────────────────────────── */
+.controls-history {
+  margin-top: 1rem;
+}
+
+.controls-history-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 0.75rem;
+}
+
+.controls-history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.controls-history-table th {
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding: 0.3rem 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.controls-history-table td {
+  padding: 0.45rem 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+  vertical-align: middle;
+}
+
+.controls-history-table tr:last-child td {
+  border-bottom: none;
+}
+
+.controls-history-table tr:hover td {
+  background: var(--bg-elevated);
+}
+
+.controls-history-link {
+  color: var(--accent-bright);
+  text-decoration: none;
+}
+
+.controls-history-link:hover {
+  text-decoration: underline;
+}
+
+.toast-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 360px;
+  pointer-events: none;
+}
+
+.toast {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius, 0.375rem);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  font-size: 0.875rem;
+  pointer-events: all;
+}
+
+.toast--success {
+  background: #dcfce7;
+  color: #15803d;
+  border-left: 3px solid #16a34a;
+}
+
+.toast--error {
+  background: #fee2e2;
+  color: #b91c1c;
+  border-left: 3px solid #dc2626;
+}
+
+.toast--warning {
+  background: #fef9c3;
+  color: #a16207;
+  border-left: 3px solid #ca8a04;
+}
+
+.toast--info {
+  background: #dbeafe;
+  color: #1d4ed8;
+  border-left: 3px solid #2563eb;
+}
+
+/* ═══ Org Chart Page ═════════════════════════════════════════════════════════ */
+/* ── Two-column page layout ─────────────────────────────────────────────── */
+.org-chart-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: var(--space-4);
+  align-items: start;
+  min-height: calc(100vh - 140px);
+}
+@media (max-width: 768px) {
+  .org-chart-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Left panel: preset picker ───────────────────────────────────────────── */
+.org-chart-left {
+  position: sticky;
+  top: var(--space-4);
+}
+
+/* ── Right panel: tree + builder shell ───────────────────────────────────── */
+.org-chart-right {
+  min-height: 0;
+}
+
+.org-right-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* ── D3 tree sub-panel ───────────────────────────────────────────────────── */
+.org-tree-panel {
+  position: relative;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  min-height: 520px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.org-tree-svg {
+  display: block;
+  width: 100%;
+  overflow: visible;
+}
+
+.org-tree-placeholder {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-align: center;
+  padding: var(--space-4);
+  margin: 0;
+}
+
+/* ── Tooltip ─────────────────────────────────────────────────────────────── */
+.org-tree-tooltip {
+  display: none;
+  position: absolute;
+  z-index: 100;
+  background: var(--bg-overlay, #0f172a);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  padding: 8px 12px;
+  pointer-events: none;
+  font-size: 0.75rem;
+  max-width: 220px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.org-tooltip-name {
+  display: block;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+
+.org-tooltip-tier {
+  display: block;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.org-tooltip-figs {
+  display: block;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ── Builder sub-panel (reserved for #829) ───────────────────────────────── */
+.org-builder-panel {
+  /* Populated by org_chart.js from issue #829 — empty for now */
+  min-height: 0;
+}
+
+/* ── Preset cards ────────────────────────────────────────────────────────── */
+.org-preset-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.org-preset-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  padding: var(--space-3);
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  text-align: left;
+  width: 100%;
+}
+.org-preset-card:hover {
+  border-color: var(--border-hover, #475569);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+.org-preset-card--active {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.25);
+}
+
+.org-preset-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-1);
+}
+
+.org-preset-card__name {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.org-preset-card__badge {
+  font-size: 0.7rem;
+}
+
+.org-preset-card__desc {
+  font-size: 0.78rem;
+  margin: 0 0 var(--space-2);
+  line-height: 1.4;
+}
+
+.org-preset-card__tiers {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-2);
+}
+
+.org-preset-card__tier {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-1);
+}
+
+.org-preset-card__tier-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  min-width: 72px;
+  padding-top: 2px;
+}
+
+.org-preset-card__roles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.org-preset-card__btn {
+  width: 100%;
+  font-size: 0.8rem;
+  padding: 6px 12px;
+}
+
+/*# sourceMappingURL=app.css.map */

--- a/agentception/static/js/org_chart_tree.js
+++ b/agentception/static/js/org_chart_tree.js
@@ -1,0 +1,414 @@
+'use strict';
+
+/**
+ * Org Chart D3 tree visualization.
+ *
+ * Fetches GET /api/org/tree and renders a vertical D3 tree inside
+ * #org-tree-panel.  Matches the visual style of dag.js: same PALETTE,
+ * same font stack, same link stroke, same zoom behaviour.
+ *
+ * Node cards show: role name, tier badge, assigned phase chips (future),
+ * and the first two compatible-figure avatars from the taxonomy.
+ *
+ * Clicking a node navigates to /roles/<slug> (the Role Studio editor).
+ *
+ * D3 is loaded from CDN in the page's {% block head %} — this module
+ * guards against d3 being absent so the page degrades gracefully.
+ */
+
+// ── Visual constants (mirror dag.js) ─────────────────────────────────────────
+
+const PALETTE = [
+  '#3b82f6', '#6366f1', '#14b8a6', '#22c55e',
+  '#f97316', '#ef4444', '#a855f7', '#06b6d4', '#eab308', '#ec4899',
+];
+
+const TIER_COLORS = {
+  'C-Suite': '#6366f1',
+  'VP':      '#14b8a6',
+  'Worker':  '#3b82f6',
+  'org':     '#a855f7',
+};
+
+const CARD_W   = 160;
+const CARD_H   = 80;
+const DX       = 200; // horizontal spacing between nodes
+const DY       = 130; // vertical spacing between tree levels
+
+// ── Module state ─────────────────────────────────────────────────────────────
+
+let _svg    = null;
+let _g      = null;
+let _zoom   = null;
+let _width  = 900;
+let _height = 520;
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+/**
+ * Initialise the org chart tree.  Called once the DOM is ready.
+ * Fetches /api/org/tree and renders the D3 tree; shows a placeholder
+ * when no active preset is selected (HTTP 404 from the endpoint).
+ */
+export async function initOrgChartTree() {
+  if (typeof d3 === 'undefined') {
+    _showMessage('D3 library not loaded — tree unavailable.');
+    return;
+  }
+
+  const panel = document.getElementById('org-tree-panel');
+  if (!panel) return;
+
+  _showMessage('Loading org tree…');
+
+  let data;
+  try {
+    const resp = await fetch('/api/org/tree');
+    if (resp.status === 404) {
+      _showMessage('No active preset selected. Choose one on the left to see the org tree.');
+      return;
+    }
+    if (!resp.ok) {
+      _showMessage(`Failed to load org tree (HTTP ${resp.status}).`);
+      return;
+    }
+    data = await resp.json();
+  } catch (err) {
+    _showMessage('Network error loading org tree.');
+    return;
+  }
+
+  _clearPanel();
+  _render(panel, data);
+}
+
+// ── Render ────────────────────────────────────────────────────────────────────
+
+function _render(panel, rootData) {
+  const rect  = panel.getBoundingClientRect();
+  _width  = Math.max(rect.width  || 900, 400);
+  _height = Math.max(rect.height || 520, 400);
+
+  // Convert the flat JSON tree into a D3 hierarchy.
+  // Each OrgTreeNode may have tier-group children (no slug) or be a leaf role.
+  const hierarchy = _buildHierarchy(rootData);
+  const root      = d3.hierarchy(hierarchy);
+
+  // Use d3.tree for a vertical (top-down) layout.
+  const treeLayout = d3.tree()
+    .nodeSize([DX, DY])
+    .separation((a, b) => (a.parent === b.parent ? 1.2 : 1.8));
+
+  treeLayout(root);
+
+  // Compute bounding box to center the tree in the panel.
+  let x0 = Infinity, x1 = -Infinity;
+  root.each(d => {
+    if (d.x < x0) x0 = d.x;
+    if (d.x > x1) x1 = d.x;
+  });
+  const treeW = x1 - x0 + CARD_W + 40;
+
+  _svg = d3.select(panel)
+    .append('svg')
+    .attr('class', 'org-tree-svg')
+    .attr('width',  '100%')
+    .attr('height', _height)
+    .attr('aria-label', 'Org chart tree visualization');
+
+  _zoom = d3.zoom()
+    .scaleExtent([0.1, 4])
+    .on('zoom', ev => _g.attr('transform', ev.transform));
+
+  _svg.call(_zoom);
+
+  _g = _svg.append('g').attr('class', 'org-tree-container');
+
+  // Arrow marker — same style as dag.js
+  _svg.append('defs').append('marker')
+    .attr('id', 'org-arrow')
+    .attr('viewBox', '0 0 10 10')
+    .attr('refX', 5)
+    .attr('refY', 5)
+    .attr('markerWidth', 5)
+    .attr('markerHeight', 5)
+    .attr('orient', 'auto-start-reverse')
+    .append('path')
+    .attr('d', 'M 0 0 L 10 5 L 0 10 z')
+    .attr('fill', '#6b7280');
+
+  // ── Links ────────────────────────────────────────────────────────────────
+  _g.append('g')
+    .attr('class', 'org-tree-links')
+    .selectAll('path')
+    .data(root.links())
+    .join('path')
+    .attr('d', d => _elbow(d))
+    .attr('fill', 'none')
+    .attr('stroke', '#6b7280')
+    .attr('stroke-width', 1.5)
+    .attr('opacity', 0.6)
+    .attr('marker-end', 'url(#org-arrow)');
+
+  // ── Nodes ────────────────────────────────────────────────────────────────
+  const nodeGroup = _g.append('g').attr('class', 'org-tree-nodes');
+
+  const node = nodeGroup
+    .selectAll('g.org-node')
+    .data(root.descendants())
+    .join('g')
+    .attr('class', 'org-node')
+    .attr('transform', d => `translate(${d.x - CARD_W / 2},${d.y - CARD_H / 2})`)
+    .style('cursor', d => d.data.slug ? 'pointer' : 'default')
+    .on('click', (_ev, d) => {
+      if (d.data.slug) {
+        window.location.href = `/roles/${d.data.slug}`;
+      }
+    });
+
+  // Card background
+  node.append('rect')
+    .attr('width',  CARD_W)
+    .attr('height', CARD_H)
+    .attr('rx', 10)
+    .attr('ry', 10)
+    .attr('fill',   d => _cardFill(d.data))
+    .attr('stroke', d => _cardStroke(d.data))
+    .attr('stroke-width', 2)
+    .attr('opacity', 0.92);
+
+  // Role name (or tier-group label)
+  node.append('text')
+    .attr('x', CARD_W / 2)
+    .attr('y', d => d.data.tier === 'org' ? CARD_H / 2 : 20)
+    .attr('text-anchor', 'middle')
+    .attr('dominant-baseline', d => d.data.tier === 'org' ? 'central' : 'auto')
+    .attr('font-size', d => d.data.tier === 'org' ? '13px' : '11px')
+    .attr('font-family', 'monospace')
+    .attr('fill', '#fff')
+    .attr('pointer-events', 'none')
+    .text(d => d.data.name || '');
+
+  // Tier badge (only for role leaf nodes)
+  node.filter(d => !!d.data.slug)
+    .append('rect')
+    .attr('x', 8)
+    .attr('y', 30)
+    .attr('width', 60)
+    .attr('height', 16)
+    .attr('rx', 4)
+    .attr('fill', d => TIER_COLORS[d.data.tier] || '#6b7280')
+    .attr('opacity', 0.75);
+
+  node.filter(d => !!d.data.slug)
+    .append('text')
+    .attr('x', 38)
+    .attr('y', 41)
+    .attr('text-anchor', 'middle')
+    .attr('dominant-baseline', 'central')
+    .attr('font-size', '8px')
+    .attr('font-family', 'monospace')
+    .attr('fill', '#fff')
+    .attr('pointer-events', 'none')
+    .text(d => d.data.tier || '');
+
+  // Figure avatar chips (first 2 figures, shown as small colored circles)
+  node.filter(d => !!d.data.slug && Array.isArray(d.data.figures) && d.data.figures.length > 0)
+    .each(function(d) {
+      const g = d3.select(this);
+      const figures = d.data.figures.slice(0, 2);
+      figures.forEach((fig, i) => {
+        const cx = CARD_W - 24 - i * 22;
+        const cy = 41;
+        g.append('circle')
+          .attr('cx', cx)
+          .attr('cy', cy)
+          .attr('r', 9)
+          .attr('fill', PALETTE[(fig.length + i) % PALETTE.length])
+          .attr('opacity', 0.85)
+          .attr('stroke', '#1e293b')
+          .attr('stroke-width', 1);
+
+        g.append('text')
+          .attr('x', cx)
+          .attr('y', cy)
+          .attr('text-anchor', 'middle')
+          .attr('dominant-baseline', 'central')
+          .attr('font-size', '6px')
+          .attr('font-family', 'monospace')
+          .attr('fill', '#fff')
+          .attr('pointer-events', 'none')
+          .text(fig.slice(0, 2).toUpperCase());
+      });
+    });
+
+  // Phase chips (assigned_phases — empty for now, reserved for future)
+  node.filter(d => !!d.data.slug && Array.isArray(d.data.assigned_phases) && d.data.assigned_phases.length > 0)
+    .each(function(d) {
+      const g = d3.select(this);
+      d.data.assigned_phases.slice(0, 2).forEach((phase, i) => {
+        const color = PALETTE[i % PALETTE.length];
+        const chipX = 8 + i * 52;
+        g.append('rect')
+          .attr('x', chipX)
+          .attr('y', 56)
+          .attr('width', 48)
+          .attr('height', 14)
+          .attr('rx', 3)
+          .attr('fill', color)
+          .attr('opacity', 0.7);
+        g.append('text')
+          .attr('x', chipX + 24)
+          .attr('y', 63)
+          .attr('text-anchor', 'middle')
+          .attr('dominant-baseline', 'central')
+          .attr('font-size', '7px')
+          .attr('font-family', 'monospace')
+          .attr('fill', '#fff')
+          .attr('pointer-events', 'none')
+          .text(phase.split('/').pop() || phase);
+      });
+    });
+
+  // Tooltip for role nodes
+  const tooltip = document.getElementById('org-tree-tooltip');
+  node.filter(d => !!d.data.slug)
+    .on('mouseover', (ev, d) => {
+      if (!tooltip) return;
+      tooltip.innerHTML =
+        `<span class="org-tooltip-name">${d.data.name}</span>` +
+        `<span class="org-tooltip-tier">${d.data.tier}</span>` +
+        (d.data.figures && d.data.figures.length
+          ? `<span class="org-tooltip-figs">Figures: ${d.data.figures.join(', ')}</span>`
+          : '');
+      tooltip.style.display = 'block';
+    })
+    .on('mousemove', ev => {
+      if (!tooltip) return;
+      const panelRect = panel.getBoundingClientRect();
+      tooltip.style.left = (ev.clientX - panelRect.left + 12) + 'px';
+      tooltip.style.top  = (ev.clientY - panelRect.top  + 12) + 'px';
+    })
+    .on('mouseout', () => {
+      if (tooltip) tooltip.style.display = 'none';
+    });
+
+  // Initial fit-to-view so the full tree is visible without manual zoom.
+  _fitView(root);
+
+  // Re-centre when the panel resizes.
+  const ro = new ResizeObserver(() => {
+    const r = panel.getBoundingClientRect();
+    _width  = Math.max(r.width  || 900, 400);
+    _height = Math.max(r.height || 520, 400);
+    _svg.attr('height', _height);
+    _fitView(root);
+  });
+  ro.observe(panel);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Convert the OrgTreeNode JSON into a flat list of nodes suitable for
+ * d3.hierarchy().  Tier-group children (leadership / workers) become
+ * intermediate nodes; roles within them become leaf nodes.
+ */
+function _buildHierarchy(node) {
+  const result = {
+    name:    node.name,
+    id:      node.id,
+    tier:    node.tier,
+    slug:    null,
+    figures: [],
+    assigned_phases: [],
+    children: [],
+  };
+
+  for (const child of node.children || []) {
+    const tierNode = {
+      name:    child.name,
+      id:      child.id,
+      tier:    child.tier,
+      slug:    null,
+      figures: [],
+      assigned_phases: [],
+      children: (child.roles || []).map(role => ({
+        name:            role.name,
+        id:              role.slug,
+        slug:            role.slug,
+        tier:            role.tier,
+        figures:         role.figures || [],
+        assigned_phases: role.assigned_phases || [],
+        children:        [],
+      })),
+    };
+    result.children.push(tierNode);
+  }
+
+  return result;
+}
+
+/**
+ * Elbow curve connector — top-to-bottom orthogonal path matching the
+ * vertical tree layout.  Same visual grammar as dag.js links.
+ */
+function _elbow(d) {
+  const srcX  = d.source.x;
+  const srcY  = d.source.y + CARD_H / 2;
+  const tgtX  = d.target.x;
+  const tgtY  = d.target.y - CARD_H / 2;
+  const midY  = (srcY + tgtY) / 2;
+  return `M${srcX},${srcY} C${srcX},${midY} ${tgtX},${midY} ${tgtX},${tgtY}`;
+}
+
+/** Card fill colour: org root purple, tier groups dark, roles by tier. */
+function _cardFill(d) {
+  if (d.tier === 'org') return '#4c1d95';
+  if (!d.slug) return '#1e293b';
+  return TIER_COLORS[d.tier] || '#6b7280';
+}
+
+/** Card border — highlight role nodes with a subtle glow stroke. */
+function _cardStroke(d) {
+  if (d.tier === 'org') return '#7c3aed';
+  if (!d.slug) return '#334155';
+  return '#64748b';
+}
+
+/** Zoom/pan the SVG so the entire tree fits within the visible panel. */
+function _fitView(root) {
+  if (!_svg || !_g || !_zoom) return;
+
+  const nodes  = root.descendants();
+  const pad    = 48;
+  const minX   = Math.min(...nodes.map(d => d.x)) - CARD_W / 2;
+  const maxX   = Math.max(...nodes.map(d => d.x)) + CARD_W / 2;
+  const minY   = Math.min(...nodes.map(d => d.y)) - CARD_H / 2;
+  const maxY   = Math.max(...nodes.map(d => d.y)) + CARD_H / 2;
+  const bboxW  = Math.max(maxX - minX, 1);
+  const bboxH  = Math.max(maxY - minY, 1);
+  const scale  = Math.min(
+    (_width  - pad * 2) / bboxW,
+    (_height - pad * 2) / bboxH,
+    2,
+  );
+  const tx = (_width  / 2) - (minX + bboxW / 2) * scale;
+  const ty = pad - minY * scale;
+
+  _svg.transition().duration(400)
+    .call(_zoom.transform, d3.zoomIdentity.translate(tx, ty).scale(scale));
+}
+
+/** Replace panel contents with a centred message string. */
+function _showMessage(msg) {
+  const panel = document.getElementById('org-tree-panel');
+  if (!panel) return;
+  panel.innerHTML = `<p class="org-tree-placeholder">${msg}</p>`;
+}
+
+/** Remove all children from the panel before (re-)rendering. */
+function _clearPanel() {
+  const panel = document.getElementById('org-tree-panel');
+  if (panel) panel.innerHTML = '';
+}

--- a/agentception/static/scss/app.scss
+++ b/agentception/static/scss/app.scss
@@ -60,3 +60,4 @@
 @use 'pages/ab-testing';
 @use 'pages/controls';
 @use 'pages/toast';
+@use 'pages/org-chart';

--- a/agentception/static/scss/pages/_org-chart.scss
+++ b/agentception/static/scss/pages/_org-chart.scss
@@ -1,0 +1,192 @@
+/* ═══ Org Chart Page ═════════════════════════════════════════════════════════ */
+
+/* ── Two-column page layout ─────────────────────────────────────────────── */
+
+.org-chart-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: var(--space-4);
+  align-items: start;
+  min-height: calc(100vh - 140px);
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Left panel: preset picker ───────────────────────────────────────────── */
+
+.org-chart-left {
+  position: sticky;
+  top: var(--space-4);
+}
+
+/* ── Right panel: tree + builder shell ───────────────────────────────────── */
+
+.org-chart-right {
+  min-height: 0;
+}
+
+.org-right-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* ── D3 tree sub-panel ───────────────────────────────────────────────────── */
+
+.org-tree-panel {
+  position: relative;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  min-height: 520px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.org-tree-svg {
+  display: block;
+  width: 100%;
+  overflow: visible;
+}
+
+.org-tree-placeholder {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-align: center;
+  padding: var(--space-4);
+  margin: 0;
+}
+
+/* ── Tooltip ─────────────────────────────────────────────────────────────── */
+
+.org-tree-tooltip {
+  display: none;
+  position: absolute;
+  z-index: 100;
+  background: var(--bg-overlay, #0f172a);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  padding: 8px 12px;
+  pointer-events: none;
+  font-size: 0.75rem;
+  max-width: 220px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.org-tooltip-name {
+  display: block;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+
+.org-tooltip-tier {
+  display: block;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.org-tooltip-figs {
+  display: block;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ── Builder sub-panel (reserved for #829) ───────────────────────────────── */
+
+.org-builder-panel {
+  /* Populated by org_chart.js from issue #829 — empty for now */
+  min-height: 0;
+}
+
+/* ── Preset cards ────────────────────────────────────────────────────────── */
+
+.org-preset-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.org-preset-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  padding: var(--space-3);
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  text-align: left;
+  width: 100%;
+
+  &:hover {
+    border-color: var(--border-hover, #475569);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  }
+
+  &--active {
+    border-color: #6366f1;
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.25);
+  }
+}
+
+.org-preset-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-1);
+}
+
+.org-preset-card__name {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.org-preset-card__badge {
+  font-size: 0.7rem;
+}
+
+.org-preset-card__desc {
+  font-size: 0.78rem;
+  margin: 0 0 var(--space-2);
+  line-height: 1.4;
+}
+
+.org-preset-card__tiers {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-2);
+}
+
+.org-preset-card__tier {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-1);
+}
+
+.org-preset-card__tier-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  min-width: 72px;
+  padding-top: 2px;
+}
+
+.org-preset-card__roles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.org-preset-card__btn {
+  width: 100%;
+  font-size: 0.8rem;
+  padding: 6px 12px;
+}

--- a/agentception/templates/org_chart.html
+++ b/agentception/templates/org_chart.html
@@ -2,13 +2,29 @@
 
 {% block title %}Org Chart — Agentception{% endblock %}
 
+{% block head %}
+  {# D3 must load before org_chart_tree.js initialises #}
+  <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js"
+          integrity="sha256-1rA8rCEWBqUBbBkMcNZKQgMoJJLtVAVVJD4/4CVblsQ="
+          crossorigin="anonymous"></script>
+  <script type="module">
+    import { initOrgChartTree } from '/static/js/org_chart_tree.js';
+    document.addEventListener('DOMContentLoaded', () => initOrgChartTree());
+    {# Re-render tree whenever the active preset changes (HTMX swaps the left panel) #}
+    document.addEventListener('htmx:afterSwap', (ev) => {
+      if (ev.detail.target && ev.detail.target.id === 'org-preset-list') {
+        initOrgChartTree();
+      }
+    });
+  </script>
+{% endblock %}
+
 {% block content %}
 <div class="page-header">
   <h1 class="page-title">Org Chart</h1>
   <p class="page-subtitle text-muted">
     Choose a preset org topology. The active org governs which agent roles the
-    pipeline spawns.  Issues #829 and #830 will add an interactive builder and
-    D3 tree to the right panel.
+    pipeline spawns.
   </p>
 </div>
 
@@ -20,21 +36,23 @@
     {% include "_org_preset_list.html" %}
   </section>
 
-  {# ── Right panel: builder shell — reserved for #829 (builder) and #830 (D3) #}
-  <section class="org-chart-right" aria-label="Org chart builder">
+  {# ── Right panel: D3 tree + builder shell (#829) ────────────────────────── #}
+  <section class="org-chart-right" aria-label="Org chart tree">
     <div id="org-right-panel" class="org-right-panel">
-      <div class="org-right-panel__placeholder">
-        <span class="org-right-panel__icon" aria-hidden="true">🌳</span>
-        <p class="org-right-panel__message text-muted">
-          Interactive builder coming in <strong>#829</strong>.
-          D3 org tree coming in <strong>#830</strong>.
-        </p>
-        {% if active_org_id %}
-        <p class="text-muted">
-          Active preset: <code>{{ active_org_id }}</code>
-        </p>
-        {% endif %}
+
+      {# D3 tree panel — populated by org_chart_tree.js (issue #830) #}
+      <div id="org-tree-panel" class="org-tree-panel">
+        <p class="org-tree-placeholder">Loading org tree…</p>
       </div>
+
+      {# Tooltip overlay for role nodes #}
+      <div id="org-tree-tooltip" class="org-tree-tooltip" role="tooltip"></div>
+
+      {# Builder shell — reserved for issue #829 #}
+      <div id="org-builder-panel" class="org-builder-panel">
+        {# Populated by org_chart.js from issue #829 #}
+      </div>
+
     </div>
   </section>
 

--- a/agentception/tests/test_agentception_org_chart.py
+++ b/agentception/tests/test_agentception_org_chart.py
@@ -1,9 +1,11 @@
-"""Tests for the /org-chart page and POST /api/org/select-preset endpoint.
+"""Tests for the /org-chart page, POST /api/org/select-preset, and GET /api/org/tree.
 
 Covers:
-- GET /org-chart renders the page with preset cards
+- GET /org-chart renders the page with preset cards and D3 tree panel
 - POST /api/org/select-preset persists the selection and returns a refreshed partial
 - POST /api/org/select-preset rejects unknown preset IDs with HTTP 422
+- GET /api/org/tree returns a hierarchical JSON tree for the active preset
+- GET /api/org/tree returns 404 when no active preset is selected
 
 Run targeted:
     docker compose exec agentception pytest agentception/tests/test_agentception_org_chart.py -v
@@ -215,3 +217,186 @@ class TestSelectPreset:
 
         assert resp.status_code == 200
         assert "org-preset-card--active" in resp.text
+
+
+class TestOrgTree:
+    """GET /api/org/tree — D3 tree data endpoint."""
+
+    def test_org_tree_returns_404_when_no_active_org(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """When no active org is set, the endpoint should return HTTP 404."""
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets),
+            patch("agentception.routes.ui.org_chart._read_pipeline_config", return_value={}),
+        ):
+            resp = client.get("/api/org/tree")
+
+        assert resp.status_code == 404
+
+    def test_org_tree_returns_200_for_active_preset(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """When an active preset is set, the endpoint should return HTTP 200."""
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets),
+            patch(
+                "agentception.routes.ui.org_chart._read_pipeline_config",
+                return_value={"active_org": "solo-cto"},
+            ),
+            patch(
+                "agentception.routes.ui.org_chart._load_taxonomy_role_index",
+                return_value={},
+            ),
+        ):
+            resp = client.get("/api/org/tree")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+
+    def test_org_tree_root_name_matches_preset(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """The root node name should match the selected preset's display name."""
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets),
+            patch(
+                "agentception.routes.ui.org_chart._read_pipeline_config",
+                return_value={"active_org": "solo-cto"},
+            ),
+            patch(
+                "agentception.routes.ui.org_chart._load_taxonomy_role_index",
+                return_value={},
+            ),
+        ):
+            resp = client.get("/api/org/tree")
+
+        data = resp.json()
+        assert data["name"] == "Solo CTO"
+        assert data["id"] == "solo-cto"
+        assert data["tier"] == "org"
+
+    def test_org_tree_contains_tier_children(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """The tree should contain leadership and workers tier children."""
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets),
+            patch(
+                "agentception.routes.ui.org_chart._read_pipeline_config",
+                return_value={"active_org": "solo-cto"},
+            ),
+            patch(
+                "agentception.routes.ui.org_chart._load_taxonomy_role_index",
+                return_value={},
+            ),
+        ):
+            resp = client.get("/api/org/tree")
+
+        data = resp.json()
+        tier_ids = {child["id"] for child in data["children"]}
+        assert "leadership" in tier_ids
+        assert "workers" in tier_ids
+
+    def test_org_tree_roles_include_slug_and_tier(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """Each role node must include slug, name, tier, assigned_phases, and figures fields."""
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets),
+            patch(
+                "agentception.routes.ui.org_chart._read_pipeline_config",
+                return_value={"active_org": "small-team"},
+            ),
+            patch(
+                "agentception.routes.ui.org_chart._load_taxonomy_role_index",
+                return_value={
+                    "cto": {"tier": "C-Suite", "label": "CTO", "title": "Chief Technology Officer", "compatible_figures": ["turing", "shannon"]},
+                    "vp-engineering": {"tier": "VP", "label": "VP Engineering", "title": "VP of Engineering", "compatible_figures": ["dijkstra"]},
+                    "python-developer": {"tier": "Worker", "label": "Python Developer", "title": "Python Developer", "compatible_figures": []},
+                },
+            ),
+        ):
+            resp = client.get("/api/org/tree")
+
+        data = resp.json()
+        leadership = next(c for c in data["children"] if c["id"] == "leadership")
+        cto_role = next((r for r in leadership["roles"] if r["slug"] == "cto"), None)
+        assert cto_role is not None
+        assert cto_role["tier"] == "C-Suite"
+        assert cto_role["name"] == "CTO"
+        assert "assigned_phases" in cto_role
+        assert isinstance(cto_role["assigned_phases"], list)
+        assert "figures" in cto_role
+        assert cto_role["figures"] == ["turing", "shannon"]
+
+    def test_org_tree_figures_capped_at_two(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """Even if a role has many compatible figures, the endpoint returns at most 2."""
+        many_figures = ["fig1", "fig2", "fig3", "fig4", "fig5"]
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets),
+            patch(
+                "agentception.routes.ui.org_chart._read_pipeline_config",
+                return_value={"active_org": "solo-cto"},
+            ),
+            patch(
+                "agentception.routes.ui.org_chart._load_taxonomy_role_index",
+                return_value={
+                    "cto": {"tier": "C-Suite", "label": "CTO", "title": "CTO", "compatible_figures": many_figures},
+                    "python-developer": {"tier": "Worker", "label": "Python Dev", "title": "Python Dev", "compatible_figures": []},
+                    "pr-reviewer": {"tier": "Worker", "label": "PR Reviewer", "title": "PR Reviewer", "compatible_figures": []},
+                },
+            ),
+        ):
+            resp = client.get("/api/org/tree")
+
+        data = resp.json()
+        leadership = next(c for c in data["children"] if c["id"] == "leadership")
+        cto_role = next(r for r in leadership["roles"] if r["slug"] == "cto")
+        assert len(cto_role["figures"]) <= 2
+
+    def test_org_tree_returns_404_for_unknown_active_org(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """If active_org references a preset not in the presets list, return HTTP 404."""
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets),
+            patch(
+                "agentception.routes.ui.org_chart._read_pipeline_config",
+                return_value={"active_org": "does-not-exist"},
+            ),
+        ):
+            resp = client.get("/api/org/tree")
+
+        assert resp.status_code == 404
+
+    def test_org_tree_org_tree_panel_present_in_page(
+        self,
+        client: TestClient,
+        sample_presets: list[dict[str, object]],
+    ) -> None:
+        """The org-chart page HTML must contain the #org-tree-panel div."""
+        with (
+            patch("agentception.routes.ui.org_chart._load_presets", return_value=sample_presets),
+            patch("agentception.routes.ui.org_chart._read_pipeline_config", return_value={}),
+        ):
+            resp = client.get("/org-chart")
+
+        assert resp.status_code == 200
+        assert 'id="org-tree-panel"' in resp.text


### PR DESCRIPTION
## Summary

Closes #830 — adds the D3 tree visualization for the active org preset inside `#org-tree-panel` within the right panel of `/org-chart`.

## Root Cause / Motivation

Issue #830 requires a D3 tree that renders the active org preset as a visual hierarchy of role cards, enriched with tier badges, figure avatar chips, and click navigation to the Role Studio editor.

## Solution

### New endpoint: `GET /api/org/tree`
- Reads the active preset from `pipeline-config.json`
- Enriches each role slug with tier and compatible-figure data from `role-taxonomy.yaml`
- Returns a typed `OrgTreeNode` hierarchy consumed by the D3 script

### New Pydantic models (`agentception/models.py`)
- `OrgTreeRole` — slug, name, tier, assigned_phases, figures (first 2)
- `OrgTreeNode` — recursive tree node (name, id, tier, roles, children)

### D3 script (`agentception/static/js/org_chart_tree.js`)
- Vertical `d3.tree()` layout with zoom-to-fit on load
- Node cards: role name, tier badge, figure avatar chips (colored circles with 2-char initials), phase label chips
- Click navigates to `/roles/<slug>` (Role Studio)
- Matches `dag.js` visual style: same PALETTE, same monospace font, same link/arrow stroke
- Graceful degradation: shows placeholder message if no active preset is selected
- ResizeObserver re-centers tree on panel resize

### Template update (`agentception/templates/org_chart.html`)
- Added `<div id="org-tree-panel">` and `<div id="org-tree-tooltip">` inside `#org-right-panel`
- Added `<div id="org-builder-panel">` shell for #829 coexistence
- D3 CDN loaded in `{% block head %}`; `initOrgChartTree()` called on `DOMContentLoaded` and re-triggered on HTMX preset swap

### SCSS (`agentception/static/scss/pages/_org-chart.scss`)
- Two-column layout, preset card styles, tree panel, tooltip, responsive breakpoint
- Compiled into `app.css` via `make css` (dart-sass)

## Verification

- [x] mypy clean (`Success: no issues found in 102 source files`)
- [x] 17 tests pass (9 pre-existing + 8 new for `/api/org/tree`)
- [x] D3 script does NOT conflict with #829's `org_chart.js` (different filename, different panel div)
- [x] `#org-tree-panel` coexists with `#org-builder-panel` inside `#org-right-panel`
- [x] Single-quoted HTML attributes used for all Jinja2 tojson expressions

## Files changed

| File | Change |
|------|--------|
| `agentception/models.py` | +`OrgTreeRole`, +`OrgTreeNode` |
| `agentception/routes/ui/org_chart.py` | +`GET /api/org/tree`, +`_load_taxonomy_role_index()` |
| `agentception/static/js/org_chart_tree.js` | New D3 tree script |
| `agentception/static/scss/pages/_org-chart.scss` | New page styles |
| `agentception/static/scss/app.scss` | +`@use 'pages/org-chart'` |
| `agentception/static/app.css` | Compiled output |
| `agentception/templates/org_chart.html` | +`#org-tree-panel`, D3 CDN, script tag |
| `agentception/tests/test_agentception_org_chart.py` | +8 tests for `TestOrgTree` |

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Role** | `python-developer` |
| **Architecture** | `john_carmack:d3:javascript` |
| **Session** | `eng-20260303T171203Z-0830` |
| **CTO Wave** | `cto-20260303T170027Z` |
| **VP Batch** | `vp-eng-ac-phase2-20260303T170027Z` |
| **Timestamp** | `2026-03-03T17:19:30Z` |

</details>