### PR TITLE
feat: org chart builder — add/remove roles and assign phases (#829)

### DIFF
--- a/agentception/routes/ui/org_chart.py
+++ b/agentception/routes/ui/org_chart.py
@@ -1,27 +1,35 @@
-"""UI routes: Org Chart page with preset org picker.
+"""UI routes: Org Chart page with preset org picker and interactive builder.
 
 Provides:
-- ``GET /org-chart`` — full-page render of the org chart with a left-panel
-  preset picker and a right-panel shell (``#org-right-panel``) reserved for
-  the interactive builder (#829) and D3 tree (#830).
+- ``GET /org-chart`` — full-page render with left panel preset picker and
+  right panel interactive builder.
 - ``POST /api/org/select-preset`` — HTMX endpoint that persists the chosen
-  preset to ``pipeline-config.json`` under the ``active_org`` key and returns
-  a refreshed left-panel partial so the active card updates in-place.
+  preset to ``pipeline-config.json`` and refreshes the left panel.
+- ``GET /api/roles/taxonomy`` — returns the role taxonomy grouped by tier
+  (c_suite / vp / worker) for the Add Role dropdown.
+- ``POST /api/org/roles/add`` — adds a role to the active builder org and
+  returns a refreshed role list partial.
+- ``DELETE /api/org/roles/{slug}`` — removes a role from the builder org and
+  returns a refreshed role list partial.
+- ``POST /api/org/roles/{slug}/phases`` — updates assigned phases for a role
+  card and returns the refreshed role list partial.
+- ``POST /api/org/templates`` — saves the current builder org as a new preset
+  in ``org-presets.yaml`` and returns the refreshed preset list partial.
 
 Preset definitions are loaded from ``org-presets.yaml`` at the repo root.
-The file is read once per request (fast — ~1 KB) so hot-editing the YAML
-during development takes effect without a service restart.
+Role list and phase assignments are persisted to ``pipeline-config.json``
+under the ``active_org_roles`` key so they survive page reloads.
 """
 from __future__ import annotations
 
 import json
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import yaml  # type: ignore[import-untyped]
 from fastapi import APIRouter, Form, HTTPException
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from starlette.requests import Request
 
 from agentception.config import settings
@@ -31,9 +39,136 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# Path to the org-presets YAML, resolved relative to the repo root so it works
-# both on the host and inside Docker (where the repo is mounted at /repo).
+# ---------------------------------------------------------------------------
+# File paths
+# ---------------------------------------------------------------------------
+
 _PRESETS_PATH = Path(__file__).parent.parent.parent.parent / "org-presets.yaml"
+
+
+def _pipeline_config_path() -> Path:
+    """Return the canonical path to pipeline-config.json for the active repo."""
+    return settings.repo_dir / ".cursor" / "pipeline-config.json"
+
+
+# ---------------------------------------------------------------------------
+# Role taxonomy — tiers used for the Add Role grouped dropdown.
+# Roles not in any tier fall into "worker" implicitly (via the _OTHER sentinel).
+# ---------------------------------------------------------------------------
+
+#: Display labels for each tier.
+TIER_LABELS: dict[str, str] = {
+    "c_suite": "C-Suite",
+    "vp": "VP / Coordinator",
+    "worker": "Worker",
+}
+
+#: Canonical role taxonomy, ordered within each tier for display.
+ROLE_TAXONOMY: dict[str, list[str]] = {
+    "c_suite": [
+        "cto", "ceo", "coo", "cfo", "cpo", "cmo", "cdo", "ciso",
+    ],
+    "vp": [
+        "vp-engineering", "vp-qa", "vp-product", "vp-data", "vp-design",
+        "vp-infrastructure", "vp-ml", "vp-mobile", "vp-platform",
+        "vp-security", "coordinator", "engineering-manager", "qa-manager",
+    ],
+    "worker": [
+        "python-developer", "api-developer", "database-architect",
+        "frontend-developer", "typescript-developer", "react-developer",
+        "ios-developer", "android-developer", "mobile-developer",
+        "full-stack-developer", "go-developer", "rails-developer",
+        "rust-developer", "test-engineer", "pr-reviewer", "devops-engineer",
+        "security-engineer", "site-reliability-engineer", "ml-engineer",
+        "ml-researcher", "data-engineer", "data-scientist",
+        "systems-programmer", "technical-writer", "architect",
+        "muse-specialist",
+    ],
+}
+
+#: Tiers that get the phase-assignment multiselect on their role card.
+_PHASE_ASSIGNABLE_TIERS: frozenset[str] = frozenset({"c_suite", "vp"})
+
+
+def _tier_for_slug(slug: str) -> str:
+    """Return the tier key for *slug*, defaulting to ``'worker'``."""
+    for tier, slugs in ROLE_TAXONOMY.items():
+        if slug in slugs:
+            return tier
+    return "worker"
+
+
+# ---------------------------------------------------------------------------
+# Typed role entry stored in pipeline-config.json
+# ---------------------------------------------------------------------------
+
+
+def _make_role_entry(slug: str) -> dict[str, Any]:
+    """Create a fresh role entry dict with an empty assigned_phases list."""
+    return {"slug": slug, "assigned_phases": []}
+
+
+# ---------------------------------------------------------------------------
+# pipeline-config.json I/O
+# ---------------------------------------------------------------------------
+
+
+def _read_pipeline_config() -> dict[str, Any]:
+    """Read pipeline-config.json, returning an empty dict on any error."""
+    path = _pipeline_config_path()
+    if not path.exists():
+        return {}
+    try:
+        raw: object = json.loads(path.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except Exception as exc:
+        logger.warning("⚠️ Could not read pipeline-config.json: %s", exc)
+        return {}
+
+
+def _write_pipeline_config(data: dict[str, Any]) -> None:
+    """Persist *data* back to pipeline-config.json atomically via a rename."""
+    path = _pipeline_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    tmp.rename(path)
+
+
+def _read_active_org_roles(config: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract and validate the ``active_org_roles`` list from *config*.
+
+    Returns an empty list when the key is missing or malformed.  Each entry
+    is coerced to have at least ``slug`` (str) and ``assigned_phases`` (list).
+    """
+    raw: object = config.get("active_org_roles", [])
+    if not isinstance(raw, list):
+        return []
+    result: list[dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        slug = item.get("slug")
+        if not isinstance(slug, str) or not slug:
+            continue
+        phases: object = item.get("assigned_phases", [])
+        if not isinstance(phases, list):
+            phases = []
+        result.append({"slug": slug, "assigned_phases": list(phases)})
+    return result
+
+
+def _read_phases(config: dict[str, Any]) -> list[str]:
+    """Return phase label strings from *config*'s ``active_labels_order`` list."""
+    raw: object = config.get("active_labels_order", [])
+    if not isinstance(raw, list):
+        return []
+    return [p for p in raw if isinstance(p, str)]
+
+
+# ---------------------------------------------------------------------------
+# org-presets.yaml I/O
+# ---------------------------------------------------------------------------
 
 
 def _load_presets() -> list[dict[str, Any]]:
@@ -55,39 +190,108 @@ def _load_presets() -> list[dict[str, Any]]:
         return []
 
 
-def _pipeline_config_path() -> Path:
-    """Return the canonical path to pipeline-config.json for the active repo."""
-    return settings.repo_dir / ".cursor" / "pipeline-config.json"
+def _save_preset(name: str, roles: list[dict[str, Any]]) -> str:
+    """Append a new preset to org-presets.yaml and return its generated slug.
 
-
-def _read_pipeline_config() -> dict[str, Any]:
-    """Read pipeline-config.json, returning an empty dict on any error."""
-    path = _pipeline_config_path()
-    if not path.exists():
-        return {}
+    The slug is derived from the name by lowercasing and replacing spaces with
+    hyphens.  If a preset with the same slug already exists it is overwritten.
+    """
+    slug = name.lower().replace(" ", "-")
     try:
-        raw: object = json.loads(path.read_text(encoding="utf-8"))
-        return raw if isinstance(raw, dict) else {}
-    except Exception as exc:
-        logger.warning("⚠️ Could not read pipeline-config.json: %s", exc)
-        return {}
+        raw_text = _PRESETS_PATH.read_text(encoding="utf-8")
+        raw: object = yaml.safe_load(raw_text)
+        if not isinstance(raw, dict):
+            raw = {}
+        raw_dict: dict[str, Any] = raw  # type: ignore[assignment]
+    except Exception:
+        raw_dict = {}
+
+    presets: object = raw_dict.get("presets", [])
+    if not isinstance(presets, list):
+        presets = []
+    preset_list: list[dict[str, Any]] = [
+        p for p in presets if isinstance(p, dict) and p.get("id") != slug
+    ]
+
+    # Build tiers from the roles list.
+    leadership: list[str] = []
+    workers: list[str] = []
+    for entry in roles:
+        role_slug: object = entry.get("slug")
+        if not isinstance(role_slug, str):
+            continue
+        tier = _tier_for_slug(role_slug)
+        if tier in ("c_suite", "vp"):
+            leadership.append(role_slug)
+        else:
+            workers.append(role_slug)
+
+    new_preset: dict[str, Any] = {
+        "id": slug,
+        "name": name,
+        "description": f"Custom org template with {len(roles)} role(s).",
+        "tiers": {"leadership": leadership, "workers": workers},
+    }
+    preset_list.append(new_preset)
+    raw_dict["presets"] = preset_list
+
+    tmp = _PRESETS_PATH.with_suffix(".tmp")
+    tmp.write_text(
+        yaml.dump(raw_dict, default_flow_style=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    tmp.rename(_PRESETS_PATH)
+    logger.info("✅ Saved preset %r to org-presets.yaml", slug)
+    return slug
 
 
-def _write_pipeline_config(data: dict[str, Any]) -> None:
-    """Persist *data* back to pipeline-config.json atomically via a rename."""
-    path = _pipeline_config_path()
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    tmp.rename(path)
+# ---------------------------------------------------------------------------
+# Helper: build template context for the builder right panel
+# ---------------------------------------------------------------------------
+
+
+def _builder_context(
+    config: dict[str, Any],
+    *,
+    active_org_id: str | None = None,
+) -> dict[str, Any]:
+    """Return the shared context dict for the builder panel partials."""
+    active_org_roles = _read_active_org_roles(config)
+    phases = _read_phases(config)
+
+    # Annotate each role entry with its tier so templates can branch.
+    annotated: list[dict[str, Any]] = []
+    for entry in active_org_roles:
+        tier = _tier_for_slug(entry["slug"])
+        annotated.append(
+            {
+                "slug": entry["slug"],
+                "assigned_phases": entry["assigned_phases"],
+                "tier": tier,
+                "phase_assignable": tier in _PHASE_ASSIGNABLE_TIERS,
+            }
+        )
+
+    return {
+        "active_org_roles": annotated,
+        "phases": phases,
+        "taxonomy": ROLE_TAXONOMY,
+        "tier_labels": TIER_LABELS,
+        "active_org_id": active_org_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
 
 
 @router.get("/org-chart", response_class=HTMLResponse)
 async def org_chart_page(request: Request) -> HTMLResponse:
-    """Org Chart page — preset picker (left) + builder shell (right).
+    """Org Chart page — preset picker (left) + interactive builder (right).
 
-    Renders the full org-chart layout.  The right panel (``#org-right-panel``)
-    is an empty shell that issues #829 and #830 will populate with the
-    interactive builder and D3 tree respectively.
+    The right panel contains the role builder (this issue) with a shell
+    reserved for the D3 tree (#830).
     """
     presets = _load_presets()
     config = _read_pipeline_config()
@@ -99,7 +303,7 @@ async def org_chart_page(request: Request) -> HTMLResponse:
         "org_chart.html",
         {
             "presets": presets,
-            "active_org_id": active_org_id,
+            **_builder_context(config, active_org_id=active_org_id),
         },
     )
 
@@ -109,14 +313,12 @@ async def select_preset(
     request: Request,
     preset_id: str = Form(...),
 ) -> HTMLResponse:
-    """Persist the chosen preset to pipeline-config.json and return a refreshed partial.
+    """Persist the chosen preset and return a refreshed left-panel partial.
 
-    Called by HTMX when the user clicks a preset card.  Writes ``active_org``
-    to ``pipeline-config.json`` and swaps the left panel so the selected card
-    gets the ``active`` CSS class without a full-page reload.
+    Writes ``active_org`` to ``pipeline-config.json`` and swaps the left panel
+    so the selected card gets the ``active`` CSS class without a full-page reload.
 
-    Returns HTTP 422 when *preset_id* does not match any known preset so HTMX
-    can surface the error in the toast system.
+    Returns HTTP 422 when *preset_id* does not match any known preset.
     """
     presets = _load_presets()
     preset_ids = {p["id"] for p in presets if "id" in p}
@@ -140,5 +342,190 @@ async def select_preset(
         {
             "presets": presets,
             "active_org_id": preset_id,
+        },
+    )
+
+
+@router.get("/api/roles/taxonomy")
+async def roles_taxonomy() -> JSONResponse:
+    """Return the role taxonomy grouped by tier for the Add Role dropdown.
+
+    Response shape::
+
+        {
+          "tiers": {
+            "c_suite":  {"label": "C-Suite",         "roles": ["cto", ...]},
+            "vp":       {"label": "VP / Coordinator", "roles": ["vp-engineering", ...]},
+            "worker":   {"label": "Worker",           "roles": ["python-developer", ...]}
+          }
+        }
+    """
+    tiers: dict[str, dict[str, Any]] = {
+        tier: {"label": TIER_LABELS[tier], "roles": roles}
+        for tier, roles in ROLE_TAXONOMY.items()
+    }
+    return JSONResponse({"tiers": tiers})
+
+
+@router.post("/api/org/roles/add", response_class=HTMLResponse)
+async def add_role(
+    request: Request,
+    slug: Annotated[str, Form()],
+) -> HTMLResponse:
+    """Append *slug* to ``active_org_roles`` in pipeline-config.json.
+
+    Silently ignores duplicates so double-submits are idempotent.  Returns the
+    refreshed ``_org_role_list.html`` partial which HTMX swaps into the builder.
+
+    Raises HTTP 422 when *slug* is not in the taxonomy.
+    """
+    all_slugs: set[str] = {
+        s for slugs in ROLE_TAXONOMY.values() for s in slugs
+    }
+    if slug not in all_slugs:
+        raise HTTPException(status_code=422, detail=f"Unknown role slug: {slug!r}")
+
+    config = _read_pipeline_config()
+    roles = _read_active_org_roles(config)
+
+    if not any(r["slug"] == slug for r in roles):
+        roles.append(_make_role_entry(slug))
+        config["active_org_roles"] = roles
+        try:
+            _write_pipeline_config(config)
+            logger.info("✅ Added role %r to active org", slug)
+        except Exception as exc:
+            logger.error("❌ Failed to write pipeline-config.json: %s", exc)
+            raise HTTPException(status_code=500, detail="Failed to add role") from exc
+    else:
+        logger.info("ℹ️ Role %r already present — skipping duplicate", slug)
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "_org_role_list.html",
+        _builder_context(config),
+    )
+
+
+@router.delete("/api/org/roles/{slug}", response_class=HTMLResponse)
+async def remove_role(
+    request: Request,
+    slug: str,
+) -> HTMLResponse:
+    """Remove the role identified by *slug* from ``active_org_roles``.
+
+    Returns the refreshed ``_org_role_list.html`` partial.  Silently succeeds
+    even if *slug* is not currently in the list (idempotent).
+    """
+    config = _read_pipeline_config()
+    roles = _read_active_org_roles(config)
+    updated = [r for r in roles if r["slug"] != slug]
+
+    if len(updated) != len(roles):
+        config["active_org_roles"] = updated
+        try:
+            _write_pipeline_config(config)
+            logger.info("✅ Removed role %r from active org", slug)
+        except Exception as exc:
+            logger.error("❌ Failed to write pipeline-config.json: %s", exc)
+            raise HTTPException(status_code=500, detail="Failed to remove role") from exc
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "_org_role_list.html",
+        _builder_context(config),
+    )
+
+
+@router.post("/api/org/roles/{slug}/phases", response_class=HTMLResponse)
+async def update_role_phases(
+    request: Request,
+    slug: str,
+) -> HTMLResponse:
+    """Persist the phase assignment for *slug* from the multiselect form data.
+
+    Reads ``phases`` from the raw request form (list of strings — one per
+    selected phase label).  Returns the refreshed ``_org_role_list.html``
+    partial.
+
+    Raises HTTP 404 when *slug* is not in the current role list.
+    """
+    form = await request.form()
+    # ``phases`` may appear as multiple values from a multi-select.
+    # form.getlist returns list[UploadFile | str]; filter to strings only.
+    selected_phases: list[str] = [
+        v for v in form.getlist("phases") if isinstance(v, str)
+    ]
+
+    config = _read_pipeline_config()
+    roles = _read_active_org_roles(config)
+
+    target_idx: int | None = None
+    for i, r in enumerate(roles):
+        if r["slug"] == slug:
+            target_idx = i
+            break
+
+    if target_idx is None:
+        raise HTTPException(status_code=404, detail=f"Role {slug!r} not in active org")
+
+    roles[target_idx]["assigned_phases"] = selected_phases
+    config["active_org_roles"] = roles
+    try:
+        _write_pipeline_config(config)
+        logger.info("✅ Updated phases for role %r: %s", slug, selected_phases)
+    except Exception as exc:
+        logger.error("❌ Failed to write pipeline-config.json: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to update phases") from exc
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "_org_role_list.html",
+        _builder_context(config),
+    )
+
+
+@router.post("/api/org/templates", response_class=HTMLResponse)
+async def save_template(
+    request: Request,
+    name: Annotated[str, Form()],
+) -> HTMLResponse:
+    """Save the current builder org as a named preset in org-presets.yaml.
+
+    After saving, returns the refreshed ``_org_preset_list.html`` partial so
+    HTMX swaps it into the left panel — the new preset appears immediately.
+
+    Raises HTTP 422 when *name* is blank or the current role list is empty.
+    """
+    name = name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="Template name must not be blank")
+
+    config = _read_pipeline_config()
+    roles = _read_active_org_roles(config)
+
+    if not roles:
+        raise HTTPException(
+            status_code=422,
+            detail="Cannot save a template with no roles. Add at least one role first.",
+        )
+
+    try:
+        slug = _save_preset(name, roles)
+        logger.info("✅ Saved org template %r (id=%r)", name, slug)
+    except Exception as exc:
+        logger.error("❌ Failed to save template: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to save template") from exc
+
+    presets = _load_presets()
+    active_org: object = config.get("active_org")
+    active_org_id: str | None = active_org if isinstance(active_org, str) else None
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "_org_preset_list.html",
+        {
+            "presets": presets,
+            "active_org_id": active_org_id,
         },
     )

--- a/agentception/static/js/org_chart.js
+++ b/agentception/static/js/org_chart.js
@@ -1,0 +1,77 @@
+"use strict";
+
+/**
+ * orgRoleSearch — Alpine.js component for the role builder's searchable dropdown.
+ *
+ * Loaded without `defer` in org_chart.html so the function is on `window` before
+ * Alpine's CDN script (deferred) initialises and discovers x-data attributes.
+ *
+ * @param {Object} taxonomy   - Role taxonomy: {tier_key: [slug, ...], ...}
+ * @param {Object} tierLabels - Human labels: {tier_key: "Display Name", ...}
+ * @returns {Object} Alpine component data object.
+ */
+function orgRoleSearch(taxonomy, tierLabels) {
+  return {
+    query: "",
+    open: false,
+    alwaysOpen: false,
+
+    /** Filtered, grouped roles matching the current query. */
+    get filtered() {
+      const q = this.query.toLowerCase().trim();
+      const groups = [];
+      for (const [tier, roles] of Object.entries(taxonomy)) {
+        const matching = q
+          ? roles.filter((r) => r.toLowerCase().includes(q))
+          : roles;
+        if (matching.length > 0) {
+          groups.push({
+            tier,
+            label: (tierLabels && tierLabels[tier]) || tier,
+            roles: matching,
+          });
+        }
+      }
+      return groups;
+    },
+
+    /**
+     * Called when the user selects a role from the dropdown.
+     * Sets the hidden form's slug value, closes the dropdown, then triggers
+     * HTMX to POST the form and swap the role list partial.
+     *
+     * @param {string} slug - The selected role slug.
+     */
+    pick(slug) {
+      const slugInput = document.getElementById("org-add-role-slug");
+      if (slugInput) {
+        slugInput.value = slug;
+      }
+      this.query = "";
+      this.open = false;
+
+      // Use $nextTick so Alpine has processed state updates before we trigger HTMX.
+      this.$nextTick(() => {
+        const form = document.getElementById("org-add-role-form");
+        if (form && typeof htmx !== "undefined") {
+          htmx.trigger(form, "submit");
+        }
+      });
+    },
+
+    /**
+     * Pick the first role in the filtered list when the user presses Enter.
+     * No-ops when the list is empty.
+     */
+    pickFirst() {
+      if (this.filtered.length > 0 && this.filtered[0].roles.length > 0) {
+        this.pick(this.filtered[0].roles[0]);
+      }
+    },
+  };
+}
+
+// Register on window so Alpine can discover the function via x-data string.
+if (typeof window !== "undefined") {
+  window.orgRoleSearch = orgRoleSearch;
+}

--- a/agentception/templates/_org_role_list.html
+++ b/agentception/templates/_org_role_list.html
@@ -1,0 +1,69 @@
+{#
+  Partial: Active org role cards — rendered by the builder endpoints that
+  add, remove, or update phase assignments.
+
+  Context:
+    active_org_roles — list of annotated role dicts:
+        slug             str   — role identifier
+        assigned_phases  list  — currently assigned phase labels
+        tier             str   — "c_suite" | "vp" | "worker"
+        phase_assignable bool  — True for c_suite and vp tiers
+    phases     — list[str] — available phase label strings
+    tier_labels — dict[str, str] — tier key → human label
+#}
+<div id="org-role-list" class="org-role-list">
+  {% if active_org_roles %}
+    {% for role in active_org_roles %}
+    <div class="org-role-card org-role-card--{{ role.tier }}">
+      <div class="org-role-card__header">
+        <span class="org-role-card__slug">{{ role.slug }}</span>
+        <span class="badge badge--outline org-role-card__tier-badge">
+          {{ tier_labels.get(role.tier, role.tier) }}
+        </span>
+        <button
+          class="org-role-card__remove btn btn--ghost btn--sm"
+          hx-delete='/api/org/roles/{{ role.slug }}'
+          hx-target="#org-role-list"
+          hx-swap="outerHTML"
+          hx-confirm="Remove {{ role.slug }} from the active org?"
+          aria-label="Remove {{ role.slug }}"
+          title="Remove role"
+        >✕</button>
+      </div>
+
+      {% if role.phase_assignable and phases %}
+      <form
+        class="org-role-card__phases"
+        hx-post='/api/org/roles/{{ role.slug }}/phases'
+        hx-target="#org-role-list"
+        hx-swap="outerHTML"
+        hx-trigger="change"
+      >
+        <label class="org-role-card__phase-label text-muted">Assigned phases</label>
+        <div class="org-role-card__phase-options">
+          {% for phase in phases %}
+          <label class="org-phase-option">
+            <input
+              type="checkbox"
+              name="phases"
+              value="{{ phase }}"
+              {% if phase in role.assigned_phases %}checked{% endif %}
+            >
+            <span class="org-phase-option__name">{{ phase }}</span>
+          </label>
+          {% endfor %}
+        </div>
+      </form>
+      {% elif role.phase_assignable and not phases %}
+      <p class="text-muted org-role-card__no-phases">
+        No phases configured in <code>pipeline-config.json</code>.
+      </p>
+      {% endif %}
+    </div>
+    {% endfor %}
+  {% else %}
+  <div class="org-role-list__empty">
+    <p class="text-muted">No roles added yet. Use the dropdown above to add roles.</p>
+  </div>
+  {% endif %}
+</div>

--- a/agentception/templates/org_chart.html
+++ b/agentception/templates/org_chart.html
@@ -2,13 +2,18 @@
 
 {% block title %}Org Chart — Agentception{% endblock %}
 
+{# Load org_chart.js synchronously (no defer) so orgRoleSearch is available
+   before Alpine initialises — Alpine's CDN script is deferred and runs after. #}
+{% block head %}
+<script src="/static/js/org_chart.js"></script>
+{% endblock %}
+
 {% block content %}
 <div class="page-header">
   <h1 class="page-title">Org Chart</h1>
   <p class="page-subtitle text-muted">
-    Choose a preset org topology. The active org governs which agent roles the
-    pipeline spawns.  Issues #829 and #830 will add an interactive builder and
-    D3 tree to the right panel.
+    Choose a preset org topology or build a custom one using the role builder.
+    The active org governs which agent roles the pipeline spawns.
   </p>
 </div>
 
@@ -20,21 +25,122 @@
     {% include "_org_preset_list.html" %}
   </section>
 
-  {# ── Right panel: builder shell — reserved for #829 (builder) and #830 (D3) #}
+  {# ── Right panel: interactive role builder ────────────────────────────────
+     Shell reserved for #829 (builder — this issue) and #830 (D3 tree).
+  #}
   <section class="org-chart-right" aria-label="Org chart builder">
     <div id="org-right-panel" class="org-right-panel">
-      <div class="org-right-panel__placeholder">
-        <span class="org-right-panel__icon" aria-hidden="true">🌳</span>
-        <p class="org-right-panel__message text-muted">
-          Interactive builder coming in <strong>#829</strong>.
+
+      <h2 class="panel-title">Role Builder</h2>
+
+      {# ── Add Role searchable dropdown — Alpine component ─────────────────
+         taxonomy: dict[tier_key -> list[slug]]
+         Single-quoted x-data attribute because tojson emits double-quoted JSON.
+      #}
+      <div
+        class="org-add-role"
+        x-data='orgRoleSearch({{ taxonomy | tojson }}, {{ tier_labels | tojson }})'
+      >
+        <div class="org-add-role__control">
+          <input
+            type="text"
+            class="org-add-role__search input"
+            placeholder="Search and add a role…"
+            x-model="query"
+            @focus="open = true"
+            @click.outside="open = false; query = ''"
+            @keydown.escape="open = false; query = ''"
+            @keydown.enter.prevent="pickFirst()"
+            aria-label="Search roles"
+            autocomplete="off"
+          >
+          <span class="org-add-role__chevron" aria-hidden="true">▾</span>
+        </div>
+
+        <div
+          class="org-add-role__dropdown"
+          x-show="open && (query.length > 0 || alwaysOpen)"
+          x-cloak
+          role="listbox"
+          aria-label="Available roles"
+        >
+          <template x-if="filtered.length === 0">
+            <p class="org-add-role__no-results text-muted">No matching roles.</p>
+          </template>
+          <template x-for="group in filtered" :key="group.tier">
+            <div class="org-add-role__group" role="group" :aria-label="group.label">
+              <div class="org-add-role__group-label text-muted" x-text="group.label"></div>
+              <template x-for="slug in group.roles" :key="slug">
+                <button
+                  type="button"
+                  class="org-add-role__option"
+                  x-text="slug"
+                  role="option"
+                  @click="pick(slug)"
+                ></button>
+              </template>
+            </div>
+          </template>
+        </div>
+
+        {# Hidden form — HTMX posts this when Alpine calls pick(slug). #}
+        <form
+          id="org-add-role-form"
+          hx-post="/api/org/roles/add"
+          hx-target="#org-role-list"
+          hx-swap="outerHTML"
+          style="display:none"
+          aria-hidden="true"
+        >
+          <input type="hidden" name="slug" id="org-add-role-slug">
+        </form>
+      </div>
+
+      {# ── Role list — HTMX swap target ────────────────────────────────── #}
+      {% include "_org_role_list.html" %}
+
+      {# ── Save as template ────────────────────────────────────────────── #}
+      <div class="org-save-template" x-data="{ showForm: false, name: '' }">
+        <button
+          type="button"
+          class="btn btn--secondary"
+          @click="showForm = !showForm"
+          x-text="showForm ? 'Cancel' : 'Save as template…'"
+        ></button>
+
+        <form
+          class="org-save-template__form"
+          x-show="showForm"
+          x-cloak
+          hx-post="/api/org/templates"
+          hx-target="#org-preset-list"
+          hx-swap="outerHTML"
+          @htmx:after-request="if (event.detail.successful) { showForm = false; name = ''; }"
+        >
+          <input
+            type="text"
+            name="name"
+            class="input org-save-template__input"
+            placeholder="Template name…"
+            x-model="name"
+            required
+            aria-label="Template name"
+          >
+          <button
+            type="submit"
+            class="btn btn--primary"
+            :disabled="!name.trim()"
+          >Save</button>
+        </form>
+      </div>
+
+      {# ── D3 tree shell — reserved for #830 ───────────────────────────── #}
+      <div id="org-d3-tree" class="org-d3-tree-shell">
+        <p class="text-muted org-d3-tree-shell__placeholder">
           D3 org tree coming in <strong>#830</strong>.
         </p>
-        {% if active_org_id %}
-        <p class="text-muted">
-          Active preset: <code>{{ active_org_id }}</code>
-        </p>
-        {% endif %}
       </div>
+
     </div>
   </section>
 

--- a/agentception/tests/test_agentception_org_chart.py
+++ b/agentception/tests/test_agentception_org_chart.py
@@ -1,9 +1,14 @@
-"""Tests for the /org-chart page and POST /api/org/select-preset endpoint.
+"""Tests for the org-chart page and its builder API endpoints.
 
 Covers:
-- GET /org-chart renders the page with preset cards
+- GET /org-chart renders the page with preset cards and builder panel
 - POST /api/org/select-preset persists the selection and returns a refreshed partial
 - POST /api/org/select-preset rejects unknown preset IDs with HTTP 422
+- GET /api/roles/taxonomy returns grouped role taxonomy
+- POST /api/org/roles/add adds a role to the active org
+- DELETE /api/org/roles/{slug} removes a role from the active org
+- POST /api/org/roles/{slug}/phases updates phase assignments
+- POST /api/org/templates saves the current org as a named preset
 
 Run targeted:
     docker compose exec agentception pytest agentception/tests/test_agentception_org_chart.py -v
@@ -14,7 +19,7 @@ import json
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -215,3 +220,253 @@ class TestSelectPreset:
 
         assert resp.status_code == 200
         assert "org-preset-card--active" in resp.text
+
+
+class TestRolesTaxonomy:
+    """GET /api/roles/taxonomy — role taxonomy endpoint."""
+
+    def test_taxonomy_returns_200(self, client: TestClient) -> None:
+        """GET /api/roles/taxonomy should return HTTP 200 with JSON."""
+        resp = client.get("/api/roles/taxonomy")
+        assert resp.status_code == 200
+        assert "application/json" in resp.headers["content-type"]
+
+    def test_taxonomy_has_all_tiers(self, client: TestClient) -> None:
+        """Response must contain c_suite, vp, and worker tiers."""
+        resp = client.get("/api/roles/taxonomy")
+        data = resp.json()
+        assert "tiers" in data
+        tiers = data["tiers"]
+        assert "c_suite" in tiers
+        assert "vp" in tiers
+        assert "worker" in tiers
+
+    def test_taxonomy_tier_has_label_and_roles(self, client: TestClient) -> None:
+        """Each tier entry must have a 'label' string and a 'roles' list."""
+        resp = client.get("/api/roles/taxonomy")
+        tiers = resp.json()["tiers"]
+        for tier_key, tier_data in tiers.items():
+            assert "label" in tier_data, f"tier {tier_key!r} missing 'label'"
+            assert "roles" in tier_data, f"tier {tier_key!r} missing 'roles'"
+            assert isinstance(tier_data["roles"], list)
+
+    def test_taxonomy_contains_known_roles(self, client: TestClient) -> None:
+        """Known roles like 'cto' and 'python-developer' must appear in the taxonomy."""
+        resp = client.get("/api/roles/taxonomy")
+        tiers = resp.json()["tiers"]
+        all_roles: list[str] = []
+        for tier_data in tiers.values():
+            all_roles.extend(tier_data["roles"])
+        assert "cto" in all_roles
+        assert "python-developer" in all_roles
+        assert "vp-engineering" in all_roles
+
+
+class TestAddRole:
+    """POST /api/org/roles/add — add role to active builder org."""
+
+    def test_add_role_returns_200(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """Adding a valid role should return HTTP 200 with an HTML role list."""
+        resp = client.post("/api/org/roles/add", data={"slug": "python-developer"})
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+
+    def test_add_role_persists_to_config(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """After adding a role, pipeline-config.json must contain that slug."""
+        client.post("/api/org/roles/add", data={"slug": "cto"})
+        written = json.loads(tmp_pipeline_config.read_text(encoding="utf-8"))
+        roles = written.get("active_org_roles", [])
+        slugs = [r["slug"] for r in roles]
+        assert "cto" in slugs
+
+    def test_add_role_role_card_in_response(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """The response HTML should contain the added role's slug."""
+        resp = client.post("/api/org/roles/add", data={"slug": "python-developer"})
+        assert "python-developer" in resp.text
+
+    def test_add_role_duplicate_is_idempotent(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """Adding the same role twice should not create duplicates in config."""
+        client.post("/api/org/roles/add", data={"slug": "cto"})
+        client.post("/api/org/roles/add", data={"slug": "cto"})
+        written = json.loads(tmp_pipeline_config.read_text(encoding="utf-8"))
+        roles = written.get("active_org_roles", [])
+        cto_entries = [r for r in roles if r["slug"] == "cto"]
+        assert len(cto_entries) == 1
+
+    def test_add_role_unknown_slug_returns_422(
+        self,
+        client: TestClient,
+    ) -> None:
+        """An unknown role slug should return HTTP 422."""
+        resp = client.post("/api/org/roles/add", data={"slug": "not-a-real-role"})
+        assert resp.status_code == 422
+
+
+class TestRemoveRole:
+    """DELETE /api/org/roles/{slug} — remove role from active builder org."""
+
+    def test_remove_role_returns_200(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """Removing a role that exists should return HTTP 200."""
+        client.post("/api/org/roles/add", data={"slug": "cto"})
+        resp = client.delete("/api/org/roles/cto")
+        assert resp.status_code == 200
+
+    def test_remove_role_removes_from_config(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """After removing a role, it must no longer appear in pipeline-config.json."""
+        client.post("/api/org/roles/add", data={"slug": "python-developer"})
+        client.delete("/api/org/roles/python-developer")
+        written = json.loads(tmp_pipeline_config.read_text(encoding="utf-8"))
+        roles = written.get("active_org_roles", [])
+        slugs = [r["slug"] for r in roles]
+        assert "python-developer" not in slugs
+
+    def test_remove_role_nonexistent_is_idempotent(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """Removing a slug not in the list should silently succeed (HTTP 200)."""
+        resp = client.delete("/api/org/roles/nonexistent-slug")
+        assert resp.status_code == 200
+
+    def test_remove_role_returns_html_list(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """Response must be HTML containing the role list container."""
+        resp = client.delete("/api/org/roles/cto")
+        assert "text/html" in resp.headers["content-type"]
+        assert "org-role-list" in resp.text
+
+
+class TestUpdateRolePhases:
+    """POST /api/org/roles/{slug}/phases — update phase assignments."""
+
+    def test_update_phases_returns_200(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """Updating phases for an existing role should return HTTP 200."""
+        client.post("/api/org/roles/add", data={"slug": "cto"})
+        resp = client.post(
+            "/api/org/roles/cto/phases",
+            data={"phases": ["ac-workflow/1-setup"]},
+        )
+        assert resp.status_code == 200
+
+    def test_update_phases_persists_to_config(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """After updating phases, the assigned phases must appear in pipeline-config.json."""
+        client.post("/api/org/roles/add", data={"slug": "vp-engineering"})
+        client.post(
+            "/api/org/roles/vp-engineering/phases",
+            data={"phases": ["phase-a", "phase-b"]},
+        )
+        written = json.loads(tmp_pipeline_config.read_text(encoding="utf-8"))
+        roles = written.get("active_org_roles", [])
+        vp = next((r for r in roles if r["slug"] == "vp-engineering"), None)
+        assert vp is not None
+        assert "phase-a" in vp["assigned_phases"]
+        assert "phase-b" in vp["assigned_phases"]
+
+    def test_update_phases_clears_when_empty(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """Submitting no phases should clear the assigned_phases list."""
+        client.post("/api/org/roles/add", data={"slug": "cto"})
+        client.post("/api/org/roles/cto/phases", data={"phases": ["phase-a"]})
+        # Now clear by sending no phases
+        client.post("/api/org/roles/cto/phases", data={})
+        written = json.loads(tmp_pipeline_config.read_text(encoding="utf-8"))
+        roles = written.get("active_org_roles", [])
+        cto = next((r for r in roles if r["slug"] == "cto"), None)
+        assert cto is not None
+        assert cto["assigned_phases"] == []
+
+    def test_update_phases_returns_404_for_missing_role(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """Updating phases for a slug not in the active org should return HTTP 404."""
+        resp = client.post(
+            "/api/org/roles/nonexistent/phases",
+            data={"phases": ["phase-a"]},
+        )
+        assert resp.status_code == 404
+
+
+class TestSaveTemplate:
+    """POST /api/org/templates — save current org as a named preset."""
+
+    def test_save_template_returns_200(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Saving a valid template should return HTTP 200 with preset list HTML."""
+        client.post("/api/org/roles/add", data={"slug": "cto"})
+        with patch(
+            "agentception.routes.ui.org_chart._PRESETS_PATH",
+            tmp_path / "org-presets.yaml",
+        ):
+            (tmp_path / "org-presets.yaml").write_text(
+                "presets: []\n", encoding="utf-8"
+            )
+            resp = client.post(
+                "/api/org/templates",
+                data={"name": "My Template"},
+            )
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+
+    def test_save_template_blank_name_returns_422(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """A blank template name should return HTTP 422."""
+        client.post("/api/org/roles/add", data={"slug": "cto"})
+        resp = client.post("/api/org/templates", data={"name": "   "})
+        assert resp.status_code == 422
+
+    def test_save_template_empty_roles_returns_422(
+        self,
+        client: TestClient,
+        tmp_pipeline_config: Path,
+    ) -> None:
+        """Saving a template with no roles should return HTTP 422."""
+        resp = client.post("/api/org/templates", data={"name": "Empty"})
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Closes #829 — adds the interactive role builder to the right panel of `/org-chart`.

## Root Cause / Motivation

Issue #828 (PR #853) established the left-panel preset picker and the right-panel
shell (`#org-right-panel`). This PR fills in the interactive builder as specified
in #829.

## Solution

**New API endpoints** in `agentception/routes/ui/org_chart.py`:

| Method | Path | Purpose |
|--------|------|---------|
| `GET` | `/api/roles/taxonomy` | Returns roles grouped by tier (C-Suite / VP / Worker) |
| `POST` | `/api/org/roles/add` | Appends a role to `active_org_roles` in `pipeline-config.json` |
| `DELETE` | `/api/org/roles/{slug}` | Removes a role (idempotent) |
| `POST` | `/api/org/roles/{slug}/phases` | Persists phase assignments from multiselect |
| `POST` | `/api/org/templates` | Saves current org as a named preset in `org-presets.yaml` |

**Role taxonomy**: C-Suite (cto, ceo, coo, …), VP/Coordinator (vp-engineering, coordinator, …), Worker (python-developer, …).  Phase assignment multiselect shown on C-Suite and VP cards, sourced from `active_labels_order` in `pipeline-config.json`.

**New files**:
- `agentception/static/js/org_chart.js` — Alpine `orgRoleSearch` component; loaded synchronously (no `defer`) in `{% block head %}` so the function is on `window` before Alpine's deferred CDN script initialises
- `agentception/templates/_org_role_list.html` — HTMX-swappable role card list

**Modified files**:
- `agentception/routes/ui/org_chart.py` — 5 new endpoints + helpers; left-panel code untouched
- `agentception/templates/org_chart.html` — builder markup injected into right panel
- `agentception/tests/test_agentception_org_chart.py` — 20 new tests (9 existing preserved)

**Persistence**: role list and phase assignments stored in `pipeline-config.json` under `active_org_roles[].assigned_phases`; templates appended to `org-presets.yaml`.

## Verification

- [x] mypy clean (0 errors across 102 source files)
- [x] 29/29 tests pass (9 existing + 20 new)
- [x] Docs: endpoints documented via docstrings; no new named result types requiring type-contracts.md entry
- [x] No changes to left-panel preset logic (issue #828's code untouched)

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Role** | `python-developer` |
| **Architecture** | `dhh:htmx:alpine:jinja2` |
| **Session** | `eng-20260303T171150Z-0829` |
| **CTO Wave** | `cto-20260303T170027Z` |
| **VP Batch** | `vp-eng-ac-phase2-20260303T170027Z` |
| **VP** | `vp-eng-ac-phase2-20260303T170027Z` |
| **Timestamp** | `2026-03-03T17:20:31Z` |

</details>