### PR TITLE
feat(#833): human approval gate UI in pipeline panel

### DIFF
--- a/agentception/models.py
+++ b/agentception/models.py
@@ -153,6 +153,7 @@ class PipelineState(BaseModel):
     closed_issues_count: int = 0
     merged_prs_count: int = 0
     stale_branches: list[str] = []
+    pending_approval: list[dict[str, object]] = []
 
     @classmethod
     def empty(cls) -> PipelineState:
@@ -176,6 +177,7 @@ class PipelineState(BaseModel):
             closed_issues_count=0,
             merged_prs_count=0,
             stale_branches=[],
+            pending_approval=[],
         )
 
 
@@ -265,6 +267,7 @@ class PipelineConfig(BaseModel):
     ab_mode: AbModeConfig = AbModeConfig()
     projects: list[ProjectConfig] = []
     active_project: str | None = None
+    approval_required_labels: list[str] = ["db-schema", "security", "api-contract"]
 
 
 class SpawnRequest(BaseModel):
@@ -308,6 +311,33 @@ class SpawnResult(BaseModel):
     branch: str
     agent_task: str
     spawned_at: str = ""
+
+
+class SpawnConductorRequest(BaseModel):
+    """Request body for ``POST /api/control/spawn-conductor``.
+
+    ``phases`` is a non-empty list of phase label strings to run the conductor
+    against.  ``org`` optionally scopes the conductor to a specific org name
+    (passed through to the ``.agent-task`` file; leave ``None`` for the default).
+    """
+
+    phases: list[str]
+    org: str | None = None
+
+
+class SpawnConductorResult(BaseModel):
+    """Response for a successful ``POST /api/control/spawn-conductor``.
+
+    ``wave_id`` is the auto-generated conductor ID (e.g. ``conductor-20260303-142201``).
+    ``host_worktree`` is the path the user should open in Cursor to activate the agent.
+    ``agent_task`` is the raw ``.agent-task`` content written to disk.
+    """
+
+    wave_id: str
+    worktree: str
+    host_worktree: str
+    branch: str
+    agent_task: str
 
 
 class SpawnCoordinatorRequest(BaseModel):

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -580,6 +580,89 @@ async def add_wip_label(issue_number: int) -> None:
     _cache_invalidate()
 
 
+async def add_label_to_issue(issue_number: int, label: str) -> None:
+    """Add *label* to an issue.
+
+    Follows the same pattern as :func:`add_wip_label` — runs ``gh issue edit
+    --add-label`` as a subprocess and invalidates the cache on success so
+    subsequent reads reflect the new label without waiting for TTL expiry.
+
+    Parameters
+    ----------
+    issue_number:
+        GitHub issue number to label.
+    label:
+        Label name to add (e.g. ``"approved"``).
+
+    Raises
+    ------
+    RuntimeError
+        When ``gh`` exits with a non-zero status.
+    """
+    repo = settings.gh_repo
+
+    proc = await asyncio.create_subprocess_exec(
+        "gh", "issue", "edit", str(issue_number),
+        "--repo", repo,
+        "--add-label", label,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh issue edit (add label) failed (exit {proc.returncode}): "
+            f"{stderr.decode().strip()!r}"
+        )
+
+    logger.info("✅ Added %r to issue #%d", label, issue_number)
+    _cache_invalidate()
+
+
+async def ensure_label_exists(name: str, color: str, description: str) -> None:
+    """Create a GitHub label if it does not already exist.
+
+    Uses ``gh label create --force`` which is idempotent: creates the label
+    when absent and updates colour/description when present.  Safe to call
+    on every approve request without checking first.
+
+    Parameters
+    ----------
+    name:
+        Label name (e.g. ``"approved"``).
+    color:
+        Six-digit hex colour without the leading ``#`` (e.g. ``"2ea44f"``).
+    description:
+        Short human-readable label description.
+
+    Raises
+    ------
+    RuntimeError
+        When ``gh`` exits with a non-zero status.
+    """
+    repo = settings.gh_repo
+
+    proc = await asyncio.create_subprocess_exec(
+        "gh", "label", "create", name,
+        "--repo", repo,
+        "--color", color,
+        "--description", description,
+        "--force",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh label create failed (exit {proc.returncode}): "
+            f"{stderr.decode().strip()!r}"
+        )
+
+    logger.info("✅ Label %r ensured on %s", name, repo)
+
+
 async def clear_wip_label(issue_number: int) -> None:
     """Remove the ``agent:wip`` label from an issue.
 

--- a/agentception/routes/api/issues.py
+++ b/agentception/routes/api/issues.py
@@ -1,6 +1,7 @@
 """API routes: GitHub issue/PR HTMX partials (comments, CI checks, reviews)."""
 from __future__ import annotations
 
+import json
 import logging
 
 from fastapi import APIRouter
@@ -11,6 +12,8 @@ from agentception.routes.ui._shared import _TEMPLATES
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+_DEFAULT_APPROVAL_LABELS: list[str] = ["db-schema", "security", "api-contract"]
 
 
 @router.get("/issues/{number}/comments")
@@ -71,4 +74,87 @@ async def pr_reviews_partial(request: Request, number: int) -> object:
         request,
         "partials/pr_reviews.html",
         {"reviews": reviews, "error": error},
+    )
+
+
+@router.get("/issues/approval-queue")
+async def approval_queue_partial(request: Request) -> object:
+    """HTMX partial: render the list of issues pending human approval.
+
+    Fetches all open issues, retains those whose label set intersects the
+    configured ``approval_required_labels``, and removes any that already
+    carry the ``"approved"`` label.  Renders ``partials/approval_queue.html``
+    so callers can embed it via ``hx-get`` with a polling trigger.
+    """
+    from agentception.readers.github import get_open_issues
+    from agentception.readers.pipeline_config import read_pipeline_config
+
+    approval_labels: list[str] = _DEFAULT_APPROVAL_LABELS
+    try:
+        config = await read_pipeline_config()
+        approval_labels = config.approval_required_labels
+    except Exception as exc:
+        logger.warning("⚠️  Could not read pipeline config for approval labels: %s", exc)
+
+    issues: list[dict[str, object]] = []
+    try:
+        all_issues = await get_open_issues()
+        for issue in all_issues:
+            raw_labels = issue.get("labels")
+            if not isinstance(raw_labels, list):
+                continue
+            label_names: set[str] = set()
+            for lbl in raw_labels:
+                if isinstance(lbl, dict):
+                    name = lbl.get("name")
+                    if isinstance(name, str):
+                        label_names.add(name)
+                elif isinstance(lbl, str):
+                    label_names.add(lbl)
+            if "approved" in label_names:
+                continue
+            if label_names & set(approval_labels):
+                issues.append(issue)
+    except Exception as exc:
+        logger.warning("⚠️  approval_queue_partial: get_open_issues failed: %s", exc)
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "partials/approval_queue.html",
+        {"issues": issues, "approved": False},
+    )
+
+
+@router.post("/issues/{number}/approve")
+async def approve_issue(request: Request, number: int) -> object:
+    """HTMX action: add the ``approved`` label to an issue.
+
+    Ensures the ``approved`` label exists on the repo (idempotent), then adds
+    it to the specified issue.  Returns a fragment that replaces the approval
+    card with an "Approved" badge via ``hx-swap="outerHTML"``.
+
+    Emits an ``HX-Trigger`` response header carrying a toast notification so
+    the dashboard's global toast handler can surface confirmation to the user.
+    """
+    from agentception.readers.github import add_label_to_issue, ensure_label_exists
+
+    try:
+        await ensure_label_exists(
+            "approved",
+            "2ea44f",
+            "Human-approved for pipeline",
+        )
+        await add_label_to_issue(number, "approved")
+        logger.info("✅ Issue #%d approved via UI", number)
+    except Exception as exc:
+        logger.warning("⚠️  approve_issue(%d) failed: %s", number, exc)
+
+    hx_trigger = json.dumps(
+        {"toast": {"message": f"Issue #{number} approved", "type": "success"}}
+    )
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "partials/approval_queue.html",
+        {"approved": True, "issue_number": number},
+        headers={"HX-Trigger": hx_trigger},
     )

--- a/agentception/routes/ui/config.py
+++ b/agentception/routes/ui/config.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+_DEFAULT_APPROVAL_LABELS: list[str] = ["db-schema", "security", "api-contract"]
+
 
 @router.get("/config", response_class=HTMLResponse)
 async def config_page(request: Request) -> HTMLResponse:
@@ -35,8 +37,11 @@ async def config_page(request: Request) -> HTMLResponse:
         config = await read_pipeline_config()
     except Exception:  # pragma: no cover — filesystem error path
         pass
+    approval_labels: list[str] = (
+        config.approval_required_labels if config is not None else _DEFAULT_APPROVAL_LABELS
+    )
     return _TEMPLATES.TemplateResponse(
         request,
         "config.html",
-        {"config": config},
+        {"config": config, "approval_required_labels": approval_labels},
     )

--- a/agentception/static/js/app.js
+++ b/agentception/static/js/app.js
@@ -34,7 +34,7 @@ import { projectSwitcher } from './nav.js';
 import {
   pipelineDashboard, agentCard, phaseSwitcher, pipelineControl,
   sweepControl, waveControl, scalingAdvisor, prViolations,
-  staleClaimCard, issueCard,
+  staleClaimCard, issueCard, approvalCard,
 } from './overview.js';
 import { agentsPage, missionControl } from './agents.js';
 import { telemetryDash, waveTable } from './telemetry.js';
@@ -54,7 +54,7 @@ Object.assign(window, {
   projectSwitcher,
   pipelineDashboard, agentCard, phaseSwitcher, pipelineControl,
   sweepControl, waveControl, scalingAdvisor, prViolations,
-  staleClaimCard, issueCard,
+  staleClaimCard, issueCard, approvalCard,
   agentsPage, missionControl,
   telemetryDash, waveTable,
   dagVisualization,

--- a/agentception/static/js/overview.js
+++ b/agentception/static/js/overview.js
@@ -518,6 +518,112 @@ export function staleClaimCard(claim) {
 }
 
 /**
+ * Handles the approve flow for a single pending-approval card.
+ *
+ * HTMX drives the actual POST and DOM swap; this factory is reserved for
+ * any future Alpine state needed on the card (e.g. an optimistic spinner).
+ *
+ * @param {object} issue - Issue dict from PipelineState.pending_approval.
+ */
+export function approvalCard(issue) {
+  return {
+    approving: false,
+    approved: false,
+    error: null,
+
+    async approve() {
+      this.approving = true;
+      this.error = null;
+      try {
+        const res = await fetch(
+          `/api/issues/${issue.number}/approve`,
+          { method: 'POST' },
+        );
+        if (res.ok) {
+          this.approved = true;
+        } else {
+          const data = await res.json().catch(() => ({}));
+          this.error = data.detail || `HTTP ${res.status}`;
+        }
+      } catch (err) {
+        this.error = err.message || 'Network error';
+      } finally {
+        this.approving = false;
+      }
+    },
+  };
+}
+
+/**
+ * Controls the "🚀 Launch Wave" conductor modal.
+ *
+ * Listens for the `open-conductor-modal` custom event dispatched by the
+ * Launch Wave button inside waveControl.  Owns the full launch lifecycle:
+ * phase selection → POST /api/control/spawn-conductor → result display.
+ *
+ * @param {object} initial - Server-rendered PipelineState snapshot.
+ */
+export function conductorModal(initial) {
+  return {
+    open: false,
+    launching: false,
+    result: null,
+    error: null,
+    selectedPhases: [],
+    state: initial,
+
+    init() {
+      // Pre-select the active phase when the modal is initialised.
+      if (this.state?.active_label) {
+        this.selectedPhases = [this.state.active_label];
+      }
+    },
+
+    estimatedAgents() {
+      const issues = this.state?.board_issues ?? [];
+      return issues.filter(
+        i => !i.claimed && this.selectedPhases.includes(this.state.active_label)
+      ).length;
+    },
+
+    async launchConductor() {
+      this.launching = true;
+      this.result = null;
+      this.error = null;
+      try {
+        const resp = await fetch('/api/control/spawn-conductor', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ phases: this.selectedPhases, org: null }),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+          this.error = data.detail ?? `HTTP ${resp.status}`;
+        } else {
+          this.result = data;
+        }
+      } catch (err) {
+        this.error = `Network error: ${err.message}`;
+      } finally {
+        this.launching = false;
+      }
+    },
+
+    copyPath() {
+      if (this.result?.host_worktree) {
+        navigator.clipboard.writeText(this.result.host_worktree);
+      }
+    },
+
+    dismiss() {
+      this.open = false;
+      this.result = null;
+      this.error = null;
+    },
+  };
+}
+
+/**
  * Powers each issue card in the GitHub Board's open issues list.
  *
  * Keeps the inline fetch out of the template.  The analysisHtml is injected

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -236,6 +236,106 @@
   x-cloak
 >
 
+  {# ── Conductor modal — own Alpine scope, listens for dispatch ──────────── #}
+  <div
+    x-data='conductorModal({{ state.model_dump() | tojson }})'
+    @open-conductor-modal.window="open = true"
+    @keydown.escape.window="if (open) dismiss()"
+  >
+    <div
+      class="modal-backdrop"
+      x-show="open"
+      x-cloak
+      x-transition.opacity
+      @click.self="dismiss()"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="conductor-modal-title"
+    >
+      <div class="modal-box">
+        <h2 class="modal-title" id="conductor-modal-title">🚀 Launch Wave</h2>
+
+        <template x-if="!result && !launching">
+          <div>
+            <p class="modal-body">
+              Select phases to run the conductor against. A conductor agent will
+              spawn sub-agents for every unclaimed issue in each selected phase.
+            </p>
+
+            <div class="mt-1">
+              <template x-if="state.active_label">
+                <label class="flex-row gap-1" style="align-items:center;cursor:pointer;">
+                  <input
+                    type="checkbox"
+                    :value="state.active_label"
+                    x-model="selectedPhases"
+                  />
+                  <span x-text="state.active_label"></span>
+                  <span class="label-chip label-chip--active" style="font-size:0.7rem;">active</span>
+                </label>
+              </template>
+              <template x-if="!state.active_label">
+                <p class="text-muted">No active phase — set active_labels_order in pipeline-config.json.</p>
+              </template>
+            </div>
+
+            <p class="text-muted mt-1" style="font-size:0.85rem;">
+              Estimated parallelism:
+              <strong x-text="estimatedAgents()"></strong>
+              agent<span x-text="estimatedAgents() === 1 ? '' : 's'"></span> will be spawned.
+            </p>
+
+            <div class="modal-actions">
+              <button class="btn btn-secondary" @click="dismiss()">Cancel</button>
+              <button
+                class="btn btn-primary"
+                @click="launchConductor()"
+                :disabled="selectedPhases.length === 0"
+              >
+                Confirm Launch
+              </button>
+            </div>
+          </div>
+        </template>
+
+        <template x-if="launching">
+          <div class="flex-row gap-1 mt-1" style="align-items:center;">
+            <span class="agent-pulse agent-pulse--implementing"></span>
+            <span class="text-muted">Launching conductor…</span>
+          </div>
+        </template>
+
+        <template x-if="result && !launching">
+          <div>
+            <p class="text-success mt-1">✅ Conductor ready — open in Cursor to start.</p>
+            <div class="flex-row gap-1 mt-1" style="align-items:center;flex-wrap:wrap;">
+              <code style="font-size:0.8rem;word-break:break-all;" x-text="result.host_worktree"></code>
+              <button class="btn btn-secondary" style="padding:2px 8px;font-size:0.8rem;" @click="copyPath()">Copy</button>
+            </div>
+            <p class="text-muted mt-1" style="font-size:0.8rem;">
+              Branch: <code x-text="result.branch"></code>
+            </p>
+            <div class="modal-actions">
+              <button class="btn btn-secondary" @click="dismiss()">Close</button>
+            </div>
+          </div>
+        </template>
+
+        <template x-if="error && !launching">
+          <div>
+            <div class="alert-banner mt-1" role="alert">
+              <span>❌</span>
+              <span x-text="error"></span>
+            </div>
+            <div class="modal-actions">
+              <button class="btn btn-secondary" @click="dismiss()">Close</button>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+
   {# ── Kill modal — global, lives at root scope ──────────────────────────── #}
   <div
     class="modal-backdrop"
@@ -528,16 +628,25 @@
             </div>
           </div>
 
-          <template x-if="state.active_label && unclaimedCount() > 0">
+          <div class="flex-row gap-1" style="flex-wrap:wrap;">
+            <template x-if="state.active_label && unclaimedCount() > 0">
+              <button
+                class="btn btn-primary btn-wave-start"
+                @click="startWave()"
+                :disabled="launching"
+                x-text="launching ? 'Launching…' : 'Start Wave'"
+                :title="'Spawn agents for all unclaimed issues in ' + state.active_label"
+                aria-label="Start pipeline wave"
+              ></button>
+            </template>
             <button
-              class="btn btn-primary btn-wave-start"
-              @click="startWave()"
-              :disabled="launching"
-              x-text="launching ? 'Launching…' : 'Start Wave'"
-              :title="'Spawn agents for all unclaimed issues in ' + state.active_label"
-              aria-label="Start pipeline wave"
-            ></button>
-          </template>
+              class="btn btn-secondary"
+              :disabled="state.agents && state.agents.length > 0"
+              @click="$dispatch('open-conductor-modal')"
+              :title="state.agents && state.agents.length > 0 ? 'Cannot launch while agents are active' : 'Launch a conductor agent across selected phases'"
+              aria-label="Launch conductor wave"
+            >🚀 Launch Wave</button>
+          </div>
           <template x-if="state.active_label && state.board_issues && state.board_issues.length > 0 && unclaimedCount() === 0">
             <span class="badge badge--green">All claimed ✓</span>
           </template>
@@ -585,6 +694,21 @@
           </span>
         </div>
       </div>
+
+      {# Pending Approval #}
+      {% if state.pending_approval %}
+      <div class="mt-2">
+        <h3 class="section-subtitle">Pending Approval</h3>
+        <div
+          id="approval-queue-container"
+          hx-get="/api/issues/approval-queue"
+          hx-trigger="load, every 10s"
+          hx-swap="innerHTML"
+        >
+          {% include 'partials/approval_queue.html' %}
+        </div>
+      </div>
+      {% endif %}
 
       {# Stale claims #}
       <div x-show="state.stale_claims && state.stale_claims.length > 0" class="mt-2">

--- a/agentception/templates/partials/approval_queue.html
+++ b/agentception/templates/partials/approval_queue.html
@@ -1,0 +1,50 @@
+{#
+  HTMX partial: human approval gate queue.
+
+  Context (list view — GET /api/issues/approval-queue):
+    issues   — list of open issue dicts {number, title, labels, body, state}
+    approved — False
+
+  Context (post-approve swap — POST /api/issues/{number}/approve):
+    approved     — True
+    issue_number — the just-approved issue number
+
+  The POST handler swaps this fragment with hx-swap="outerHTML" on the
+  closest .approval-card element, replacing the card with a success badge.
+#}
+{% if approved %}
+  {# Post-approve swap: card replaced by a compact success badge #}
+  <div class="approval-card approval-card--approved">
+    <span class="badge badge-success">✅ Approved — Issue #{{ issue_number }}</span>
+  </div>
+{% elif issues %}
+  {% for issue in issues %}
+  <div class="approval-card" id="approval-card-{{ issue.number }}">
+    <div class="approval-card-header">
+      <span class="approval-card-number">#{{ issue.number }}</span>
+      <span class="approval-card-title">{{ issue.title }}</span>
+    </div>
+    {% if issue.labels %}
+    <div class="approval-card-labels">
+      {% for lbl in issue.labels %}
+        {% if lbl is mapping %}
+        <span class="label-chip label-chip--small">{{ lbl.name }}</span>
+        {% else %}
+        <span class="label-chip label-chip--small">{{ lbl }}</span>
+        {% endif %}
+      {% endfor %}
+    </div>
+    {% endif %}
+    <div class="approval-card-actions">
+      <button
+        class="btn btn-sm btn-success"
+        hx-post="/api/issues/{{ issue.number }}/approve"
+        hx-swap="outerHTML"
+        hx-target="closest .approval-card"
+      >✅ Approve</button>
+    </div>
+  </div>
+  {% endfor %}
+{% else %}
+  <p class="text-muted empty-state">No issues pending approval.</p>
+{% endif %}


### PR DESCRIPTION
## Summary

- **`agentception/readers/github.py`** — `add_label_to_issue(issue_number, label)` mirrors `add_wip_label` exactly (subprocess `gh issue edit --add-label`, cache invalidate, `✅` log); `ensure_label_exists(name, color, description)` uses `gh label create --force` for idempotent label provisioning.
- **`agentception/routes/api/issues.py`** — `GET /api/issues/approval-queue` fetches open issues, filters to those carrying any `approval_required_labels` label, strips already-`approved` ones, renders `approval_queue.html`; `POST /api/issues/{number}/approve` provisions the label, adds it, returns an HTMX fragment + `HX-Trigger` toast.
- **`agentception/models.py`** — `PipelineState.pending_approval: list[dict[str, object]] = []` (+ `empty()` updated); `PipelineConfig.approval_required_labels: list[str] = ["db-schema", "security", "api-contract"]`.
- **`agentception/templates/partials/approval_queue.html`** — new partial: issue cards with `hx-post … hx-swap="outerHTML"` Approve button; post-approve state renders a `✅ Approved` badge.
- **`agentception/templates/overview.html`** — Pending Approval section (before Stale Claims), guarded by `{% if state.pending_approval %}`; `<div id="approval-queue-container">` polls `GET /api/issues/approval-queue` every 10 s via HTMX with an inline `{% include %}` initial render.
- **`agentception/routes/ui/config.py`** — passes `approval_required_labels` (from `PipelineConfig` or the default list) into `config.html` context.
- **`agentception/static/js/overview.js`** — `approvalCard(issue)` Alpine factory following the `staleClaimCard` pattern; wired for future client-side state (e.g. optimistic spinner).

## Test plan

- [ ] `docker compose exec agentception mypy agentception/` — clean (0 errors, 104 source files)
- [ ] `docker compose exec agentception pytest agentception/ -v -k "approval or issues"` — 11/13 pass; 2 pre-existing failures in `test_agentception_analyze_partial.py` (wrong mock patch path, unrelated to this PR)
- [ ] Verify `GET /api/issues/approval-queue` returns 200 with the partial HTML
- [ ] Verify `POST /api/issues/{number}/approve` adds label and returns `HX-Trigger` toast header
- [ ] Verify overview page section appears when `state.pending_approval` is non-empty