### PR TITLE
fix: correct d3@7.9.0 SRI hash in org_chart.html and dag.html

### DIFF
--- a/agentception/templates/dag.html
+++ b/agentception/templates/dag.html
@@ -5,7 +5,7 @@
 {% block head %}
   {# D3 must load before Alpine initialises dagVisualization() #}
   <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js"
-          integrity="sha256-1rA8rCEWBqUBbBkMcNZKQgMoJJLtVAVVJD4/4CVblsQ="
+          integrity="sha256-8glLv2FBs1lyLE/kVOtsSw8OQswQzHr5IfwVj864ZTk="
           crossorigin="anonymous"></script>
 {% endblock %}
 

--- a/agentception/templates/org_chart.html
+++ b/agentception/templates/org_chart.html
@@ -8,7 +8,7 @@
 {% block head %}
 <script src="/static/js/org_chart.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js"
-        integrity="sha256-1rA8rCEWBqUBbBkMcNZKQgMoJJLtVAVVJD4/4CVblsQ="
+        integrity="sha256-8glLv2FBs1lyLE/kVOtsSw8OQswQzHr5IfwVj864ZTk="
         crossorigin="anonymous"></script>
 <script type="module">
   import { initOrgChartTree } from '/static/js/org_chart_tree.js';


### PR DESCRIPTION
## Summary

Browsers were blocking `d3.min.js` on both `/org-chart` and `/dag` with:

> Failed to find a valid digest in the 'integrity' attribute for resource 'https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js' with computed SHA-256 integrity '8glLv2FBs1lyLE/kVOtsSw8OQswQzHr5IfwVj864ZTk='. The resource has been blocked.

The hash stored in both templates (`sha256-1rA8rCEWBqUBbBkMcNZKQgMoJJLtVAVVJD4/4CVblsQ=`) did not match the actual file. Correct hash confirmed by computing it directly:

```bash
curl -sL https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js \
  | openssl dgst -sha256 -binary | base64
# → 8glLv2FBs1lyLE/kVOtsSw8OQswQzHr5IfwVj864ZTk=
```

Both `org_chart.html` (added in #853/#854) and `dag.html` (pre-existing, same wrong hash) are fixed in this PR.