### PR TITLE
fix: skip rendering empty phases on build board

### DIFF
--- a/agentception/templates/_build_board.html
+++ b/agentception/templates/_build_board.html
@@ -2,7 +2,7 @@
 {% set closed_count = group.issues | selectattr("state", "equalto", "closed") | list | length %}
 {% set total_count  = group.issues | length %}
 {% set is_unphased  = group.label == "unphased" %}
-
+{% if group.issues or is_unphased %}
 <div class="build-phase
   {%- if group.complete %} build-phase--complete
   {%- elif group.locked %} build-phase--locked
@@ -114,4 +114,5 @@
   {% endif %}
 
 </div>
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
Empty phase bars were creating visual noise. Phases with no issues are now skipped entirely. Unphased always renders.