### PR TITLE
feat(agentception): dispatcher queue + one-shot Dispatcher prompt

### DIFF
--- a/.cursor/agentception-dispatcher.md
+++ b/.cursor/agentception-dispatcher.md
@@ -1,0 +1,146 @@
+# AgentCeption Dispatcher
+
+You are the **AgentCeption Dispatcher** — a one-shot agent that drains the
+pending launch queue and spawns the right agent at the right level of the tree.
+
+You run once, spawn everything, wait for completion, and exit.
+You do not loop indefinitely. You do not poll. You are not a daemon.
+
+---
+
+## Step 1 — Read the queue
+
+Call the `build_get_pending_launches` MCP tool.
+
+It returns a list of pending launches shaped like:
+
+```json
+{
+  "pending": [
+    {
+      "run_id": "issue-1234",
+      "issue_number": 1234,
+      "role": "python-developer",
+      "branch": "feat/issue-1234",
+      "host_worktree_path": "/Users/gabriel/.cursor/worktrees/maestro/issue-1234",
+      "batch_id": "issue-1234-20260303T120000Z-a1b2"
+    }
+  ],
+  "count": 1
+}
+```
+
+If `count` is 0, the queue is empty. Print "Queue is empty — nothing to dispatch." and exit.
+
+---
+
+## Step 2 — Understand the tree
+
+Each item's `role` tells you what KIND of agent to spawn:
+
+| Role | Type | What it does |
+|------|------|--------------|
+| `cto` | Root | Surveys all GitHub issues + PRs, decides VP structure, spawns VPs |
+| `vp-engineering`, `vp-product`, etc. | Manager | Surveys a subset of issues, spawns leaf workers |
+| `python-developer`, `frontend-developer`, etc. | Leaf | Implements one issue, opens one PR, exits |
+
+**You do not decide what the agent does.** The role file at
+`{host_worktree_path}/.cursor/roles/{role}.md` (relative to the repo root,
+not the worktree) defines everything. You just spawn the right agent with the
+right briefing and let it drive.
+
+The canonical role files live at:
+`/Users/gabriel/dev/tellurstori/maestro/.cursor/roles/{role}.md`
+
+---
+
+## Step 3 — Claim and spawn (up to 3 at a time)
+
+For each pending launch (batch up to 3 simultaneously using parallel Task calls):
+
+### 3a. Claim the run
+
+```bash
+curl -s -X POST http://localhost:7777/api/build/acknowledge/{run_id}
+```
+
+This atomically marks the run as `implementing` so no other Dispatcher can
+double-claim it. If the response is `{"ok": false, ...}`, skip this item —
+it was already claimed.
+
+### 3b. Spawn the agent via Task tool
+
+Use `subagent_type="generalPurpose"` — **never `shell`**. Only `generalPurpose`
+agents have the Task tool and can spawn their own children.
+
+The prompt to pass to the Task:
+
+```
+You are an AgentCeption agent. Your full briefing is in your .agent-task file.
+
+WORKTREE: {host_worktree_path}
+ROLE: {role}
+RUN_ID: {run_id}
+GH_REPO: {gh_repo}
+AC_URL: http://localhost:7777
+
+Step 1: Read your role file:
+  /Users/gabriel/dev/tellurstori/maestro/.cursor/roles/{role}.md
+
+Step 2: Read your .agent-task file:
+  {host_worktree_path}/.agent-task
+
+Step 3: Follow your role instructions exactly.
+  - If you are a leaf worker: implement the issue, open a PR.
+  - If you are a manager: survey GitHub and spawn child agents via the Task tool.
+
+Step 4: Report progress via MCP tools at every significant step:
+  build_report_step    — when you start a step
+  build_report_blocker — when you are blocked
+  build_report_decision — when you make a design decision
+  build_report_done    — when you finish and have a PR URL
+
+Always pass agent_run_id="{run_id}" to every MCP report call.
+```
+
+---
+
+## Step 4 — Wait for all spawned Tasks to complete
+
+After spawning a batch of up to 3 Tasks simultaneously, wait for all of them
+to return before proceeding.
+
+---
+
+## Step 5 — Check for more
+
+After each batch completes, call `build_get_pending_launches` again.
+If more items were queued while you were working (user dispatched more from
+the UI), spawn them too.
+
+Repeat until the queue is empty.
+
+---
+
+## Step 6 — Exit
+
+Print a summary:
+
+```
+Dispatcher complete.
+  Launched: N agents
+  Roles: [list of roles spawned]
+  Queue: empty
+```
+
+Then exit. You are done.
+
+---
+
+## Rules
+
+- Never spawn more than 3 Tasks simultaneously — this is the observed Cursor concurrency ceiling.
+- Always use `subagent_type="generalPurpose"` for agent Tasks.
+- Always claim (acknowledge) before spawning — prevents double-dispatch.
+- Do not describe implementation details to child agents — the role file does that.
+- Do not loop indefinitely — drain the queue and exit.

--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -269,12 +269,15 @@ async def _upsert_prs(
 # ---------------------------------------------------------------------------
 
 
-_ACTIVE_STATUSES = {"implementing", "reviewing", "stale"}
+_ACTIVE_STATUSES = {"implementing", "reviewing", "stale", "pending_launch"}
 """Statuses that indicate a run is expected to have a live worktree.
 
 Runs in these states that are absent from the current poller tick are
 orphaned (worktree was removed without a clean status transition) and
 must be flipped to ``unknown`` so the UI does not show phantom agents.
+
+``pending_launch`` is included so that dispatch-created runs are not
+swept to ``unknown`` before the coordinator picks them up.
 """
 
 
@@ -316,7 +319,10 @@ async def _upsert_agent_runs(
                 )
             )
         else:
-            existing.status = agent.status.value
+            # Never overwrite a pending_launch status from the poller — only
+            # the acknowledge endpoint may advance that transition.
+            if existing.status != "pending_launch":
+                existing.status = agent.status.value
             existing.pr_number = agent.pr_number
             existing.last_activity_at = now
 
@@ -426,6 +432,91 @@ async def persist_wave_complete(wave_id: str, spawn_count: int, skip_count: int)
 # ---------------------------------------------------------------------------
 # Agent messages (async fire-and-forget)
 # ---------------------------------------------------------------------------
+
+
+async def persist_agent_run_dispatch(
+    run_id: str,
+    issue_number: int,
+    role: str,
+    branch: str,
+    worktree_path: str,
+    batch_id: str,
+    host_worktree_path: str,
+) -> None:
+    """Insert an ACAgentRun row with status ``pending_launch`` at dispatch time.
+
+    Called by ``POST /api/build/dispatch`` immediately after the worktree and
+    ``.agent-task`` file are created.  The coordinator agent reads these rows
+    via ``build_get_pending_launches`` and transitions them to ``implementing``
+    when it claims the work.
+
+    ``host_worktree_path`` is stored in the ``spawn_mode`` field as a JSON
+    blob because ACAgentRun has no dedicated host-path column — this is the
+    least-invasive way to pass it to the coordinator without a migration.
+
+    Best-effort — swallows exceptions so a DB outage never blocks dispatch.
+    """
+    import json as _json
+
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun).where(ACAgentRun.id == run_id)
+            )
+            existing = result.scalar_one_or_none()
+            if existing is not None:
+                # Already exists (re-dispatch after worktree removed). Reset.
+                existing.status = "pending_launch"
+                existing.last_activity_at = _now()
+            else:
+                session.add(
+                    ACAgentRun(
+                        id=run_id,
+                        wave_id=None,
+                        issue_number=issue_number,
+                        pr_number=None,
+                        branch=branch,
+                        worktree_path=worktree_path,
+                        role=role,
+                        status="pending_launch",
+                        attempt_number=0,
+                        spawn_mode=_json.dumps({"host_worktree": host_worktree_path}),
+                        batch_id=batch_id,
+                        spawned_at=_now(),
+                        last_activity_at=_now(),
+                    )
+                )
+            await session.commit()
+        logger.info("✅ persist_agent_run_dispatch: run_id=%s issue=%d", run_id, issue_number)
+    except Exception as exc:
+        logger.warning("⚠️  persist_agent_run_dispatch failed (non-fatal): %s", exc)
+
+
+async def acknowledge_agent_run(run_id: str) -> bool:
+    """Transition a ``pending_launch`` run to ``implementing``.
+
+    Called by the coordinator agent via ``POST /api/build/acknowledge/{run_id}``
+    to atomically claim the run before spawning its Task worker.
+
+    Returns ``True`` when the transition succeeded, ``False`` when the run was
+    not found or was not in ``pending_launch`` state (idempotency guard).
+    """
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun).where(ACAgentRun.id == run_id)
+            )
+            run = result.scalar_one_or_none()
+            if run is None or run.status != "pending_launch":
+                return False
+            run.status = "implementing"
+            run.last_activity_at = _now()
+            await session.commit()
+        logger.info("✅ acknowledge_agent_run: %s → implementing", run_id)
+        return True
+    except Exception as exc:
+        logger.warning("⚠️  acknowledge_agent_run failed: %s", exc)
+        return False
 
 
 async def persist_agent_event(

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -810,6 +810,54 @@ async def get_runs_for_issue_numbers(
         return {}
 
 
+async def get_pending_launches() -> list[dict[str, Any]]:
+    """Return all agent runs with ``status='pending_launch'``, oldest first.
+
+    Each dict contains everything the coordinator needs to claim the run and
+    spawn a worker Task: run_id, issue_number, role, branch, worktree paths,
+    batch_id, and the AC callback URL hint.
+
+    Falls back to ``[]`` on DB error.
+    """
+    import json as _json
+
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun)
+                .where(ACAgentRun.status == "pending_launch")
+                .order_by(ACAgentRun.spawned_at.asc())
+            )
+            rows = result.scalars().all()
+
+        launches: list[dict[str, Any]] = []
+        for row in rows:
+            # host_worktree is stashed in spawn_mode as JSON by persist_agent_run_dispatch
+            host_worktree: str | None = None
+            if row.spawn_mode:
+                try:
+                    meta = _json.loads(row.spawn_mode)
+                    host_worktree = meta.get("host_worktree")
+                except (ValueError, AttributeError):
+                    pass
+            launches.append(
+                {
+                    "run_id": row.id,
+                    "issue_number": row.issue_number,
+                    "role": row.role,
+                    "branch": row.branch,
+                    "worktree_path": row.worktree_path,
+                    "host_worktree_path": host_worktree,
+                    "batch_id": row.batch_id,
+                    "spawned_at": row.spawned_at.isoformat(),
+                }
+            )
+        return launches
+    except Exception as exc:
+        logger.warning("⚠️  get_pending_launches DB query failed (non-fatal): %s", exc)
+        return []
+
+
 async def get_agent_events_tail(
     run_id: str,
     after_id: int = 0,

--- a/agentception/docs/cursor-agent-spawning.md
+++ b/agentception/docs/cursor-agent-spawning.md
@@ -1,0 +1,276 @@
+# Cursor Agent Spawning — Empirical Reference
+
+> Ground truth derived from live stress tests run 2026-03-03.  
+> No inherited assumptions. Everything here was directly observed.
+
+---
+
+## Is the Task Tool Real? (Read This First)
+
+**Yes. It is a first-class Cursor primitive, not a hallucination.**
+
+If a future agent questions whether the `Task` tool exists, here is the chain of evidence:
+
+### 1. It appears in Cursor's injected tool schema
+
+Every Cursor agent session receives an XML `<functions>` block that lists every tool
+available to that agent. The `Task` tool appears in that block with this description
+(verbatim as of 2026-03-03):
+
+```
+"Launch a new agent to handle complex, multi-step tasks autonomously.
+The Task tool launches specialized subagents (subprocesses) that autonomously
+handle complex tasks. Each subagent_type has specific capabilities and tools
+available to it."
+```
+
+Parameters:
+
+| Parameter | Type | Notes |
+|---|---|---|
+| `description` | string | 3–5 word label shown in UI |
+| `prompt` | string | Full task instruction for the sub-agent |
+| `subagent_type` | enum | `generalPurpose \| explore \| shell \| browser-use` |
+| `model` | optional string | `fast` or omit for default |
+| `readonly` | optional bool | Restricts write operations |
+| `resume` | optional string | Agent ID to resume a prior agent |
+| `run_in_background` | optional bool | Returns immediately, polls later |
+| `attachments` | optional array | Video file paths for browser-use agents |
+
+The full tool list injected into this session:
+`Shell`, `Glob`, `Grep`, `Read`, `Delete`, `StrReplace`, `Write`, `EditNotebook`,
+`TodoWrite`, `ReadLints`, `SemanticSearch`, `WebSearch`, `WebFetch`, `GenerateImage`,
+`AskQuestion`, **`Task`**, `CallMcpTool`, `FetchMcpResource`, `SwitchMode`
+
+### 2. It is documented in this codebase
+
+`.cursor/pipeline-howto.md` line ~241 (written by the team, not by an AI session):
+
+```
+## Platform Constraint: 4-Wide Branching, Unlimited Depth
+**The Task tool supports 4 concurrent sub-agents per spawning agent.**
+```
+
+And line ~48:
+
+```
+Each leaf agent [...] spawns a fresh leaf agent via the Task tool — before it exits.
+```
+
+This document predates the 2026-03-03 stress tests and was written from prior human
+experience running multi-tier agent pipelines.
+
+### 3. It was empirically verified (2026-03-03)
+
+Six timestamp files written independently to disk by three separate agent layers:
+
+```
+/tmp/depth-test/layer1.start   written by Layer 1  (child of this agent)
+/tmp/depth-test/layer2.start   written by Layer 2  (grandchild)
+/tmp/depth-test/layer3.start   written by Layer 3  (great-grandchild)
+/tmp/depth-test/layer3.end     written by Layer 3
+/tmp/depth-test/layer2.end     written by Layer 2
+/tmp/depth-test/layer1.end     written by Layer 1
+```
+
+No single agent could have written all six files — layers 2 and 3 only existed
+inside sub-agent processes spawned via the `Task` tool. The files are on the host
+filesystem and can be inspected at any time with `ls /tmp/depth-test/`.
+
+### 4. The failure mode when using the wrong subagent type is documented
+
+When a `shell` sub-agent (which does NOT receive the `Task` tool) was incorrectly
+instructed to spawn children, it fell back to bash process backgrounding and hit:
+
+```
+nice(5) failed: operation not permitted
+```
+
+This is a sandbox restriction on process management syscalls. It is NOT evidence
+that agent spawning is impossible — it is evidence that only `generalPurpose` agents
+receive the `Task` tool and can recursively spawn.
+
+---
+
+## TL;DR
+
+| Claim | Status | Evidence |
+|---|---|---|
+| `generalPurpose` agents have the `Task` tool | ✅ Confirmed | Tree tests — children spawned grandchildren |
+| `shell` agents have the `Task` tool | ❌ False | Hierarchical test failed; child tried `bash &` backgrounding instead |
+| 3-layer deep nesting works (grandchildren of grandchildren) | ✅ Confirmed | Depth test — 6 timestamp files written across 3 layers |
+| Concurrency ceiling at root level ≈ 3 | ✅ Observed | Stress test — 10 simultaneous Task calls → peak 3 concurrent |
+| Any single layer saturates at ≈ 3 concurrent | 🔲 Likely | Consistent with root observation; not yet isolated per-layer |
+
+---
+
+## Key Facts
+
+### 1. Only `generalPurpose` agents can spawn children
+
+```
+subagent_type="generalPurpose"  → has Task tool → can recursively spawn
+subagent_type="shell"           → no Task tool  → cannot spawn children
+```
+
+The `shell` subagent type is effectively a leaf node. Never use it for
+a coordinator or branch role — only for terminal work (git, scripts, commands).
+
+### 2. Three tiers of depth confirmed (2026-03-03)
+
+```
+Me (root / Layer 0)
+└── Layer 1 [generalPurpose]
+    └── Layer 2 [generalPurpose]
+        └── Layer 3 [shell]
+```
+
+Timestamp files written independently by each layer to `/tmp/depth-test/`:
+
+```
+layer1.start  1772593602.959480000   T+0s
+layer2.start  1772593613.214887000   T+10s
+layer3.start  1772593620.089525000   T+17s
+layer3.end    1772593621.104261000   T+18s  (1s sleep)
+layer2.end    1772593629.604523000   T+27s
+layer1.end    1772593638.543183000   T+36s
+```
+
+Spawn overhead is approximately **7–10 seconds per tier**.
+
+### 3. Concurrency ceiling ≈ 3 at any given layer
+
+From the 10-agent simultaneous stress test (4 separate runs):
+- Peak concurrency observed: **3**
+- Agents started in waves of ~3, approximately 1.2–1.3 seconds apart
+- Later agents queued and waited until a slot freed
+
+This appears to be a Cursor sandbox ceiling, not a hard product limit.
+It may vary by session, machine, or Cursor version.
+
+> **Implication for architecture:** Fan-out of 3 per node is the safe
+> maximum to avoid queueing. Width-3 trees will flow smoothly; width-10
+> trees will work but queue into serial execution.
+
+### 4. Bash backgrounding in a sandboxed agent fails
+
+When a `shell` agent tried to spawn children via `command &` + `wait`,
+it hit:
+```
+nice(5) failed: operation not permitted
+```
+The Cursor sandbox blocks certain process management syscalls. This is
+not a limitation of the `generalPurpose` agent type — only of direct
+shell backgrounding.
+
+---
+
+## Architecture Patterns
+
+### Safe: Width-3 fan-out tree
+
+```
+root (generalPurpose)
+├── branch-A (generalPurpose)
+│   ├── leaf-A1 (shell)
+│   ├── leaf-A2 (shell)
+│   └── leaf-A3 (shell)
+├── branch-B (generalPurpose)
+│   ├── leaf-B1 (shell)
+│   ├── leaf-B2 (shell)
+│   └── leaf-B3 (shell)
+└── branch-C (generalPurpose)
+    ├── leaf-C1 (shell)
+    ├── leaf-C2 (shell)
+    └── leaf-C3 (shell)
+```
+
+Total agents: 12. Root saturates at 3, each branch saturates at 3.
+Wall clock: ~spawn_overhead × depth + max_leaf_work.
+
+### AgentCeption Org Model
+
+Maps directly to org hierarchy:
+
+```
+CTO agent (generalPurpose)
+├── VP Engineering (generalPurpose)   spawns per-ticket worker agents
+├── VP Product (generalPurpose)       spawns per-ticket writer agents
+└── VP QA (generalPurpose)            spawns per-PR reviewer agents
+```
+
+Each VP can fan out to 3 worker agents simultaneously.
+Workers are `shell` or `generalPurpose` depending on whether they need
+to spawn further (e.g., a debugging agent that spawns a search + a fix agent).
+
+---
+
+## Coordination Patterns
+
+### Polling for child completion
+
+Children signal completion by writing a sentinel file:
+
+```bash
+# Child
+echo done > /tmp/run-{id}/child-{n}.done
+
+# Parent — poll loop
+for i in $(seq 30); do
+  [ -f /tmp/run-{id}/child-{n}.done ] && break
+  sleep 2
+done
+```
+
+Or via MCP tool calls back to AgentCeption's API (preferred for structured data).
+
+### Preferred IPC: MCP → AgentCeption API
+
+Children call back to AgentCeption via the MCP build tools:
+- `build_report_step` — progress update
+- `build_report_blocker` — blocked on something
+- `build_report_decision` — logged a design decision  
+- `build_report_done` — work complete
+
+This gives the web dashboard live visibility without polling filesystem state.
+
+---
+
+## Open Questions
+
+| Question | Notes |
+|---|---|
+| Does the ~3 ceiling apply independently per layer, or globally? | Not yet isolated. Hierarchical test pending. |
+| What is the absolute depth limit? | Tested to 3. Likely deeper is fine. |
+| Does concurrency ceiling vary by session/machine/Cursor version? | Unknown. Needs repeated measurement. |
+| Can a `generalPurpose` child use ALL parent tools, or a subset? | Unclear. Need to test MCP access from nested agents. |
+
+---
+
+## Test Artifacts
+
+| Test | Date | Files | Result |
+|---|---|---|---|
+| Depth test (3 layers) | 2026-03-03 | `/tmp/depth-test/layer*.{start,end,done}` | ✅ All 3 layers confirmed |
+| Parallelism stress test (10 agents × 4 runs) | 2026-03-03 | `.cursor/stress-test-parallelism.md` | Peak concurrency = 3 |
+| Hierarchical test (failed) | 2026-03-03 | `.cursor/stress-test-parallelism.md` | ❌ Shell child tried bash bg → sandbox blocked |
+| Tree test 1 (3 branches × 3 leaves) | 2026-03-03 | `/tmp/tree-test-1/` | ✅ All 38 files present — leaves ran parallel within each branch |
+| Tree test 2 (4 branches, wider) | 2026-03-03 | `/tmp/tree-test-2/` | 🔲 Pending |
+
+### Tree Test 1 — Full Timeline (2026-03-03)
+
+Structure: root → Branch A/B/C (generalPurpose) → Leaves 1/2/3 per branch (shell)
+
+```
+T+0s      root.start
+T+18s     A.start      ← first branch dispatched
+T+21s     B.start      ← second branch dispatched
+T+28s     C.start      ← third branch (slight queue delay)
+T+26-28s  A1/A2/A3.start   ← within 1.6s of each other (parallel ✅)
+T+28-31s  B1/B2/B3.start   ← within 3s of each other (parallel ✅)
+T+35-38s  C1/C2/C3.start   ← within 3s of each other (parallel ✅)
+T+63s     root.end
+```
+
+Wall clock: **63s** for 9 agents across 2 levels. Serial equivalent would be ~162s.
+Speedup: **2.6×** over fully serial execution.

--- a/agentception/mcp/build_tools.py
+++ b/agentception/mcp/build_tools.py
@@ -14,8 +14,30 @@ from __future__ import annotations
 import logging
 
 from agentception.db.persist import persist_agent_event
+from agentception.db.queries import get_pending_launches
 
 logger = logging.getLogger(__name__)
+
+
+async def build_get_pending_launches() -> dict[str, object]:
+    """Return all pending launch records from the AgentCeption DB.
+
+    The Dispatcher calls this once to discover what the UI has queued.
+    Each item in ``pending`` contains:
+      - ``run_id``             — worktree id (e.g. "issue-1234")
+      - ``issue_number``       — GitHub issue number
+      - ``role``               — role slug (e.g. "cto", "python-developer")
+      - ``branch``             — git branch to work on
+      - ``host_worktree_path`` — full path on the HOST filesystem
+      - ``batch_id``           — batch fingerprint
+
+    The ``role`` field is the tree entry point — the Dispatcher spawns
+    whatever role was assigned. A leaf worker runs directly; a manager
+    (VP, CTO) reads its role file and spawns its own children.
+    """
+    launches = await get_pending_launches()
+    logger.info("✅ build_get_pending_launches: %d pending", len(launches))
+    return {"pending": launches, "count": len(launches)}
 
 
 async def build_report_step(

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -24,6 +24,7 @@ import logging
 from typing import cast
 
 from agentception.mcp.build_tools import (
+    build_get_pending_launches,
     build_report_blocker,
     build_report_decision,
     build_report_done,
@@ -137,7 +138,22 @@ TOOLS: list[ACToolDef] = [
             "additionalProperties": False,
         },
     ),
-    # ── Build tools — agents call these to report lifecycle events ──────────
+    # ── Build tools — Dispatcher reads queue; agents report lifecycle events ─
+    ACToolDef(
+        name="build_get_pending_launches",
+        description=(
+            "Return all issues queued for launch from the AgentCeption UI. "
+            "Call this once to discover your work. Each item has run_id, issue_number, "
+            "role, host_worktree_path, and batch_id. The role tells you what kind of "
+            "agent to spawn — a leaf worker implements one issue directly; a manager "
+            "(VP, CTO) reads its role file and spawns its own children via the Task tool."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    ),
     ACToolDef(
         name="build_report_step",
         description=(
@@ -343,6 +359,7 @@ def call_tool(name: str, arguments: dict[str, object]) -> ACToolResult:
     if name in (
         "plan_get_labels",
         "plan_spawn_coordinator",
+        "build_get_pending_launches",
         "build_report_step",
         "build_report_blocker",
         "build_report_decision",
@@ -381,6 +398,13 @@ async def call_tool_async(
     Returns:
         An :class:`~agentception.mcp.types.ACToolResult`.  Never raises.
     """
+    if name == "build_get_pending_launches":
+        result = await build_get_pending_launches()
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=False,
+        )
+
     if name == "build_report_step":
         issue_num = arguments.get("issue_number")
         step = arguments.get("step_name")

--- a/agentception/routes/api/build.py
+++ b/agentception/routes/api/build.py
@@ -1,14 +1,16 @@
 """Build phase API routes.
 
-These endpoints serve two audiences:
+Three audiences:
 
-1. **The Build UI** — ``POST /api/build/dispatch`` creates a worktree and
-   ``.agent-task`` file so a human can point Cursor at a specific GitHub issue.
+1. **The Build UI** — ``POST /api/build/dispatch`` creates a worktree,
+   ``.agent-task`` file, and a ``pending_launch`` DB record.
 
-2. **Running agents** — the four ``POST /api/build/report/*`` endpoints let
-   agents push structured lifecycle events back to AgentCeption from inside
-   their Cursor session.  Agents find the URL via ``AC_URL`` in their
-   ``.agent-task`` file.
+2. **The AgentCeption Coordinator** — ``GET /api/build/pending-launches``
+   exposes the launch queue; ``POST /api/build/acknowledge/{run_id}``
+   atomically claims a run before the coordinator spawns its Task worker.
+
+3. **Running agents** — ``POST /api/build/report/*`` lets agents push
+   structured lifecycle events back to AgentCeption.
 """
 from __future__ import annotations
 
@@ -23,7 +25,8 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from agentception.config import settings
-from agentception.db.persist import persist_agent_event
+from agentception.db.persist import acknowledge_agent_run, persist_agent_event, persist_agent_run_dispatch
+from agentception.db.queries import get_pending_launches
 
 logger = logging.getLogger(__name__)
 
@@ -52,9 +55,11 @@ class DispatchResponse(BaseModel):
 
     run_id: str
     worktree: str
+    host_worktree: str
     branch: str
     agent_task_path: str
     batch_id: str
+    status: str = "pending_launch"
 
 
 def _make_batch_id(issue_number: int) -> str:
@@ -66,25 +71,28 @@ def _make_batch_id(issue_number: int) -> str:
 
 @router.post("/dispatch", response_model=DispatchResponse)
 async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
-    """Create a git worktree and ``.agent-task`` file for a single GitHub issue.
+    """Create a worktree, ``.agent-task``, and a ``pending_launch`` DB record.
 
-    The worktree is created under ``settings.worktrees_dir`` (default
-    ``/tmp/worktrees``).  The ``.agent-task`` file embeds everything a Cursor
-    agent needs: issue number, role, repo, and the AgentCeption callback URL
-    so the agent can call ``POST /api/build/report/*`` to push events.
+    The worktree is the isolated git checkout the agent will work in.
+    The ``.agent-task`` file is the agent's full briefing — role, scope,
+    repo, callbacks.  The ``pending_launch`` DB record is what the
+    AgentCeption Dispatcher reads via ``build_get_pending_launches`` to know
+    what to spawn next.
 
-    Returns the worktree path, branch, and agent-task location so the UI can
-    direct the user to open the worktree in Cursor.
+    Agents are NOT launched here.  The Dispatcher (a Cursor prompt the user
+    pastes once per wave) polls the pending queue and spawns the right role —
+    which may be a leaf worker, a VP, or a CTO depending on what was selected.
 
     Raises:
-        HTTPException 409: When a worktree for this issue already exists.
-        HTTPException 500: When ``git worktree add`` fails.
+        HTTPException 409: Worktree already exists.
+        HTTPException 500: git worktree add or .agent-task write failed.
     """
     run_id = f"issue-{req.issue_number}"
     slug = f"issue-{req.issue_number}"
     branch = f"feat/issue-{req.issue_number}"
     batch_id = _make_batch_id(req.issue_number)
     worktree_path = str(Path(settings.worktrees_dir) / slug)
+    host_worktree_path = str(Path(settings.host_worktrees_dir) / slug)
 
     if Path(worktree_path).exists():
         raise HTTPException(
@@ -102,37 +110,37 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     if proc.returncode != 0:
         err = stderr.decode().strip()
         logger.error("❌ dispatch: git worktree add failed — %s", err)
-        raise HTTPException(
-            status_code=500,
-            detail=f"git worktree add failed: {err}",
-        )
+        raise HTTPException(status_code=500, detail=f"git worktree add failed: {err}")
 
     logger.info("✅ dispatch: worktree created at %s", worktree_path)
 
     ac_url = getattr(settings, "ac_url", "http://localhost:7777")
+    role_file = str(Path(settings.repo_dir) / ".cursor" / "roles" / f"{req.role}.md")
     agent_task = (
+        f"RUN_ID={run_id}\n"
         f"ISSUE_NUMBER={req.issue_number}\n"
         f"ISSUE_TITLE={req.issue_title}\n"
         f"ROLE={req.role}\n"
+        f"ROLE_FILE={role_file}\n"
         f"GH_REPO={req.repo}\n"
         f"BRANCH={branch}\n"
-        f"WORKTREE={worktree_path}\n"
+        f"WORKTREE={host_worktree_path}\n"
         f"BATCH_ID={batch_id}\n"
-        f"SPAWN_MODE=manual\n"
+        f"SPAWN_MODE=dispatcher\n"
         f"AC_URL={ac_url}\n"
         f"\n"
-        f"# Agent instructions\n"
-        f"# ─────────────────\n"
-        f"# 1. Read the issue: gh issue view {req.issue_number} --repo {req.repo}\n"
-        f"# 2. Implement the changes described in the issue.\n"
-        f"# 3. Report progress via HTTP callbacks:\n"
+        f"# How this works\n"
+        f"# ──────────────\n"
+        f"# 1. Read your role file at ROLE_FILE to understand your scope and children.\n"
+        f"# 2. If you are a leaf worker: read the issue, implement, open PR.\n"
+        f"#    If you are a manager: survey GitHub and spawn child agents via Task tool.\n"
+        f"# 3. Report progress via MCP tools (preferred) or HTTP:\n"
         f"#      curl -s -X POST {ac_url}/api/build/report/step"
         f' -H "Content-Type: application/json"'
         f" -d '{{\"issue_number\":{req.issue_number},\"step_name\":\"<step>\",\"agent_run_id\":\"{run_id}\"}}'\n"
         f"#      curl -s -X POST {ac_url}/api/build/report/done"
         f' -H "Content-Type: application/json"'
         f" -d '{{\"issue_number\":{req.issue_number},\"pr_url\":\"<url>\",\"agent_run_id\":\"{run_id}\"}}'\n"
-        f"# 4. Open a PR when done.\n"
     )
 
     agent_task_path = str(Path(worktree_path) / ".agent-task")
@@ -150,13 +158,62 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
 
     logger.info("✅ dispatch: .agent-task written to %s", agent_task_path)
 
+    # Write pending_launch record — this is what the Dispatcher reads.
+    await persist_agent_run_dispatch(
+        run_id=run_id,
+        issue_number=req.issue_number,
+        role=req.role,
+        branch=branch,
+        worktree_path=worktree_path,
+        batch_id=batch_id,
+        host_worktree_path=host_worktree_path,
+    )
+
     return DispatchResponse(
         run_id=run_id,
         worktree=worktree_path,
+        host_worktree=host_worktree_path,
         branch=branch,
         agent_task_path=agent_task_path,
         batch_id=batch_id,
+        status="pending_launch",
     )
+
+
+# ---------------------------------------------------------------------------
+# Pending launches — Dispatcher reads this to know what to spawn
+# ---------------------------------------------------------------------------
+
+
+@router.get("/pending-launches")
+async def list_pending_launches() -> dict[str, object]:
+    """Return all runs waiting to be claimed by the Dispatcher.
+
+    The AgentCeption Dispatcher calls this once at startup to discover what
+    the UI has queued.  Each item includes the run_id, role, issue number,
+    and host-side worktree path so the Dispatcher can spawn the right agent
+    at the right level of the tree (leaf worker, VP, or CTO).
+    """
+    launches = await get_pending_launches()
+    return {"pending": launches, "count": len(launches)}
+
+
+@router.post("/acknowledge/{run_id}")
+async def acknowledge_launch(run_id: str) -> dict[str, object]:
+    """Atomically claim a pending run before spawning its Task agent.
+
+    The Dispatcher calls this immediately before it spawns the Task so the
+    run cannot be double-claimed if two Dispatchers run concurrently.
+    Transitions the run from ``pending_launch`` → ``implementing``.
+
+    Returns ``{"ok": true}`` on success or ``{"ok": false, "reason": "..."}``
+    when the run was not found or already claimed (idempotency guard).
+    """
+    ok = await acknowledge_agent_run(run_id)
+    if not ok:
+        return {"ok": False, "reason": f"Run {run_id!r} not found or not in pending_launch state"}
+    logger.info("✅ acknowledge_launch: %s claimed", run_id)
+    return {"ok": True, "run_id": run_id}
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -159,9 +159,16 @@
 
           <template x-if="dispatchSuccess">
             <div class="build-modal__success">
-              <p>✅ Worktree created!</p>
-              <p class="build-modal__success-path" x-text="'Open in Cursor: ' + dispatchResult.worktree"></p>
-              <p class="build-modal__success-hint">The <code>.agent-task</code> file is ready. Open the worktree folder in Cursor and start the agent.</p>
+              <p>⏳ Queued for launch</p>
+              <p class="build-modal__success-hint">
+                Issue <strong x-text="'#' + dispatchIssue.number"></strong>
+                is ready with role <strong x-text="dispatchResult.role ?? dispatchRole"></strong>.
+              </p>
+              <p class="build-modal__success-hint">
+                Paste the <strong>Dispatcher prompt</strong> into Cursor to launch it
+                along with any other queued issues.
+              </p>
+              <pre class="build-modal__prompt-hint" x-text="'Worktree: ' + dispatchResult.host_worktree"></pre>
             </div>
           </template>
         </div>


### PR DESCRIPTION
## Summary

- **Pending launch queue**: `POST /api/build/dispatch` now writes an `ACAgentRun(status=pending_launch)` record alongside the worktree + `.agent-task` file. The queue is readable via `GET /api/build/pending-launches` and the new `build_get_pending_launches` MCP tool.
- **Atomic claim**: `POST /api/build/acknowledge/{run_id}` transitions `pending_launch → implementing` — prevents double-dispatch if two Dispatchers run concurrently.
- **One-shot Dispatcher prompt** (`.cursor/agentception-dispatcher.md`): user pastes this into Cursor once per wave. It reads the queue, spawns `generalPurpose` Task agents (≤3 at a time), waits, drains any new items, and exits. Cost = a few cents for the dispatcher itself, proportional to work for the workers.
- **Tree-entry-point model**: the `role` field at dispatch time determines the depth — leaf worker, VP, or CTO. Same Dispatcher prompt handles all cases. Prunable at any node.
- **UI**: dispatch modal now shows "Queued for launch" instead of "Open in Cursor manually."

## Test plan

- [ ] Dispatch an issue from `/build` UI — confirm `pending_launch` record appears in `GET /api/build/pending-launches`
- [ ] Call `POST /api/build/acknowledge/{run_id}` — confirm `ok: true` and status transitions to `implementing`
- [ ] Call acknowledge again — confirm `ok: false` (idempotency guard)
- [ ] Verify `build_get_pending_launches` MCP tool returns correct payload
- [ ] Paste `.cursor/agentception-dispatcher.md` into Cursor and confirm it reads queue + spawns Tasks