### PR TITLE
fix: use canonical worktrees_dir in plan/draft; rename brain_dump → plan_text

### DIFF
--- a/agentception/models.py
+++ b/agentception/models.py
@@ -343,7 +343,7 @@ class SpawnConductorResult(BaseModel):
 class SpawnCoordinatorRequest(BaseModel):
     """Request body for ``POST /api/control/spawn-coordinator``.
 
-    ``brain_dump`` is the user's raw unstructured text — feature ideas, bug
+    ``plan_text`` is the user's raw unstructured text — feature ideas, bug
     descriptions, or any free-form list of work items.  The coordinator agent
     reads this field from its ``.agent-task`` file and runs the Phase Planner
     step in ``parallel-bugs-to-issues.md``, producing labelled GitHub issues.
@@ -353,7 +353,7 @@ class SpawnCoordinatorRequest(BaseModel):
     Leave blank for the default label scheme.
     """
 
-    brain_dump: str
+    plan_text: str
     label_prefix: str = ""
 
 

--- a/agentception/routes/api/_shared.py
+++ b/agentception/routes/api/_shared.py
@@ -126,13 +126,13 @@ def _build_agent_task(
 
 def _build_coordinator_task(
     slug: str,
-    brain_dump: str,
+    plan_text: str,
     label_prefix: str,
     worktree: Path,
     host_worktree: Path,
     branch: str,
 ) -> str:
-    """Build the ``.agent-task`` content for a brain-dump coordinator worktree.
+    """Build the ``.agent-task`` content for a plan coordinator worktree.
 
     The coordinator agent reads ``WORKFLOW=bugs-to-issues`` and follows
     ``parallel-bugs-to-issues.md``: it runs the Phase Planner, creates GitHub
@@ -140,7 +140,7 @@ def _build_coordinator_task(
     launches sub-agents.  AgentCeption's only job is to prepare the worktree
     and this file — the Cursor background agent does all LLM work.
 
-    The ``BRAIN_DUMP`` section is appended as a freeform block after the
+    The ``PLAN_DUMP`` section is appended as a freeform block after the
     structured key=value header so the coordinator can read it verbatim.
     """
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -164,7 +164,7 @@ def _build_coordinator_task(
         f"ATTEMPT_N=0\n"
         f"REQUIRED_OUTPUT=phase_plan\n"
         f"ON_BLOCK=stop\n"
-        f"\nBRAIN_DUMP:\n{brain_dump}\n"
+        f"\nPLAN_DUMP:\n{plan_text}\n"
     )
 
 

--- a/agentception/routes/api/control.py
+++ b/agentception/routes/api/control.py
@@ -452,7 +452,7 @@ async def sweep_stale(dry_run: bool = False) -> SweepResult:
     """Delete all stale agent branches, remove orphan worktrees, and clear stale agent:wip labels.
 
     A branch is stale when it is an agent branch (``feat/issue-N`` or
-    ``feat/brain-dump-*``) with no live git worktree checked out on it.
+        ``feat/plan-*``) with no live git worktree checked out on it.
     A claim is stale when an issue carries ``agent:wip`` but has no matching
     worktree directory.
 
@@ -580,12 +580,12 @@ async def spawn_coordinator(body: SpawnCoordinatorRequest) -> SpawnCoordinatorRe
     HTTP 500
         When ``git worktree add`` fails.
     """
-    brain_dump = body.brain_dump.strip()
-    if not brain_dump:
-        raise HTTPException(status_code=422, detail="brain_dump must not be empty")
+    plan_text = body.plan_text.strip()
+    if not plan_text:
+        raise HTTPException(status_code=422, detail="plan_text must not be empty")
 
     now_slug = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    slug = f"brain-dump-{now_slug}"
+    slug = f"plan-{now_slug}"
     branch = f"feat/{slug}"
     worktree_path = settings.worktrees_dir / slug
     host_worktree_path = settings.host_worktrees_dir / slug
@@ -621,7 +621,7 @@ async def spawn_coordinator(body: SpawnCoordinatorRequest) -> SpawnCoordinatorRe
 
     agent_task_content = _build_coordinator_task(
         slug=slug,
-        brain_dump=brain_dump,
+        plan_text=plan_text,
         label_prefix=body.label_prefix,
         worktree=worktree_path,
         host_worktree=host_worktree_path,

--- a/agentception/routes/api/plan.py
+++ b/agentception/routes/api/plan.py
@@ -2,14 +2,18 @@
 
 POST /api/plan/draft
 --------------------
-Input:  PlanDraftRequest(dump: str)  — non-empty, non-whitespace text
+Input:  PlanDraftRequest(text: str)  — non-empty, non-whitespace plan text
 Output: PlanDraftResponse            — draft_id (uuid4), task_file path,
                                        output_path, status='pending'
 
 Side effects
 ------------
-1. ``git worktree add /tmp/worktrees/plan-draft-<draft_id>`` is executed
+1. ``git worktree add <worktrees_dir>/plan-draft-<draft_id>`` is executed
    (awaited; it is fast and must succeed before we write the task file).
+   The worktree is created under ``settings.worktrees_dir`` — the canonical
+   Docker-mounted path (``/worktrees`` in-container, ``~/.cursor/worktrees/maestro``
+   on the host) — so mypy/pytest can reference it via ``/worktrees/<name>``
+   inside the container without path mismatches.
 2. A ``.agent-task`` file is written to the new worktree using the K=V format
    that is compatible with the future TOML migration (issue #888).
 
@@ -37,12 +41,12 @@ import asyncio
 import json
 import logging
 import uuid
-from pathlib import Path
 
 import yaml
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, field_validator
 
+from agentception.config import settings
 from agentception.mcp.plan_tools import plan_spawn_coordinator
 from agentception.models import EnrichedManifest, EnrichedPhase
 
@@ -50,24 +54,22 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/plan", tags=["plan"])
 
-_WORKTREES_BASE = Path("/tmp/worktrees")
-
 
 class PlanDraftRequest(BaseModel):
     """Request body for POST /api/plan/draft.
 
-    ``dump`` is the raw brain-dump text submitted by the DAW or a human.
+    ``text`` is the raw plan text submitted by the user.
     Empty or whitespace-only strings are rejected at validation time (422).
     """
 
-    dump: str
+    text: str
 
-    @field_validator("dump")
+    @field_validator("text")
     @classmethod
-    def dump_must_not_be_blank(cls, v: str) -> str:
-        """Reject empty or whitespace-only dump strings before the handler runs."""
+    def text_must_not_be_blank(cls, v: str) -> str:
+        """Reject empty or whitespace-only plan text before the handler runs."""
         if not v or not v.strip():
-            raise ValueError("dump must not be empty or whitespace-only")
+            raise ValueError("text must not be empty or whitespace-only")
         return v
 
 
@@ -91,29 +93,37 @@ class PlanDraftResponse(BaseModel):
 
 @router.post("/draft")
 async def post_plan_draft(request: PlanDraftRequest) -> PlanDraftResponse:
-    """Accept a brain dump, create a git worktree, and write an .agent-task file.
+    """Accept plan text, create a git worktree, and write an .agent-task file.
 
     Steps:
     1. Generate a uuid4 draft_id.
-    2. Run ``git worktree add /tmp/worktrees/plan-draft-<draft_id>`` (awaited).
-    3. Write a K=V .agent-task to that path so an agent can pick it up.
+    2. Run ``git worktree add <worktrees_dir>/plan-draft-<draft_id>`` off origin/dev.
+       Uses the canonical ``settings.worktrees_dir`` so the path is visible inside
+       Docker at ``/worktrees/plan-draft-<draft_id>`` — never ``/tmp/``.
+    3. Write a K=V .agent-task to that path so a Cursor agent can pick it up.
     4. Return PlanDraftResponse immediately.
 
-    Returns 422 if dump is empty/whitespace (validated by PlanDraftRequest).
+    Returns 422 if text is empty/whitespace (validated by PlanDraftRequest).
     Returns 500 if the git worktree add subprocess fails.
     """
     draft_id = str(uuid.uuid4())
-    worktree_path = _WORKTREES_BASE / f"plan-draft-{draft_id}"
+    slug = f"plan-draft-{draft_id}"
+    branch = f"feat/{slug}"
+    worktree_path = settings.worktrees_dir / slug
+    host_worktree_path = settings.host_worktrees_dir / slug
     task_file_path = worktree_path / ".agent-task"
     # The output file is where the Cursor agent writes the finished PlanSpec YAML.
     # The AgentCeption poller watches *this file* (not the directory) and emits
     # ``task_output_ready`` when it appears on disk.
-    output_file_path = worktree_path / ".plan-output.yaml"
+    output_file_path = host_worktree_path / ".plan-output.yaml"
 
     logger.info("✅ Plan draft %s — creating worktree at %s", draft_id, worktree_path)
 
+    repo_dir = str(settings.repo_dir)
     proc = await asyncio.create_subprocess_exec(
-        "git", "worktree", "add", str(worktree_path),
+        "git", "-C", repo_dir,
+        "worktree", "add", "-b", branch,
+        str(worktree_path), "origin/dev",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
@@ -145,7 +155,7 @@ async def post_plan_draft(request: PlanDraftRequest) -> PlanDraftResponse:
         # TOML schema, then produce valid TOML matching that schema.
         f"mcp_tools_hint=call plan_get_schema() to get the PlanSpec TOML schema first\n"
         f"output_schema=plan_get_schema\n"
-        f"plan_draft.dump={request.dump}\n"
+        f"plan_draft.text={request.text}\n"
     )
     task_file_path.write_text(task_content, encoding="utf-8")
 

--- a/agentception/tests/e2e/test_agentception_workflow_e2e.py
+++ b/agentception/tests/e2e/test_agentception_workflow_e2e.py
@@ -144,7 +144,7 @@ def test_spawn_coordinator_creates_worktree(
     ):
         response = client.post(
             "/api/control/spawn-coordinator",
-            json={"brain_dump": _SAMPLE_DUMP, "label_prefix": ""},
+            json={"plan_text": _SAMPLE_DUMP, "label_prefix": ""},
         )
 
     assert response.status_code == 200
@@ -154,11 +154,11 @@ def test_spawn_coordinator_creates_worktree(
     assert "host_worktree" in data
     assert "branch" in data
     assert "agent_task" in data
-    assert data["slug"].startswith("brain-dump-"), (
-        f"slug must start with 'brain-dump-', got {data['slug']!r}"
+    assert data["slug"].startswith("plan-"), (
+        f"slug must start with 'plan-', got {data['slug']!r}"
     )
-    assert data["branch"].startswith("feat/brain-dump-"), (
-        f"branch must start with 'feat/brain-dump-', got {data['branch']!r}"
+    assert data["branch"].startswith("feat/plan-"), (
+        f"branch must start with 'feat/plan-', got {data['branch']!r}"
     )
 
     assert created, "worktree directory was never created by git worktree add"
@@ -168,9 +168,9 @@ def test_spawn_coordinator_creates_worktree(
     assert "WORKFLOW=bugs-to-issues" in content, (
         "coordinator .agent-task must declare WORKFLOW=bugs-to-issues"
     )
-    assert "BRAIN_DUMP:" in content, (
-        "coordinator .agent-task must embed the original brain dump text"
-    )
+    assert "PLAN_DUMP:" in content, (
+            "coordinator .agent-task must embed the original plan text"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/tests/test_agentception_plan_api.py
+++ b/agentception/tests/test_agentception_plan_api.py
@@ -1,11 +1,11 @@
 """Tests for POST /api/plan/draft (issue #872) and POST /api/plan/launch (issue #873).
 
 POST /api/plan/draft covers:
-- Valid dump returns 200 with status=pending and a uuid4 draft_id.
-- Empty dump returns 422.
-- Whitespace-only dump returns 422.
+- Valid text returns 200 with status=pending and a uuid4 draft_id.
+- Empty text returns 422.
+- Whitespace-only text returns 422.
 - After a valid POST the .agent-task file is written with WORKFLOW=plan-spec
-  and the dump text.
+  and the plan text.
 - asyncio.create_subprocess_exec is called with ``git worktree add``.
 
 POST /api/plan/launch covers:
@@ -72,7 +72,7 @@ async def test_post_valid_dump_returns_200_pending(
     async_client: AsyncClient,
     tmp_path: Path,
 ) -> None:
-    """POST with a valid dump string must return 200 and status='pending'."""
+    """POST with valid plan text must return 200 and status='pending'."""
     proc_mock = _make_proc_mock(returncode=0)
 
     with (
@@ -81,13 +81,17 @@ async def test_post_valid_dump_returns_200_pending(
             return_value=proc_mock,
         ) as mock_exec,
         patch(
-            "agentception.routes.api.plan._WORKTREES_BASE",
+            "agentception.routes.api.plan.settings.worktrees_dir",
+            tmp_path,
+        ),
+        patch(
+            "agentception.routes.api.plan.settings.host_worktrees_dir",
             tmp_path,
         ),
     ):
         response = await async_client.post(
             "/api/plan/draft",
-            json={"dump": "I want a song about mountains"},
+            json={"text": "I want a song about mountains"},
         )
 
     assert response.status_code == 200
@@ -110,8 +114,8 @@ async def test_agent_task_written_with_workflow_plan_spec(
     async_client: AsyncClient,
     tmp_path: Path,
 ) -> None:
-    """After a valid POST the .agent-task must contain WORKFLOW=plan-spec and the dump."""
-    dump_text = "Build a calm lo-fi track with piano and soft drums"
+    """After a valid POST the .agent-task must contain WORKFLOW=plan-spec and the plan text."""
+    plan_text = "Build a calm lo-fi track with piano and soft drums"
     proc_mock = _make_proc_mock(returncode=0)
 
     with (
@@ -120,13 +124,17 @@ async def test_agent_task_written_with_workflow_plan_spec(
             return_value=proc_mock,
         ),
         patch(
-            "agentception.routes.api.plan._WORKTREES_BASE",
+            "agentception.routes.api.plan.settings.worktrees_dir",
+            tmp_path,
+        ),
+        patch(
+            "agentception.routes.api.plan.settings.host_worktrees_dir",
             tmp_path,
         ),
     ):
         response = await async_client.post(
             "/api/plan/draft",
-            json={"dump": dump_text},
+            json={"text": plan_text},
         )
 
     assert response.status_code == 200
@@ -136,7 +144,7 @@ async def test_agent_task_written_with_workflow_plan_spec(
 
     content = task_file.read_text(encoding="utf-8")
     assert "WORKFLOW=plan-spec" in content
-    assert dump_text in content
+    assert plan_text in content
     # Output path must be a specific file so the AgentCeption poller can watch
     # for it; the mcp_tools_hint guides the Cursor agent to call plan_get_schema.
     assert ".plan-output.yaml" in content
@@ -149,7 +157,7 @@ async def test_git_worktree_add_called(
     async_client: AsyncClient,
     tmp_path: Path,
 ) -> None:
-    """POST must call asyncio.create_subprocess_exec with 'git worktree add'."""
+    """POST must call asyncio.create_subprocess_exec with 'git -C <repo> worktree add -b ...'."""
     proc_mock = _make_proc_mock(returncode=0)
 
     with (
@@ -158,25 +166,31 @@ async def test_git_worktree_add_called(
             return_value=proc_mock,
         ) as mock_exec,
         patch(
-            "agentception.routes.api.plan._WORKTREES_BASE",
+            "agentception.routes.api.plan.settings.worktrees_dir",
+            tmp_path,
+        ),
+        patch(
+            "agentception.routes.api.plan.settings.host_worktrees_dir",
             tmp_path,
         ),
     ):
         response = await async_client.post(
             "/api/plan/draft",
-            json={"dump": "Any valid dump text"},
+            json={"text": "Any valid plan text"},
         )
 
     assert response.status_code == 200
-    # Verify the subprocess was called with the git worktree add arguments
+    # git -C <repo_dir> worktree add -b <branch> <path> origin/dev
     call_args = mock_exec.call_args
     assert call_args is not None
     args = call_args[0]
     assert args[0] == "git"
-    assert args[1] == "worktree"
-    assert args[2] == "add"
-    # 4th arg is the worktree path
-    assert "plan-draft-" in args[3]
+    assert args[1] == "-C"           # repo flag
+    assert args[3] == "worktree"
+    assert args[4] == "add"
+    assert args[5] == "-b"           # named branch
+    assert "plan-draft-" in args[6]  # branch name contains slug
+    assert "plan-draft-" in str(args[7])  # worktree path
 
 
 # ---------------------------------------------------------------------------
@@ -186,20 +200,20 @@ async def test_git_worktree_add_called(
 
 @pytest.mark.anyio
 async def test_post_empty_dump_returns_422(async_client: AsyncClient) -> None:
-    """POST with an empty dump string must return 422."""
+    """POST with empty text must return 422."""
     response = await async_client.post(
         "/api/plan/draft",
-        json={"dump": ""},
+        json={"text": ""},
     )
     assert response.status_code == 422
 
 
 @pytest.mark.anyio
 async def test_post_whitespace_dump_returns_422(async_client: AsyncClient) -> None:
-    """POST with a whitespace-only dump string must return 422."""
+    """POST with whitespace-only text must return 422."""
     response = await async_client.post(
         "/api/plan/draft",
-        json={"dump": "   \t\n  "},
+        json={"text": "   \t\n  "},
     )
     assert response.status_code == 422
 


### PR DESCRIPTION
## Summary

- **Worktree path bug fixed**: `POST /api/plan/draft` was creating worktrees under `/tmp/worktrees/` which is not bind-mounted into Docker. Agents running mypy/pytest via `docker compose exec` would fail with `No such file or directory` for any `/worktrees/plan-draft-*` path. Now uses `settings.worktrees_dir` (Docker-visible at `/worktrees/`, host at `~/.cursor/worktrees/maestro/`) — same as every other spawn endpoint.

- **`git worktree add` hardened**: now uses `git -C <repo_dir> worktree add -b <branch> <path> origin/dev` (matching `_do_spawn`) instead of a bare `git worktree add` with no repo dir or branch flag.

- **`brain_dump` → `plan_text` rename** (API layer only): `SpawnCoordinatorRequest.brain_dump` → `.plan_text`, `BRAIN_DUMP:` key in `.agent-task` → `PLAN_DUMP:`, coordinator slug prefix `brain-dump-*` → `plan-*`, `PlanDraftRequest.dump` → `.text`.

- Broader UI/template/route rename (`brain_dump.py`, `brain_dump.html`, `/brain-dump` URL, etc.) is handled separately — tracked in the rename feature branch.

## Test plan
- [x] `test_agentception_plan_api.py` — 10/10 passing
- [x] `test_agentception_workflow_e2e.py` — 5/5 passing
- [x] `test_agentception_spawn.py` + `test_agentception_spawn_conductor.py` — 24 passing

Closes the Docker worktree path mismatch that caused `mypy: can't read file '/worktrees/issue-N/agentception'` in plan-draft agent runs.