### PR TITLE
fix: use loop.index0 not $index in unphased x-show

### DIFF
--- a/agentception/templates/_build_board.html
+++ b/agentception/templates/_build_board.html
@@ -44,7 +44,7 @@
       {%- endif %}"
       x-data
       @click='$dispatch("inspect-issue", {{ issue | tojson }})'
-      {% if is_unphased %}x-show="$index < limit"{% endif %}
+      {% if is_unphased %}x-show="{{ loop.index0 }} < limit"{% endif %}
     >
 
       {# header: number + role label + state dot #}


### PR DESCRIPTION
`$index` is an Alpine magic variable only available inside `x-for`. Jinja2 for loops need `loop.index0` which renders as a literal number Alpine can evaluate.