### PR TITLE
feat(plan): replace heuristic phase planner with direct Claude/OpenRouter LLM call

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -79,6 +79,13 @@ class AgentCeptionSettings(BaseSettings):
     poll_interval_seconds: int = 5
     github_cache_seconds: int = 10
     database_url: str | None = None
+    openrouter_api_key: str = ""
+    """OpenRouter API key for direct LLM calls (plan phase preview, enrichment).
+
+    Set via ``AC_OPENROUTER_API_KEY`` env var.  When absent the Phase Planner
+    falls back to the keyword-based heuristic classifier — no LLM is required
+    for the service to start.
+    """
     """Async database URL for AgentCeption's own ac_* tables.
 
     Set via ``AC_DATABASE_URL`` env var (docker-compose injects this).

--- a/agentception/readers/llm_phase_planner.py
+++ b/agentception/readers/llm_phase_planner.py
@@ -1,0 +1,217 @@
+"""LLM-powered phase planner — converts a brain dump into a PlanResult via Claude.
+
+This is the production replacement for the keyword-based heuristic in
+``phase_planner.py``.  It calls Claude Sonnet via OpenRouter and asks it to
+group the user's free-form ideas into sequenced phases.
+
+The output schema is identical to the heuristic planner so the route and UI
+require no changes.  When ``AC_OPENROUTER_API_KEY`` is absent the route falls
+back to the heuristic — this module is never called in that case.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from agentception.models import PhasePreview, PlanResult
+from agentception.services.llm import call_openrouter
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = """\
+## Identity
+
+You are a Staff-level Technical Program Manager with the mental model of a \
+dependency-graph theorist. You think the way Dijkstra thought about shortest \
+paths: everything is a node, every hard dependency is a directed edge, and your \
+only job is to find the critical path and eliminate it as fast as possible. You \
+are ruthlessly pragmatic — you ship, you sequence, you parallelize.
+
+Your single obsession: **What is the minimum number of phases needed to deliver \
+this work safely, in the right order, with maximum parallelism within each phase?**
+
+You do not gold-plate plans. You do not invent work. You do not pad phases. You \
+extract signal from the user's brain dump and impose order on it.
+
+## Context you must internalize
+
+You are producing a **phase plan preview** that will be shown to the user before \
+they confirm. Upon confirmation, an AI coordinator agent will be dispatched. That \
+coordinator will read your phase plan and expand each phase into fully-specified \
+GitHub issues — with titles, detailed bodies, acceptance criteria, labels, and \
+cross-issue depends_on chains. You are NOT writing the issues. You are drawing \
+the map the coordinator will follow.
+
+This means:
+- Your phase descriptions will appear verbatim on a confirmation card the human \
+  reads. Write for a human who wants to confirm intent, not for a machine.
+- Your estimated_issue_count is the coordinator's workload estimate per phase. \
+  Be accurate — one GitHub issue per discrete unit of work (not per bullet point, \
+  not one giant issue per phase).
+- Your depends_on wiring gates the entire downstream pipeline. If you get the \
+  dependency graph wrong, agents will block each other or ship in the wrong order.
+
+## The four phases — strict definitions
+
+You MUST use only these labels. No others. No custom labels. No sub-phases.
+
+**phase-0 — Foundations & Critical Fixes**
+Work that everything else depends on. This phase answers: "What would cause \
+phase-1 to be blocked or to produce wrong results if we skipped it?" Include:
+- Critical bugs that would corrupt data or block core flows
+- Security vulnerabilities that must be patched before new code ships
+- Schema migrations, DB changes, or API contracts that later work will call
+- Foundational data models or interfaces that multiple features will import
+Gate criterion: nothing in phase-1 can be correctly implemented without this.
+
+**phase-1 — Infrastructure & Core Services**
+The load-bearing internals that features will stand on. This phase answers: \
+"What internal plumbing must exist before user-facing work can begin?" Include:
+- New API endpoints, routes, or service layers features will call
+- Auth, sessions, permissions logic that features gate behind
+- Data pipelines or background jobs features depend on
+- Refactors that would cause merge conflicts if done during feature work
+Gate criterion: all phase-2 feature work can start once this merges.
+
+**phase-2 — Features & User-Facing Work**
+New capabilities visible to users. This phase answers: "What does the user \
+actually get?" Include:
+- New UI screens, components, or flows
+- New product behaviors (enable X, expose Y, add Z)
+- Integrations that add capability (notifications, exports, search)
+Gate criterion: user-visible deliverables are code-complete and testable.
+
+**phase-3 — Polish, Tests & Debt**
+Everything that makes the codebase better without adding new capability. Include:
+- Test coverage additions and integration tests
+- Documentation and docstring passes
+- Refactors that improve maintainability but change no behavior
+- Performance optimization, linting, type-safety improvements
+- Removal of deprecated code or dead endpoints
+Gate criterion: codebase is clean, covered, and ready for the next initiative.
+
+## Dependency rules
+
+- depends_on uses the linear order: phase-1 depends on phase-0, phase-2 depends \
+  on phase-1, etc. You do NOT need to list transitive dependencies (if phase-2 \
+  depends on phase-1, which depends on phase-0, phase-2 only lists ["phase-1"]).
+- If a phase has no predecessor (first emitted phase), its depends_on is [].
+- If items in phase-2 are completely independent of phase-1 (rare), they may \
+  omit phase-1 from depends_on — but default to the linear chain unless you have \
+  a specific reason not to.
+
+## Anti-patterns — never do these
+
+- Do NOT emit an empty phase (no items → no phase).
+- Do NOT create a phase-0 just because it exists — only if there is genuine \
+  gating work.
+- Do NOT split one logical task across two phases to fill them.
+- Do NOT lump everything into a single phase to avoid making a decision.
+- Do NOT invent tasks the user did not mention.
+- Do NOT write issue-level detail in description — that is the coordinator's job.
+- Do NOT exceed 4 phases — if you think you need 5, you are under-grouping.
+
+## estimated_issue_count guidance
+
+Think: how many distinct pull requests would a careful engineer open for this \
+phase? Each PR = one issue. A multi-step migration is usually 2–3 issues. A \
+single UI component is usually 1. A "refactor X module" is usually 1–2. A \
+"write tests for Y" is 1. Be honest — the coordinator will be assigned this \
+workload.
+
+## Output format — STRICT
+
+Return ONLY valid JSON. No explanation. No markdown fences. No preamble. \
+No trailing commentary. The response must be parseable by json.loads() as-is.
+
+{
+  "phases": [
+    {
+      "label": "phase-0",
+      "description": "One sentence: the theme of this phase for the human confirmation card.",
+      "estimated_issue_count": 2,
+      "depends_on": []
+    },
+    {
+      "label": "phase-1",
+      "description": "One sentence: what gets built in this phase.",
+      "estimated_issue_count": 4,
+      "depends_on": ["phase-0"]
+    }
+  ]
+}
+"""
+
+
+def _strip_fences(raw: str) -> str:
+    """Remove markdown code fences if the model wraps its JSON in them."""
+    raw = raw.strip()
+    if raw.startswith("```"):
+        # Drop the opening fence line and the closing ``` (if present).
+        lines = raw.splitlines()
+        # First line is ```json or ``` — skip it.
+        inner = "\n".join(lines[1:])
+        if inner.rstrip().endswith("```"):
+            inner = inner.rstrip()[:-3].rstrip()
+        return inner.strip()
+    return raw
+
+
+async def plan_phases_llm(dump: str) -> PlanResult:
+    """Call Claude via OpenRouter to convert a brain dump into a PlanResult.
+
+    Args:
+        dump: Raw plan text from the user.
+
+    Returns:
+        A :class:`~agentception.models.PlanResult` with one or more phases.
+
+    Raises:
+        ValueError: When ``dump`` is empty, the LLM returns invalid JSON, or
+            the response contains no phases.
+        RuntimeError: Propagated from :func:`~agentception.services.llm.call_openrouter`
+            when the API key is missing.
+        httpx.HTTPStatusError: On non-2xx responses from OpenRouter.
+    """
+    dump = dump.strip()
+    if not dump:
+        raise ValueError("Plan text must not be empty.")
+
+    raw = await call_openrouter(dump, system_prompt=_SYSTEM_PROMPT, temperature=0.2)
+    raw = _strip_fences(raw)
+
+    try:
+        data: object = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.error("❌ LLM returned invalid JSON: %s\nRaw: %s", exc, raw[:500])
+        raise ValueError(f"LLM returned invalid JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError(f"LLM returned unexpected top-level type: {type(data).__name__}")
+
+    raw_phases: object = data.get("phases", [])
+    if not isinstance(raw_phases, list):
+        raise ValueError(f"LLM 'phases' field is not a list: {type(raw_phases).__name__}")
+
+    phases: list[PhasePreview] = []
+    for item in raw_phases:
+        if not isinstance(item, dict):
+            logger.warning("⚠️ Skipping non-dict phase entry: %r", item)
+            continue
+        try:
+            phases.append(
+                PhasePreview(
+                    label=str(item["label"]),
+                    description=str(item["description"]),
+                    estimated_issue_count=int(item["estimated_issue_count"]),
+                    depends_on=[str(d) for d in item.get("depends_on", [])],
+                )
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning("⚠️ Skipping malformed phase entry %r: %s", item, exc)
+
+    if not phases:
+        raise ValueError("LLM returned no valid phases — check the prompt or input.")
+
+    logger.info("✅ LLM phase plan: %d phases for %d-char dump", len(phases), len(dump))
+    return PlanResult(phases=phases)

--- a/agentception/routes/ui/plan_ui.py
+++ b/agentception/routes/ui/plan_ui.py
@@ -17,6 +17,7 @@ from starlette.requests import Request
 
 from agentception.models import PlanRequest, PlanResult
 from agentception.readers.phase_planner import plan_phases
+from agentception.readers.llm_phase_planner import plan_phases_llm
 from ._shared import _TEMPLATES
 
 logger = logging.getLogger(__name__)
@@ -164,23 +165,42 @@ async def _build_recent_plans() -> list[dict[str, str]]:
 
 @router.post("/api/plan/preview", response_model=PlanResult)
 async def plan_preview(body: PlanRequest) -> PlanResult:
-    """Run the Phase Planner against a plan without creating any GitHub resources.
+    """Convert free-form plan text into sequenced phase cards.
 
-    This is Step -1 of the coordinator workflow — it analyses the raw plan text,
-    groups work items into sequenced phases, and returns a ``PlanResult`` that the
-    UI shows as a confirmation card deck.  The user can then press "Create Issues"
-    to fire the full coordinator, or go back to edit their plan.
+    Tries the LLM path first (Claude via OpenRouter) when
+    ``AC_OPENROUTER_API_KEY`` is configured.  Falls back to the keyword
+    heuristic when the key is absent or the LLM call fails, so the page
+    always works even without a key.
 
     Raises
     ------
     HTTP 422
         When ``dump`` is empty or contains no extractable work items.
     """
+    from agentception.config import settings as _cfg
+
+    if _cfg.openrouter_api_key:
+        try:
+            result = await plan_phases_llm(body.dump)
+            logger.info(
+                "✅ Phase plan (LLM): %d phases for %d chars",
+                len(result.phases), len(body.dump),
+            )
+            return result
+        except Exception as exc:
+            logger.warning(
+                "⚠️ LLM phase planner failed — falling back to heuristic: %s", exc
+            )
+
+    # Heuristic fallback — always available, no network required.
     try:
         result = plan_phases(body.dump)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    logger.info("✅ Phase plan: %d phases for plan of %d chars", len(result.phases), len(body.dump))
+    logger.info(
+        "✅ Phase plan (heuristic): %d phases for %d chars",
+        len(result.phases), len(body.dump),
+    )
     return result
 
 

--- a/agentception/services/__init__.py
+++ b/agentception/services/__init__.py
@@ -1,0 +1,2 @@
+"""AgentCeption service layer — external integrations and shared clients."""
+from __future__ import annotations

--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -1,0 +1,113 @@
+"""Async OpenRouter client for AgentCeption's direct LLM calls.
+
+AgentCeption calls OpenRouter directly (not via Cursor) for tasks that are
+pure text-in / text-out and need no file-system tools — e.g. converting a
+brain dump into a structured phase plan.
+
+Usage::
+
+    from agentception.services.llm import call_openrouter
+
+    text = await call_openrouter(
+        user_prompt="...",
+        system_prompt="You are a planner...",
+    )
+
+The key is read from ``settings.openrouter_api_key`` (env var
+``AC_OPENROUTER_API_KEY``).  A missing key raises ``RuntimeError`` so callers
+can catch it and fall back to a heuristic path.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from agentception.config import settings
+
+logger = logging.getLogger(__name__)
+
+_OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+_MODEL = "anthropic/claude-sonnet-4.6"
+_DEFAULT_TIMEOUT = 90.0  # seconds — LLM calls can be slow
+
+
+async def call_openrouter(
+    user_prompt: str,
+    *,
+    system_prompt: str | None = None,
+    temperature: float = 0.2,
+    max_tokens: int = 2048,
+) -> str:
+    """Call Claude Sonnet via OpenRouter and return the text of the first choice.
+
+    Args:
+        user_prompt: The user-turn message content.
+        system_prompt: Optional system-turn message prepended before the user turn.
+        temperature: Sampling temperature (0.0–1.0).  Lower = more deterministic.
+        max_tokens: Maximum tokens in the completion.
+
+    Returns:
+        The raw text string of the model's first completion choice.
+
+    Raises:
+        RuntimeError: When ``AC_OPENROUTER_API_KEY`` is not set.
+        httpx.HTTPStatusError: On non-2xx responses from OpenRouter.
+        httpx.TimeoutException: When the request exceeds ``_DEFAULT_TIMEOUT``.
+    """
+    api_key = settings.openrouter_api_key
+    if not api_key:
+        raise RuntimeError(
+            "AC_OPENROUTER_API_KEY is not configured — "
+            "set it in .env and restart the agentception service."
+        )
+
+    messages: list[dict[str, str]] = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": user_prompt})
+
+    payload: dict[str, object] = {
+        "model": _MODEL,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+
+    logger.info("✅ LLM call — model=%s prompt_chars=%d", _MODEL, len(user_prompt))
+
+    async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
+        resp = await client.post(
+            _OPENROUTER_URL,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "HTTP-Referer": "https://agentception.local",
+                "X-Title": "AgentCeption",
+            },
+            json=payload,
+        )
+        resp.raise_for_status()
+
+    data: object = resp.json()
+    if not isinstance(data, dict):
+        raise ValueError(f"Unexpected OpenRouter response type: {type(data)}")
+
+    choices: object = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError(f"OpenRouter returned no choices: {data}")
+
+    first: object = choices[0]
+    if not isinstance(first, dict):
+        raise ValueError(f"Unexpected choice format: {first}")
+
+    message: object = first.get("message")
+    if not isinstance(message, dict):
+        raise ValueError(f"Unexpected message format: {first}")
+
+    content: object = message.get("content", "")
+    if not isinstance(content, str):
+        raise ValueError(f"Unexpected content type: {type(content)}")
+
+    logger.info("✅ LLM response — %d chars", len(content))
+    return content

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -76,6 +76,9 @@ services:
       # Same DB as Maestro during the monorepo phase; ac_* prefix avoids collisions.
       # When AgentCeption is extracted, point this at its own DB.
       AC_DATABASE_URL: "postgresql+asyncpg://maestro:${DB_PASSWORD}@postgres:5432/maestro"
+      # OpenRouter key — powers the LLM Phase Planner on POST /api/plan/preview.
+      # Falls back to the keyword heuristic when absent.
+      AC_OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
     volumes:
       # Live code — host edits are instantly visible; no rebuild needed
       - ./agentception:/app/agentception


### PR DESCRIPTION
## Summary

- Replaces the keyword-based `phase_planner.py` classifier with a direct Claude Sonnet 4.6 call via OpenRouter
- Adds a Dijkstra-inspired dependency-graph cognitive architecture to the system prompt — the model now reasons about critical paths, phase gate criteria, and the downstream coordinator context
- Heuristic remains as a zero-config fallback when `AC_OPENROUTER_API_KEY` is absent
- mypy clean, 23/23 tests pass, live curl confirms 4-phase plans with substantive descriptions

## New files

- `agentception/services/llm.py` — async `httpx` OpenRouter client
- `agentception/readers/llm_phase_planner.py` — LLM phase planner with JSON fence stripping and graceful error handling

## Test plan

- [ ] `POST /api/plan/preview` with a multi-topic dump returns well-reasoned phase cards
- [ ] Removing `AC_OPENROUTER_API_KEY` falls back to heuristic (no crash)
- [ ] All 23 existing plan tests pass