### PR TITLE
feat: Run Conductor button with worktree path handoff

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -12,6 +12,8 @@ from typing import Any
 
 from sqlalchemy import select, text
 
+from pathlib import Path
+
 from agentception.db.engine import get_session
 from agentception.db.models import (
     ACAgentMessage,
@@ -19,6 +21,7 @@ from agentception.db.models import (
     ACIssue,
     ACPipelineSnapshot,
     ACPullRequest,
+    ACWave,
 )
 
 logger = logging.getLogger(__name__)
@@ -632,3 +635,56 @@ async def get_merged_prs_count(repo: str, hours: int = 24) -> int:
     except Exception as exc:
         logger.warning("⚠️  get_merged_prs_count failed (non-fatal): %s", exc)
         return 0
+
+
+# ---------------------------------------------------------------------------
+# Conductor spawn history
+# ---------------------------------------------------------------------------
+
+
+async def get_conductor_history(
+    limit: int = 5,
+    worktrees_dir: Path | None = None,
+    host_worktrees_dir: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Return the last *limit* conductor spawns with current active/completed status.
+
+    Status is ``"active"`` when the worktree directory still exists on disk and
+    ``"completed"`` once it has been removed.  Falls back to ``[]`` on any DB
+    error so the UI degrades gracefully without surfacing the error to the user.
+    """
+    from sqlalchemy import desc
+
+    from agentception.config import settings
+
+    wt_dir = worktrees_dir or settings.worktrees_dir
+    host_wt_dir = host_worktrees_dir or settings.host_worktrees_dir
+
+    try:
+        async with get_session() as session:
+            stmt = (
+                select(ACWave)
+                .where(ACWave.role == "conductor")
+                .order_by(desc(ACWave.started_at))
+                .limit(limit)
+            )
+            result = await session.execute(stmt)
+            waves = result.scalars().all()
+
+        entries: list[dict[str, Any]] = []
+        for wave in waves:
+            worktree = Path(wt_dir) / wave.id
+            host_worktree = Path(host_wt_dir) / wave.id
+            entries.append(
+                {
+                    "wave_id": wave.id,
+                    "worktree": str(worktree),
+                    "host_worktree": str(host_worktree),
+                    "started_at": wave.started_at.strftime("%Y-%m-%d %H:%M UTC"),
+                    "status": "active" if worktree.exists() else "completed",
+                }
+            )
+        return entries
+    except Exception as exc:
+        logger.warning("⚠️  get_conductor_history DB query failed (non-fatal): %s", exc)
+        return []

--- a/agentception/routes/api/control.py
+++ b/agentception/routes/api/control.py
@@ -640,6 +640,31 @@ async def spawn_coordinator(body: SpawnCoordinatorRequest) -> SpawnCoordinatorRe
     )
 
 
+class ConductorHistoryEntry(BaseModel):
+    """One entry in the conductor spawn history returned by ``GET /control/conductor-history``."""
+
+    wave_id: str
+    worktree: str
+    host_worktree: str
+    started_at: str
+    status: str  # "active" (worktree exists) | "completed" (worktree removed)
+
+
+@router.get("/control/conductor-history", tags=["control"])
+async def conductor_history() -> list[ConductorHistoryEntry]:
+    """Return the last 5 conductor spawns with their current status.
+
+    Status is ``"active"`` when the worktree directory is still present on disk
+    and ``"completed"`` once it has been removed.  Returns ``[]`` when the DB
+    is unavailable rather than raising an error — callers should treat an empty
+    list as "no history yet."
+    """
+    from agentception.db.queries import get_conductor_history
+
+    entries = await get_conductor_history(limit=5)
+    return [ConductorHistoryEntry(**e) for e in entries]
+
+
 @router.post("/control/spawn-conductor", tags=["control"])
 async def spawn_conductor(body: SpawnConductorRequest) -> SpawnConductorResult:
     """Seed a conductor worktree that orchestrates a multi-phase wave.

--- a/agentception/routes/ui/overview.py
+++ b/agentception/routes/ui/overview.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import json as _json
 import logging
 from itertools import groupby as _groupby
 
@@ -50,12 +51,23 @@ async def overview(request: Request) -> HTMLResponse:
     state = get_state() or PipelineState.empty()
     all_phase_labels: list[str] = []
     label_is_pinned: bool = False
+    active_org: str | None = None
 
     try:
         pipeline_cfg = await read_pipeline_config()
         all_phase_labels = pipeline_cfg.active_labels_order
     except Exception as exc:
         logger.warning("⚠️ Could not read pipeline config: %s", exc)
+
+    try:
+        _cfg_path = _settings.repo_dir / ".cursor" / "pipeline-config.json"
+        if _cfg_path.exists():
+            _raw_cfg: object = _json.loads(_cfg_path.read_text(encoding="utf-8"))
+            if isinstance(_raw_cfg, dict):
+                _org_val = _raw_cfg.get("active_org")
+                active_org = _org_val if isinstance(_org_val, str) else None
+    except Exception as exc:
+        logger.warning("⚠️ Could not read active_org from pipeline config: %s", exc)
 
     try:
         from agentception.readers.active_label_override import get_pin
@@ -122,6 +134,7 @@ async def overview(request: Request) -> HTMLResponse:
             "pr_violations": [v.model_dump() for v in pr_violations],
             "poller_paused": poller_paused,
             "phase_lanes": phase_lanes,
+            "active_org": active_org,
         },
     )
 

--- a/agentception/static/js/app.js
+++ b/agentception/static/js/app.js
@@ -14,8 +14,8 @@
  *   nav.js          — projectSwitcher
  *   overview.js     — pipelineDashboard, agentCard, phaseSwitcher,
  *                     pipelineControl, sweepControl, waveControl,
- *                     conductorModal, scalingAdvisor, prViolations,
- *                     staleClaimCard, issueCard
+ *                     conductorModal, runConductorPanel, scalingAdvisor,
+ *                     prViolations, staleClaimCard, issueCard
  *   agents.js       — agentsPage, missionControl
  *   telemetry.js    — telemetryDash, waveTable
  *   dag.js          — dagVisualization
@@ -35,7 +35,7 @@ import { projectSwitcher } from './nav.js';
 import {
   pipelineDashboard, agentCard, phaseSwitcher, pipelineControl,
   sweepControl, waveControl, conductorModal, scalingAdvisor, prViolations,
-  staleClaimCard, issueCard, approvalCard,
+  staleClaimCard, issueCard, approvalCard, runConductorPanel,
 } from './overview.js';
 import { agentsPage, missionControl } from './agents.js';
 import { telemetryDash, waveTable } from './telemetry.js';
@@ -55,7 +55,7 @@ Object.assign(window, {
   projectSwitcher,
   pipelineDashboard, agentCard, phaseSwitcher, pipelineControl,
   sweepControl, waveControl, conductorModal, scalingAdvisor, prViolations,
-  staleClaimCard, issueCard, approvalCard,
+  staleClaimCard, issueCard, approvalCard, runConductorPanel,
   agentsPage, missionControl,
   telemetryDash, waveTable,
   dagVisualization,

--- a/agentception/static/js/overview.js
+++ b/agentception/static/js/overview.js
@@ -624,6 +624,91 @@ export function conductorModal(initial) {
 }
 
 /**
+ * "Run Conductor" button panel — one-click conductor spawn with result modal and history.
+ *
+ * Dispatched to by the `open-run-conductor-modal` custom event from the
+ * secondary "Run Conductor" button in the wave-control-card header.
+ * Calls POST /api/control/spawn-conductor with the active phase and org,
+ * then shows the result in a modal with a copy-path affordance.
+ *
+ * @param {string|null} activeLabel - Server-rendered active phase label.
+ * @param {string[]}    allLabels   - All configured phase labels (fallback).
+ * @param {string|null} activeOrg   - active_org from pipeline-config.json.
+ */
+export function runConductorPanel(activeLabel, allLabels, activeOrg) {
+  return {
+    open: false,
+    launching: false,
+    result: null,
+    error: null,
+    history: [],
+    historyOpen: false,
+    activeLabel,
+    allLabels,
+    activeOrg,
+    copied: false,
+
+    init() {
+      this.fetchHistory();
+    },
+
+    async fetchHistory() {
+      try {
+        const resp = await fetch('/api/control/conductor-history');
+        if (resp.ok) this.history = await resp.json();
+      } catch (_) {
+        // Non-fatal — history section stays empty.
+      }
+    },
+
+    async launch() {
+      const phases = this.activeLabel ? [this.activeLabel] : this.allLabels;
+      if (!phases.length) {
+        this.error = 'No active phase configured — set active_labels_order in pipeline-config.json.';
+        return;
+      }
+      this.launching = true;
+      this.result = null;
+      this.error = null;
+      try {
+        const resp = await fetch('/api/control/spawn-conductor', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ phases, org: this.activeOrg || null }),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+          this.error = data.detail ?? `HTTP ${resp.status}`;
+        } else {
+          this.result = data;
+          await this.fetchHistory();
+        }
+      } catch (err) {
+        this.error = `Network error: ${err.message}`;
+      } finally {
+        this.launching = false;
+      }
+    },
+
+    async copyPath(path) {
+      if (!path) return;
+      try {
+        await navigator.clipboard.writeText(path);
+        this.copied = true;
+        setTimeout(() => { this.copied = false; }, 2000);
+      } catch (_) {}
+    },
+
+    dismiss() {
+      this.open = false;
+      this.result = null;
+      this.error = null;
+      this.copied = false;
+    },
+  };
+}
+
+/**
  * Powers each issue card in the GitHub Board's open issues list.
  *
  * Keeps the inline fetch out of the template.  The analysisHtml is injected

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -236,6 +236,137 @@
   x-cloak
 >
 
+  {# ── Run Conductor panel — own Alpine scope, listens for dispatch ──────── #}
+  <div
+    x-data='runConductorPanel({{ active_phase_label | tojson }}, {{ all_phase_labels | tojson }}, {{ active_org | tojson }})'
+    x-init="init()"
+    @open-run-conductor-modal.window="open = true; fetchHistory()"
+    @keydown.escape.window="if (open) dismiss()"
+  >
+    <div
+      class="modal-backdrop"
+      x-show="open"
+      x-cloak
+      x-transition.opacity
+      @click.self="dismiss()"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="run-conductor-modal-title"
+    >
+      <div class="modal-box">
+        <h2 class="modal-title" id="run-conductor-modal-title">🎼 Run Conductor</h2>
+
+        <template x-if="!result && !launching && !error">
+          <div>
+            <p class="modal-body">
+              Spawn a conductor agent for the active phase. The conductor will
+              orchestrate sub-agents across all unclaimed issues without manual
+              intervention per-issue.
+            </p>
+            <template x-if="activeLabel">
+              <p class="text-muted mt-1" style="font-size:0.9rem;">
+                Phase: <span class="label-chip label-chip--active" x-text="activeLabel"></span>
+                <template x-if="activeOrg">
+                  &nbsp;· Org: <code x-text="activeOrg"></code>
+                </template>
+              </p>
+            </template>
+            <template x-if="!activeLabel">
+              <p class="text-muted mt-1">No active phase configured — set <code>active_labels_order</code> in pipeline-config.json.</p>
+            </template>
+            <div class="modal-actions">
+              <button class="btn btn-secondary" @click="dismiss()">Cancel</button>
+              <button
+                class="btn btn-primary"
+                @click="launch()"
+                :disabled="!activeLabel"
+              >Run Conductor</button>
+            </div>
+          </div>
+        </template>
+
+        <template x-if="launching">
+          <div class="flex-row gap-1 mt-1" style="align-items:center;">
+            <span class="agent-pulse agent-pulse--implementing"></span>
+            <span class="text-muted">Spawning conductor worktree…</span>
+          </div>
+        </template>
+
+        <template x-if="result && !launching">
+          <div>
+            <p class="text-success mt-1">✅ Conductor ready — open the folder in Cursor to start.</p>
+            <div class="flex-row gap-1 mt-1" style="align-items:center;flex-wrap:wrap;">
+              <code style="font-size:0.8rem;word-break:break-all;" x-text="result.host_worktree"></code>
+              <button
+                class="btn btn-secondary"
+                style="padding:2px 8px;font-size:0.8rem;"
+                @click="copyPath(result.host_worktree)"
+                x-text="copied ? '✅ Copied!' : '📋 Copy path'"
+              ></button>
+            </div>
+            <p class="text-muted mt-1" style="font-size:0.85rem;">
+              Open this folder in Cursor — the conductor will start automatically.
+            </p>
+            <p class="mt-1" style="font-size:0.85rem;">
+              <a href="/agents" class="btn btn-sm btn-secondary">Monitor agents →</a>
+            </p>
+            <div class="modal-actions">
+              <button class="btn btn-secondary" @click="dismiss()">Close</button>
+            </div>
+          </div>
+        </template>
+
+        <template x-if="error && !launching">
+          <div>
+            <div class="alert-banner mt-1" role="alert">
+              <span>❌</span>
+              <span x-text="error"></span>
+            </div>
+            <div class="modal-actions">
+              <button class="btn btn-secondary" @click="dismiss()">Close</button>
+              <button class="btn btn-primary" @click="error = null; result = null">Try Again</button>
+            </div>
+          </div>
+        </template>
+
+        {# ── History section ─────────────────────────────────────────────── #}
+        <template x-if="history.length > 0">
+          <div class="mt-2" style="border-top:1px solid var(--border);padding-top:0.75rem;">
+            <button
+              class="btn btn-sm btn-secondary"
+              style="font-size:0.8rem;margin-bottom:0.5rem;"
+              @click="historyOpen = !historyOpen"
+              x-text="historyOpen ? '▾ Hide history' : '▸ Show last ' + history.length + ' conductor' + (history.length === 1 ? '' : 's')"
+            ></button>
+            <template x-if="historyOpen">
+              <div>
+                <template x-for="entry in history" :key="entry.wave_id">
+                  <div style="margin-bottom:0.5rem;padding:0.4rem 0.5rem;background:var(--bg-secondary);border-radius:4px;font-size:0.8rem;">
+                    <div class="flex-row gap-1" style="align-items:center;flex-wrap:wrap;">
+                      <span
+                        class="badge"
+                        :class="entry.status === 'active' ? 'badge--green' : 'badge--dim'"
+                        x-text="entry.status"
+                      ></span>
+                      <code style="word-break:break-all;flex:1;" x-text="entry.host_worktree"></code>
+                      <button
+                        class="btn btn-sm btn-secondary"
+                        style="padding:1px 6px;font-size:0.75rem;"
+                        @click="copyPath(entry.host_worktree)"
+                      >📋</button>
+                    </div>
+                    <div class="text-muted" style="margin-top:0.2rem;" x-text="entry.started_at"></div>
+                  </div>
+                </template>
+              </div>
+            </template>
+          </div>
+        </template>
+
+      </div>
+    </div>
+  </div>
+
   {# ── Conductor modal — own Alpine scope, listens for dispatch ──────────── #}
   <div
     x-data='conductorModal({{ state.model_dump() | tojson }})'
@@ -646,6 +777,13 @@
               :title="state.agents && state.agents.length > 0 ? 'Cannot launch while agents are active' : 'Launch a conductor agent across selected phases'"
               aria-label="Launch conductor wave"
             >🚀 Launch Wave</button>
+            <button
+              class="btn btn-secondary"
+              style="font-size:0.85rem;"
+              @click="$dispatch('open-run-conductor-modal')"
+              title="Spawn a conductor agent for the active phase"
+              aria-label="Run conductor agent"
+            >🎼 Run Conductor</button>
           </div>
           <template x-if="state.active_label && state.board_issues && state.board_issues.length > 0 && unclaimedCount() === 0">
             <span class="badge badge--green">All claimed ✓</span>

--- a/agentception/tests/test_agentception_run_conductor.py
+++ b/agentception/tests/test_agentception_run_conductor.py
@@ -1,0 +1,239 @@
+"""Tests for the "Run Conductor" feature (Issue #835).
+
+Covers:
+- GET /api/control/conductor-history — returns history entries, empty on DB failure
+- ConductorHistoryEntry model fields
+- get_conductor_history() DB query helper (status resolution)
+- Overview route exposes active_org in template context
+
+Run targeted:
+    pytest agentception/tests/test_agentception_run_conductor.py -v
+"""
+from __future__ import annotations
+
+import datetime
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    """Synchronous test client with full lifespan."""
+    with TestClient(app) as c:
+        yield c
+
+
+# ── GET /api/control/conductor-history ────────────────────────────────────────
+
+
+def test_conductor_history_empty_when_no_db_entries(client: TestClient) -> None:
+    """GET /api/control/conductor-history returns [] when DB has no conductor waves."""
+    with patch(
+        "agentception.db.queries.get_conductor_history",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        response = client.get("/api/control/conductor-history")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_conductor_history_returns_entries(client: TestClient) -> None:
+    """GET /api/control/conductor-history returns entries from get_conductor_history."""
+    fake_entries = [
+        {
+            "wave_id": "conductor-20260303-142201",
+            "worktree": "/worktrees/conductor-20260303-142201",
+            "host_worktree": "/host/conductor-20260303-142201",
+            "started_at": "2026-03-03 14:22 UTC",
+            "status": "completed",
+        },
+    ]
+    with patch(
+        "agentception.db.queries.get_conductor_history",
+        new_callable=AsyncMock,
+        return_value=fake_entries,
+    ):
+        response = client.get("/api/control/conductor-history")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    entry = data[0]
+    assert entry["wave_id"] == "conductor-20260303-142201"
+    assert entry["host_worktree"] == "/host/conductor-20260303-142201"
+    assert entry["started_at"] == "2026-03-03 14:22 UTC"
+    assert entry["status"] == "completed"
+
+
+def test_conductor_history_status_active_when_worktree_exists(client: TestClient) -> None:
+    """GET /api/control/conductor-history status is 'active' when worktree dir exists."""
+    fake_entries = [
+        {
+            "wave_id": "conductor-20260303-150000",
+            "worktree": "/worktrees/conductor-20260303-150000",
+            "host_worktree": "/host/conductor-20260303-150000",
+            "started_at": "2026-03-03 15:00 UTC",
+            "status": "active",
+        },
+    ]
+    with patch(
+        "agentception.db.queries.get_conductor_history",
+        new_callable=AsyncMock,
+        return_value=fake_entries,
+    ):
+        response = client.get("/api/control/conductor-history")
+
+    assert response.status_code == 200
+    assert response.json()[0]["status"] == "active"
+
+
+def test_conductor_history_returns_at_most_five(client: TestClient) -> None:
+    """GET /api/control/conductor-history returns at most 5 entries."""
+    fake_entries = [
+        {
+            "wave_id": f"conductor-2026030{i}-120000",
+            "worktree": f"/worktrees/conductor-2026030{i}-120000",
+            "host_worktree": f"/host/conductor-2026030{i}-120000",
+            "started_at": f"2026-03-0{i} 12:00 UTC",
+            "status": "completed",
+        }
+        for i in range(1, 6)
+    ]
+    with patch(
+        "agentception.db.queries.get_conductor_history",
+        new_callable=AsyncMock,
+        return_value=fake_entries,
+    ):
+        response = client.get("/api/control/conductor-history")
+
+    assert response.status_code == 200
+    assert len(response.json()) == 5
+
+
+# ── ConductorHistoryEntry model ───────────────────────────────────────────────
+
+
+def test_conductor_history_entry_model_fields() -> None:
+    """ConductorHistoryEntry must expose all required fields."""
+    from agentception.routes.api.control import ConductorHistoryEntry
+
+    entry = ConductorHistoryEntry(
+        wave_id="conductor-20260303-142201",
+        worktree="/worktrees/conductor-20260303-142201",
+        host_worktree="/host/conductor-20260303-142201",
+        started_at="2026-03-03 14:22 UTC",
+        status="completed",
+    )
+    assert entry.wave_id == "conductor-20260303-142201"
+    assert entry.host_worktree == "/host/conductor-20260303-142201"
+    assert entry.status == "completed"
+
+
+# ── get_conductor_history DB query helper ─────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_get_conductor_history_status_resolved_from_worktree_dir(
+    tmp_path: Path,
+) -> None:
+    """get_conductor_history marks a wave 'active' only when its dir exists."""
+    from agentception.db.queries import get_conductor_history
+
+    worktrees = tmp_path / "worktrees"
+    worktrees.mkdir()
+    host_worktrees = tmp_path / "host"
+    host_worktrees.mkdir()
+
+    wave_id_active = "conductor-20260303-100000"
+    wave_id_done = "conductor-20260303-110000"
+
+    # Create a directory only for the "active" wave.
+    (worktrees / wave_id_active).mkdir()
+
+    # Build fake ACWave objects the SQLAlchemy query would return.
+    def _make_wave(wave_id: str) -> MagicMock:
+        m = MagicMock()
+        m.id = wave_id
+        m.started_at = datetime.datetime(2026, 3, 3, 10, 0, 0, tzinfo=datetime.timezone.utc)
+        return m
+
+    fake_waves = [_make_wave(wave_id_active), _make_wave(wave_id_done)]
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = fake_waves
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("agentception.db.queries.get_session", return_value=mock_session):
+        entries = await get_conductor_history(
+            limit=5,
+            worktrees_dir=worktrees,
+            host_worktrees_dir=host_worktrees,
+        )
+
+    assert len(entries) == 2
+    active_entry = next(e for e in entries if e["wave_id"] == wave_id_active)
+    done_entry = next(e for e in entries if e["wave_id"] == wave_id_done)
+    assert active_entry["status"] == "active"
+    assert done_entry["status"] == "completed"
+
+
+@pytest.mark.anyio
+async def test_get_conductor_history_returns_empty_on_db_error(
+    tmp_path: Path,
+) -> None:
+    """get_conductor_history returns [] when the DB session raises an exception."""
+    from agentception.db.queries import get_conductor_history
+
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(side_effect=RuntimeError("DB unavailable"))
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("agentception.db.queries.get_session", return_value=mock_session):
+        entries = await get_conductor_history(
+            limit=5,
+            worktrees_dir=tmp_path,
+            host_worktrees_dir=tmp_path,
+        )
+
+    assert entries == []
+
+
+# ── Overview route — active_org exposure ──────────────────────────────────────
+
+
+def test_overview_page_renders_without_active_org(client: TestClient) -> None:
+    """GET / should render successfully even when active_org is absent from config."""
+    # Patch Path.exists so the config path appears missing, forcing active_org = None.
+    from pathlib import Path as _Path
+
+    original_exists = _Path.exists
+
+    def _fake_exists(self: _Path) -> bool:
+        if "pipeline-config.json" in str(self):
+            return False
+        return original_exists(self)
+
+    with patch.object(_Path, "exists", _fake_exists):
+        response = client.get("/")
+    # Accept 200 or a redirect — the important thing is no 500.
+    assert response.status_code in (200, 302, 307)
+
+
+def test_overview_exposes_run_conductor_button(client: TestClient) -> None:
+    """GET / must include the 'Run Conductor' button markup in the response."""
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Run Conductor" in response.text
+    assert "open-run-conductor-modal" in response.text


### PR DESCRIPTION
## Summary

- Adds a secondary **🎼 Run Conductor** button to the pipeline panel header (less prominent than "Launch Wave")
- Clicking the button opens a modal that calls `POST /api/control/spawn-conductor` with the active phase and `active_org` from pipeline-config.json
- Result modal shows the worktree path in monospace, a 📋 copy button, instruction text ("Open this folder in Cursor — the conductor will start automatically"), and a link to `/agents`
- Collapsible history section shows the last 5 conductor spawns with worktree path, timestamp, and status (active = dir exists, completed = dir removed)

## Changes

- `agentception/db/queries.py` — `get_conductor_history()` helper queries `ac_waves` for conductor spawns and resolves active/completed status from the worktree directory existence
- `agentception/routes/api/control.py` — `ConductorHistoryEntry` model + `GET /api/control/conductor-history` endpoint
- `agentception/routes/ui/overview.py` — reads `active_org` from raw pipeline-config.json and exposes it in the template context
- `agentception/templates/overview.html` — `runConductorPanel` modal div + **🎼 Run Conductor** secondary button in the wave-control-card header
- `agentception/static/js/overview.js` — `runConductorPanel` Alpine component (launch, history fetch, copy-path, dismiss)
- `agentception/static/js/app.js` — registers `runConductorPanel`
- `agentception/tests/test_agentception_run_conductor.py` — 9 tests covering endpoint, model, DB helper, and overview route

## Test plan

- [x] `docker compose exec agentception mypy agentception/` — clean (110 files, 0 errors)
- [x] `docker compose exec agentception pytest agentception/tests/test_agentception_run_conductor.py -v` — 9/9 passed
- [ ] Manual: click **🎼 Run Conductor** in the pipeline panel → modal opens → conductor spawns → path displayed with copy button → history section shows after spawn

Closes #835