### PR TITLE
fix: Plan nav link only highlighted when active

### DIFF
--- a/agentception/static/scss/app.scss
+++ b/agentception/static/scss/app.scss
@@ -22,7 +22,7 @@
 //     _worktrees.scss   Agent Sandboxes / worktrees page
 //     _docs.scss        Docs page (Markdown prose rendering)
 //     _transcripts.scss Transcripts page, scrollbar, media queries
-//     _brain-dump.scss  Brain Dump page
+//     _plan.scss        Plan page
 //     _roles.scss       Cognitive Architecture Studio
 //     _agents.scss      Agents list page
 //     _config.scss      Pipeline Config page
@@ -51,7 +51,7 @@
 @use 'pages/worktrees';
 @use 'pages/docs';
 @use 'pages/transcripts';
-@use 'pages/brain-dump';
+@use 'pages/plan';
 @use 'pages/roles';
 @use 'pages/agents';
 @use 'pages/config';

--- a/agentception/static/scss/pages/_plan.scss
+++ b/agentception/static/scss/pages/_plan.scss
@@ -680,11 +680,13 @@
 /* ── Nav CTA highlight ───────────────────────────────────────────────────── */
 .topnav .nav-cta {
   font-weight: 600;
-  color: var(--accent, #6366f1) !important;
 }
-.topnav .nav-cta:hover,
 .topnav .nav-cta.active {
+  color: var(--accent, #6366f1) !important;
   background: rgba(99, 102, 241, 0.1) !important;
+}
+.topnav .nav-cta:hover:not(.active) {
+  background: rgba(99, 102, 241, 0.06) !important;
 }
 
 /* Responsive: stack at narrow viewports */


### PR DESCRIPTION
The `nav-cta` class applied `color: accent !important` unconditionally, making Plan always appear purple even when Build or Ship was the active page. Now accent color only applies on `.active` (and a lighter tint on `:hover:not(.active)`). Also renames `_brain-dump.scss` → `_plan.scss` and updates the `app.scss` import.