### PR TITLE
fix(agentception): single-quote @click attrs with tojson in build board

### DIFF
--- a/agentception/templates/_build_board.html
+++ b/agentception/templates/_build_board.html
@@ -28,7 +28,7 @@
       {% else %} build-issue--open
       {% endif %}"
       x-data
-      @click="$dispatch('inspect-issue', {{ issue | tojson }})"
+      @click='$dispatch("inspect-issue", {{ issue | tojson }})'
     >
       <div class="build-issue__meta">
         <a class="build-issue__number" href="{{ issue.url }}" target="_blank" rel="noopener"
@@ -58,7 +58,7 @@
       {% elif not group.locked and issue.state == 'open' %}
       <div class="build-issue__dispatch">
         <button class="build-issue__assign-btn"
-                @click.stop="$dispatch('open-dispatch', {{ issue | tojson }})">
+                @click.stop='$dispatch("open-dispatch", {{ issue | tojson }})'>
           Assign →
         </button>
       </div>


### PR DESCRIPTION
Alpine was truncating $dispatch expressions at the first JSON double-quote. Applied the project's established single-quote rule to both @click directives in _build_board.html.